### PR TITLE
retrieveGitCoordinates - Improvement and Tests

### DIFF
--- a/documentation/docs/scripts/gitUtils.md
+++ b/documentation/docs/scripts/gitUtils.md
@@ -1,0 +1,45 @@
+# GitUtils
+
+## Description
+Provides git utility functions.
+
+## Constructors
+
+### GitUtils()
+
+Default no-argument constructor. Instances of the GitUtils class does not hold any instance specific state.
+
+#### Example
+
+```groovy
+new GitUtils()
+```
+
+## Method Details
+
+### retrieveGitCoordinates(script)
+
+#### Description
+Retrieves the git-remote-url and git-branch. The parameters 'GIT_URL' and 'GIT_BRANCH' are retrieved from Jenkins job configuration. If these are not set, the git-url and git-branch are retrieved from the same repository where the Jenkinsfile resides.
+
+#### Parameters
+
+* `script` The script calling the method. Basically the `Jenkinsfile`. It is assumed that the script provides access to the parameters defined when launching the build, especially `GIT_URL` and `GIT_BRANCH`.
+
+#### Return value
+
+A map containing git-url and git-branch: `[url: gitUrl, branch: gitBranch]`
+
+## Exceptions
+
+* `AbortException`
+    * If there is no SCM present. This happens when the there is no `Jenkinsfile`, when the pipeline is defined in the job configuration.
+    * If only one of `GIT_URL`,  `GIT_BRANCH` is set in the Jenkins job configuration.
+
+#### Example
+
+```groovy
+def gitCoordinates = new GitUtils().retrieveGitCoordinates(this)
+def gitUrl = gitCoordinates.url
+def gitBranch = gitCoordinates.branch
+```

--- a/documentation/docs/scripts/utils.md
+++ b/documentation/docs/scripts/utils.md
@@ -47,29 +47,3 @@ def parameters = [DEPLOY_ACCOUNT: 'deploy-account']
 assert utils.getMandatoryParameter(parameters, 'DEPLOY_ACCOUNT', null) == 'deploy-account'
 assert utils.getMandatoryParameter(parameters, 'DEPLOY_USER', 'john_doe') == 'john_doe'
 ```
-
-### retrieveGitCoordinates(script)
-
-#### Description
-Retrieves the git-remote-url and git-branch. The parameters 'GIT_URL' and 'GIT_BRANCH' are retrieved from Jenkins job configuration. If these are not set, the git-url and git-branch are retrieved from the same repository where the Jenkinsfile resides.
-
-
-#### Parameters
-
-* `script` The script calling the method. Basically the `Jenkinsfile`. It is assumed that the script provides access to the parameters defined when launching the build, especially `GIT_URL`and `GIT_BRANCH`.
-
-#### Return value
-
-A map containing git-url and git-branch: `[url: gitUrl, branch: gitBranch]`
-
-## Exceptions
-
-* `AbortException`: if only one of `GIT_URL`,  `GIT_BRANCH` is set in the Jenkins job configuration.
-
-#### Example
-
-```groovy
-def gitCoordinates = new Utils().retrieveGitCoordinates(this)
-def gitUrl = gitCoordinates.url
-def gitBranch = gitCoordinates.branch
-```

--- a/src/com/sap/piper/GitUtils.groovy
+++ b/src/com/sap/piper/GitUtils.groovy
@@ -1,0 +1,41 @@
+package com.sap.piper
+
+import hudson.AbortException
+
+/**
+ * Retrieves the git url and branch either from the job parameters or from the configured SCMs.
+ * The git url and branch are stored as a map (gitCoordinates) in the commonPipelineEnvironment.
+ * @params script The pipeline script to be able to get the parameters from the job configuration.
+ * @return The gitCoordinates
+ */
+def retrieveGitCoordinates(script) {
+    def gitUrl = script.params.GIT_URL
+    def gitBranch = script.params.GIT_BRANCH
+    if (!gitUrl && !gitBranch) {
+        echo "[INFO] Parameters 'GIT_URL' and 'GIT_BRANCH' not set in Jenkins job configuration. Assuming application to be built is contained in the same repository as this Jenkinsfile."
+        try {
+            //[Q] Why not scm.userRemoteConfigs[0].url? [A] To throw an AbortException for the test case.
+            gitUrl = retrieveScm().userRemoteConfigs[0].getUrl()
+            gitBranch = retrieveScm().branches[0].getName()
+        } catch (AbortException e) {
+            error "No Source Code Management setup present. If you define the Pipeline directly in the Jenkins job configuration you have to set up parameters GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters."
+        }
+    } else if (!gitBranch) {
+        error "Parameter 'GIT_BRANCH' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built."
+    } else if (!gitUrl) {
+        error "Parameter 'GIT_URL' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built."
+    }
+    echo "[INFO] Building '${gitBranch}@${gitUrl}'."
+
+    script.commonPipelineEnvironment.setGitCoordinates([url: gitUrl, branch: gitBranch])
+
+    return [url: gitUrl, branch: gitBranch]
+}
+
+/*
+ * Do not remove/inline this method. The tests rely on it.
+ */
+def retrieveScm() {
+    return scm
+}
+

--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -15,23 +15,3 @@ def getMandatoryParameter(Map map, paramName, defaultValue) {
     return paramValue
 
 }
-
-def retrieveGitCoordinates(script){
-    def gitUrl = script.params.GIT_URL
-    def gitBranch = script.params.GIT_BRANCH
-    if(!gitUrl && !gitBranch) {
-        echo "[INFO] Parameters 'GIT_URL' and 'GIT_BRANCH' not set in Jenkins job configuration. Assuming application to be built is contained in the same repository as this Jenkinsfile."
-        gitUrl = scm.userRemoteConfigs[0].url
-        gitBranch = scm.branches[0].name
-    }
-    else if(!gitBranch) {
-        error "Parameter 'GIT_BRANCH' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built."
-    }
-    else if(!gitUrl) {
-        error "Parameter 'GIT_URL' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built."
-    }
-    echo "[INFO] Building '${gitBranch}@${gitUrl}'."
-
-    return [url: gitUrl, branch: gitBranch]
-}
-

--- a/test/groovy/GitUtilsTest.groovy
+++ b/test/groovy/GitUtilsTest.groovy
@@ -1,0 +1,116 @@
+import com.sap.piper.GitUtils
+import hudson.AbortException
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+class GitUtilsTest extends PiperTestBase {
+
+    @Rule
+    public ExpectedException thrown = new ExpectedException().none()
+
+    private gitUtils = new GitUtils()
+
+    class MyScmParts {
+        def url
+        def name
+    }
+
+
+    @Before
+    void setUp() {
+        super.setUp()
+        messages.clear()
+        GroovySystem.metaClassRegistry.removeMetaClass(gitUtils.class)
+        gitUtils.metaClass.echo = { s -> messages.add(s)}
+        gitUtils.metaClass.error = { s -> throw new AbortException(s) }
+    }
+
+    @Test
+    void retrieveGitCoordinatesWithParametersTest() {
+        binding.setVariable('params', [GIT_URL: "github.com:user1/my_repo.git", GIT_BRANCH: "master"])
+        def gitCoordinates = withPipeline(defaultPipeline()).execute(gitUtils)
+        assert messages[0] == "[INFO] Building 'master@github.com:user1/my_repo.git'."
+        assert gitCoordinates.url == "github.com:user1/my_repo.git"
+        assert gitCoordinates.branch == "master"
+    }
+
+    @Test
+    void retrieveGitCoordinatesFromScmTest() {
+        gitUtils.metaClass.scm = [userRemoteConfigs: [new MyScmParts([url: "github.com:user1/remote_repo.git"])], branches: [new MyScmParts([name: "feature1"])]]
+        binding.setVariable('params', [GIT_URL: null, GIT_BRANCH: null])
+        def gitCoordinates = withPipeline(defaultPipeline()).execute(gitUtils)
+        assert messages[0] == "[INFO] Parameters 'GIT_URL' and 'GIT_BRANCH' not set in Jenkins job configuration. Assuming application to be built is contained in the same repository as this Jenkinsfile."
+        assert messages[1] == "[INFO] Building 'feature1@github.com:user1/remote_repo.git'."
+        assert gitCoordinates.url == "github.com:user1/remote_repo.git"
+        assert gitCoordinates.branch == "feature1"
+    }
+
+    @Test
+    void retrieveGitCoordinatesWithNoScmPresentTest() {
+        gitUtils.metaClass.retrieveScm = { -> throw new AbortException('SCM not found.')}
+        thrown.expect(AbortException)
+        thrown.expectMessage("No Source Code Management setup present. If you define the Pipeline directly in the Jenkins job configuration you have to set up parameters GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters.")
+        binding.setVariable('params', [GIT_URL: null, GIT_BRANCH: null])
+        withPipeline(defaultPipeline()).execute(gitUtils)
+    }
+
+    @Test
+    void retrieveGitCoordinatesOnlyWithUrlTest() {
+        gitUtils.metaClass.retrieveScm = { -> throw new AbortException('SCM not found.')}
+        thrown.expect(AbortException)
+        thrown.expectMessage("Parameter 'GIT_BRANCH' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built.")
+        binding.setVariable('params', [GIT_URL: "github.com:user1/my_repo.git", GIT_BRANCH: null])
+        withPipeline(defaultPipeline()).execute(gitUtils)
+    }
+
+    @Test
+    void retrieveGitCoordinatesOnlyWithBranchTest() {
+        gitUtils.metaClass.retrieveScm = { -> throw new AbortException('SCM not found.')}
+        thrown.expect(AbortException)
+        thrown.expectMessage("Parameter 'GIT_URL' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built.")
+        binding.setVariable('params', [GIT_URL: null, GIT_BRANCH: "master"])
+        withPipeline(defaultPipeline()).execute(gitUtils)
+    }
+
+    @Test
+    void retrieveGitCoordinatesFromCommonPipelineEnvironmentTest() {
+        binding.setVariable('params', [GIT_URL: "github.com:user1/my_repo.git", GIT_BRANCH: "master"])
+        def gitCoordinates = withPipeline(cpePipeline()).execute(gitUtils)
+        assert messages[0] == "[INFO] Building 'master@github.com:user1/my_repo.git'."
+        assert gitCoordinates.url == "github.com:user1/my_repo.git"
+        assert gitCoordinates.branch == "master"
+    }
+
+
+    private defaultPipeline(){
+        return '''
+               import com.sap.piper.Utils
+               @Library('piper-library-os')
+
+               execute(gitUtils) {
+                 node() {
+                   def gitCoordinates = gitUtils.retrieveGitCoordinates(this)
+                   return gitCoordinates
+                 }
+               }
+               return this
+               '''
+    }
+
+    private cpePipeline(){
+        return '''
+               import com.sap.piper.Utils
+               @Library('piper-library-os')
+
+               execute(gitUtils) {
+                 node() {
+                   gitUtils.retrieveGitCoordinates(this)
+                   return commonPipelineEnvironment.getGitCoordinates()
+                 }
+               }
+               return this
+               '''
+    }
+}

--- a/test/groovy/UtilsTest.groovy
+++ b/test/groovy/UtilsTest.groovy
@@ -37,7 +37,7 @@ class UtilsTest {
     }
 
     @Test
-    void valueGetmandatoryParameterTest() {
+    void valueGetMandatoryParameterTest() {
 
         parameters.put('test', 'value')
 

--- a/test/groovy/UtilsTest.groovy
+++ b/test/groovy/UtilsTest.groovy
@@ -37,7 +37,7 @@ class UtilsTest {
     }
 
     @Test
-    void valueGetMandatoryParameterTest() {
+    void valueGetmandatoryParameterTest() {
 
         parameters.put('test', 'value')
 

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -2,6 +2,7 @@ class commonPipelineEnvironment implements Serializable {
     private Map configProperties = [:]
 
     private String mtarFilePath
+    private Map gitCoordinates
 
     def setConfigProperties(map) {
         configProperties = map
@@ -23,5 +24,11 @@ class commonPipelineEnvironment implements Serializable {
     }
     void setMtarFilePath(mtarFilePath) {
         this.mtarFilePath = mtarFilePath
+    }
+    def getGitCoordinates() {
+        return gitCoordinates
+    }
+    void setGitCoordinates(gitCoordinates) {
+        this.gitCoordinates = gitCoordinates
     }
 }


### PR DESCRIPTION
1. - [x] Better error message when no SCM present.
2. - [x] Store gitUrl and gitBranch in commonPipelineEnvironment (Needed for declarative pipelines).
3. Tests:
    - [x] Mocked job parameters.
    - [x] Mocked parameters from scm.
    - [x] Only git branch present.
    - [x] Only git url present.
    - [x] No scm present.
    - [x] Check for git url and branch in commonPipelineEnvironment.
4. - [x] Documentation