### PR TITLE
withMandatoryParameter supports a error message from the caller

### DIFF
--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -107,20 +107,22 @@ class ConfigurationHelper implements Serializable {
         return false
     }
 
-    def getMandatoryProperty(key, defaultValue = null) {
+    def getMandatoryProperty(key, defaultValue = null, errorMessage = null) {
 
         def paramValue = config[key]
 
         if (paramValue == null)
             paramValue = defaultValue
 
-        if (paramValue == null)
-            throw new IllegalArgumentException("ERROR - NO VALUE AVAILABLE FOR ${key}")
+        if (paramValue == null) {
+            if(! errorMessage) errorMessage = "ERROR - NO VALUE AVAILABLE FOR ${key}"
+            throw new IllegalArgumentException(errorMessage)
+        }
         return paramValue
     }
 
-    def withMandatoryProperty(key){
-        getMandatoryProperty(key)
+    def withMandatoryProperty(key, errorMessage = null){
+        getMandatoryProperty(key, null, errorMessage)
         return this
     }
 }

--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -5,9 +5,14 @@ import groovy.test.GroovyAssert
 import static org.hamcrest.Matchers.*
 
 import org.junit.Assert
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 
 class ConfigurationHelperTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none()
 
     private static getConfiguration() {
         Map configuration = [dockerImage: 'maven:3.2-jdk-8-onbuild']
@@ -114,4 +119,33 @@ class ConfigurationHelperTest {
         Assert.assertThat(config, hasEntry('executeDocker2', false))
         Assert.assertThat(config, hasEntry('executeDocker3', false))
     }
+
+    @Test
+    public void testWithMandoryParameterReturnDefaultFailureMessage() {
+
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR myKey')
+
+        new ConfigurationHelper().withMandatoryProperty('myKey')
+    }
+
+    @Test
+    public void testWithMandoryParameterReturnCustomerFailureMessage() {
+
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage('My error message')
+
+        new ConfigurationHelper().withMandatoryProperty('myKey', 'My error message')
+    }
+
+    @Test
+    public void testWithMandoryParameterDefaultCustomFailureMessageProvidedSucceeds() {
+        new ConfigurationHelper([myKey: 'myValue']).withMandatoryProperty('myKey', 'My error message')
+    }
+
+    @Test
+    public void testWithMandoryParameterDefaultCustomFailureMessageNotProvidedSucceeds() {
+        new ConfigurationHelper([myKey: 'myValue']).withMandatoryProperty('myKey')
+    }
+
 }


### PR DESCRIPTION
For some transport related steps it would be cool to have a message providing more details about what is going wrong. 