### PR TITLE
Fix merging if no default values exist

### DIFF
--- a/src/com/sap/piper/ConfigurationMerger.groovy
+++ b/src/com/sap/piper/ConfigurationMerger.groovy
@@ -10,6 +10,8 @@ class ConfigurationMerger {
         Map filteredConfig = configKeys?configs.subMap(configKeys):configs
         Map merged = [:]
 
+        defaults = defaults ?: [:]
+
         merged.putAll(defaults)
 
         for(String key : filteredConfig.keySet())

--- a/test/groovy/com/sap/piper/ConfigurationMergerTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationMergerTest.groovy
@@ -64,6 +64,17 @@ class ConfigurationMergerTest {
     }
 
     @Test
+    void testMergeDeepStructureWithMissingDefaults(){
+        Map defaults = [others:[apples: 18]]
+        Map configuration = [fruits: [bananaaas: 50, cucumbers: 1000]]
+        Set configurationKeys = ['fruits']
+        Map merged = ConfigurationMerger.merge(configuration, configurationKeys, defaults)
+        Assert.assertEquals(50, merged.fruits.bananaaas)
+        Assert.assertEquals(18, merged.others.apples)
+        Assert.assertEquals(1000, merged.fruits.cucumbers)
+    }
+
+    @Test
    void testReadConfigInsideMerge() {
         DefaultValueCache.createInstance([steps:[myStep:[overwrite: 'x', defaultKey1:'defaultValue1']]])
         def config = [commonPipelineEnvironment: [configuration: [steps:[myStep:[overwrite: 'y', key1:'value1']]]]]

--- a/test/groovy/com/sap/piper/ConfigurationMergerTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationMergerTest.groovy
@@ -50,13 +50,13 @@ class ConfigurationMergerTest {
 
     @Test
     void testMergeDeepStructure(){
-        Map defaults = [fruits: [apples: 1, oranges: 10, bananaaas: 0]]
-        Map configuration = [fruits: [bananaaas: 50, cucumbers: 1000]]
+        Map defaults = [fruits: [apples: 1, oranges: 10, bananas: 0]]
+        Map configuration = [fruits: [bananas: 50, cucumbers: 1000]]
         Set configurationKeys = ['fruits']
         Map parameters = [fruits: [apples: 18], veggie: []]
         Set parameterKeys = ['fruits']
         Map merged = ConfigurationMerger.merge(parameters, parameterKeys, configuration, configurationKeys, defaults)
-        Assert.assertEquals(50, merged.fruits.bananaaas)
+        Assert.assertEquals(50, merged.fruits.bananas)
         Assert.assertEquals(18, merged.fruits.apples)
         Assert.assertEquals(10, merged.fruits.oranges)
         Assert.assertEquals(1000, merged.fruits.cucumbers)
@@ -66,10 +66,10 @@ class ConfigurationMergerTest {
     @Test
     void testMergeDeepStructureWithMissingDefaults(){
         Map defaults = [others:[apples: 18]]
-        Map configuration = [fruits: [bananaaas: 50, cucumbers: 1000]]
+        Map configuration = [fruits: [bananas: 50, cucumbers: 1000]]
         Set configurationKeys = ['fruits']
         Map merged = ConfigurationMerger.merge(configuration, configurationKeys, defaults)
-        Assert.assertEquals(50, merged.fruits.bananaaas)
+        Assert.assertEquals(50, merged.fruits.bananas)
         Assert.assertEquals(18, merged.others.apples)
         Assert.assertEquals(1000, merged.fruits.cucumbers)
     }


### PR DESCRIPTION
In line

https://github.com/SAP/jenkins-library/compare/fix/merging?expand=1#diff-07e7b5ab7692947662654f171daa514fR19

defaults[key] might be null, thus merge(filteredConfig[key], null, defaults[key]) will fail 