### PR TITLE
Build mkdocs and abort travis build on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install:
 - pip install --user mkdocs mkdocs-material
 script:
 - mvn test -B
-- cd documentation && mkdocs build --clean --verbose --strict
+- if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then cd documentation && mkdocs build --clean --verbose --strict; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,7 @@ install:
 script:
 - mvn test -B
 - if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then cd documentation && mkdocs build --clean --verbose --strict; fi;
+cache:
+  directories:
+  - $HOME/.m2
+  - $HOME/.cache/pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ install:
 - pip install --user mkdocs mkdocs-material
 script:
 - mvn test -B
-- mkdocs --version
+- cd documentation && mkdocs build --clean --verbose --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,7 @@
 language: groovy
 sudo: false
+install:
+- pip install --user mkdocs mkdocs-material
+script:
+- mvn test -B
+- mkdocs --version


### PR DESCRIPTION
To build the documentation mkdocs, a python package, is necessary. The
material theme is used and also needs to be installed.
To find errors in the documentation it is built with mkdocs usind strict
mode: Thus any warnings result in errors and abort the travis build.
Also we activated caching.