### PR TITLE
GitUtils: Extract lines matching a pattern from a set of commits

### DIFF
--- a/src/com/sap/piper/GitUtils.groovy
+++ b/src/com/sap/piper/GitUtils.groovy
@@ -15,3 +15,17 @@ String getGitCommitIdOrNull() {
 String getGitCommitId() {
     return sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
 }
+
+String[] extractLogLines(String filter = '',
+                         String from = 'origin/master',
+                         String to = 'HEAD',
+                         String format = '%b') {
+
+    sh ( returnStdout: true,
+         script: """#!/bin/bash
+                    git log --pretty=format:${format} ${from}..${to}
+                 """
+       )?.split('\n')
+        ?.findAll { line -> line ==~ /${filter}/ }
+
+}

--- a/src/com/sap/piper/GitUtils.groovy
+++ b/src/com/sap/piper/GitUtils.groovy
@@ -1,7 +1,11 @@
 package com.sap.piper
 
+boolean insideWorkTree() {
+    return sh(returnStatus: true, script: 'git rev-parse --is-inside-work-tree 1>/dev/null 2>&1') == 0
+}
+
 String getGitCommitIdOrNull() {
-    if (sh(returnStatus: true, script: 'git rev-parse --is-inside-work-tree 1>/dev/null 2>&1') == 0) {
+    if ( insideWorkTree() ) {
         return getGitCommitId()
     } else {
         return null

--- a/test/groovy/com/sap/piper/GitUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/GitUtilsTest.groovy
@@ -99,6 +99,16 @@ class GitUtilsTest extends BasePipelineTest {
     }
 
     @Test
+    void testExtractLogLinesFilterPreserveDuplicates() {
+        jscr.setReturnValue('#!/bin/bash git log --pretty=format:%b origin/master..HEAD', '123\nabc\n123')
+        String[] log = gitUtils.extractLogLines('12.*')
+        assertThat(log, is(notNullValue()))
+        assertThat(log.size(),is(equalTo(2)))
+        assertThat(log[0], is(equalTo('123')))
+        assertThat(log[1], is(equalTo('123')))
+    }
+
+    @Test
     void testExtractLogLinesFilterNoMatch() {
         jscr.setReturnValue('#!/bin/bash git log --pretty=format:%b origin/master..HEAD', 'abc\n123')
         String[] log = gitUtils.extractLogLines('xyz')

--- a/test/groovy/com/sap/piper/GitUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/GitUtilsTest.groovy
@@ -11,6 +11,8 @@ import util.MockHelper
 import util.Rules
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
 import static org.junit.Assert.assertNull
 
 class GitUtilsTest extends BasePipelineTest {
@@ -36,6 +38,19 @@ class GitUtilsTest extends BasePipelineTest {
         object.metaClass.static.invokeMethod = helper.getMethodInterceptor()
         object.metaClass.methodMissing = helper.getMethodMissingInterceptor()
     }
+
+    @Test
+    void TestIsInsideWorkTree() {
+        jscr.setReturnValue('git rev-parse --is-inside-work-tree 1>/dev/null 2>&1', 0)
+        assertTrue(gitUtils.insideWorkTree())
+    }
+
+    @Test
+    void TestIsNotInsideWorkTree() {
+        jscr.setReturnValue('git rev-parse --is-inside-work-tree 1>/dev/null 2>&1', 1)
+        assertFalse(gitUtils.insideWorkTree())
+    }
+
 
     @Test
     void testGetGitCommitId() {

--- a/test/groovy/util/JenkinsShellCallRule.groovy
+++ b/test/groovy/util/JenkinsShellCallRule.groovy
@@ -33,18 +33,22 @@ class JenkinsShellCallRule implements TestRule {
 
                 testInstance.helper.registerAllowedMethod("sh", [String.class], {
                     command ->
-                        shell.add(command.replaceAll(/\s+/," ").trim())
+                        shell.add(unify(command))
                 })
 
                 testInstance.helper.registerAllowedMethod("sh", [Map.class], {
                     m ->
                         shell.add(m.script.replaceAll(/\s+/," ").trim())
                         if (m.returnStdout || m.returnStatus)
-                            return returnValues[m.script]
+                            return returnValues[unify(m.script)]
                 })
 
                 base.evaluate()
             }
         }
+    }
+
+    private static String unify(String s) {
+        s.replaceAll(/\s+/," ").trim()
     }
 }

--- a/vars/isChangeInDevelopment.groovy
+++ b/vars/isChangeInDevelopment.groovy
@@ -33,8 +33,6 @@ String getChangeId(GitUtils gitUtils, String from = 'origin/master', String to =
 
     def log = gitUtils.extractLogLines(".*${label}.*", from, to)
 
-    echo "LOG: ${log}"
-
     def changeIds = log.collect { line -> line.replaceAll(label,'').trim() } .unique()
         changeIds.retainAll { line -> ! line.isEmpty() }
 

--- a/vars/isChangeInDevelopment.groovy
+++ b/vars/isChangeInDevelopment.groovy
@@ -1,0 +1,48 @@
+import com.sap.piper.GitUtils
+import groovy.transform.Field
+
+@Field def STEP_NAME = 'isChangeInDevelopment'
+
+def call(parameters = [:]) {
+
+
+    Set parameterKeys = [
+        ]
+
+    Set stepConfigurationKeys = [
+        ]
+
+    handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
+
+        GitUtils gitUtils = new GitUtils()
+
+        if( ! gitUtils.insideWorkTree() ) {
+            throw new hudson.AbortException('Cannot retrieve change status. Not is a git work tree.')
+        } else {
+            echo '[INFO] Inside a git work tree.'
+        }
+
+        def changeId = getChangeId(gitUtils, 'HEAD~2')
+        echo "CHANGE-ID: ${changeId}"
+    }
+}
+
+String getChangeId(GitUtils gitUtils, String from = 'origin/master', String to = 'HEAD') {
+
+    def label = 'ChangeDocument\\s?:'
+
+    def log = gitUtils.extractLogLines('.*', from, to)
+
+    echo "LOG: ${log}"
+
+    def changeIds = log.collect { line -> line.replaceAll(label,'').trim() } .unique()
+        changeIds.retainAll { line -> ! line.isEmpty() }
+
+    if( changeIds.size() == 0 ) {
+        throw new hudson.AbortException('Cannot retrieve changeId from git commits.')
+    } else if (changeIds.size() > 1) {
+        throw new hudson.AbortException("Multiple ChangeIds found: ${changeIds}.")
+    }
+
+    return changeIds.get(0)
+}

--- a/vars/isChangeInDevelopment.groovy
+++ b/vars/isChangeInDevelopment.groovy
@@ -31,7 +31,7 @@ String getChangeId(GitUtils gitUtils, String from = 'origin/master', String to =
 
     def label = 'ChangeDocument\\s?:'
 
-    def log = gitUtils.extractLogLines('.*ChangeDocument\\s?:.*', from, to)
+    def log = gitUtils.extractLogLines(".*${label}.*", from, to)
 
     echo "LOG: ${log}"
 

--- a/vars/isChangeInDevelopment.groovy
+++ b/vars/isChangeInDevelopment.groovy
@@ -14,14 +14,6 @@ def call(parameters = [:]) {
 
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
 
-        GitUtils gitUtils = new GitUtils()
-
-        if( ! gitUtils.insideWorkTree() ) {
-            throw new hudson.AbortException('Cannot retrieve change status. Not is a git work tree.')
-        } else {
-            echo '[INFO] Inside a git work tree.'
-        }
-
         def changeId = getChangeId(gitUtils, 'HEAD~2')
         echo "CHANGE-ID: ${changeId}"
     }
@@ -30,6 +22,14 @@ def call(parameters = [:]) {
 String getChangeId(GitUtils gitUtils, String from = 'origin/master', String to = 'HEAD') {
 
     def label = 'ChangeDocument\\s?:'
+
+    GitUtils gitUtils = new GitUtils()
+
+    if( ! gitUtils.insideWorkTree() ) {
+        throw new hudson.AbortException('Cannot retrieve change status. Not in a git work tree.')
+    } else {
+        echo '[INFO] Inside a git work tree.'
+    }
 
     def log = gitUtils.extractLogLines(".*${label}.*", from, to)
 

--- a/vars/isChangeInDevelopment.groovy
+++ b/vars/isChangeInDevelopment.groovy
@@ -31,7 +31,7 @@ String getChangeId(GitUtils gitUtils, String from = 'origin/master', String to =
 
     def label = 'ChangeDocument\\s?:'
 
-    def log = gitUtils.extractLogLines('.*ChangeDocument\\s?:', from, to)
+    def log = gitUtils.extractLogLines('.*ChangeDocument\\s?:.*', from, to)
 
     echo "LOG: ${log}"
 

--- a/vars/isChangeInDevelopment.groovy
+++ b/vars/isChangeInDevelopment.groovy
@@ -31,7 +31,7 @@ String getChangeId(GitUtils gitUtils, String from = 'origin/master', String to =
 
     def label = 'ChangeDocument\\s?:'
 
-    def log = gitUtils.extractLogLines('ChangeDocument\\s?:', from, to)
+    def log = gitUtils.extractLogLines('.*ChangeDocument\\s?:', from, to)
 
     echo "LOG: ${log}"
 

--- a/vars/isChangeInDevelopment.groovy
+++ b/vars/isChangeInDevelopment.groovy
@@ -31,7 +31,7 @@ String getChangeId(GitUtils gitUtils, String from = 'origin/master', String to =
 
     def label = 'ChangeDocument\\s?:'
 
-    def log = gitUtils.extractLogLines('.*', from, to)
+    def log = gitUtils.extractLogLines('ChangeDocument\\s?:', from, to)
 
     echo "LOG: ${log}"
 


### PR DESCRIPTION
In preparation of SOLMAN features. Here we need to get a change
document ID out of the commit message.

Start and end commit can be provided as well as a log format
and a filter condition.