### PR TITLE
Deploy mkdocs when merging to master

### DIFF
--- a/.travis.env
+++ b/.travis.env
@@ -1,0 +1,6 @@
+# Encrypted SSH-key
+ENCRYPTED_FILE="deploy-key.enc"
+
+# Travis-CI variables used for decrypting ENCRYPTED_FILE
+KEY="$encrypted_key"
+IV="$encrypted_iv"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: groovy
 sudo: false
+branches:
+  only:
+  - master
 install:
 - pip install --user mkdocs mkdocs-material
 script:
-- mvn test -B
-- if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then cd documentation && mkdocs build --clean --verbose --strict; fi;
+- if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then chmod +x pull-request.sh && ./pull-request.sh; else chmod +x gh-pages-deploy.sh && ./gh-pages-deploy.sh; fi;
 cache:
   directories:
-  - $HOME/.m2
-  - $HOME/.cache/pip
+  - "$HOME/.cache/pip"
+  - "$HOME/.m2"

--- a/gh-pages-deploy.sh
+++ b/gh-pages-deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+echo "Found change on master: Deployment of documentation"
+
+. .travis.env
+
+# We can't deploy if any of these vars are empty
+for variable in "$KEY" "$IV" "$ENCRYPTED_FILE"; do
+    if [ -z "$variable" ]; then
+        echo "ERROR: Found empty KEY, IV, or ENCRYPTED_FILE variable. Exiting."
+        exit 1
+    fi
+done
+
+openssl aes-256-cbc -K "$KEY" -iv "$IV" -in "$ENCRYPTED_FILE" -out deploy-key -d
+
+chmod 600 deploy-key
+eval `ssh-agent -s`
+ssh-add deploy-key
+git config user.name "Travis CI Publisher"
+git remote add gh-token "git@github.com:$TRAVIS_REPO_SLUG.git";
+git fetch gh-token && git fetch gh-token gh-pages:gh-pages
+echo "Pushing to gh-pages of repository $TRAVIS_REPO_SLUG"
+cd $TRAVIS_BUILD_DIR/documentation
+mkdocs gh-deploy -v --clean --remote-name gh-token

--- a/pull-request.sh
+++ b/pull-request.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "Found pull request: Running maven tests and building documentation"
+
+# Run tests
+mvn test -B
+
+# Build documentation to check for build errors and warnings
+echo "Building documentation to check for errors"
+cd $TRAVIS_BUILD_DIR/documentation
+mkdocs build --clean --verbose --strict
+exit $?


### PR DESCRIPTION
Only changes to master and PRs starts the travis job.
On PR Maven tests and mkdocs build for warnings and error check is done.
On change on master Maven is **not** run and the documentation is built
and deployed using a deploy key. The encrypted deploy key is not part of
this commit, it needs to be provided by an admin for this repository.