### PR TITLE
No forwarding of config map in to ChangeManagement class.

### DIFF
--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -17,25 +17,6 @@ public class ChangeManagement implements Serializable {
         this.gitUtils = gitUtils ?: new GitUtils()
     }
 
-    String getChangeDocumentId(Map config) {
-
-            if(config.changeDocumentId) {
-                script.echo "[INFO] Use changeDocumentId '${config.changeDocumentId}' from configuration."
-                return config.changeDocumentId
-            }
-
-            script.echo "[INFO] Retrieving changeDocumentId from git commit(s) [FROM: ${config.gitFrom}, TO: ${config.gitTo}]"
-            def changeDocumentId = getChangeDocumentId(
-                                        config.gitFrom,
-                                        config.gitTo,
-                                        config.gitChangeDocumentLabel,
-                                        config.gitFormat
-                                   )
-            script.echo "[INFO] ChangeDocumentId '${changeDocumentId}' retrieved from git commit(s)."
-
-            return changeDocumentId
-        }
-
     String getChangeDocumentId(
                               String from = 'origin/master',
                               String to = 'HEAD',

--- a/test/groovy/CheckChangeInDevelopmentTest.groovy
+++ b/test/groovy/CheckChangeInDevelopmentTest.groovy
@@ -87,6 +87,29 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
     }
 
     @Test
+    public void ifChangeIdPresentAsParameterAndFromCommitsChangeIdFromParameterIsUsedTest() {
+        ChangeManagement cm = getChangeManagementUtils(true, '0815')
+
+        jsr.step.checkChangeInDevelopment(
+            changeDocumentId: '42',
+            cmUtils: cm,
+            endpoint: 'https://example.org/cm')
+
+        assert cmUtilReceivedParams.changeId == '42'
+    }
+
+    @Test
+    public void ifChangeIdNotPresentAsParameterButFromCommitsChangeIdFromCommitsIsUsedTest() {
+        ChangeManagement cm = getChangeManagementUtils(true, '0815')
+
+        jsr.step.checkChangeInDevelopment(
+            cmUtils: cm,
+            endpoint: 'https://example.org/cm')
+
+        assert cmUtilReceivedParams.changeId == '0815'
+    }
+
+    @Test
     public void changeDocumentIdRetrievalFailsTest() {
 
         thrown.expect(AbortException)

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -39,15 +39,6 @@ public class ChangeManagementTest extends BasePiperTest {
         .around(logging)
 
     @Test
-    public void testGetChangeIdFromConfigWhenProvidedInsideConfig() {
-        String[] viaGitUtils = ['0815']
-        def changeDocumentId = new ChangeManagement(nullScript, gitUtilsMock(false, viaGitUtils))
-            .getChangeDocumentId([changeDocumentId: '0042'])
-
-        assertThat(logging.log, containsString('[INFO] Use changeDocumentId \'0042\' from configuration.'))
-        assertThat(changeDocumentId, is(equalTo('0042')))
-    }
-    @Test
     public void testRetrieveChangeDocumentIdOutsideGitWorkTreeTest() {
 
         thrown.expect(ChangeManagementException)
@@ -92,22 +83,6 @@ public class ChangeManagementTest extends BasePiperTest {
         String[] changeIds = [ 'a', 'a' ]
         def changeID = new ChangeManagement(nullScript, gitUtilsMock(true, changeIds)).getChangeDocumentId()
 
-        assert changeID == 'a'
-    }
-
-    @Test
-    public void testRetrieveChangeDocumentWithUniqueResult() {
-
-        String[] changeIds = [ 'a' ];
-
-        def params = [ gitFrom: 'origin/master',
-                       gitTo: 'HEAD',
-                       gitChangeDocumentLabel: 'ChangeDocument\\s?:',
-                       gitFormat: '%b']
-
-        def changeID = new ChangeManagement(nullScript, gitUtilsMock(true, changeIds)).getChangeDocumentId(params)
-
-        assertThat(logging.log, containsString('[INFO] ChangeDocumentId \'a\' retrieved from git commit(s). '))
         assert changeID == 'a'
     }
 

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -46,18 +46,32 @@ def call(parameters = [:]) {
                                                       parameters, parameterKeys,
                                                       stepConfigurationKeys)
 
+        def changeId = configuration.changeDocumentId
 
-        def changeId
+        if(changeId?.trim()) {
 
-        try {
+          echo "[INFO] ChangeDocumentId retrieved from parameters."
 
-            changeId = cm.getChangeDocumentId(configuration)
+        } else {
 
-            if(! changeId?.trim()) {
-                throw new ChangeManagementException("ChangeId is null or empty.")
+          echo "[INFO] Retrieving ChangeDocumentId from commit history [from: ${configuration.gitFrom}, to: ${configuration.gitTo}]." +
+               "Searching for pattern '${configuration.gitChangeDocumentLabel}'. Searching with format '${configuration.gitFormat}'."
+
+            try {
+                changeId = cm.getChangeDocumentId(
+                                                  configuration.gitFrom,
+                                                  configuration.gitTo,
+                                                  configuration.gitChangeDocumentLabel,
+                                                  configuration.gitFormat
+                                                 )
+                if(changeId?.trim()) {
+                    echo "[INFO] ChangeDocumentId '${changeId}' retrieved from commit history"
+                } else {
+                    throw new ChangeManagementException("ChangeId is null or empty.")
+                }
+            } catch(ChangeManagementException ex) {
+                throw new AbortException(ex.getMessage())
             }
-        } catch(ChangeManagementException ex) {
-            throw new AbortException(ex.getMessage())
         }
 
         boolean isInDevelopment


### PR DESCRIPTION
Forwarding of the configuration map into utils classes increases maintainance efforts later in case configuration keys are changed.

An approach handling retrieval of configuration only inside the steps in much clearer compared with forwarding the config map and picking properties later on down the code.