### PR TITLE
Validate required parameters via config helper

### DIFF
--- a/test/groovy/CheckChangeInDevelopmentTest.groovy
+++ b/test/groovy/CheckChangeInDevelopmentTest.groovy
@@ -134,8 +134,10 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
     @Test
     public void nullChangeDocumentIdTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("ChangeId is null or empty.")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("No changeDocumentId provided. Neither via parameter 'changeDocumentId' " +
+                             "nor via label 'configuration.gitChangeIdLabel' in commit range " +
+                             "[from: origin/master, to: HEAD].")
 
         ChangeManagement cm = getChangeManagementUtils(false, null)
         jsr.step.checkChangeInDevelopment(
@@ -146,8 +148,10 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
     @Test
     public void emptyChangeDocumentIdTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("ChangeId is null or empty.")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("No changeDocumentId provided. Neither via parameter 'changeDocumentId' " +
+                             "nor via label 'configuration.gitChangeIdLabel' in commit range " +
+                             "[from: origin/master, to: HEAD].")
 
         ChangeManagement cm = getChangeManagementUtils(false, '')
         jsr.step.checkChangeInDevelopment(

--- a/test/groovy/TransportRequestCreateTest.groovy
+++ b/test/groovy/TransportRequestCreateTest.groovy
@@ -61,8 +61,8 @@ public class TransportRequestCreateTest extends BasePiperTest {
     @Test
     public void changeIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Change document id not provided (parameter: 'changeDocumentId').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR changeDocumentId")
 
         jsr.step.call(script: nullScript, developmentSystemId: '001')
     }
@@ -70,8 +70,8 @@ public class TransportRequestCreateTest extends BasePiperTest {
     @Test
     public void developmentSystemIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Development system id not provided (parameter: 'developmentSystemId').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR developmentSystemId")
 
         jsr.step.call(script: nullScript, changeDocumentId: '001')
     }

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -57,8 +57,8 @@ public class TransportRequestReleaseTest extends BasePiperTest {
     @Test
     public void changeIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Change document id not provided (parameter: 'changeDocumentId').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR changeDocumentId")
 
         jsr.step.call(script: nullScript, transportRequestId: '001')
     }
@@ -66,8 +66,8 @@ public class TransportRequestReleaseTest extends BasePiperTest {
     @Test
     public void transportRequestIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Transport Request id not provided (parameter: 'transportRequestId').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR transportRequestId")
 
         jsr.step.call(script: nullScript, changeDocumentId: '001')
     }

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -60,8 +60,8 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void changeDocumentIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Change document id not provided (parameter: 'changeDocumentId').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR changeDocumentId")
 
         jsr.step.call(script: nullScript, transportRequestId: '001', applicationId: 'app', filePath: '/path')
     }
@@ -69,8 +69,8 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void transportRequestIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Transport Request id not provided (parameter: 'transportRequestId').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR transportRequestId")
 
         jsr.step.call(script: nullScript, changeDocumentId: '001', applicationId: 'app', filePath: '/path')
     }
@@ -78,8 +78,8 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void applicationIdNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("Application id not provided (parameter: 'applicationId').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR applicationId")
 
         jsr.step.call(script: nullScript, changeDocumentId: '001', transportRequestId: '001', filePath: '/path')
     }
@@ -87,8 +87,8 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void filePathNotProvidedTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage("File path not provided (parameter: 'filePath').")
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR filePath")
 
         jsr.step.call(script: nullScript, changeDocumentId: '001', transportRequestId: '001', applicationId: 'app')
     }

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -45,13 +45,14 @@ def call(parameters = [:]) {
 
         ChangeManagement cm = parameters?.cmUtils ?: new ChangeManagement(script, gitUtils)
 
-        Map configuration = ConfigurationHelper
-                            .loadStepDefaults(this)
-                            .mixinGeneralConfig(script.commonPipelineEnvironment, generalConfigurationKeys)
-                            .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, stepConfigurationKeys)
-                            .mixinStepConfig(script.commonPipelineEnvironment, stepConfigurationKeys)
-                            .mixin(parameters, parameterKeys)
-                            .use()
+        ConfigurationHelper configHelper = ConfigurationHelper
+                                           .loadStepDefaults(this)
+                                           .mixinGeneralConfig(script.commonPipelineEnvironment, generalConfigurationKeys)
+                                           .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, stepConfigurationKeys)
+                                           .mixinStepConfig(script.commonPipelineEnvironment, stepConfigurationKeys)
+                                           .mixin(parameters, parameterKeys)
+
+        Map configuration = configHelper.use()
 
         def changeId = configuration.changeDocumentId
 
@@ -73,17 +74,23 @@ def call(parameters = [:]) {
                                                  )
                 if(changeId?.trim()) {
                     echo "[INFO] ChangeDocumentId '${changeId}' retrieved from commit history"
-                } else {
-                    throw new ChangeManagementException("ChangeId is null or empty.")
                 }
             } catch(ChangeManagementException ex) {
                 throw new AbortException(ex.getMessage())
             }
         }
 
+        configuration = configHelper.mixin([changeDocumentId: changeId?.trim() ?: null], ['changeDocumentId'] as Set)
+                                    .withMandatoryProperty('endpoint')
+                                    .withMandatoryProperty('changeDocumentId',
+                                        "No changeDocumentId provided. Neither via parameter 'changeDocumentId' " +
+                                        "nor via label 'configuration.gitChangeIdLabel' in commit range " +
+                                        "[from: ${configuration.gitFrom}, to: ${configuration.gitTo}].")
+                                    .use()
+
         boolean isInDevelopment
 
-        echo "[INFO] Checking if change document '$changeId' is in development."
+        echo "[INFO] Checking if change document '${configuration.changeDocumentId}' is in development."
 
         withCredentials([usernamePassword(
             credentialsId: configuration.credentialsId,
@@ -91,7 +98,11 @@ def call(parameters = [:]) {
             usernameVariable: 'username')]) {
 
             try {
-                isInDevelopment = cm.isChangeInDevelopment(changeId, configuration.endpoint, username, password, configuration.cmClientOpts)
+                isInDevelopment = cm.isChangeInDevelopment(configuration.changeDocumentId,
+                                                           configuration.endpoint,
+                                                           username,
+                                                           password,
+                                                           configuration.cmClientOpts)
             } catch(ChangeManagementException ex) {
                 throw new AbortException(ex.getMessage())
             }

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -41,31 +41,27 @@ def call(parameters = [:]) {
                             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, stepConfigurationKeys)
                             .mixinStepConfig(script.commonPipelineEnvironment, stepConfigurationKeys)
                             .mixin(parameters, parameterKeys)
+                            .withMandatoryProperty('endpoint')
+                            .withMandatoryProperty('changeDocumentId')
+                            .withMandatoryProperty('developmentSystemId')
                             .use()
-
-        def changeDocumentId = configuration.changeDocumentId
-        if(!changeDocumentId) throw new AbortException('Change document id not provided (parameter: \'changeDocumentId\').')
-
-        def developmentSystemId = configuration.developmentSystemId
-        if(!developmentSystemId) throw new AbortException('Development system id not provided (parameter: \'developmentSystemId\').')
-
-        def credentialsId = configuration.credentialsId
-        if(!credentialsId) throw new AbortException('Credentials id not provided (parameter: \'credentialsId\').')
-
-        def endpoint = configuration.endpoint
-        if(!endpoint) throw new AbortException('Solution Manager endpoint not provided (parameter: \'endpoint\').')
 
         def transportRequestId
 
-        echo "[INFO] Creating transport request for change document '$changeDocumentId' and development system '$developmentSystemId'."
+        echo "[INFO] Creating transport request for change document '${configuration.changeDocumentId}' and development system '${configuration.developmentSystemId}'."
 
         withCredentials([usernamePassword(
-            credentialsId: credentialsId,
+            credentialsId: configuration.credentialsId,
             passwordVariable: 'password',
             usernameVariable: 'username')]) {
 
             try {
-                transportRequestId = cm.createTransportRequest(changeDocumentId, developmentSystemId, endpoint, username, password, configuration.clientOpts)
+                transportRequestId = cm.createTransportRequest(configuration.changeDocumentId,
+                                                               configuration.developmentSystemId,
+                                                               configuration.endpoint,
+                                                               username,
+                                                               password,
+                                                               configuration.clientOpts)
             } catch(ChangeManagementException ex) {
                 throw new AbortException(ex.getMessage())
             }

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -41,34 +41,30 @@ def call(parameters = [:]) {
                             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, stepConfigurationKeys)
                             .mixinStepConfig(script.commonPipelineEnvironment, stepConfigurationKeys)
                             .mixin(parameters, parameterKeys)
+                            .withMandatoryProperty('changeDocumentId')
+                            .withMandatoryProperty('transportRequestId')
+                            .withMandatoryProperty('endpoint')
                             .use()
 
-        def changeDocumentId = configuration.changeDocumentId
-        if(!changeDocumentId) throw new AbortException("Change document id not provided (parameter: 'changeDocumentId').")
-
-        def transportRequestId = configuration.transportRequestId
-        if(!transportRequestId) throw new AbortException("Transport Request id not provided (parameter: 'transportRequestId').")
-
-        def credentialsId = configuration.credentialsId
-        if(!credentialsId) throw new AbortException("Credentials id not provided (parameter: 'credentialsId').")
-
-        def endpoint = configuration.endpoint
-        if(!endpoint) throw new AbortException("Solution Manager endpoint not provided (parameter: 'endpoint').")
-
-        echo "[INFO] Closing transport request '$transportRequestId' for change document '$changeDocumentId'."
+        echo "[INFO] Closing transport request '${configuration.transportRequestId}' for change document '${configuration.changeDocumentId}'."
 
         withCredentials([usernamePassword(
-            credentialsId: credentialsId,
+            credentialsId: configuration.credentialsId,
             passwordVariable: 'password',
             usernameVariable: 'username')]) {
 
             try {
-                cm.releaseTransportRequest(changeDocumentId, transportRequestId, endpoint, username, password, configuration.cmClientOpts)
+                cm.releaseTransportRequest(configuration.changeDocumentId,
+                                           configuration.transportRequestId,
+                                           configuration.endpoint,
+                                           username,
+                                           password,
+                                           configuration.cmClientOpts)
             } catch(ChangeManagementException ex) {
                 throw new AbortException(ex.getMessage())
             }
         }
 
-        echo "[INFO] Transport Request '${transportRequestId}' has been successfully closed."
+        echo "[INFO] Transport Request '${configuration.transportRequestId}' has been successfully closed."
     }
 }

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -41,40 +41,33 @@ def call(parameters = [:]) {
                             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, stepConfigurationKeys)
                             .mixinStepConfig(script.commonPipelineEnvironment, stepConfigurationKeys)
                             .mixin(parameters, parameterKeys)
+                            .withMandatoryProperty('endpoint')
+                            .withMandatoryProperty('changeDocumentId')
+                            .withMandatoryProperty('transportRequestId')
+                            .withMandatoryProperty('applicationId')
+                            .withMandatoryProperty('filePath')
                             .use()
 
-        def changeDocumentId = configuration.changeDocumentId
-        if(!changeDocumentId) throw new AbortException("Change document id not provided (parameter: 'changeDocumentId').")
-
-        def transportRequestId = configuration.transportRequestId
-        if(!transportRequestId) throw new AbortException("Transport Request id not provided (parameter: 'transportRequestId').")
-
-        def applicationId = configuration.applicationId
-        if(!applicationId) throw new AbortException("Application id not provided (parameter: 'applicationId').")
-
-        def filePath = configuration.filePath
-        if(!filePath) throw new AbortException("File path not provided (parameter: 'filePath').")
-
-        def credentialsId = configuration.credentialsId
-        if(!credentialsId) throw new AbortException("Credentials id not provided (parameter: 'credentialsId').")
-
-        def endpoint = configuration.endpoint
-        if(!endpoint) throw new AbortException("Solution Manager endpoint not provided (parameter: 'endpoint').")
-
-        echo "[INFO] Uploading file '$filePath' to transport request '$transportRequestId' of change document '$changeDocumentId'."
+        echo "[INFO] Uploading file '${configuration.filePath}' to transport request '${configuration.transportRequestId}' of change document '${configuration.changeDocumentId}'."
 
         withCredentials([usernamePassword(
-            credentialsId: credentialsId,
+            credentialsId: configuration.credentialsId,
             passwordVariable: 'password',
             usernameVariable: 'username')]) {
 
             try {
-                cm.uploadFileToTransportRequest(changeDocumentId, transportRequestId, applicationId, filePath, endpoint, username, password)
+                cm.uploadFileToTransportRequest(configuration.changeDocumentId,
+                                                configuration.transportRequestId,
+                                                configuration.applicationId,
+                                                configuration.filePath,
+                                                configuration.endpoint,
+                                                username,
+                                                password)
             } catch(ChangeManagementException ex) {
                 throw new AbortException(ex.getMessage())
             }
         }
 
-        echo "[INFO] File '$filePath' has been successfully uploaded to transport request '$transportRequestId' of change document '$changeDocumentId'."
+        echo "[INFO] File '${configuration.filePath}' has been successfully uploaded to transport request '${configuration.transportRequestId}' of change document '${configuration.changeDocumentId}'."
     }
 }


### PR DESCRIPTION
  - In case a parameter is missing we do not thrown and AbortException
    anmore, but an IllegalArgumentExcpetion, since that exception is
    thrown by the configuration helper. The difference is: AbortExceptions
    are contained in the log without stacktrace, other exceptions are
    printed with stack trace.
  - Exception messages are changed to the standard error message triggered
    inside the configuration helper. In case the changeDocumentId is
    retrieved also from the commit history we keep an exception message
    pointing to that.
  - Having references to the parameters is droped. Instead the parameters
    are directly used from the configuration map.
  - in case of long signatures line breaks are inserted in order to
    simplify reading the code.