### PR TITLE
Limit usage of ConfigurationHelper to the builder pattern

### DIFF
--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -102,19 +102,11 @@ class ConfigurationHelper implements Serializable {
         this.config = config
     }
 
-    def getConfigProperty(key) {
+    /* private */ def getConfigPropertyNested(key) {
         return getConfigPropertyNested(config, key)
     }
 
-    def getConfigProperty(key, defaultValue) {
-        def value = getConfigProperty(key)
-        if (value == null) {
-            return defaultValue
-        }
-        return value
-    }
-
-    private getConfigPropertyNested(Map config, key) {
+    /* private */ static getConfigPropertyNested(Map config, key) {
 
         def separator = '/'
 
@@ -135,42 +127,22 @@ class ConfigurationHelper implements Serializable {
         return config[parts.head()]
     }
 
-    def isPropertyDefined(key){
+     private void existsMandatoryProperty(key, errorMessage) {
 
-        def value = getConfigProperty(key)
-
-        if(value == null){
-            return false
-        }
-
-        if(value.class == String){
-            return value?.isEmpty() == false
-        }
-
-        if(value){
-            return true
-        }
-
-        return false
-    }
-
-    def getMandatoryProperty(key, defaultValue = null, errorMessage = null) {
-
-        def paramValue = getConfigProperty(key, defaultValue)
+        def paramValue = getConfigPropertyNested(config, key)
 
         if (paramValue == null) {
             if(! errorMessage) errorMessage = "ERROR - NO VALUE AVAILABLE FOR ${key}"
             throw new IllegalArgumentException(errorMessage)
         }
-        return paramValue
     }
 
-    def withMandatoryProperty(key, errorMessage = null, condition = null){
+    ConfigurationHelper withMandatoryProperty(key, errorMessage = null, condition = null){
         if(condition){
             if(condition(this.config))
-                getMandatoryProperty(key, null, errorMessage)
+                existsMandatoryProperty(key, errorMessage)
         }else{
-            getMandatoryProperty(key, null, errorMessage)
+            existsMandatoryProperty(key, errorMessage)
         }
         return this
     }

--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -23,70 +23,32 @@ class ConfigurationHelperTest {
     }
 
     @Test
-    void testGetProperty() {
-        def configuration = new ConfigurationHelper(getConfiguration())
-        Assert.assertEquals('maven:3.2-jdk-8-onbuild', configuration.getConfigProperty('dockerImage'))
-        Assert.assertEquals('maven:3.2-jdk-8-onbuild', configuration.getConfigProperty('dockerImage', 'default'))
-        Assert.assertEquals('default', configuration.getConfigProperty('something', 'default'))
-        Assert.assertTrue(configuration.isPropertyDefined('dockerImage'))
-        Assert.assertFalse(configuration.isPropertyDefined('something'))
-    }
-
-    @Test
     void testGetPropertyNestedLeafNodeIsString() {
-        def configuration = new ConfigurationHelper([a:[b: 'c']])
-        assertThat(configuration.getConfigProperty('a/b'), is('c'))
+        assertThat(ConfigurationHelper.getConfigPropertyNested([a:[b: 'c']], 'a/b'), is('c'))
     }
 
     @Test
     void testGetPropertyNestedLeafNodeIsMap() {
-        def configuration = new ConfigurationHelper([a:[b: [c: 'd']]])
-        assertThat(configuration.getConfigProperty('a/b'), is([c: 'd']))
+        assertThat(ConfigurationHelper.getConfigPropertyNested([a:[b: [c: 'd']]], 'a/b'), is([c: 'd']))
     }
 
     @Test
     void testGetPropertyNestedPathNotFound() {
-        def configuration = new ConfigurationHelper([a:[b: 'c']])
-        assertThat(configuration.getConfigProperty('a/c'), is((nullValue())))
+        assertThat(ConfigurationHelper.getConfigPropertyNested([a:[b: 'c']], 'a/c'), is((nullValue())))
     }
 
     void testGetPropertyNestedPathStartsWithTokenizer() {
-        def configuration = new ConfigurationHelper([k:'v'])
-        assertThat(configuration.getConfigProperty('/k'), is(('v')))
+        assertThat(ConfigurationHelper.getConfigPropertyNested([k:'v'], '/k'), is(('v')))
     }
 
     @Test
     void testGetPropertyNestedPathEndsWithTokenizer() {
-        def configuration = new ConfigurationHelper([k:'v'])
-        assertThat(configuration.getConfigProperty('k/'), is(('v')))
+        assertThat(ConfigurationHelper.getConfigPropertyNested([k:'v'], 'k/'), is(('v')))
     }
 
     @Test
     void testGetPropertyNestedPathManyTokenizer() {
-        def configuration = new ConfigurationHelper([k1:[k2 : 'v']])
-        assertThat(configuration.getConfigProperty('///k1/////k2///'), is(('v')))
-    }
-
-    @Test
-    void testIsPropertyDefined() {
-        def configuration = new ConfigurationHelper(getConfiguration())
-        Assert.assertTrue(configuration.isPropertyDefined('dockerImage'))
-        Assert.assertFalse(configuration.isPropertyDefined('something'))
-    }
-
-    @Test
-    void testIsPropertyDefinedWithInteger() {
-        def configuration = new ConfigurationHelper([dockerImage: 3])
-        Assert.assertTrue(configuration.isPropertyDefined('dockerImage'))
-    }
-
-    @Test
-    void testGetMandatoryProperty() {
-        def configuration = new ConfigurationHelper(getConfiguration())
-        Assert.assertEquals('maven:3.2-jdk-8-onbuild', configuration.getMandatoryProperty('dockerImage'))
-        Assert.assertEquals('default', configuration.getMandatoryProperty('something', 'default'))
-
-        GroovyAssert.shouldFail { configuration.getMandatoryProperty('something') }
+        assertThat(ConfigurationHelper.getConfigPropertyNested([k1:[k2 : 'v']], '///k1/////k2///'), is(('v')))
     }
 
     @Test


### PR DESCRIPTION
it is the duty of the configuration helper to build a map
providing the configuration. Having facilites to use the
ConfigurationHelper as some kind of configuration registry
makes life more complicated.

Is there any use-case for having the ConfigurationHelper
as configuration registry?

If not we should make the getConfigProperty methods
private.

And: yes, I know about the bug that private fields and
method are not really private in groovy ...