### PR TITLE
Update mkdocs.yml to MkDocs 0.17.0 format

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -14,13 +14,14 @@ pages:
         - Version: scripts/version.md
     - 'Required Plugins': jenkins/requiredPlugins.md
 
-theme: 'material'
-extra:
-    logo: 'images/piper_head_white.png'
-    site_favicon: 'images/favicon.ico'
+theme: 
+    name: 'material'
     palette:
       primary: 'teal'
       accent: 'purple'
+    logo: 'images/piper_head_white.png'
+    favicon: 'images/favicon.ico'
+extra:
     font:
       text: 'Slabo 13px'
       code: 'Ubuntu Mono'


### PR DESCRIPTION
MkDocs 0.17 features theme customization options [1] which are picked up
supported with mkdocs-material 2.0.1 [2] and later. These are now the
minimum required versions to compile our gh-pages documentation.

[1] http://www.mkdocs.org/about/release-notes/#major-additions-to-version-0170
[2] https://github.com/squidfunk/mkdocs-material/releases/tag/2.0.0