### PR TITLE
transport request id from commit history

### DIFF
--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -43,22 +43,34 @@ public class ChangeManagement implements Serializable {
                               String format = '%b'
                             ) {
 
+        return getLabeledItem('ChangeDocumentId', from, to, label, format)
+    }
+
+    private String getLabeledItem(
+                              String name,
+                              String from,
+                              String to,
+                              String label,
+                              String format
+                            ) {
+
         if( ! gitUtils.insideWorkTree() ) {
-            throw new ChangeManagementException('Cannot retrieve change document id. Not in a git work tree. Change document id is extracted from git commit messages.')
+            throw new ChangeManagementException("Cannot retrieve ${name}. Not in a git work tree. ${name} is extracted from git commit messages.")
         }
 
-        def changeIds = gitUtils.extractLogLines(".*${label}.*", from, to, format)
+        def items = gitUtils.extractLogLines(".*${label}.*", from, to, format)
                                 .collect { line -> line?.replaceAll(label,'')?.trim() }
                                 .unique()
 
-            changeIds.retainAll { line -> line != null && ! line.isEmpty() }
-        if( changeIds.size() == 0 ) {
-            throw new ChangeManagementException("Cannot retrieve changeId from git commits. Change id retrieved from git commit messages via pattern '${label}'.")
-        } else if (changeIds.size() > 1) {
-            throw new ChangeManagementException("Multiple ChangeIds found: ${changeIds}. Change id retrieved from git commit messages via pattern '${label}'.")
+        items.retainAll { line -> line != null && ! line.isEmpty() }
+
+        if( items.size() == 0 ) {
+            throw new ChangeManagementException("Cannot retrieve ${name} from git commits. ${name} retrieved from git commit messages via pattern '${label}'.")
+        } else if (items.size() > 1) {
+            throw new ChangeManagementException("Multiple ${name}s found: ${items}. ${name} retrieved from git commit messages via pattern '${label}'.")
         }
 
-        return changeIds.get(0)
+        return items[0]
     }
 
     boolean isChangeInDevelopment(String changeId, String endpoint, String username, String password, String cmclientOpts = '') {

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -36,6 +36,46 @@ public class ChangeManagement implements Serializable {
             return changeDocumentId
         }
 
+    String getTransportRequestId(def commonPipelineEnvironment,
+                                 String transportRequestId,
+                                 String label,
+                                 String gitFrom,
+                                 String gitTo,
+                                 String gitFormat
+                                 ) {
+
+        String _transportRequestId = transportRequestId
+
+        if(_transportRequestId) {
+            commonPipelineEnvironment.setTransportRequestId(_transportRequestId)
+        }
+
+        _transportRequestId = commonPipelineEnvironment.getTransportRequestId()
+
+        if(_transportRequestId) {
+            return _transportRequestId
+        }
+
+        try {
+            script.echo "[INFO] Retrieving transportRequestId from git commit(s) [FROM: ${gitFrom}, TO: ${gitTo}]"
+
+            _transportRequestId = getTransportRequestId(
+                           label,
+                           gitFrom,
+                           gitTo,
+                           gitFormat
+                         )
+
+            script.echo "[INFO] Transport request id '${_transportRequestId}' retrieved from git commit(s)."
+            commonPipelineEnvironment.setTransportRequestId(_transportRequestId)
+
+        } catch(ChangeManagementException e) {
+            script.echo "[WARN] Cannot retrieve transport request id from commit history."
+            // OK, we return null
+        }
+        return _transportRequestId
+    }
+
     String getChangeDocumentId(
                               String from = 'origin/master',
                               String to = 'HEAD',
@@ -44,6 +84,16 @@ public class ChangeManagement implements Serializable {
                             ) {
 
         return getLabeledItem('ChangeDocumentId', from, to, label, format)
+    }
+
+    String getTransportRequestId(
+                              String label = 'TransportRequest\\s?:',
+                              String from = 'origin/master',
+                              String to = 'HEAD',
+                              String format = '%b'
+      ) {
+
+        return getLabeledItem('TransportRequestId', from, to, label, format)
     }
 
     private String getLabeledItem(

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -4,6 +4,8 @@ import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
 
+import com.sap.piper.cm.ChangeManagement
+
 import util.BasePiperTest
 import util.JenkinsStepRule
 import util.JenkinsLoggingRule
@@ -66,10 +68,22 @@ public class TransportRequestReleaseTest extends BasePiperTest {
     @Test
     public void transportRequestIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Transport Request id not provided (parameter: 'transportRequestId').")
+        ChangeManagement cm = new ChangeManagement(nullScript) {
+            String getTransportRequestId(def commonPipelineEnvironment,
+                                         String transportRequestId,
+                                         String gitLabel,
+                                         String gitFrom,
+                                         String gitTo,
+                                         String gitFormat
+                                         ) {
+                return null
+            }
+        }
 
-        jsr.step.call(script: nullScript, changeDocumentId: '001')
+        thrown.expect(AbortException)
+        thrown.expectMessage("Transport Request id not provided (parameter: 'transportRequestId' or via commit history).")
+
+        jsr.step.call(script: nullScript, changeDocumentId: '001', cmUtils: cm)
     }
 
     @Test

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -1,8 +1,12 @@
+import java.util.Map
+
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
+
+import com.sap.piper.cm.ChangeManagement
 
 import util.BasePiperTest
 import util.JenkinsStepRule
@@ -66,10 +70,22 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void transportRequestIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Transport Request id not provided (parameter: 'transportRequestId').")
+        ChangeManagement cm = new ChangeManagement(nullScript) {
+            String getTransportRequestId(def commonPipelineEnvironment,
+                                         String transportRequestId,
+                                         String gitLabel,
+                                         String gitFrom,
+                                         String gitTo,
+                                         String gitFormat
+                                         ) {
+                return null
+            }
+        }
 
-        jsr.step.call(script: nullScript, changeDocumentId: '001', applicationId: 'app', filePath: '/path')
+        thrown.expect(AbortException)
+        thrown.expectMessage("Transport Request id not provided (parameter: 'transportRequestId' or via commit history).")
+
+        jsr.step.call(script: nullScript, changeDocumentId: '001', applicationId: 'app', filePath: '/path', cmUtils: cm)
     }
 
     @Test

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -48,9 +48,9 @@ public class ChangeManagementTest extends BasePiperTest {
     public void testRetrieveChangeDocumentIdOutsideGitWorkTreeTest() {
 
         thrown.expect(ChangeManagementException)
-        thrown.expectMessage('Cannot retrieve change document id. ' +
+        thrown.expectMessage('Cannot retrieve ChangeDocumentId. ' +
                              'Not in a git work tree. ' +
-                             'Change document id is extracted from git commit messages.')
+                             'ChangeDocumentId is extracted from git commit messages.')
 
         new ChangeManagement(nullScript, gitUtilsMock(false, new String[0])).getChangeDocumentId()
     }
@@ -59,7 +59,7 @@ public class ChangeManagementTest extends BasePiperTest {
     public void testRetrieveChangeDocumentIdNothingFound() {
 
         thrown.expect(ChangeManagementException)
-        thrown.expectMessage('Cannot retrieve changeId from git commits.')
+        thrown.expectMessage('Cannot retrieve ChangeDocumentId from git commits.')
 
         new ChangeManagement(nullScript, gitUtilsMock(true, new String[0])).getChangeDocumentId()
     }
@@ -68,7 +68,7 @@ public class ChangeManagementTest extends BasePiperTest {
     public void testRetrieveChangeDocumentIdReturnsArrayWithNullValue() {
 
         thrown.expect(ChangeManagementException)
-        thrown.expectMessage('Cannot retrieve changeId from git commits.')
+        thrown.expectMessage('Cannot retrieve ChangeDocumentId from git commits.')
 
         new ChangeManagement(nullScript, gitUtilsMock(true, (String[])[ null ])).getChangeDocumentId()
     }
@@ -77,7 +77,7 @@ public class ChangeManagementTest extends BasePiperTest {
     public void testRetrieveChangeDocumentNotUnique() {
 
         thrown.expect(ChangeManagementException)
-        thrown.expectMessage('Multiple ChangeIds found')
+        thrown.expectMessage('Multiple ChangeDocumentIds found')
 
         String[] changeIds = [ 'a', 'b' ]
         new ChangeManagement(nullScript, gitUtilsMock(true, changeIds)).getChangeDocumentId()

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -21,6 +21,8 @@ class commonPipelineEnvironment implements Serializable {
 
     private String mtarFilePath
 
+    private String transportRequestId
+
     def reset() {
         appContainerProperties = [:]
         artifactVersion = null
@@ -35,6 +37,7 @@ class commonPipelineEnvironment implements Serializable {
         influxCustomDataMap = [pipeline_data: [:], step_data: [:]]
 
         mtarFilePath = null
+        transportRequestId = null
     }
 
     def setAppContainerProperty(property, value) {
@@ -110,5 +113,13 @@ class commonPipelineEnvironment implements Serializable {
 
     def getPipelineMeasurement (measurementName) {
         return influxCustomDataMap.pipeline_data[measurementName]
+    }
+
+    def setTransportRequestId(transportRequestId) {
+        this.transportRequestId = transportRequestId
+    }
+
+    def getTransportRequestId() {
+        return this.transportRequestId
     }
 }

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -62,6 +62,10 @@ def call(parameters = [:]) {
             }
         }
 
+        if(script.commonPipelineEnvironment) {
+            script.commonPipelineEnvironment.setTransportRequestId(transportRequestId)
+        }
+
         echo "[INFO] Transport Request '$transportRequestId' has been successfully created."
         return transportRequestId
     }

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -14,12 +14,20 @@ import hudson.AbortException
     'changeDocumentId',
     'transportRequestId',
     'credentialsId',
-    'endpoint'
+    'endpoint',
+    'gitFrom',
+    'gitTo',
+    'gitFormat',
+    'labelTransportRequestId'
   ]
 
 @Field Set stepConfigurationKeys = [
     'credentialsId',
-    'endpoint'
+    'endpoint',
+    'gitFrom',
+    'gitTo',
+    'gitFormat',
+    'labelTransportRequestId'
   ]
 
 def call(parameters = [:]) {
@@ -28,7 +36,7 @@ def call(parameters = [:]) {
 
         def script = parameters?.script ?: [commonPipelineEnvironment: commonPipelineEnvironment]
 
-        ChangeManagement cm = new ChangeManagement(script)
+        ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
         Map configuration = ConfigurationMerger.merge(script, STEP_NAME,
                                                       parameters, parameterKeys,
@@ -37,8 +45,15 @@ def call(parameters = [:]) {
         def changeDocumentId = configuration.changeDocumentId
         if(!changeDocumentId) throw new AbortException("Change document id not provided (parameter: 'changeDocumentId').")
 
-        def transportRequestId = configuration.transportRequestId
-        if(!transportRequestId) throw new AbortException("Transport Request id not provided (parameter: 'transportRequestId').")
+        def transportRequestId = cm.getTransportRequestId(
+                                                          script.commonPipelineEnvironment,
+                                                          configuration.transportRequestId,
+                                                          configuration.gitLabel,
+                                                          configuration.gitFrom,
+                                                          configuration.gitTo,
+                                                          configuration.gitFormat
+                                                         )
+        if(!transportRequestId) throw new AbortException("Transport Request id not provided (parameter: 'transportRequestId' or via commit history).")
 
         def credentialsId = configuration.credentialsId
         if(!credentialsId) throw new AbortException("Credentials id not provided (parameter: 'credentialsId').")

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -16,12 +16,20 @@ import hudson.AbortException
     'applicationId',
     'filePath',
     'credentialsId',
-    'endpoint'
+    'endpoint',
+    'gitFrom',
+    'gitTo',
+    'gitFormat',
+    'labelTransportRequestId'
   ]
 
 @Field Set generalConfigurationKeys = [
     'credentialsId',
-    'endpoint'
+    'endpoint',
+    'gitFrom',
+    'gitTo',
+    'gitFormat',
+    'labelTransportRequestId'
   ]
 
 def call(parameters = [:]) {
@@ -30,7 +38,7 @@ def call(parameters = [:]) {
 
         def script = parameters?.script ?: [commonPipelineEnvironment: commonPipelineEnvironment]
 
-        ChangeManagement cm = new ChangeManagement(script)
+        ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
         Map configuration = ConfigurationMerger.merge(parameters.script, STEP_NAME,
                                                       parameters, parameterKeys,
@@ -39,8 +47,15 @@ def call(parameters = [:]) {
         def changeDocumentId = configuration.changeDocumentId
         if(!changeDocumentId) throw new AbortException("Change document id not provided (parameter: 'changeDocumentId').")
 
-        def transportRequestId = configuration.transportRequestId
-        if(!transportRequestId) throw new AbortException("Transport Request id not provided (parameter: 'transportRequestId').")
+        def transportRequestId = cm.getTransportRequestId(
+                                                          script.commonPipelineEnvironment,
+                                                          configuration.transportRequestId,
+                                                          configuration.gitLabel,
+                                                          configuration.gitFrom,
+                                                          configuration.gitTo,
+                                                          configuration.gitFormat
+                                                         )
+        if(!transportRequestId) throw new AbortException("Transport Request id not provided (parameter: 'transportRequestId' or via commit history).")
 
         def applicationId = configuration.applicationId
         if(!applicationId) throw new AbortException("Application id not provided (parameter: 'applicationId').")


### PR DESCRIPTION
- [x] implement feature
- [ ] tests
- [ ] docu

The transport request ID should be retrieved from the commit history in the same way like the change document id.