### PR TITLE
Use UTC time zone for artifact version time stamp

### DIFF
--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -1,6 +1,5 @@
 #!groovy
 import com.lesfurets.jenkins.unit.BasePipelineTest
-import com.sap.piper.DefaultValueCache
 import com.sap.piper.GitUtils
 import org.junit.Before
 import org.junit.Rule
@@ -47,7 +46,7 @@ class ArtifactSetVersionTest extends BasePipelineTest {
         })
 
         jscr.setReturnValue('git rev-parse HEAD', 'testCommitId')
-        jscr.setReturnValue("date +'%Y%m%d%H%M%S'", '20180101010203')
+        jscr.setReturnValue("date --universal +'%Y%m%d%H%M%S'", '20180101010203')
         jscr.setReturnValue('git diff --quiet HEAD', 0)
 
         gitUtils = new GitUtils()

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -1,9 +1,7 @@
-import com.sap.piper.ConfigurationLoader
 import com.sap.piper.ConfigurationMerger
 import com.sap.piper.GitUtils
 import com.sap.piper.Utils
 import com.sap.piper.versioning.ArtifactVersioning
-
 import groovy.text.SimpleTemplateEngine
 
 def call(Map parameters = [:]) {
@@ -126,10 +124,5 @@ def call(Map parameters = [:]) {
 }
 
 def getTimestamp(pattern){
-    return sh(returnStdout: true, script: "date +'${pattern}'").trim()
+    return sh(returnStdout: true, script: "date --universal +'${pattern}'").trim()
 }
-
-
-
-
-


### PR DESCRIPTION
By using UTC, we avoid potential issues when development happens in
different time zones. Also, daylight saving time does not exist in UTC.