### PR TITLE
Use fileExists to check whether archivePath really exists

### DIFF
--- a/test/groovy/NeoDeploymentTest.groovy
+++ b/test/groovy/NeoDeploymentTest.groovy
@@ -43,6 +43,10 @@ class NeoDeploymentTest extends BasePipelineTest {
         propertiesFilePath = "${tmp.getRoot().toURI().getPath()}workspace/config.properties"
 
         helper.registerAllowedMethod('error', [String], { s -> throw new AbortException(s) })
+        helper.registerAllowedMethod('fileExists', [String], { s ->
+            f = new File(s)
+            return f.exists()
+        })
         helper.registerAllowedMethod('usernamePassword', [Map], { m -> return m })
         helper.registerAllowedMethod('withCredentials', [List, Closure], { l, c ->
             if(l[0].credentialsId == 'myCredentialsId') {

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -11,11 +11,8 @@ def call(parameters = [:]) {
             script = [commonPipelineEnvironment: commonPipelineEnvironment]
         }
 
-        def archivePath = new File(utils.getMandatoryParameter(parameters, 'archivePath', null))
-        if (!archivePath.isAbsolute()) {
-            archivePath = new File(pwd(), archivePath.getPath())
-        }
-        if (!archivePath.exists()){
+        def archivePath = utils.getMandatoryParameter(parameters, 'archivePath', null)
+        if (!fileExists(archivePath)){
             error "Archive cannot be found with parameter archivePath: '${archivePath}'."
         }
 
@@ -34,11 +31,8 @@ def call(parameters = [:]) {
             }
         }
         if (deployMode == 'warPropertiesFile') {
-            propertiesFile = new File(utils.getMandatoryParameter(parameters, 'propertiesFile', null))
-            if (!propertiesFile.isAbsolute()) {
-                propertiesFile = new File(pwd(), propertiesFile.getPath())
-            }
-            if (!propertiesFile.exists()){
+            propertiesFile = utils.getMandatoryParameter(parameters, 'propertiesFile', null)
+            if (!fileExists(propertiesFile)){
                 error "Properties file cannot be found with parameter propertiesFile: '${propertiesFile}'."
             }
         }
@@ -84,7 +78,7 @@ def call(parameters = [:]) {
             def commonDeployParams =
                 """--user '${username}' \
                    --password '${password}' \
-                   --source "${archivePath.getAbsolutePath()}" \
+                   --source "${archivePath}" \
                 """
 
             if (deployMode == 'mta') {
@@ -114,7 +108,7 @@ def call(parameters = [:]) {
                 sh """#!/bin/bash
                       "${neoExecutable}" ${warAction} \
                       ${commonDeployParams} \
-                      ${propertiesFile.getAbsolutePath()}
+                      ${propertiesFile}
                    """
             }
         }


### PR DESCRIPTION
When running on a slave we have to use the Pipeline method fileExists,
using the File class' exist on the absolute path fails.
The neo deployment uses the relative path as well.
The fileExists method is mocked with LesFurets.