### PR TITLE
Remove node from test pipeline

### DIFF
--- a/test/groovy/PipelineExecuteTest.groovy
+++ b/test/groovy/PipelineExecuteTest.groovy
@@ -76,9 +76,7 @@ class PipelineExecuteTest extends PiperTestBase {
 
                execute() {
 
-                 node() {
                    pipelineExecute repoUrl: "https://test.com/myRepo.git"
-                 }
 
                }
 
@@ -92,9 +90,7 @@ class PipelineExecuteTest extends PiperTestBase {
 
                execute() {
 
-                 node() {
                    pipelineExecute repoUrl: "https://test.com/anotherRepo.git", branch: 'feature', path: 'path/to/Jenkinsfile', credentialsId: 'abcd1234'
-                 }
 
                }
 
@@ -108,9 +104,7 @@ class PipelineExecuteTest extends PiperTestBase {
 
                execute() {
 
-                 node() {
                    pipelineExecute()
-                 }
 
                }
 


### PR DESCRIPTION
node() is not necessary in the LesFurets unit tests. This is especially
misleading for the pipelineExecute step, as the step itself opens a node
closure when loading a pipeline. If used like this in Jenkins
unnecessary executors will be used.