### PR TITLE
Disable download logs in Maven by default

### DIFF
--- a/documentation/docs/steps/mavenExecute.md
+++ b/documentation/docs/steps/mavenExecute.md
@@ -6,16 +6,17 @@ Executes a maven command inside a Docker container.
 
 ## Parameters
 
-| parameter            | mandatory | default           | example values             |
-| ---------------------|-----------|-------------------|----------------------------|
-| `dockerImage`        | no        | 'maven:3.5-jdk-7' |                            |
-| `globalSettingsFile` | no        |                   | 'local_folder/settings.xml'|
-| `projectSettingsFile`| no        |                   |                            |
-| `pomPath`            | no        |                   | 'local_folder/m2'          |
-| `flags`              | no        |                   | '-o'                       |
-| `goals`              | no        |                   | 'clean install'            |
-| `m2Path`             | no        |                   | 'local_folder/m2'          |
-| `defines`            | no        |                   | '-Dmaven.tests.skip=true'  |
+| parameter                      | mandatory | default           | example values             |
+| -------------------------------|-----------|-------------------|----------------------------|
+| `dockerImage`                  | no        | 'maven:3.5-jdk-7' |                            |
+| `globalSettingsFile`           | no        |                   | 'local_folder/settings.xml'|
+| `projectSettingsFile`          | no        |                   |                            |
+| `pomPath`                      | no        |                   | 'local_folder/m2'          |
+| `flags`                        | no        |                   | '-o'                       |
+| `goals`                        | no        |                   | 'clean install'            |
+| `m2Path`                       | no        |                   | 'local_folder/m2'          |
+| `defines`                      | no        |                   | '-Dmaven.tests.skip=true'  |
+| `logSuccessfulMavenTransfers`  | no        | `false`           | 'true'                     |
 
 * `dockerImage` Name of the docker image that should be used.
 * `globalSettingsFile` Path or url to the mvn settings file that should be used as global settings file. 
@@ -25,6 +26,7 @@ Executes a maven command inside a Docker container.
 * `goals` Maven goals that should be executed.
 * `m2Path` Path to the location of the local repository that should be used.
 * `defines` Additional properties.
+* `logSuccessfulMavenTransfers` configures maven to log successful downloads. This is set to `false` by default to reduce the noise in build logs.
 
 ## Step configuration
 The following parameters can also be specified as step parameters using the global configuration file:

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -77,6 +77,7 @@ steps:
     influxServer: 'jenkins'
   mavenExecute:
     dockerImage: 'maven:3.5-jdk-7'
+    logSuccessfulMavenTransfers: false
   mtaBuild:
     buildTarget: 'NEO'
     mtaJarLocation: 'mta.jar'

--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -69,7 +69,7 @@ class ArtifactSetVersionTest extends BasePiperTest {
         assertEquals('1.2.3-20180101010203_testCommitId', jer.env.getArtifactVersion())
         assertEquals('testCommitId', jer.env.getGitCommitId())
 
-        assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
+        assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
         assertThat(jscr.shell, hasItem('git add .'))
         assertThat(jscr.shell, hasItem("git commit -m 'update version 1.2.3-20180101010203_testCommitId'"))
         assertThat(jscr.shell, hasItem("git remote set-url origin myGitSshUrl"))
@@ -82,7 +82,7 @@ class ArtifactSetVersionTest extends BasePiperTest {
         jsr.step.call(script: jsr.step, juStabGitUtils: gitUtils, buildTool: 'maven', commitVersion: false)
 
         assertEquals('1.2.3-20180101010203_testCommitId', jer.env.getArtifactVersion())
-        assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
+        assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
     }
 
     @Test
@@ -90,7 +90,7 @@ class ArtifactSetVersionTest extends BasePiperTest {
         jsr.step.call(juStabGitUtils: gitUtils, buildTool: 'maven', commitVersion: false)
 
         assertEquals('1.2.3-20180101010203_testCommitId', jer.env.getArtifactVersion())
-        assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
+        assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
     }
 
     @Test

--- a/test/groovy/MavenExecuteTest.groovy
+++ b/test/groovy/MavenExecuteTest.groovy
@@ -1,18 +1,14 @@
-
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
-
+import util.BasePiperTest
 import util.JenkinsDockerExecuteRule
+import util.JenkinsShellCallRule
 import util.JenkinsStepRule
+import util.Rules
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
-
-import util.BasePiperTest
-import util.JenkinsShellCallRule
-import util.Rules
 
 class MavenExecuteTest extends BasePiperTest {
 
@@ -35,7 +31,16 @@ class MavenExecuteTest extends BasePiperTest {
         jsr.step.mavenExecute(script: nullScript, goals: 'clean install')
         assertEquals('maven:3.5-jdk-7', jder.dockerParams.dockerImage)
 
-        assert jscr.shell[0] == 'mvn clean install'
+        assert jscr.shell[0] == 'mvn --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install'
+    }
+
+    @Test
+    void testExecuteBasicMavenCommandWithDownloadLogsEnabled() throws Exception {
+
+        jsr.step.mavenExecute(script: nullScript, goals: 'clean install', logSuccessfulMavenTransfers: true)
+        assertEquals('maven:3.5-jdk-7', jder.dockerParams.dockerImage)
+
+        assert jscr.shell[0] == 'mvn --batch-mode clean install'
     }
 
     @Test
@@ -52,7 +57,7 @@ class MavenExecuteTest extends BasePiperTest {
             m2Path: 'm2Path',
             defines: '-Dmaven.tests.skip=true')
         assertEquals('maven:3.5-jdk-8-alpine', jder.dockerParams.dockerImage)
-        String mvnCommand = "mvn --global-settings 'globalSettingsFile.xml' -Dmaven.repo.local='m2Path' --settings 'projectSettingsFile.xml' --file 'pom.xml' -o clean install -Dmaven.tests.skip=true"
+        String mvnCommand = "mvn --global-settings 'globalSettingsFile.xml' -Dmaven.repo.local='m2Path' --settings 'projectSettingsFile.xml' --file 'pom.xml' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -o clean install -Dmaven.tests.skip=true"
         assertTrue(jscr.shell.contains(mvnCommand))
     }
 
@@ -62,6 +67,6 @@ class MavenExecuteTest extends BasePiperTest {
         jsr.step.mavenExecute(script: nullScript, goals: 'clean install')
         assertEquals('maven:3.5-jdk-7', jder.dockerParams.dockerImage)
 
-        assert jscr.shell[0] == 'mvn clean install'
+        assert jscr.shell[0] == 'mvn --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install'
     }
 }

--- a/test/groovy/MavenExecuteTest.groovy
+++ b/test/groovy/MavenExecuteTest.groovy
@@ -57,7 +57,7 @@ class MavenExecuteTest extends BasePiperTest {
             m2Path: 'm2Path',
             defines: '-Dmaven.tests.skip=true')
         assertEquals('maven:3.5-jdk-8-alpine', jder.dockerParams.dockerImage)
-        String mvnCommand = "mvn --global-settings 'globalSettingsFile.xml' -Dmaven.repo.local='m2Path' --settings 'projectSettingsFile.xml' --file 'pom.xml' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -o clean install -Dmaven.tests.skip=true"
+        String mvnCommand = "mvn --global-settings 'globalSettingsFile.xml' -Dmaven.repo.local='m2Path' --settings 'projectSettingsFile.xml' --file 'pom.xml' -o --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install -Dmaven.tests.skip=true"
         assertTrue(jscr.shell.contains(mvnCommand))
     }
 

--- a/test/groovy/com/sap/piper/versioning/MavenArtifactVersioningTest.groovy
+++ b/test/groovy/com/sap/piper/versioning/MavenArtifactVersioningTest.groovy
@@ -42,7 +42,7 @@ class MavenArtifactVersioningTest extends BasePiperTest{
         av = new MavenArtifactVersioning(nullScript, [filePath: 'pom.xml'])
         assertEquals('1.2.3', av.getVersion())
         av.setVersion('1.2.3-20180101')
-        assertEquals('mvn --file \'pom.xml\' versions:set -DnewVersion=1.2.3-20180101', jscr.shell[0])
+        assertEquals('mvn --file \'pom.xml\' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101', jscr.shell[0])
     }
 
     @Test
@@ -50,6 +50,6 @@ class MavenArtifactVersioningTest extends BasePiperTest{
         av = new MavenArtifactVersioning(nullScript, [filePath: 'snapshot/pom.xml'])
         assertEquals('1.2.3', av.getVersion())
         av.setVersion('1.2.3-20180101')
-        assertEquals('mvn --file \'snapshot/pom.xml\' versions:set -DnewVersion=1.2.3-20180101', jscr.shell[0])
+        assertEquals('mvn --file \'snapshot/pom.xml\' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101', jscr.shell[0])
     }
 }

--- a/vars/mavenExecute.groovy
+++ b/vars/mavenExecute.groovy
@@ -1,4 +1,3 @@
-import com.sap.piper.ConfigurationLoader
 import com.sap.piper.ConfigurationMerger
 
 def call(Map parameters = [:]) {
@@ -17,7 +16,8 @@ def call(Map parameters = [:]) {
             'flags',
             'goals',
             'm2Path',
-            'defines'
+            'defines',
+            'logSuccessfulMavenTransfers'
         ]
         Set stepConfigurationKeys = [
             'dockerImage',
@@ -64,6 +64,13 @@ def call(Map parameters = [:]) {
         def mavenFlags = configuration.flags
         if (mavenFlags?.trim()) {
             command += " ${mavenFlags}"
+        }
+
+        final disableDownloadsFlag = ' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+        if (!configuration.logSuccessfulMavenTransfers) {
+            if (!command.contains(disableDownloadsFlag)) {
+                command += disableDownloadsFlag
+            }
         }
 
         def mavenGoals = configuration.goals

--- a/vars/mavenExecute.groovy
+++ b/vars/mavenExecute.groovy
@@ -66,10 +66,16 @@ def call(Map parameters = [:]) {
             command += " ${mavenFlags}"
         }
 
-        final disableDownloadsFlag = ' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+        // Always use Maven's batch mode
+        if (!(command.contains('-B') || command.contains('--batch-mode'))){
+            command += ' --batch-mode'
+        }
+
+        // Disable log for successful transfers by default. Note this requires the batch-mode flag.
+        final String disableSuccessfulMavenTransfersLogFlag = ' -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
         if (!configuration.logSuccessfulMavenTransfers) {
-            if (!command.contains(disableDownloadsFlag)) {
-                command += disableDownloadsFlag
+            if (!command.contains(disableSuccessfulMavenTransfersLogFlag)) {
+                command += disableSuccessfulMavenTransfersLogFlag
             }
         }
 


### PR DESCRIPTION
This commit adds a flag to Maven by default, which disables the messages
like "Downloading from central".

The logger is set to level "warn", so errors will still be visible, but
successful messages won't clutter logs anymore.

This option is also set by default in the GitLab CI template file for
maven.

See [1] for reference on the option.

1: https://stackoverflow.com/a/35653426/8843830