### PR TITLE
Disable tool validation inside neoDeploy and mtaBuild

### DIFF
--- a/test/groovy/MTABuildTest.groovy
+++ b/test/groovy/MTABuildTest.groovy
@@ -4,6 +4,7 @@ import org.yaml.snakeyaml.parser.ParserException
 
 import org.junit.BeforeClass
 import org.junit.ClassRule
+import org.junit.Ignore
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -238,6 +239,7 @@ public class MtaBuildTest extends BasePipelineTest {
         assert jscr.shell.find { c -> c.contains('java -jar mta.jar --mtar com.mycompany.northwind.mtar --build-target=NEO build')}
     }
 
+    @Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void skipValidationInCaseMtarJarFileIsUsedFromWorkingDir() {
         jscr.setReturnValue('ls mta.jar', 0)
@@ -245,6 +247,7 @@ public class MtaBuildTest extends BasePipelineTest {
         assert !toolMtaValidateCalled
     }
 
+    @Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void performValidationInCaseMtarJarFileIsNotUsedFromWorkingDir() {
         jscr.setReturnValue('ls mta.jar', 1)
@@ -252,6 +255,7 @@ public class MtaBuildTest extends BasePipelineTest {
         assert toolMtaValidateCalled
     }
 
+    @Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void toolJavaValidateCalled() {
 
@@ -260,6 +264,7 @@ public class MtaBuildTest extends BasePipelineTest {
         assert toolJavaValidateCalled
     }
 
+    @Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void toolValidateNotCalledWhenJavaHomeIsUnsetButJavaIsInPath() {
 

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -6,6 +6,7 @@ import com.lesfurets.jenkins.unit.BasePipelineTest
 
 import org.junit.BeforeClass
 import org.junit.ClassRule
+import org.junit.Ignore
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -446,6 +447,7 @@ class NeoDeployTest extends BasePipelineTest {
         assert jlr.log.contains("Deprecated parameter 'deployAccount' is used. This will not work anymore in future versions. Use parameter 'account' instead.")
     }
 
+	@Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void skipValidationWhenNeoToolsetIsInPathButNeoHomeNotProvidedViaConfigNorEnvironment() {
 
@@ -458,6 +460,7 @@ class NeoDeployTest extends BasePipelineTest {
         assert !toolNeoValidateCalled
     }
 
+    @Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void performValidationWhenNeoToolsetIsNotInPathAndNeoHomeNotProvidedViaConfigNorEnvironment() {
 
@@ -470,6 +473,7 @@ class NeoDeployTest extends BasePipelineTest {
         assert toolNeoValidateCalled
     }
 
+    @Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void toolJavaValidateCalled() {
 
@@ -480,6 +484,7 @@ class NeoDeployTest extends BasePipelineTest {
         assert toolJavaValidateCalled
     }
 
+    @Ignore('Tool validation disabled since it does not work properly in conjunction with slaves.')
     @Test
     void toolValidateSkippedIfJavaHomeNotSetButJavaInPath() {
 

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -36,7 +36,11 @@ def call(Map parameters = [:]) {
             def mtaJarLocation = configuration?.mtaJarLocation ?: env?.MTA_JAR_LOCATION
             def returnCodeLsMtaJar = sh script: "ls ${DEFAULT_MTA_JAR_NAME}", returnStatus:true
             if(mtaJarLocation || ( !mtaJarLocation && returnCodeLsMtaJar != 0)) {
-                toolValidate tool: 'mta', home: mtaJarLocation
+                // toolValidate commented since it is does not work in
+                // conjunction with jenkins slaves.
+                // TODO: switch on again when the issue is resolved.
+                // toolValidate tool: 'mta', home: mtaJarLocation
+                echo 'toolValidate (mta) is disabled.'
             } else {
                 echo "mta toolset (${DEFAULT_MTA_JAR_NAME}) has been found in current working directory. Using this version without further tool validation."
             }
@@ -51,7 +55,12 @@ def call(Map parameters = [:]) {
 
             def rc = sh script: 'which java' , returnStatus: true
             if(script.JAVA_HOME || (!script.JAVA_HOME && rc != 0)) {
-                toolValidate tool: 'java', home: script.JAVA_HOME
+                // toolValidate commented since it is does not work in
+                // conjunction with jenkins slaves.
+                // TODO: switch on again when the issue is resolved.
+                echo 'toolValidate (mta) is disabled.'
+                // toolValidate tool: 'java', home: script.JAVA_HOME
+                echo 'toolValidate (java) is disabled.'
             } else {
                 echo 'Tool validation (java) skipped. JAVA_HOME not set, but java executable in path.'
             }

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -210,7 +210,11 @@ def call(parameters = [:]) {
 
                     def rc = sh script: "which ${NEO_DEFAULT_CMD}", returnStatus: true
                     if(neoHome || (!neoHome && rc != 0)) {
-                        toolValidate tool: 'neo', home: neoHome
+                        // toolValidate commented since it is does not work in
+                        // conjunction with jenkins slaves.
+                        // TODO: switch on again when the issue is resolved.
+                        // toolValidate tool: 'neo', home: neoHome
+                        echo 'toolValidate (neo) is disabled.'
                     } else {
                         echo "neo (${NEO_DEFAULT_CMD}) has been found in path. Using this neo version without futher tool validation."
                     }
@@ -232,7 +236,11 @@ def call(parameters = [:]) {
                         echo "Skipping tool validate check (java). " +
                              "Java executable in path, but no JAVA_HOME found."
                     } else {
-                        toolValidate tool: 'java', home: javaHome
+                        // toolValidate commented since it is does not work in
+                        // conjunction with jenkins slaves.
+                        // TODO: switch on again when the issue is resolved.
+                        //toolValidate tool: 'java', home: javaHome
+                        echo 'toolValidate (java) is disabled.'
                     }
                 }
 


### PR DESCRIPTION
We know about two issues:

1.) groovy based file systems checks seems to be executed on Jenkins
    master even if there is a node which is dispatched to a slave.
2.) Environment variable contained in the value of a provided
    variable are not expanded. Example: In case we describe neoHome like
    "$JENKINS_HOME/tools/neo" we do not expand $JENKINS_HOME. Hence the
    file exists check for file '$JENKINS_HOME/tools/neo' fails.