### PR TITLE
Report all missing mandatory parameters instead of only the first on

### DIFF
--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -269,4 +269,42 @@ class ConfigurationHelperTest {
         assert config.c instanceof java.lang.String
         assert config.nextLevel.b instanceof java.lang.String
     }
+
+    @Test
+    public void testWithMandatoryParameterCollectFailuresAllParamtersArePresentResultsInNoExceptionThrown() {
+        new ConfigurationHelper([myKey1: 'a', myKey2: 'b'])
+                                   .collectValidationFailures()
+                                   .withMandatoryProperty('myKey1')
+                                   .withMandatoryProperty('myKey2')
+                                   .use()
+    }
+
+    @Test
+    public void testWithMandatoryParameterCollectFailuresMultipleMissingParametersDoNotResultInFailuresDuringWithMandatoryProperties() {
+        new ConfigurationHelper([:]).collectValidationFailures()
+                                    .withMandatoryProperty('myKey1')
+                                    .withMandatoryProperty('myKey2')
+    }
+
+    @Test
+    public void testWithMandatoryParameterCollectFailuresMultipleMissingParametersResultsInFailureDuringUse() {
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR: myKey2, myKey3')
+        new ConfigurationHelper([myKey1:'a']).collectValidationFailures()
+                                   .withMandatoryProperty('myKey1')
+                                   .withMandatoryProperty('myKey2')
+                                   .withMandatoryProperty('myKey3')
+                                   .use()
+    }
+
+    @Test
+    public void testWithMandatoryParameterCollectFailuresOneMissingParametersResultsInFailureDuringUse() {
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR myKey2')
+        new ConfigurationHelper([myKey1:'a']).collectValidationFailures()
+                                   .withMandatoryProperty('myKey1')
+                                   .withMandatoryProperty('myKey2')
+                                   .use()
+    }
+
 }


### PR DESCRIPTION
With the current approach we fail at the first mandatory parameter
which is not present. Any other missing mandatory parameter is not
reported.

In case of multiple missing parameters somebody fixes the reported
parameter and encounters the next missing parameter at the next build.
And so on, until all parameters are fixed.

With the proposal here we catch all missing parameters and report them
all at once. This speeds up the time it needs to fix configuration
issues.

By default the old behaviour is not changed. In order to trigger the
new behavour a call to method collectValidationFailures() is
required.

We can also discuss if it would make sense to change the default
behaviour so that we fail always reporting all missing parameters.