### PR TITLE
Enable docu build for PR again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: groovy
 sudo: false
+install:
+- pip install --user mkdocs mkdocs-material
 script:
 - mvn test -B
+- if [[ "${TRAVIS_PULL_REQUEST}" != "false" ]]; then cd documentation && mkdocs build --clean --verbose --strict && cd ..; fi;
 cache:
   directories:
   - $HOME/.m2
+  - $HOME/.cache/pip
 after_success:
   - mvn -DrepoToken=$COVERALLS_REPO_TOKEN org.jacoco:jacoco-maven-plugin:report org.eluder.coveralls:coveralls-maven-plugin:report
 notifications:


### PR DESCRIPTION
Docu build is performed without deployment into gh-pages branch for pull requests in order to ensure we have no failures inside the documentation.

Some days ago preparing the mkdocs setup (pip) failed since it was not possible to get all the dependencies for mkdocs (issues with unsecure https).

Now the situation changed. There is still a warning when preparing mkdocs, but the build does not fail. In case we encounter issues again we should try to upgrade the python version  to 2.7.9 or above. Accoding to a log message when having the failing mkdocs preparation the issue with the unsecure https is resolved with 2.7.9 and higher, but we was on python version 2.7.6.