### PR TITLE
add mtaJarName to make 'mta.jar' configurable

### DIFF
--- a/documentation/docs/steps/mtaBuild.md
+++ b/documentation/docs/steps/mtaBuild.md
@@ -18,13 +18,14 @@ Note that a version is formed by `major.minor.patch`, and a version is compatibl
 | `script`         | yes       |                                                        |                    |
 | `buildTarget`    | yes       | `'NEO'`                                                | 'CF', 'NEO', 'XSA' |
 | `extension`    | no       |                                                            |                    |
-| `mtaJarLocation` | no        |                                                        |                    |
+| `mtaJarLocation` | no        | `'mta.jar'`                                        |                    |
 | `applicationName`| no        |                                                        |                    |
 
 * `script` - The common script environment of the Jenkinsfile running. Typically the reference to the script calling the pipeline step is provided with the `this` parameter, as in `script: this`. This allows the function to access the [`commonPipelineEnvironment`](commonPipelineEnvironment.md) for retrieving, for example, configuration parameters.
 * `buildTarget` - The target platform to which the mtar can be deployed.
 * `extension` - The path to the extension descriptor file.
-* `mtaJarLocation` - The path of the `mta.jar` file. If no parameter is provided, the path is retrieved from the environment variables using the environment variable`MTA_JAR_LOCATION`. If no parameter and no environment variable is provided, the path is retrieved from the step configuration using the step configuration key `mtaJarLocation`. If the previous configurations are not provided, `mta.jar` is expected on the current working directory, and if it is not located on the current working directory an AbortException is thrown.
+* `mtaJarLocation` - The location of the SAP Multitarget Application Archive Builder jar file, including file name and extension. First, the location is retrieved from the environment variables using the environment variable`MTA_JAR_LOCATION`. If no environment variable is provided, the location is retrieved from the parameters, or the step configuration using the key `mtaJarLocation`. If SAP Multitarget Application Archive Builder is not found on one of the previous locations an AbortException is thrown.
+Note that the environment variable `MTA_JAR_LOCATION` has priority. In case that the script runs on multiple nodes, SAP Multitarget Application Archive Builder must be located on all the nodes, therefore the environment variable must be also configured on all the nodes.
 * `applicationName` - The name of the application which is being built. If the parameter has been provided and no `mta.yaml` exists, the `mta.yaml` will be automatically generated using this parameter and the information (`name` and `version`) from `package.json` before the actual build starts.
 
 ## Step configuration
@@ -43,6 +44,7 @@ The file name of the resulting archive is returned with this step. The file name
 
 ## Exceptions
 * `AbortException`:
+    * If SAP Multitarget Application Archive Builder is not found.
     * If there is an invalid `buildTarget`.
     * If there is no key `ID` inside the `mta.yaml` file.
 

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -20,6 +20,7 @@ steps:
     influxServer: 'jenkins'
   mtaBuild:
     buildTarget: 'NEO'
+    mtaJarLocation: 'mta.jar'
   neoDeploy:
     deployMode: 'mta'
     warAction: 'deploy'

--- a/src/com/sap/piper/VersionUtils.groovy
+++ b/src/com/sap/piper/VersionUtils.groovy
@@ -1,0 +1,25 @@
+package com.sap.piper
+
+import hudson.AbortException
+
+
+class VersionUtils implements Serializable {
+
+    def static verifyVersion(script, name, executable, version, versionOption) {
+
+        script.echo "Verifying $name version $version or compatible version."
+
+        def toolVersion
+        try {
+          toolVersion = script.sh returnStdout: true, script: """#!/bin/bash
+                                                                 $executable $versionOption"""
+        } catch(AbortException e) {
+          throw new AbortException("The verification of $name failed. Please check '$executable'. $e.message.")
+        }
+        def installedVersion = new Version(toolVersion)
+        if (!installedVersion.isCompatibleVersion(new Version(version))) {
+          throw new AbortException("The installed version of $name is ${installedVersion.toString()}. Please install version $version or a compatible version.")
+        }
+        script.echo "Verification success. $name version ${installedVersion.toString()} is installed."
+    }
+}

--- a/src/com/sap/piper/tools/JavaArchiveDescriptor.groovy
+++ b/src/com/sap/piper/tools/JavaArchiveDescriptor.groovy
@@ -1,63 +1,93 @@
 package com.sap.piper.tools
 
+import com.sap.piper.VersionUtils
 import com.sap.piper.EnvironmentUtils
 import com.sap.piper.FileUtils
 
 import hudson.AbortException
 
 
-class JavaArchiveDescriptor extends ToolDescriptor {
+class JavaArchiveDescriptor implements Serializable {
 
+    final name
+    final environmentKey
+    final stepConfigurationKey
+    final version
+    final versionOption
     final javaTool
     final javaOptions
 
-    JavaArchiveDescriptor(name, environmentKey, stepConfigurationKey, executablePath, executableName, version, versionOption, javaTool, javaOptions = '') {
-        super(name, environmentKey, stepConfigurationKey, executablePath, executableName, version, versionOption)
+    JavaArchiveDescriptor(name, environmentKey, stepConfigurationKey, version, versionOption, javaTool, javaOptions = '') {
+        this.name = name
+        this.environmentKey = environmentKey
+        this.stepConfigurationKey = stepConfigurationKey
+        this.version = version
+        this.versionOption = versionOption
         this.javaTool = javaTool
         this.javaOptions = javaOptions
     }
 
-    @Override
-    def getToolLocation(script, configuration, log = true) {
+    def getFile(script, configuration, log = true) {
 
-        def home
+        def javaArchiveFile
         if (EnvironmentUtils.isEnvironmentVariable(script, environmentKey)) {
-            home = EnvironmentUtils.getEnvironmentVariable(script, environmentKey)
-            if (log) script.echo "$name home '$home' retrieved from environment."
+            javaArchiveFile = EnvironmentUtils.getEnvironmentVariable(script, environmentKey)
+            if (log) script.echo "$name file '$javaArchiveFile' retrieved from environment."
+            if (!isJavaArchiveFile(javaArchiveFile)) script.error "$environmentKey has an unexpected format."
         }
         else if (configuration.containsKey(stepConfigurationKey)) {
-            home = configuration.get(stepConfigurationKey)
-            if (log) script.echo "$name home '$home' retrieved from configuration."
-        } else if (isOnCurrentWorkingDirectory(script)){
-            home = ''
-            if (log) script.echo "$name expected on current working directory."
+            javaArchiveFile = configuration.get(stepConfigurationKey)
+            if (log) script.echo "$name file '$javaArchiveFile' retrieved from configuration."
+            if (!isJavaArchiveFile(javaArchiveFile)) script.error "$stepConfigurationKey has an unexpected format."
         } else {
             throw new AbortException(getMessage())
         }
-        return home
+        return javaArchiveFile
     }
 
-    @Override
-    def getToolExecutable(script, configuration, log = true) {
+    def isJavaArchiveFile(String javaArchiveFile) {
+        def group = javaArchiveFile =~ /(.+[\/\\])(\w+[.]jar)/
+        if (!group.matches() || group[0].size() == 0) group = javaArchiveFile =~ /(\w+[.]jar)/
+        if (!group.matches() || group[0].size() == 0) return false
+        return true
+    }
 
-        def javaArchive = getTool(script, configuration, log)
-        if (log) script.echo "Using $name '$javaArchive'."
+    def getCall(script, configuration, log = true) {
+
+        def javaArchiveFile = getFile(script, configuration, log)
+        if (log) script.echo "Using $name '$javaArchiveFile'."
         def javaExecutable = javaTool.getToolExecutable(script, configuration, false)
         def javaCall = "$javaExecutable -jar"
         if (javaOptions) javaCall += " $javaOptions"
-        return "$javaCall $javaArchive"
+        return "$javaCall $javaArchiveFile"
     }
 
-    @Override
+    def verify(script, configuration) {
+
+        verifyFile(script, configuration)
+        verifyVersion(script, configuration)
+    }
+
+    def verifyFile(script, configuration) {
+
+        def javaArchiveFile = getFile(script, configuration, false)
+        script.echo "Verifying $name '$javaArchiveFile'."
+        FileUtils.validateFile(script, javaArchiveFile)
+        script.echo "Verification success. $name '$javaArchiveFile' exists."
+    }
+
+    def verifyVersion(script, configuration) {
+
+        def javaArchiveCall = getCall(script, configuration, false)
+        VersionUtils.verifyVersion(script, name, javaArchiveCall, version, versionOption)
+    }
+
     def getMessage() {
-        def configOptions = "Please, configure $name home. $name home can be set "
+        def configOptions = "Please, configure $name. $name can be set "
         if (environmentKey) configOptions += "using the environment variable '$environmentKey'"
         if (environmentKey && stepConfigurationKey) configOptions += ", or "
-        if (stepConfigurationKey) configOptions += "using the configuration key '$stepConfigurationKey'."
+        if (stepConfigurationKey) configOptions += "using the configuration key '$stepConfigurationKey'"
+        configOptions += ", or it must be located on the current working directory."
         return configOptions
-    }
-
-    def isOnCurrentWorkingDirectory(script) {
-        return FileUtils.isFile(script, executableName)
     }
 }

--- a/src/com/sap/piper/tools/JavaArchiveDescriptor.groovy
+++ b/src/com/sap/piper/tools/JavaArchiveDescriptor.groovy
@@ -86,8 +86,7 @@ class JavaArchiveDescriptor implements Serializable {
         def configOptions = "Please, configure $name. $name can be set "
         if (environmentKey) configOptions += "using the environment variable '$environmentKey'"
         if (environmentKey && stepConfigurationKey) configOptions += ", or "
-        if (stepConfigurationKey) configOptions += "using the configuration key '$stepConfigurationKey'"
-        configOptions += ", or it must be located on the current working directory."
+        if (stepConfigurationKey) configOptions += "using the configuration key '$stepConfigurationKey'."
         return configOptions
     }
 }

--- a/src/com/sap/piper/tools/JavaArchiveDescriptor.groovy
+++ b/src/com/sap/piper/tools/JavaArchiveDescriptor.groovy
@@ -33,12 +33,12 @@ class JavaArchiveDescriptor implements Serializable {
         if (EnvironmentUtils.isEnvironmentVariable(script, environmentKey)) {
             javaArchiveFile = EnvironmentUtils.getEnvironmentVariable(script, environmentKey)
             if (log) script.echo "$name file '$javaArchiveFile' retrieved from environment."
-            if (!isJavaArchiveFile(javaArchiveFile)) script.error "$environmentKey has an unexpected format."
+            if (!isJavaArchiveFile(javaArchiveFile)) script.error "The value '$javaArchiveFile' of the environment variable '$environmentKey' has an unexpected format."
         }
         else if (configuration.containsKey(stepConfigurationKey)) {
             javaArchiveFile = configuration.get(stepConfigurationKey)
             if (log) script.echo "$name file '$javaArchiveFile' retrieved from configuration."
-            if (!isJavaArchiveFile(javaArchiveFile)) script.error "$stepConfigurationKey has an unexpected format."
+            if (!isJavaArchiveFile(javaArchiveFile)) script.error "The value '$javaArchiveFile' of the configuration key '$stepConfigurationKey' has an unexpected format."
         } else {
             throw new AbortException(getMessage())
         }

--- a/src/com/sap/piper/tools/ToolDescriptor.groovy
+++ b/src/com/sap/piper/tools/ToolDescriptor.groovy
@@ -13,7 +13,7 @@ class ToolDescriptor implements Serializable {
     final environmentKey
     final stepConfigurationKey
     final executablePath
-    final executableName
+    public executableName
     final version
     final versionOption
 

--- a/src/com/sap/piper/tools/ToolDescriptor.groovy
+++ b/src/com/sap/piper/tools/ToolDescriptor.groovy
@@ -13,7 +13,7 @@ class ToolDescriptor implements Serializable {
     final environmentKey
     final stepConfigurationKey
     final executablePath
-    public executableName
+    final executableName
     final version
     final versionOption
 

--- a/test/groovy/MTABuildTest.groovy
+++ b/test/groovy/MTABuildTest.groovy
@@ -111,36 +111,13 @@ public class MtaBuildTest extends BasePipelineTest {
 
 
     @Test
-    void mtaJarLocationNotSetTest() {
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> getVersionWithoutEnvVarsAndNotInCurrentDir(m) })
-
-        thrown.expect(AbortException)
-        thrown.expectMessage("Please, configure SAP Multitarget Application Archive Builder home. SAP Multitarget Application Archive Builder home can be set using the environment variable 'MTA_JAR_LOCATION', or " +
-                             "using the configuration key 'mtaJarLocation'.")
-
-        jsr.step.call(buildTarget: 'NEO')
-    }
-
-    @Test
-    void mtaJarLocationOnCurrentWorkingDirectoryTest() {
-
-        jsr.step.call(buildTarget: 'NEO')
-
-        assert jscr.shell.find { c -> c.contains(' -jar mta.jar --mtar ')}
-
-        assert jlr.log.contains("SAP Multitarget Application Archive Builder expected on current working directory.")
-        assert jlr.log.contains("Using SAP Multitarget Application Archive Builder 'mta.jar'.")
-    }
-
-    @Test
     void mtaJarLocationAsParameterTest() {
 
-        jsr.step.call(mtaJarLocation: '/mylocation/mta', buildTarget: 'NEO')
+        jsr.step.call(mtaJarLocation: '/mylocation/mta/mta.jar', buildTarget: 'NEO')
 
         assert jscr.shell.find { c -> c.contains('-jar /mylocation/mta/mta.jar --mtar')}
 
-        assert jlr.log.contains("SAP Multitarget Application Archive Builder home '/mylocation/mta' retrieved from configuration.")
+        assert jlr.log.contains("SAP Multitarget Application Archive Builder file '/mylocation/mta/mta.jar' retrieved from configuration.")
         assert jlr.log.contains("Using SAP Multitarget Application Archive Builder '/mylocation/mta/mta.jar'.")
     }
 
@@ -187,7 +164,7 @@ public class MtaBuildTest extends BasePipelineTest {
         jsr.step.call(buildTarget: 'NEO')
 
         assert jscr.shell.find { c -> c.contains("-jar /env/mta/mta.jar --mtar")}
-        assert jlr.log.contains("SAP Multitarget Application Archive Builder home '/env/mta' retrieved from environment.")
+        assert jlr.log.contains("SAP Multitarget Application Archive Builder file '/env/mta/mta.jar' retrieved from environment.")
         assert jlr.log.contains("Using SAP Multitarget Application Archive Builder '/env/mta/mta.jar'.")
     }
 
@@ -195,14 +172,26 @@ public class MtaBuildTest extends BasePipelineTest {
     @Test
     void mtaJarLocationFromCustomStepConfigurationTest() {
 
-        jer.env.configuration = [steps:[mtaBuild:[mtaJarLocation: '/config/mta']]]
+        jer.env.configuration = [steps:[mtaBuild:[mtaJarLocation: '/config/mta/mta.jar']]]
 
         jsr.step.call(script: [commonPipelineEnvironment: jer.env],
                       buildTarget: 'NEO')
 
         assert jscr.shell.find(){ c -> c.contains("-jar /config/mta/mta.jar --mtar")}
-        assert jlr.log.contains("SAP Multitarget Application Archive Builder home '/config/mta' retrieved from configuration.")
+        assert jlr.log.contains("SAP Multitarget Application Archive Builder file '/config/mta/mta.jar' retrieved from configuration.")
         assert jlr.log.contains("Using SAP Multitarget Application Archive Builder '/config/mta/mta.jar'.")
+    }
+
+
+    @Test
+    void mtaJarLocationFromDefaultStepConfigurationTest() {
+
+        jsr.step.call(script: [commonPipelineEnvironment: jer.env],
+                      buildTarget: 'NEO')
+
+        assert jscr.shell.find(){ c -> c.contains("-jar mta.jar --mtar")}
+        assert jlr.log.contains("SAP Multitarget Application Archive Builder file 'mta.jar' retrieved from configuration.")
+        assert jlr.log.contains("Using SAP Multitarget Application Archive Builder 'mta.jar'.")
     }
 
 
@@ -363,7 +352,7 @@ public class MtaBuildTest extends BasePipelineTest {
         if(m.script.contains('JAVA_HOME')) {
             return ''
         } else if(m.script.contains('MTA_JAR_LOCATION')) {
-            return '/env/mta'
+            return '/env/mta/mta.jar'
         } else if(m.script.contains('which java')) {
             return 0
         } else {

--- a/test/groovy/ToolValidateTest.groovy
+++ b/test/groovy/ToolValidateTest.groovy
@@ -221,7 +221,7 @@ class ToolValidateTest extends BasePipelineTest {
         if(m.script.contains('JAVA_HOME')) {
             return '/env/java'
         } else if(m.script.contains('MTA_JAR_LOCATION')) {
-            return '/env/mta'
+            return '/env/mta/mta.jar'
         } else if(m.script.contains('NEO_HOME')) {
             return '/env/neo'
         } else if(m.script.contains('CM_CLI_HOME')) {

--- a/test/groovy/com/sap/piper/tools/JavaArchiveDescriptorTest.groovy
+++ b/test/groovy/com/sap/piper/tools/JavaArchiveDescriptorTest.groovy
@@ -50,7 +50,7 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
 
         script = loadScript('mtaBuild.groovy').mtaBuild
 
-        configuration = [:]
+        configuration = [:] //no default configuration
     }
 
     @Test
@@ -74,6 +74,16 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
         assert javaArchiveFile == '/config/mta/mta.jar'
         assert jlr.log.contains("SAP Multitarget Application Archive Builder file '/config/mta/mta.jar' retrieved from configuration.")
     }
+
+    @Test
+    void getJavaArchiveFileFailedTest() {
+
+        thrown.expect(AbortException)
+        thrown.expectMessage("Please, configure SAP Multitarget Application Archive Builder. SAP Multitarget Application Archive Builder can be set using the environment variable 'MTA_JAR_LOCATION', or " +
+                             "using the configuration key 'mtaJarLocation'.")
+
+        javaArchive.getFile(script, configuration)
+     }
 
     @Test
     void getJavaArchiveFileFromEnvironment_UnexpectedFormatTest() {

--- a/test/groovy/com/sap/piper/tools/JavaArchiveDescriptorTest.groovy
+++ b/test/groovy/com/sap/piper/tools/JavaArchiveDescriptorTest.groovy
@@ -89,7 +89,7 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
     void getJavaArchiveFileFromEnvironment_UnexpectedFormatTest() {
 
         thrown.expect(AbortException)
-        thrown.expectMessage("MTA_JAR_LOCATION has an unexpected format.")
+        thrown.expectMessage("The value '/env/mta/mta.jarr' of the environment variable 'MTA_JAR_LOCATION' has an unexpected format.")
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> getUnexpectedFormatEnvVars(m) })
 
@@ -100,7 +100,7 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
     void getJavaArchiveFileFromConfiguration_UnexpectedFormatTest() {
 
         thrown.expect(AbortException)
-        thrown.expectMessage("mtaJarLocation has an unexpected format.")
+        thrown.expectMessage("The value '/config/mta/mta.jarr' of the configuration key 'mtaJarLocation' has an unexpected format.")
 
         configuration = [mtaJarLocation: '/config/mta/mta.jarr']
 

--- a/test/groovy/com/sap/piper/tools/JavaArchiveDescriptorTest.groovy
+++ b/test/groovy/com/sap/piper/tools/JavaArchiveDescriptorTest.groovy
@@ -8,6 +8,7 @@ import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
 
 import util.JenkinsLoggingRule
+import util.JenkinsErrorRule
 import util.Rules
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
@@ -28,7 +29,7 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
                 .around(thrown)
                 .around(jlr)
 
-    private static tool
+    private static javaArchive
     private static configuration
 
     private script
@@ -38,13 +39,14 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
     static void init() {
 
         def java = new ToolDescriptor('Java', 'JAVA_HOME', '', '/bin/', 'java', '1.8.0', '-version 2>&1')
-        tool = new JavaArchiveDescriptor('SAP Multitarget Application Archive Builder', 'MTA_JAR_LOCATION', 'mtaJarLocation', '/', 'mta.jar', '1.0.6', '-v', java)
+        javaArchive = new JavaArchiveDescriptor('SAP Multitarget Application Archive Builder', 'MTA_JAR_LOCATION', 'mtaJarLocation', '1.0.6', '-v', java)
     }
 
     @Before
     void setup() {
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> getNoEnvVars(m) })
+        helper.registerAllowedMethod('error', [String], { s -> throw new hudson.AbortException(s) })
 
         script = loadScript('mtaBuild.groovy').mtaBuild
 
@@ -52,110 +54,108 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
     }
 
     @Test
-    void getToolHomeFromEnvironmentTest() {
+    void getJavaArchiveFileFromEnvironmentTest() {
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> getEnvVars(m) })
 
-        def toolHome = tool.getToolLocation(script, configuration)
+        def javaArchiveFile = javaArchive.getFile(script, configuration)
 
-        assert toolHome == '/env/mta'
-        assert jlr.log.contains("$tool.name home '/env/mta' retrieved from environment.")
+        assert javaArchiveFile == '/env/mta/mta.jar'
+        assert jlr.log.contains("SAP Multitarget Application Archive Builder file '/env/mta/mta.jar' retrieved from environment.")
     }
 
     @Test
-    void getToolHomeFromConfigurationTest() {
+    void getJavaArchiveFileFromConfigurationTest() {
 
-        configuration = [mtaJarLocation: '/config/mta']
+        configuration = [mtaJarLocation: '/config/mta/mta.jar']
 
-        def toolHome = tool.getToolLocation(script, configuration)
+        def javaArchiveFile = javaArchive.getFile(script, configuration)
 
-        assert toolHome == '/config/mta'
-        assert jlr.log.contains("$tool.name home '/config/mta' retrieved from configuration.")
+        assert javaArchiveFile == '/config/mta/mta.jar'
+        assert jlr.log.contains("SAP Multitarget Application Archive Builder file '/config/mta/mta.jar' retrieved from configuration.")
     }
 
     @Test
-    void getToolHomeFromCurrentWorkingDirectoryTest() {
+    void getJavaArchiveFileFromEnvironment_UnexpectedFormatTest() {
 
-        def toolHome = tool.getToolLocation(script, configuration)
+        thrown.expect(AbortException)
+        thrown.expectMessage("MTA_JAR_LOCATION has an unexpected format.")
 
-        assert toolHome == ''
-        assert jlr.log.contains("$tool.name expected on current working directory.")
+        helper.registerAllowedMethod('sh', [Map], { Map m -> getUnexpectedFormatEnvVars(m) })
+
+        javaArchive.getFile(script, configuration)
     }
 
     @Test
-    void getToolTest() {
+    void getJavaArchiveFileFromConfiguration_UnexpectedFormatTest() {
 
-        configuration = [mtaJarLocation: '/config/mta']
+        thrown.expect(AbortException)
+        thrown.expectMessage("mtaJarLocation has an unexpected format.")
 
-        def toolExecutable = tool.getTool(script, configuration)
+        configuration = [mtaJarLocation: '/config/mta/mta.jarr']
 
-        assert toolExecutable == '/config/mta/mta.jar'
+        javaArchive.getFile(script, configuration)
     }
 
     @Test
-    void getToolExecutableTest() {
+    void getJavaArchiveCallTest() {
 
-        configuration = [mtaJarLocation: '/config/mta']
+        configuration = [mtaJarLocation: '/config/mta/mta.jar']
 
-        def toolExecutable = tool.getToolExecutable(script, configuration)
+        def javaArchiveCall = javaArchive.getCall(script, configuration)
 
-        assert toolExecutable == 'java -jar /config/mta/mta.jar'
-        assert jlr.log.contains("Using $tool.name '/config/mta/mta.jar'.")
+        assert javaArchiveCall == 'java -jar /config/mta/mta.jar'
+        assert jlr.log.contains("Using SAP Multitarget Application Archive Builder '/config/mta/mta.jar'.")
     }
 
     @Test
-    void verifyToolHomeTest() {
+    void verifyJavaArchiveFileTest() {
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> getEnvVars(m) })
 
-        tool.verifyToolLocation(script, configuration)
+        javaArchive.verifyFile(script, configuration)
 
-        assert jlr.log.contains("Verifying $tool.name location '/env/mta'.")
-        assert jlr.log.contains("Verification success. $tool.name location '/env/mta' exists.")
+        assert jlr.log.contains("Verifying SAP Multitarget Application Archive Builder '/env/mta/mta.jar'.")
+        assert jlr.log.contains("Verification success. SAP Multitarget Application Archive Builder '/env/mta/mta.jar' exists.")
     }
 
     @Test
-    void verifyToolExecutableTest() {
+    void verifyJavaArchiveVersionTest() {
 
-        helper.registerAllowedMethod('sh', [Map], { Map m -> getEnvVars(m) })
-
-        tool.verifyToolExecutable(script, configuration)
-
-        assert jlr.log.contains("Verifying $tool.name '/env/mta/mta.jar'.")
-        assert jlr.log.contains("Verification success. $tool.name '/env/mta/mta.jar' exists.")
-    }
-
-    @Test
-    void verifyToolVersionTest() {
+        configuration = [mtaJarLocation: 'mta.jar']
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> getVersion(m) })
 
-        tool.verifyVersion(script, configuration)
+        javaArchive.verifyVersion(script, configuration)
 
-        assert jlr.log.contains("Verifying $tool.name version $tool.version or compatible version.")
-        assert jlr.log.contains("Verification success. $tool.name version $tool.version is installed.")
+        assert jlr.log.contains("Verifying SAP Multitarget Application Archive Builder version 1.0.6 or compatible version.")
+        assert jlr.log.contains("Verification success. SAP Multitarget Application Archive Builder version 1.0.6 is installed.")
     }
 
     @Test
-    void verifyToolVersion_FailedTest() {
+    void verifyJavaArchiveVersion_FailedTest() {
+
+        configuration = [mtaJarLocation: 'mta.jar']
 
         thrown.expect(AbortException)
-        thrown.expectMessage("The verification of $tool.name failed. Please check 'java -jar mta.jar'. script returned exit code 127.")
+        thrown.expectMessage("The verification of SAP Multitarget Application Archive Builder failed. Please check 'java -jar mta.jar'. script returned exit code 127.")
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> getVersionFailed(m) })
 
-        tool.verifyVersion(script, configuration)
+        javaArchive.verifyVersion(script, configuration)
     }
 
     @Test
-    void verifyToolVersion_IncompatibleVersionTest() {
+    void verifyJavaArchiveVersion_IncompatibleVersionTest() {
+
+        configuration = [mtaJarLocation: '/config/mta/mta.jar']
 
         thrown.expect(AbortException)
-        thrown.expectMessage("The installed version of $tool.name is 1.0.5. Please install version $tool.version or a compatible version.")
+        thrown.expectMessage("The installed version of SAP Multitarget Application Archive Builder is 1.0.5. Please install version 1.0.6 or a compatible version.")
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> getIncompatibleVersion(m) })
 
-        tool.verifyVersion(script, configuration)
+        javaArchive.verifyVersion(script, configuration)
     }
 
 
@@ -164,7 +164,18 @@ class JavaArchiveDescriptorTest extends BasePipelineTest {
         if(m.script.contains('JAVA_HOME')) {
             return '/env/java'
         } else if(m.script.contains('MTA_JAR_LOCATION')) {
-            return '/env/mta'
+            return '/env/mta/mta.jar'
+        } else {
+            return 0
+        }
+    }
+
+    private getUnexpectedFormatEnvVars(Map m) {
+
+        if(m.script.contains('JAVA_HOME')) {
+            return '/env/java'
+        } else if(m.script.contains('MTA_JAR_LOCATION')) {
+            return '/env/mta/mta.jarr'
         } else {
             return 0
         }

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -36,7 +36,7 @@ def call(Map parameters = [:]) {
         def java = new ToolDescriptor('Java', 'JAVA_HOME', '', '/bin/', 'java', '1.8.0', '-version 2>&1')
         java.verify(this, configuration)
 
-        def mta = new JavaArchiveDescriptor('SAP Multitarget Application Archive Builder', 'MTA_JAR_LOCATION', 'mtaJarLocation', '/', 'mta.jar', '1.0.6', '-v', java)
+        def mta = new JavaArchiveDescriptor('SAP Multitarget Application Archive Builder', 'MTA_JAR_LOCATION', 'mtaJarLocation', '1.0.6', '-v', java)
         mta.verify(this, configuration)
 
         def mtaYmlName = "${pwd()}/mta.yaml"
@@ -62,7 +62,7 @@ def call(Map parameters = [:]) {
         }
 
         def mtarFileName = "${id}.mtar"
-        def mtaJar = mta.getToolExecutable(this, configuration)
+        def mtaJar = mta.getCall(this, configuration)
         def buildTarget = configuration.buildTarget
 
         def mtaCall = "${mtaJar} --mtar ${mtarFileName} --build-target=${buildTarget}"

--- a/vars/toolValidate.groovy
+++ b/vars/toolValidate.groovy
@@ -27,7 +27,7 @@ def call(Map parameters = [:]) {
                 return
             case 'mta':
                 def java = new ToolDescriptor('Java', 'JAVA_HOME', '', '/bin/', 'java', '1.8.0', '-version 2>&1')
-                def mta = new JavaArchiveDescriptor('SAP Multitarget Application Archive Builder', 'MTA_JAR_LOCATION', 'mtaJarLocation', '/', 'mta.jar', '1.0.6', '-v', java)
+                def mta = new JavaArchiveDescriptor('SAP Multitarget Application Archive Builder', 'MTA_JAR_LOCATION', 'mtaJarLocation', '1.0.6', '-v', java)
                 mta.verifyVersion(this, [mtaJarLocation: home])
                 return
             case 'neo':


### PR DESCRIPTION
Adds the parameter and step configuration 'mtaJarName' to make the SAP
Multitarget Archive Builder jar file configurable.
Issue #73