### PR TITLE
[fix] misplaced quotation mark in assertion message

### DIFF
--- a/test/groovy/util/JenkinsLoggingRule.groovy
+++ b/test/groovy/util/JenkinsLoggingRule.groovy
@@ -57,7 +57,7 @@ class JenkinsLoggingRule implements TestRule {
                         throw caught
                     }
 
-                    expected.each { substring -> assertThat("Substring '${substring} not contained in log.'",
+                    expected.each { substring -> assertThat("Substring '${substring}' not contained in log.",
                                                             log,
                                                             containsString(substring)) }
 


### PR DESCRIPTION
@CCFenner  mentioned the misplaced quotation mark alread in PR #199 , but by error I forgot to fix it.