### PR TITLE
Make commit of new version optional in `artifactSetVersion` step

### DIFF
--- a/documentation/docs/steps/artifactSetVersion.md
+++ b/documentation/docs/steps/artifactSetVersion.md
@@ -20,13 +20,14 @@ none
 | ----------|-----------|---------|-----------------|
 | script | no | empty `commonPipelineEnvironment` |  |
 | buildTool | no | maven | maven, docker |
+| commitVersion | no | `true` | `true`, `false` |
 | dockerVersionSource | no  | `''`  | FROM, (ENV name),appVersion  |
 | filePath | no | buildTool=`maven`: pom.xml <br />docker: Dockerfile |   |
 | gitCommitId |  no | `GitUtils.getGitCommitId()`   |   |
-| gitCredentialsId |  yes | as defined in custom configuration  |   |
+| gitCredentialsId |  If `commitVersion` is `true` | as defined in custom configuration  |   |
 | gitUserEMail | no |  |   |
 | gitUserName | no |   |   |
-| gitSshUrl | yes  |  |   |
+| gitSshUrl | If `commitVersion` is `true` |  |   |
 | tagPrefix | no  | 'build_'  |   |
 | timestamp | no  |  current time in format according to `timestampTemplate`  |   |
 | timestampTemplate | no | `%Y%m%d%H%M%S` |   |
@@ -34,6 +35,7 @@ none
 
 * `script` defines the global script environment of the Jenkinsfile run. Typically `this` is passed to this parameter. This allows the function to access the [`commonPipelineEnvironment`](commonPipelineEnvironment.md) for retrieving e.g. configuration parameters.
 * `buildTool` defines the tool which is used for building the artifact.
+* `commitVersion` controls if the changed version is committed and pushed to the repository.
 * `dockerVersionSource` specifies the source to be used for the main version which is used for generating the automatic version.
 
     * This can either be the version of the base image - as retrieved from the `FROM` statement within the Dockerfile, e.g. `FROM jenkins:2.46.2`
@@ -53,6 +55,7 @@ Following parameters can also be specified as step parameters using the global c
 
 * `artifactType`
 * `buildTool`
+* `commitVersion`
 * `dockerVersionSource`
 * `filePath`
 * `gitCredentialsId`

--- a/documentation/docs/steps/artifactSetVersion.md
+++ b/documentation/docs/steps/artifactSetVersion.md
@@ -9,7 +9,10 @@ The version generated using this step will contain:
 * Timestamp
 * CommitId (by default the long version of the hash)
 
-After conducting automatic versioning the new version is pushed as a new tag into the source code repository (e.g. GitHub)
+Optionally, but enabled by default, the new version is pushed as a new tag into the source code repository (e.g. GitHub).
+If this option is chosen, git credentials and the repository URL needs to be provided.
+Since you might not want to configure the git credentials in Jenkins, committing and pushing can be disabled using the `commitVersion` parameter as described below.
+If you require strict reproducibility of your builds, this should be used.
 
 ## Prerequsites
 none
@@ -35,7 +38,7 @@ none
 
 * `script` defines the global script environment of the Jenkinsfile run. Typically `this` is passed to this parameter. This allows the function to access the [`commonPipelineEnvironment`](commonPipelineEnvironment.md) for retrieving e.g. configuration parameters.
 * `buildTool` defines the tool which is used for building the artifact.
-* `commitVersion` controls if the changed version is committed and pushed to the repository.
+* `commitVersion` controls if the changed version is committed and pushed to the git repository. If this is enabled (which is the default), you need to provide `gitCredentialsId` and `gitSshUrl`.
 * `dockerVersionSource` specifies the source to be used for the main version which is used for generating the automatic version.
 
     * This can either be the version of the base image - as retrieved from the `FROM` statement within the Dockerfile, e.g. `FROM jenkins:2.46.2`

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -7,6 +7,7 @@ steps:
   artifactSetVersion:
     timestampTemplate: '%Y%m%d%H%M%S'
     tagPrefix: 'build_'
+    commitVersion: true
     maven:
       filePath: 'pom.xml'
       versioningTemplate: '${version}-${timestamp}${commitId?"_"+commitId:""}'

--- a/src/com/sap/piper/GitUtils.groovy
+++ b/src/com/sap/piper/GitUtils.groovy
@@ -7,3 +7,7 @@ def getGitCommitIdOrNull() {
         return null
     }
 }
+
+def getGitCommitId() {
+    return sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+}

--- a/src/com/sap/piper/GitUtils.groovy
+++ b/src/com/sap/piper/GitUtils.groovy
@@ -1,7 +1,9 @@
 package com.sap.piper
 
-import com.cloudbees.groovy.cps.NonCPS
-
-def getGitCommitId() {
-    return sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+def getGitCommitIdOrNull() {
+    if (fileExists('.git')) {
+        return sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    } else {
+        return null
+    }
 }

--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -1,19 +1,12 @@
 #!groovy
 import com.lesfurets.jenkins.unit.BasePipelineTest
-import com.sap.piper.DefaultValueCache
 import com.sap.piper.GitUtils
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
-import util.JenkinsLoggingRule
-import util.JenkinsReadMavenPomRule
-import util.JenkinsShellCallRule
-import util.JenkinsWriteFileRule
-import util.JenkinsStepRule
-import util.JenkinsEnvironmentRule
-import util.Rules
+import util.*
 
 import static org.junit.Assert.assertEquals
 
@@ -67,6 +60,14 @@ class ArtifactSetVersionTest extends BasePipelineTest {
         assertEquals ("git remote set-url origin myGitSshUrl", jscr.shell[6])
         assertEquals ("git tag build_1.2.3-20180101010203_testCommitId", jscr.shell[7])
         assertEquals ("git push origin build_1.2.3-20180101010203_testCommitId", jscr.shell[8])
+    }
+
+    @Test
+    void testVersioningWithoutCommit() {
+        jsr.step.call(script: [commonPipelineEnvironment: jer.env], juStabGitUtils: gitUtils, buildTool: 'maven', commitVersion: false)
+
+        assertEquals('1.2.3-20180101010203_testCommitId', jer.env.getArtifactVersion())
+        assertEquals('mvn versions:set -DnewVersion=1.2.3-20180101010203_testCommitId --file pom.xml', jscr.shell[3])
     }
 
     @Test

--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -45,6 +45,8 @@ class ArtifactSetVersionTest extends BasePipelineTest {
 
         gitUtils = new GitUtils()
         prepareObjectInterceptors(gitUtils)
+
+        this.helper.registerAllowedMethod('fileExists', [String.class], {true})
     }
 
     @Test

--- a/test/groovy/com/sap/piper/GitUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/GitUtilsTest.groovy
@@ -6,12 +6,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
-import util.JenkinsReadMavenPomRule
 import util.JenkinsShellCallRule
+import util.MockHelper
 import util.Rules
-import util.SharedLibraryCreator
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertNull
 
 class GitUtilsTest extends BasePipelineTest {
 
@@ -27,6 +27,7 @@ class GitUtilsTest extends BasePipelineTest {
     void init() throws Exception {
         gitUtils = new GitUtils()
         prepareObjectInterceptors(gitUtils)
+        gitUtils.fileExists = MockHelper
 
         jscr.setReturnValue('git rev-parse HEAD', 'testCommitId')
     }
@@ -39,9 +40,14 @@ class GitUtilsTest extends BasePipelineTest {
 
     @Test
     void testGetGitCommitId() {
+        this.helper.registerAllowedMethod('fileExists', [String.class], {true})
+        assertEquals('testCommitId', gitUtils.getGitCommitIdOrNull())
+    }
 
-        assertEquals('testCommitId', gitUtils.getGitCommitId())
-
+    @Test
+    void testGetGitCommitIdNotAGitRepo() {
+        this.helper.registerAllowedMethod('fileExists', [String.class], {false})
+        assertNull(gitUtils.getGitCommitIdOrNull())
     }
 
 }

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -91,10 +91,10 @@ def call(Map parameters = [:]) {
 
         artifactVersioning.setVersion(newVersion)
 
+        def gitCommitId
+
         if (configuration.commitVersion) {
             sh 'git add .'
-
-            def gitCommitId
 
             sshagent([configuration.gitCredentialsId]) {
                 def gitUserMailConfig = ''
@@ -112,18 +112,17 @@ def call(Map parameters = [:]) {
 
                 gitCommitId = gitUtils.getGitCommitId()
             }
-
-            if (buildTool == 'docker' && configuration.artifactType == 'appContainer') {
-                script.commonPipelineEnvironment.setAppContainerProperty('artifactVersion', newVersion)
-                script.commonPipelineEnvironment.setAppContainerProperty('gitCommitId', gitCommitId)
-            } else {
-                //standard case
-                script.commonPipelineEnvironment.setArtifactVersion(newVersion)
-                script.commonPipelineEnvironment.setGitCommitId(gitCommitId)
-            }
-        } else {
-            script.commonPipelineEnvironment.setArtifactVersion(newVersion)
         }
+
+        if (buildTool == 'docker' && configuration.artifactType == 'appContainer') {
+            script.commonPipelineEnvironment.setAppContainerProperty('artifactVersion', newVersion)
+            script.commonPipelineEnvironment.setAppContainerProperty('gitCommitId', gitCommitId)
+        } else {
+            //standard case
+            script.commonPipelineEnvironment.setArtifactVersion(newVersion)
+            script.commonPipelineEnvironment.setGitCommitId(gitCommitId)
+        }
+
         echo "[${stepName}]New version: ${newVersion}"
     }
 }

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -15,8 +15,10 @@ def call(Map parameters = [:]) {
             gitUtils = new GitUtils()
         }
 
-        if (sh(returnStatus: true, script: 'git diff --quiet HEAD') != 0)
-            error "[${stepName}] Files in the workspace have been changed previously - aborting ${stepName}"
+        if (fileExists('.git')) {
+            if (sh(returnStatus: true, script: 'git diff --quiet HEAD') != 0)
+                error "[${stepName}] Files in the workspace have been changed previously - aborting ${stepName}"
+        }
 
         def script = parameters.script
         if (script == null)
@@ -41,7 +43,7 @@ def call(Map parameters = [:]) {
             'versioningTemplate'
         ]
         Map pipelineDataMap = [
-            gitCommitId: gitUtils.getGitCommitId()
+            gitCommitId: gitUtils.getGitCommitIdOrNull()
         ]
         Set stepConfigurationKeys = [
             'artifactType',
@@ -110,7 +112,7 @@ def call(Map parameters = [:]) {
                 sh "git tag ${configuration.tagPrefix}${newVersion}"
                 sh "git push origin ${configuration.tagPrefix}${newVersion}"
 
-                gitCommitId = gitUtils.getGitCommitId()
+                gitCommitId = gitUtils.getGitCommitIdOrNull()
             }
         }
 


### PR DESCRIPTION
You might not want to add a new commit for each version, when versions
are automatically created. This commit makes this feature optional, but
enabled by default to maintain API compatibility.