### PR TITLE
Make docker more resilent wrt to environment

### DIFF
--- a/test/groovy/DockerExecuteTest.groovy
+++ b/test/groovy/DockerExecuteTest.groovy
@@ -16,9 +16,11 @@ class DockerExecuteTest extends PiperTestBase {
 
         docker = new DockerMock()
         binding.setVariable('docker', docker)
+        binding.setVariable('Jenkins', [instance: [pluginManager: [plugins: [new PluginMock()]]]])
 
         echos = ''
         helper.registerAllowedMethod("echo", [String.class], { String s -> echos += " $s" })
+        helper.registerAllowedMethod('sh', [Map.class], {return 0})
     }
 
     @Test
@@ -74,4 +76,14 @@ class DockerExecuteTest extends PiperTestBase {
             return parameters
         }
     }
+
+    private class PluginMock {
+        def getShortName() {
+            return 'docker-workflow'
+        }
+        boolean isActive() {
+            return true
+        }
+    }
+
 }

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -2,9 +2,10 @@ import com.cloudbees.groovy.cps.NonCPS
 
 def call(Map parameters = [:], body) {
 
+    def STEP_NAME = 'dockerExecute'
     def PLUGIN_ID_DOCKER_WORKFLOW = 'docker-workflow'
 
-    handlePipelineStepErrors(stepName: 'dockerExecute', stepParameters: parameters){
+    handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters){
         def dockerImage = parameters.get('dockerImage', '')
         Map dockerEnvVars = parameters.get('dockerEnvVars', [:])
         def dockerOptions = parameters.get('dockerOptions', '')
@@ -13,19 +14,19 @@ def call(Map parameters = [:], body) {
         if(dockerImage) {
 
             if (! Jenkins.instance.pluginManager.plugins.find { p -> p.isActive() && p.getShortName() == PLUGIN_ID_DOCKER_WORKFLOW } ) {
-                echo "[WARNING][dockerExecute] Docker not supported. Plugin '${PLUGIN_ID_DOCKER_WORKFLOW}' is not installed or not active. Configured docker image '${dockerImage}' will not be used."
+                echo "[WARNING][${STEP_NAME}] Docker not supported. Plugin '${PLUGIN_ID_DOCKER_WORKFLOW}' is not installed or not active. Configured docker image '${dockerImage}' will not be used."
                 dockerImage = null
             }
 
             def returnCode = sh script: 'which docker > /dev/null', returnStatus: true
             if(returnCode != 0) {
-                echo "[WARNING][dockerExecute] No docker environment found (command 'which docker' did not return with '0'). Configured docker image '${dockerImage}' will not be used."
+                echo "[WARNING][${STEP_NAME}] No docker environment found (command 'which docker' did not return with '0'). Configured docker image '${dockerImage}' will not be used."
                 dockerImage = null
             }
         }
 
         if(!dockerImage){
-            echo '[INFO][dockerExecute] Running on local environment.'
+            echo "[INFO][${STEP_NAME}] Running on local environment."
             body()
         }else{
             def image = docker.image(dockerImage)


### PR DESCRIPTION
We check
  1.) if docker-workflow plugin is installed
  2.) if docker itself is installed on the system hosting Jenkins

If one of the conditions is not fullfilled we try to execute
locally.

We expect use cases for the piper-lib where we cannot make strong assumtions about the environment wrt to docker.