### PR TITLE
Use Set instead of List for configuration keys

### DIFF
--- a/src/com/sap/piper/ConfigurationMerger.groovy
+++ b/src/com/sap/piper/ConfigurationMerger.groovy
@@ -4,7 +4,7 @@ import com.cloudbees.groovy.cps.NonCPS
 
 class ConfigurationMerger {
     @NonCPS
-    def static merge(Map configs, List configKeys, Map defaults=[:]) {
+    def static merge(Map configs, Set configKeys, Map defaults=[:]) {
         Map merged = [:]
         merged.putAll(defaults)
         merged.putAll(filterByKeyAndNull(configs, configKeys))
@@ -13,7 +13,7 @@ class ConfigurationMerger {
     }
 
     @NonCPS
-    def static merge(Map parameters, List parameterKeys, Map configurationMap, List configurationKeys, Map defaults=[:]){
+    def static merge(Map parameters, Set parameterKeys, Map configurationMap, Set configurationKeys, Map defaults=[:]){
         Map merged = merge(configurationMap, configurationKeys, defaults)
         merged.putAll(filterByKeyAndNull(parameters, parameterKeys))
 
@@ -21,9 +21,9 @@ class ConfigurationMerger {
     }
 
     @NonCPS
-    def static mergeWithPipelineData(Map parameters, List parameterKeys,
+    def static mergeWithPipelineData(Map parameters, Set parameterKeys,
                             Map pipelineDataMap,
-                            Map configurationMap, List configurationKeys,
+                            Map configurationMap, Set configurationKeys,
                             Map stepDefaults=[:]
     ){
         Map merged = [:]
@@ -36,7 +36,7 @@ class ConfigurationMerger {
     }
 
     @NonCPS
-    private static filterByKeyAndNull(Map map, List keys) {
+    private static filterByKeyAndNull(Map map, Set keys) {
         Map filteredMap = map.findAll {
             if(it.value == null){
                 return false

--- a/test/groovy/com/sap/piper/ConfigurationMergerTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationMergerTest.groovy
@@ -9,9 +9,9 @@ class ConfigurationMergerTest {
     void testMerge(){
         Map defaults = [dockerImage: 'mvn']
         Map parameters = [goals: 'install', flags: '']
-        List parameterKeys = ['flags']
+        Set parameterKeys = ['flags']
         Map configuration = [flags: '-B']
-        List configurationKeys = ['flags']
+        Set configurationKeys = ['flags']
         Map merged = ConfigurationMerger.merge(parameters, parameterKeys, configuration, configurationKeys, defaults)
         Assert.assertEquals('mvn', merged.dockerImage)
         Assert.assertNull(merged.goals)
@@ -22,7 +22,7 @@ class ConfigurationMergerTest {
     void testMergeParameterWithDefault(){
         Map defaults = [nonErpDestinations: []]
         Map parameters = [nonErpDestinations: null]
-        List parameterKeys = ['nonErpDestinations']
+        Set parameterKeys = ['nonErpDestinations']
         Map merged = ConfigurationMerger.merge(parameters, parameterKeys, defaults)
         Assert.assertEquals([], merged.nonErpDestinations)
     }
@@ -31,9 +31,9 @@ class ConfigurationMergerTest {
     void testMergeCustomPipelineValues(){
         Map defaults = [dockerImage: 'mvn']
         Map parameters = [goals: 'install', flags: '']
-        List parameterKeys = ['flags']
+        Set parameterKeys = ['flags']
         Map configuration = [flags: '-B']
-        List configurationKeys = ['flags']
+        Set configurationKeys = ['flags']
         Map pipelineDataMap = [artifactVersion: '1.2.3', flags: 'test']
         Map merged = ConfigurationMerger.mergeWithPipelineData(parameters, parameterKeys, pipelineDataMap, configuration, configurationKeys, defaults)
         Assert.assertEquals('', merged.flags)

--- a/vars/influxWriteData.groovy
+++ b/vars/influxWriteData.groovy
@@ -17,7 +17,7 @@ def call(Map parameters = [:]) {
         final Map stepDefaults = ConfigurationLoader.defaultStepConfiguration(script, stepName)
         final Map stepConfiguration = ConfigurationLoader.stepConfiguration(script, stepName)
 
-        List parameterKeys = [
+        Set parameterKeys = [
             'artifactVersion',
             'influxServer',
             'influxPrefix'
@@ -25,7 +25,7 @@ def call(Map parameters = [:]) {
         Map pipelineDataMap = [
             artifactVersion: commonPipelineEnvironment.getArtifactVersion()
         ]
-        List stepConfigurationKeys = [
+        Set stepConfigurationKeys = [
             'influxServer',
             'influxPrefix'
         ]

--- a/vars/mavenExecute.groovy
+++ b/vars/mavenExecute.groovy
@@ -11,7 +11,7 @@ def call(Map parameters = [:]) {
 
         final Map stepConfiguration = ConfigurationLoader.stepConfiguration(script, 'mavenExecute')
 
-        List parameterKeys = [
+        Set parameterKeys = [
             'dockerImage',
             'globalSettingsFile',
             'projectSettingsFile',
@@ -21,7 +21,7 @@ def call(Map parameters = [:]) {
             'm2Path',
             'defines'
         ]
-        List stepConfigurationKeys = [
+        Set stepConfigurationKeys = [
             'dockerImage',
             'globalSettingsFile',
             'projectSettingsFile',

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -7,7 +7,7 @@ def call(parameters = [:]) {
 
     def stepName = 'neoDeploy'
 
-    List parameterKeys = [
+    Set parameterKeys = [
         'applicationName',
         'archivePath',
         'account',
@@ -27,7 +27,7 @@ def call(parameters = [:]) {
         'warAction'
         ]
 
-    List stepConfigurationKeys = [
+    Set stepConfigurationKeys = [
         'account',
         'dockerEnvVars',
         'dockerImage',


### PR DESCRIPTION
Lists are used if
  o the order of the entries is important
  o duplicates are reasonable/allowed

Sets are used if
  o the order of the entries does not matter
  o duplicates are not allowed/reasonable

Here is our use case the order of the entries is not significant and it does not
make sense to have duplicates. Hence Sets are appropritate.

The longer we wait with fixing the harder will it be to fix it.