### PR TITLE
Remove Utils#retrieveGitCoordinates

### DIFF
--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -15,23 +15,3 @@ def getMandatoryParameter(Map map, paramName, defaultValue) {
     return paramValue
 
 }
-
-def retrieveGitCoordinates(script){
-    def gitUrl = script.params.GIT_URL
-    def gitBranch = script.params.GIT_BRANCH
-    if(!gitUrl && !gitBranch) {
-        echo "[INFO] Parameters 'GIT_URL' and 'GIT_BRANCH' not set in Jenkins job configuration. Assuming application to be built is contained in the same repository as this Jenkinsfile."
-        gitUrl = scm.userRemoteConfigs[0].url
-        gitBranch = scm.branches[0].name
-    }
-    else if(!gitBranch) {
-        error "Parameter 'GIT_BRANCH' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built."
-    }
-    else if(!gitUrl) {
-        error "Parameter 'GIT_URL' not set in Jenkins job configuration. Either set both GIT_URL and GIT_BRANCH of the application to be built as Jenkins job parameters or put this Jenkinsfile into the same repository as the application to be built."
-    }
-    echo "[INFO] Building '${gitBranch}@${gitUrl}'."
-
-    return [url: gitUrl, branch: gitBranch]
-}
-


### PR DESCRIPTION
The method is related to an outdated use case

It was intended for getting the coordinates of a payload repo when the
pipeline repo is specified in the pipeline job.

That has been changed so that the pipeline (or at least a stub pipeline)
is now always contained in the payload repo and the payload repo is
always specified in the pipeline job itself.