### PR TITLE
Do not repeat the same parameter names for different configuration la…

### DIFF
--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -9,8 +9,7 @@ import com.sap.piper.cm.ChangeManagementException
 
 @Field def STEP_NAME = 'checkChangeInDevelopment'
 
-@Field Set parameterKeys = [
-    'changeDocumentId',
+@Field Set stepConfigurationKeys = [
     'cmClientOpts',
     'credentialsId',
     'endpoint',
@@ -21,17 +20,7 @@ import com.sap.piper.cm.ChangeManagementException
     'gitFormat'
   ]
 
-@Field Set stepConfigurationKeys = [
-    'changeDocumentId',
-    'cmClientOpts',
-    'credentialsId',
-    'endpoint',
-    'failIfStatusIsNotInDevelopment',
-    'gitFrom',
-    'gitTo',
-    'gitChangeDocumentLabel',
-    'gitFormat'
-  ]
+@Field Set parameterKeys = stepConfigurationKeys.plus('changeDocumentId')
 
 @Field Set generalConfigurationKeys = stepConfigurationKeys
 

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -11,19 +11,13 @@ import hudson.AbortException
 
 @Field def STEP_NAME = 'transportRequestCreate'
 
-@Field Set parameterKeys = [
-    'changeDocumentId',
-    'clientOpts',
-    'developmentSystemId',
-    'credentialsId',
-    'endpoint'
-  ]
-
 @Field Set stepConfigurationKeys = [
     'credentialsId',
     'clientOpts',
     'endpoint'
   ]
+
+@Field Set parameterKeys = stepConfigurationKeys.plus(['changeDocumentId', 'developmentSystemId'])
 
 @Field generalConfigurationKeys = stepConfigurationKeys
 

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -11,19 +11,16 @@ import hudson.AbortException
 
 @Field def STEP_NAME = 'transportRequestRelease'
 
-@Field Set parameterKeys = [
-    'changeDocumentId',
-    'cmClientOpts',
-    'transportRequestId',
-    'credentialsId',
-    'endpoint'
-  ]
-
 @Field Set stepConfigurationKeys = [
     'credentialsId',
     'cmClientOpts',
     'endpoint'
   ]
+
+@Field Set parameterKeys = stepConfigurationKeys.plus([
+    'changeDocumentId',
+    'transportRequestId',
+  ])
 
 @Field Set generalConfigurationKeys = stepConfigurationKeys
 

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -11,19 +11,16 @@ import hudson.AbortException
 
 @Field def STEP_NAME = 'transportRequestUploadFile'
 
-@Field Set parameterKeys = [
-    'changeDocumentId',
-    'transportRequestId',
-    'applicationId',
-    'filePath',
-    'credentialsId',
-    'endpoint'
-  ]
-
 @Field Set generalConfigurationKeys = [
     'credentialsId',
     'endpoint'
   ]
+
+@Field Set parameterKeys = generalConfigurationKeys.plus([
+    'applicationId',
+    'changeDocumentId',
+    'filePath',
+    'transportRequestId'])
 
 @Field Set stepConfigurationKeys = generalConfigurationKeys
 


### PR DESCRIPTION
…yers

changeId is removed from the step parameters since the changeId
is specific to the build. Hence there is no reason for providing
it from the deeper configuration layers.