### PR TITLE
Remove empty string as default for neo credentials id

### DIFF
--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -98,7 +98,7 @@ def call(parameters = [:]) {
 
         def deployHost
         def deployAccount
-        def credentialsId = configuration.get('neoCredentialsId', '')
+        def credentialsId = configuration.get('neoCredentialsId')
         def deployMode = configuration.deployMode
         def warAction
         def propertiesFile


### PR DESCRIPTION
We have a default value configured at the level of the shipped defaults.

grep neoCredentialsId resources/default_pipeline_environment.yml