### PR TITLE
[refactor] re-use getConfigPropery inside getMandatoryProperty

### DIFF
--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -109,10 +109,7 @@ class ConfigurationHelper implements Serializable {
 
     def getMandatoryProperty(key, defaultValue = null, errorMessage = null) {
 
-        def paramValue = config[key]
-
-        if (paramValue == null)
-            paramValue = defaultValue
+        def paramValue = getConfigProperty(key, defaultValue)
 
         if (paramValue == null) {
             if(! errorMessage) errorMessage = "ERROR - NO VALUE AVAILABLE FOR ${key}"


### PR DESCRIPTION
... instead of accessing the config map directy.

With that we ensure that getMandatoryProperty behaves the same like
getConfigProperty. Currently we differ e.g. with trim().