### PR TITLE
LibraryLoadingTestExecutionListener: restore tracked methods on afterTestMethod

### DIFF
--- a/test/groovy/util/LibraryLoadingTestExecutionListener.groovy
+++ b/test/groovy/util/LibraryLoadingTestExecutionListener.groovy
@@ -138,6 +138,9 @@ class LibraryLoadingTestExecutionListener extends AbstractTestExecutionListener 
         helper.clearAllowedMethodCallbacks(LibraryLoadingTestExecutionListener.TRACKED_ON_METHODS)
         LibraryLoadingTestExecutionListener.TRACKED_ON_METHODS.clear()
 
+        helper.putAllAllowedMethodCallbacks(LibraryLoadingTestExecutionListener.RESTORE_ON_METHODS)
+        LibraryLoadingTestExecutionListener.RESTORE_ON_METHODS.clear()
+
         LibraryLoadingTestExecutionListener.START_METHOD_TRACKING = false
 
         testInstance.getNullScript().commonPipelineEnvironment.reset()


### PR DESCRIPTION
PrepareDefaultValuesTest registers the methods "libraryResource" and "readYaml" to provide test specific configuration values. This had impacts to other test classes.
It looks like that the restoration of allowedMethods after a test method run has been forgotten.