### PR TITLE
Provide configuration layer for custom configuration

### DIFF
--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -8,12 +8,8 @@ class DefaultValueCache implements Serializable {
     // Contains defaults values provided by this library itself
     private Map defaultValues
 
-    // intended for describing e.g. the system landscape on customer side
-    private Map customDefaultValues
-
-    private DefaultValueCache(Map customeDefaultValues, Map customDefaultValues){
+    private DefaultValueCache(Map defaultValues){
         this.defaultValues = defaultValues
-        this.customDefaultValues = customDefaultValues ?: [:]
     }
 
     @NonCPS
@@ -21,18 +17,13 @@ class DefaultValueCache implements Serializable {
         return instance
     }
 
-    static createInstance(Map defaultValues, Map customDefaultValues){
-        instance = new DefaultValueCache(defaultValues, customDefaultValues)
+    static createInstance(Map defaultValues){
+        instance = new DefaultValueCache(defaultValues)
     }
 
     @NonCPS
     Map getDefaultValues(){
         return defaultValues
-    }
-
-    @NonCPS
-    Map getCustomDefaultValues(){
-        return customDefaultValues
     }
 
     static reset(){

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -5,10 +5,15 @@ import com.cloudbees.groovy.cps.NonCPS
 class DefaultValueCache implements Serializable {
     private static DefaultValueCache instance
 
+    // Contains defaults values provided by this library itself
     private Map defaultValues
 
-    private DefaultValueCache(Map defaultValues){
+    // intended for describing e.g. the system landscape on customer side
+    private Map customDefaultValues
+
+    private DefaultValueCache(Map customeDefaultValues, Map customDefaultValues){
         this.defaultValues = defaultValues
+        this.customDefaultValues = customDefaultValues ?: [:]
     }
 
     @NonCPS
@@ -16,13 +21,18 @@ class DefaultValueCache implements Serializable {
         return instance
     }
 
-    static createInstance(Map defaultValues){
-        instance = new DefaultValueCache(defaultValues)
+    static createInstance(Map defaultValues, Map customDefaultValues){
+        instance = new DefaultValueCache(defaultValues, customDefaultValues)
     }
 
     @NonCPS
     Map getDefaultValues(){
         return defaultValues
+    }
+
+    @NonCPS
+    Map getCustomDefaultValues(){
+        return customDefaultValues
     }
 
     static reset(){

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -5,7 +5,6 @@ import com.cloudbees.groovy.cps.NonCPS
 class DefaultValueCache implements Serializable {
     private static DefaultValueCache instance
 
-    // Contains defaults values provided by this library itself
     private Map defaultValues
 
     private DefaultValueCache(Map defaultValues){

--- a/test/groovy/PrepareDefaultValuesTest.groovy
+++ b/test/groovy/PrepareDefaultValuesTest.groovy
@@ -1,5 +1,7 @@
+import org.junit.Before
 import org.junit.Rule;
 import org.junit.Test
+import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain;
 
 import com.sap.piper.DefaultValueCache
@@ -11,25 +13,89 @@ import util.Rules
 public class PrepareDefaultValuesTest extends BasePiperTest {
 
     private JenkinsStepRule jsr = new JenkinsStepRule(this)
+    private ExpectedException thrown = ExpectedException.none()
 
     @Rule
     public RuleChain ruleChain = Rules
         .getCommonRules(this)
+        .around(thrown)
         .around(jsr)
 
-	@Test
-	public void testMerge() {
+    @Before
+    public void setup() {
 
-		helper.registerAllowedMethod("libraryResource", [String], { fileName-> return fileName })
-		helper.registerAllowedMethod("readYaml", [Map], { m ->
-			switch(m.text) {
-				case 'default_pipeline_environment.yml': return [a: 'x']
-				default: return [the:'end']
-			}
-		})
-		jsr.step.call(script: nullScript)
-		
-		
-		println DefaultValueCache.getInstance().getDefaultValues()
-	}
+        helper.registerAllowedMethod("libraryResource", [String], { fileName-> return fileName })
+        helper.registerAllowedMethod("readYaml", [Map], { m ->
+            switch(m.text) {
+                case 'default_pipeline_environment.yml': return [default: 'config']
+                case 'custom.yml': return [custom: 'myConfig']
+                case 'not_found': throw new hudson.AbortException('No such library resource not_found could be found')
+                default: return [the:'end']
+            }
+        })
+
+    }
+
+    @Test
+    public void testDefaultPipelineEnvironmentOnly() {
+
+        jsr.step.call(script: nullScript)
+
+        assert DefaultValueCache.getInstance().getDefaultValues().size() == 1
+        assert DefaultValueCache.getInstance().getDefaultValues().default == 'config'
+    }
+
+    @Test
+    public void testReInitializeOnCustomConfig() {
+
+        DefaultValueCache.createInstance([key:'value'])
+
+        // existing instance is dropped in case a custom config is provided.
+        jsr.step.call(script: nullScript, customDefaults: 'custom.yml')
+
+        assert DefaultValueCache.getInstance().getDefaultValues().size() == 2
+        assert DefaultValueCache.getInstance().getDefaultValues().default == 'config'
+        assert DefaultValueCache.getInstance().getDefaultValues().custom == 'myConfig'
+    }
+
+    @Test
+    public void testNoReInitializeWithoutCustomConfig() {
+
+        DefaultValueCache.createInstance([key:'value'])
+
+        jsr.step.call(script: nullScript)
+
+        assert DefaultValueCache.getInstance().getDefaultValues().size() == 1
+        assert DefaultValueCache.getInstance().getDefaultValues().key == 'value'
+    }
+
+    @Test
+    public void testAttemptToLoadNonExistingConfigFile() {
+
+        // Behavior documented here based on reality check
+        thrown.expect(hudson.AbortException.class)
+        thrown.expectMessage('No such library resource not_found could be found')
+
+        jsr.step.call(script: nullScript, customDefaults: 'not_found')
+    }
+
+    @Test
+    public void testDefaultPipelineEnvironmentWithCustomConfigReferencedAsString() {
+
+        jsr.step.call(script: nullScript, customDefaults: 'custom.yml')
+
+        assert DefaultValueCache.getInstance().getDefaultValues().size() == 2
+        assert DefaultValueCache.getInstance().getDefaultValues().default == 'config'
+        assert DefaultValueCache.getInstance().getDefaultValues().custom == 'myConfig'
+    }
+
+    @Test
+    public void testDefaultPipelineEnvironmentWithCustomConfigReferencedAsList() {
+
+        jsr.step.call(script: nullScript, customDefaults: ['custom.yml'])
+
+        assert DefaultValueCache.getInstance().getDefaultValues().size() == 2
+        assert DefaultValueCache.getInstance().getDefaultValues().default == 'config'
+        assert DefaultValueCache.getInstance().getDefaultValues().custom == 'myConfig'
+    }
 }

--- a/test/groovy/PrepareDefaultValuesTest.groovy
+++ b/test/groovy/PrepareDefaultValuesTest.groovy
@@ -1,0 +1,35 @@
+import org.junit.Rule;
+import org.junit.Test
+import org.junit.rules.RuleChain;
+
+import com.sap.piper.DefaultValueCache
+
+import util.BasePiperTest
+import util.JenkinsStepRule;
+import util.Rules
+
+public class PrepareDefaultValuesTest extends BasePiperTest {
+
+    private JenkinsStepRule jsr = new JenkinsStepRule(this)
+
+    @Rule
+    public RuleChain ruleChain = Rules
+        .getCommonRules(this)
+        .around(jsr)
+
+	@Test
+	public void testMerge() {
+
+		helper.registerAllowedMethod("libraryResource", [String], { fileName-> return fileName })
+		helper.registerAllowedMethod("readYaml", [Map], { m ->
+			switch(m.text) {
+				case 'default_pipeline_environment.yml': return [a: 'x']
+				default: return [the:'end']
+			}
+		})
+		jsr.step.call(script: nullScript)
+		
+		
+		println DefaultValueCache.getInstance().getDefaultValues()
+	}
+}

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -1,32 +1,28 @@
 import com.sap.piper.DefaultValueCache
 import com.sap.piper.MapUtils
 
-import hudson.AbortException
-
 def call(Map parameters = [:]) {
     handlePipelineStepErrors (stepName: 'prepareDefaultValues', stepParameters: parameters) {
         if(!DefaultValueCache.getInstance() || parameters.customDefaults) {
+            def defaultValues = [:]
             def configurationFiles = ['default_pipeline_environment.yml']
-            def defaultConfiguration = [:]
-
             def customDefaults = parameters.customDefaults
+            
             if(customDefaults in String) // >> filename resolves to Map
                 customDefaults = [].plus(customDefaults)
-            // customDefaults is Map / null
-            configurationFiles += customDefaults
+            if(customDefaults in List)
+                configurationFiles += customDefaults
         /*
         if(defaults instanceof Map) // >> config map
             defaults = [].plus(defaults)
         */
-        //if(configurationFiles in List) // >> list of String / Map
             for (def configFileName : configurationFiles){
                 def configuration = readYaml text: libraryResource(configFileName)
-                defaultConfiguration = MapUtils.merge(
-                        MapUtils.pruneNull(defaultConfiguration),
+                defaultValues = MapUtils.merge(
+                        MapUtils.pruneNull(defaultValues),
                         MapUtils.pruneNull(configuration))
             }
-
-            DefaultValueCache.createInstance(defaultConfiguration)
+            DefaultValueCache.createInstance(defaultValues)
         }
     }
 }

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -19,8 +19,8 @@ def call(Map parameters = [:]) {
             for (def configFileName : configurationFiles){
                 def configuration = readYaml text: libraryResource(configFileName)
                 defaultValues = MapUtils.merge(
-                        MapUtils.pruneNull(defaultValues),
-                        MapUtils.pruneNull(configuration))
+                        MapUtils.pruneNulls(defaultValues),
+                        MapUtils.pruneNulls(configuration))
             }
             DefaultValueCache.createInstance(defaultValues)
         }

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -9,7 +9,7 @@ def call(Map parameters = [:]) {
             def customDefaults = parameters.customDefaults
 
             if(customDefaults in String)
-                customDefaults = [].plus(customDefaults)
+                customDefaults = [customDefaults]
             if(customDefaults in List)
                 configurationFiles += customDefaults
             for (def configFileName : configurationFiles){

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -5,15 +5,15 @@ def call(Map parameters = [:]) {
     handlePipelineStepErrors (stepName: 'prepareDefaultValues', stepParameters: parameters) {
         if(!DefaultValueCache.getInstance() || parameters.customDefaults) {
             def defaultValues = [:]
-            def configurationFiles = ['default_pipeline_environment.yml']
+            def configFileList = ['default_pipeline_environment.yml']
             def customDefaults = parameters.customDefaults
 
             if(customDefaults in String)
                 customDefaults = [customDefaults]
             if(customDefaults in List)
-                configurationFiles += customDefaults
-            for (def configFileName : configurationFiles){
-                if(configurationFiles.size() > 1) echo "Loading configuration file '${}'"
+                configFileList += customDefaults
+            for (def configFileName : configFileList){
+                if(configFileList.size() > 1) echo "Loading configuration file '${configFileName}'"
                 def configuration = readYaml text: libraryResource(configFileName)
                 defaultValues = MapUtils.merge(
                         MapUtils.pruneNulls(defaultValues),

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -7,16 +7,13 @@ def call(Map parameters = [:]) {
             def defaultValues = [:]
             def configurationFiles = ['default_pipeline_environment.yml']
             def customDefaults = parameters.customDefaults
-            
-            if(customDefaults in String) // >> filename resolves to Map
+
+            if(customDefaults in String)
                 customDefaults = [].plus(customDefaults)
             if(customDefaults in List)
                 configurationFiles += customDefaults
-        /*
-        if(defaults instanceof Map) // >> config map
-            defaults = [].plus(defaults)
-        */
             for (def configFileName : configurationFiles){
+                if(configurationFiles.size() > 1) echo "Loading configuration file '${}'"
                 def configuration = readYaml text: libraryResource(configFileName)
                 defaultValues = MapUtils.merge(
                         MapUtils.pruneNulls(defaultValues),

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -1,10 +1,26 @@
 import com.sap.piper.DefaultValueCache
 
+import hudson.AbortException
+
 def call(Map parameters = [:]) {
     handlePipelineStepErrors (stepName: 'prepareDefaultValues', stepParameters: parameters) {
         if(!DefaultValueCache.getInstance()) {
             Map defaultValues  = readYaml text: libraryResource('default_pipeline_environment.yml')
-            DefaultValueCache.createInstance(defaultValues)
+            Map customDefaultValues = null
+
+            def customDefaults = null
+
+            try {
+              customDefaults = libraryResource('pipeline_environment.yml')
+            } catch(AbortException e) {
+                // custom defaults file not found, that's OK the file is optional.
+            }
+
+            if( customDefaults) {
+                customDefaultValues = readYaml text: customDefaults
+            }
+            echo "CUSTOM_DEFAULT_VALUES: '${customDefaultValues}'."
+            DefaultValueCache.createInstance(defaultValues, customDefaultValues)
         }
     }
 }

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -4,7 +4,7 @@ def call(Map parameters = [:]) {
 
         def script = parameters.script
 
-        prepareDefaultValues script: script
+        prepareDefaultValues script: script, customDefaults: parameters.customDefaults
 
         String configFile = parameters.get('configFile')
 


### PR DESCRIPTION
_This is more a proposal than a ready-to-merge pull request. Feedback, questions, other approaches, etc. welcome ..._

**functional gap:** At the moment we have no configuration layer in place for describing a system landscape on customer side.

**details:** At the moment we have these configuration layers:

* the library defaults described in ```resources/default_pipeline_environment.yml```. The content in this file provides defaults set by the library itself. This file should not be modified at customer side. 
* project specific configuration layer, based on file ```.pipeline/config.yml```. 

But there is no configuration layer for describing common properties for e.g. a customer landscape (... values which are the same for all projects of a customer).

We are currently preparing the integration with SAP-Solution manager. In a system landscape there is normally exactly one such instance. The only way right now would be to define e.g. the SAP-Solution manager endpoint url in each and every ```.pipeline/config.yml```.

With the approach here we get a configuration layer which enables us / the user of the lib to descibe the system landscape only once, instead of spreading around the same properties around in each project.

I'm quite sure we will have more elements in a system landscape than only a SolutionManager, so I assume that the proposal here is not only for one very specific use-case.

**how it works:*** Customer can create an additional repository containing a shared-lib-like directory layout. Inside ```resources``` a customer maintains a yml file named ```pipeline_environment.yml```. Inside that file a system landscape can be described. The structure of that file is defined by the piper-lib, of course a customer can extend the format. Sample (proposal):

```
changeManagement:
  endpoint: https://example.org/mySolutionManager
```

IMO it makes sense to structure the values according to the system elements (e.g. source code repo, binary repo, SAP-SolutionManager.

The additional repository needs to be denoted in the pipeline script in the same way like the piper-lib-os, or it can be configured as loaded by default inside Jenkins.

**Overlaps:** Some tools, e.g. npm, maven require some landscape definitions in their specific config files, e.g. ```.npmrc```, ```settings.xml```, so it will not be possible/reasonable to have the complete landscape definition here.

**other possible approaches:** It would also be possible to provide such a configuration via system properties either via Manage Jenkins > Global Properties or even via plain bash-like system properties. But with such an approach we would have a gap to our yml based configuration framework, e.g. merging configurations would be harded.

**missing:** At the moment merging the new system landscape configuration layer with the other already existing configuration layers is not implemented.