### PR TITLE
fix quotation inside neo deploy

### DIFF
--- a/test/groovy/NeoDeploymentTest.groovy
+++ b/test/groovy/NeoDeploymentTest.groovy
@@ -60,7 +60,7 @@ class NeoDeploymentTest extends PiperTestBase {
 
         withPipeline(defaultPipeline()).execute(archivePath, 'myCredentialsId')
 
-        assert shellCalls[0] =~ /#!\/bin\/bash \/opt\/neo\/tools\/neo\.sh deploy-mta --user anonymous --host test\.deploy\.host\.com --source ".*" --account trialuser123 --password \*\*\*\*\*\*\*\* --synchronous/
+        assert shellCalls[0] =~ /#!\/bin\/bash "\/opt\/neo\/tools\/neo\.sh" deploy-mta --user 'anonymous' --host 'test\.deploy\.host\.com' --source ".*" --account 'trialuser123' --password '\*\*\*\*\*\*\*\*' --synchronous/
 
         assert messages[1] == "[neoDeploy] Neo executable \"/opt/neo/tools/neo.sh\" retrieved from environment."
 
@@ -90,7 +90,7 @@ class NeoDeploymentTest extends PiperTestBase {
 
         withPipeline(noCredentialsIdPipeline()).execute(archivePath)
 
-        assert shellCalls[0] =~ /#!\/bin\/bash \/opt\/neo\/tools\/neo\.sh deploy-mta --user defaultUser --host test\.deploy\.host\.com --source ".*" --account trialuser123 --password \*\*\*\*\*\*\*\* --synchronous/
+        assert shellCalls[0] =~ /#!\/bin\/bash "\/opt\/neo\/tools\/neo\.sh" deploy-mta --user 'defaultUser' --host 'test\.deploy\.host\.com' --source ".*" --account 'trialuser123' --password '\*\*\*\*\*\*\*\*' --synchronous/
 
         assert messages[1] == "[neoDeploy] Neo executable \"/opt/neo/tools/neo.sh\" retrieved from environment."
     }
@@ -103,7 +103,7 @@ class NeoDeploymentTest extends PiperTestBase {
 
         withPipeline(noCredentialsIdPipeline()).execute(archivePath)
 
-        assert shellCalls[0] =~ /#!\/bin\/bash neo deploy-mta --user defaultUser --host test\.deploy\.host\.com --source ".*" --account trialuser123 --password \*\*\*\*\*\*\*\* --synchronous/
+        assert shellCalls[0] =~ /#!\/bin\/bash "neo" deploy-mta --user 'defaultUser' --host 'test\.deploy\.host\.com' --source ".*" --account 'trialuser123' --password '\*\*\*\*\*\*\*\*' --synchronous/
 
         assert messages[1] == "Using Neo executable from PATH."
     }
@@ -116,7 +116,7 @@ class NeoDeploymentTest extends PiperTestBase {
 
         withPipeline(neoHomeParameterPipeline()).execute(archivePath, 'myCredentialsId')
 
-        assert shellCalls[0] =~ /#!\/bin\/bash \/etc\/neo\/tools\/neo\.sh deploy-mta --user anonymous --host test\.deploy\.host\.com --source ".*" --account trialuser123 --password \*\*\*\*\*\*\*\* --synchronous/
+        assert shellCalls[0] =~ /#!\/bin\/bash "\/etc\/neo\/tools\/neo\.sh" deploy-mta --user 'anonymous' --host 'test\.deploy\.host\.com' --source ".*" --account 'trialuser123' --password '\*\*\*\*\*\*\*\*' --synchronous.*/
 
         assert messages[1] == "[neoDeploy] Neo executable \"/etc/neo/tools/neo.sh\" retrieved from parameters."
 

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -45,12 +45,12 @@ def call(parameters = [:]) {
                 usernameVariable: 'username'
         )]) {
             sh """#!/bin/bash
-                    ${neoExecutable} deploy-mta \
-                      --user ${username} \
-                      --host ${deployHost} \
+                    "${neoExecutable}" deploy-mta \
+                      --user '${username}' \
+                      --host '${deployHost}' \
                       --source "${archivePath.getAbsolutePath()}" \
-                      --account ${deployAccount} \
-                      --password ${password} \
+                      --account '${deployAccount}' \
+                      --password '${password}' \
                       --synchronous
                """
         }


### PR DESCRIPTION
Without proper quotation characters with a special semantics
on shell level (e.g. "${}", "!", """ gets escaped on shell level
before handed over to the neo tool.

neoExecutable is surrounded by double quotes since we may have
shell ${variables} inside the groovy variable.

All other variables (user, host, account, password) are surrounded
by single quotes since we do not expect to be variables used here.

The neoExecutable is