### PR TITLE
remove printing the callstack

### DIFF
--- a/test/groovy/util/JenkinsSetupRule.groovy
+++ b/test/groovy/util/JenkinsSetupRule.groovy
@@ -44,7 +44,6 @@ class JenkinsSetupRule implements TestRule {
 
                 base.evaluate()
 
-                testInstance.printCallStack()
             }
         }
     }


### PR DESCRIPTION
I guess nobody is interested in the callstack printed into the log
during the tests.