### PR TITLE
Check if inside git repo via rev-parse --is-inside-work-tree

### DIFF
--- a/src/com/sap/piper/GitUtils.groovy
+++ b/src/com/sap/piper/GitUtils.groovy
@@ -1,7 +1,7 @@
 package com.sap.piper
 
 String getGitCommitIdOrNull() {
-    if (fileExists('.git')) {
+    if (sh(returnStatus: true, script: 'git rev-parse --is-inside-work-tree 1>/dev/null 2>&1') == 0) {
         return getGitCommitId()
     } else {
         return null

--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -61,6 +61,7 @@ class ArtifactSetVersionTest extends BasePipelineTest {
         jscr.setReturnValue('git rev-parse HEAD', 'testCommitId')
         jscr.setReturnValue("date --universal +'%Y%m%d%H%M%S'", '20180101010203')
         jscr.setReturnValue('git diff --quiet HEAD', 0)
+        jscr.setReturnValue('git rev-parse --is-inside-work-tree 1>/dev/null 2>&1', 0)
 
         binding.setVariable('Jenkins', [instance: [pluginManager: [plugins: [new DockerExecuteTest.PluginMock()]]]])
 
@@ -78,12 +79,12 @@ class ArtifactSetVersionTest extends BasePipelineTest {
         assertEquals('1.2.3-20180101010203_testCommitId', jer.env.getArtifactVersion())
         assertEquals('testCommitId', jer.env.getGitCommitId())
 
-        assertEquals('mvn --file \'pom.xml\' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId', jscr.shell[5])
-        assertEquals('git add .', jscr.shell[6])
-        assertEquals ("git commit -m 'update version 1.2.3-20180101010203_testCommitId'", jscr.shell[7])
-        assertEquals ("git remote set-url origin myGitSshUrl", jscr.shell[8])
-        assertEquals ("git tag build_1.2.3-20180101010203_testCommitId", jscr.shell[9])
-        assertEquals ("git push origin build_1.2.3-20180101010203_testCommitId", jscr.shell[10])
+        assertEquals('mvn --file \'pom.xml\' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId', jscr.shell[6])
+        assertEquals('git add .', jscr.shell[7])
+        assertEquals ("git commit -m 'update version 1.2.3-20180101010203_testCommitId'", jscr.shell[8])
+        assertEquals ("git remote set-url origin myGitSshUrl", jscr.shell[9])
+        assertEquals ("git tag build_1.2.3-20180101010203_testCommitId", jscr.shell[10])
+        assertEquals ("git push origin build_1.2.3-20180101010203_testCommitId", jscr.shell[11])
     }
 
     @Test
@@ -91,7 +92,7 @@ class ArtifactSetVersionTest extends BasePipelineTest {
         jsr.step.call(script: jsr.step, juStabGitUtils: gitUtils, buildTool: 'maven', commitVersion: false)
 
         assertEquals('1.2.3-20180101010203_testCommitId', jer.env.getArtifactVersion())
-        assertEquals('mvn --file \'pom.xml\' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId', jscr.shell[5])
+        assertEquals('mvn --file \'pom.xml\' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId', jscr.shell[6])
     }
 
     @Test
@@ -99,14 +100,14 @@ class ArtifactSetVersionTest extends BasePipelineTest {
         jsr.step.call(juStabGitUtils: gitUtils, buildTool: 'maven', commitVersion: false)
 
         assertEquals('1.2.3-20180101010203_testCommitId', jer.env.getArtifactVersion())
-        assertEquals('mvn --file \'pom.xml\' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId', jscr.shell[5])
+        assertEquals('mvn --file \'pom.xml\' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId', jscr.shell[6])
     }
 
     @Test
     void testVersioningCustomGitUserAndEMail() {
         jsr.step.call(script: jsr.step, juStabGitUtils: gitUtils, buildTool: 'maven', gitSshUrl: 'myGitSshUrl', gitUserEMail: 'test@test.com', gitUserName: 'test')
 
-        assertEquals ('git -c user.email="test@test.com" -c user.name="test" commit -m \'update version 1.2.3-20180101010203_testCommitId\'', jscr.shell[7])
+        assertEquals ('git -c user.email="test@test.com" -c user.name="test" commit -m \'update version 1.2.3-20180101010203_testCommitId\'', jscr.shell[8])
     }
 
     @Test

--- a/test/groovy/com/sap/piper/GitUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/GitUtilsTest.groovy
@@ -27,7 +27,6 @@ class GitUtilsTest extends BasePipelineTest {
     void init() throws Exception {
         gitUtils = new GitUtils()
         prepareObjectInterceptors(gitUtils)
-        gitUtils.fileExists = MockHelper
 
         jscr.setReturnValue('git rev-parse HEAD', 'testCommitId')
     }
@@ -40,13 +39,13 @@ class GitUtilsTest extends BasePipelineTest {
 
     @Test
     void testGetGitCommitId() {
-        this.helper.registerAllowedMethod('fileExists', [String.class], {true})
+        jscr.setReturnValue('git rev-parse --is-inside-work-tree 1>/dev/null 2>&1', 0)
         assertEquals('testCommitId', gitUtils.getGitCommitIdOrNull())
     }
 
     @Test
     void testGetGitCommitIdNotAGitRepo() {
-        this.helper.registerAllowedMethod('fileExists', [String.class], {false})
+        jscr.setReturnValue('git rev-parse --is-inside-work-tree 1>/dev/null 2>&1', 128)
         assertNull(gitUtils.getGitCommitIdOrNull())
     }
 


### PR DESCRIPTION
This approach works also in case we are in a subdirectory of the git repo,
e.g. in the closure of a dir statement.

The decission is delegate to git rather than using internal knowledge
about git file names. Well, the directory will be always named '.git',
but nevertheless ...

May endup in a false positive in case we did not clone a repo AND there
is another git repo somewhere upwards in the file system. Maybe some
other git repo is located upstairs containing e.g. the jenkins setup.
The advantage of working also for subdirectories outweights the disadvantage
for the false positive. It is not likely that we have to deal with another
git repo upstairs, since the pipeline script is expected to be located in
the payload git repo. A phantom repo upstairs looks like a pure academical
discussion.