### PR TITLE
Support check for log messages in case of exceptions in code under test

### DIFF
--- a/test/groovy/util/JenkinsLoggingRule.groovy
+++ b/test/groovy/util/JenkinsLoggingRule.groovy
@@ -1,18 +1,31 @@
 package util
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
+
+import org.junit.Assert
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
+
+import static org.hamcrest.Matchers.containsString
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Matchers
 
 class JenkinsLoggingRule implements TestRule {
 
     final BasePipelineTest testInstance
 
+    def expected = []
+
     String log = ""
 
     JenkinsLoggingRule(BasePipelineTest testInstance) {
         this.testInstance = testInstance
+    }
+
+    public void expect(String substring) {
+        expected.add(substring)
     }
 
     @Override
@@ -30,7 +43,30 @@ class JenkinsLoggingRule implements TestRule {
                         log += "$echoInput \n"
                 })
 
-                base.evaluate()
+                Throwable caught
+
+                try {
+                    base.evaluate()
+                } catch(Throwable thr) {
+                    caught = thr
+                } finally {
+                    if(caught instanceof AssertionError) {
+                        // Be polite, give other rules the advantage.
+                        // We expect other rules located closer to the test case
+                        // to throw an AssertionError in case of a violation.
+                        throw caught
+                    }
+
+                    expected.each { substring -> assertThat("Substring '${substring} not contained in log.'",
+                                                            log,
+                                                            containsString(substring)) }
+
+                    if(caught != null) {
+                        // do not swallow, so that other rules located farer away
+                        // to the test case can react
+                        throw caught
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
With the current approach of checking log entries we are not able to
check log entries in case of a failure. But is is important to assert
log messages in case of a failure. Having reasonable log messages
simplified troubleshooting.

Hence we add JenkinsLoggingRule.expect(substring) and check after the
base of that rule has been called.

This interfears with other rules also working with an expect approach,
like e.g. ExpectedException. Which violation is presented depends on
the order or the rules around the test case.