### PR TITLE
Introduce CredentialsRule

### DIFF
--- a/test/groovy/CheckChangeInDevelopmentTest.groovy
+++ b/test/groovy/CheckChangeInDevelopmentTest.groovy
@@ -11,6 +11,7 @@ import com.sap.piper.cm.ChangeManagementException
 
 import hudson.AbortException
 import util.BasePiperTest
+import util.JenkinsCredentialsRule
 import util.JenkinsStepRule
 import util.Rules
 
@@ -24,18 +25,8 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
         .getCommonRules(this)
         .around(thrown)
         .around(jsr)
-
-    @Before
-    public void setup() {
-        helper.registerAllowedMethod('usernamePassword', [Map], { Map m ->
-            binding.setProperty('username', 'defaultUser')
-            binding.setProperty('password', '********')
-        })
-
-        helper.registerAllowedMethod('withCredentials', [List, Closure], { List l, Closure c ->
-            c()
-        })
-    }
+        .around(new JenkinsCredentialsRule(this)
+            .withCredentials('CM', 'anonymous', '********'))
 
     @After
     public void tearDown() {
@@ -57,7 +48,7 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
         assert cmUtilReceivedParams == [
             changeId: '001',
             endpoint: 'https://example.org/cm',
-            userName: 'defaultUser',
+            userName: 'anonymous',
             password: '********',
             cmclientOpts: null
         ]

--- a/test/groovy/TransportRequestCreateTest.groovy
+++ b/test/groovy/TransportRequestCreateTest.groovy
@@ -8,6 +8,7 @@ import com.sap.piper.cm.ChangeManagement
 import com.sap.piper.cm.ChangeManagementException
 
 import util.BasePiperTest
+import util.JenkinsCredentialsRule
 import util.JenkinsStepRule
 import util.JenkinsLoggingRule
 import util.Rules
@@ -26,26 +27,11 @@ public class TransportRequestCreateTest extends BasePiperTest {
         .around(thrown)
         .around(jsr)
         .around(jlr)
+        .around(new JenkinsCredentialsRule(this)
+            .withCredentials('CM', 'anonymous', '********'))
 
     @Before
     public void setup() {
-
-        helper.registerAllowedMethod('usernamePassword', [Map.class], {m -> return m})
-
-        helper.registerAllowedMethod('withCredentials', [List, Closure], { l, c ->
-
-            credentialsId = l[0].credentialsId
-            binding.setProperty('username', 'anonymous')
-            binding.setProperty('password', '********')
-            try {
-                c()
-            } finally {
-                binding.setProperty('username', null)
-                binding.setProperty('password', null)
-            }
-         })
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> return 0 })
 
         nullScript.commonPipelineEnvironment.configuration = [steps:
                                      [transportRequestCreate:

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -5,6 +5,7 @@ import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
 
 import util.BasePiperTest
+import util.JenkinsCredentialsRule
 import util.JenkinsStepRule
 import util.JenkinsLoggingRule
 import util.Rules
@@ -23,26 +24,11 @@ public class TransportRequestReleaseTest extends BasePiperTest {
         .around(thrown)
         .around(jsr)
         .around(jlr)
+        .around(new JenkinsCredentialsRule(this)
+            .withCredentials('CM', 'anonymous', '********'))
 
     @Before
     public void setup() {
-
-        helper.registerAllowedMethod('usernamePassword', [Map.class], {m -> return m})
-
-        helper.registerAllowedMethod('withCredentials', [List, Closure], { l, c ->
-
-            credentialsId = l[0].credentialsId
-            binding.setProperty('username', 'anonymous')
-            binding.setProperty('password', '********')
-            try {
-                c()
-            } finally {
-                binding.setProperty('username', null)
-                binding.setProperty('password', null)
-            }
-         })
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> return 0 })
 
         nullScript.commonPipelineEnvironment.configuration = [steps:
                                      [transportRequestRelease:

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -8,6 +8,7 @@ import com.sap.piper.cm.ChangeManagement
 import com.sap.piper.cm.ChangeManagementException
 
 import util.BasePiperTest
+import util.JenkinsCredentialsRule
 import util.JenkinsStepRule
 import util.JenkinsLoggingRule
 import util.Rules
@@ -26,26 +27,11 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
         .around(thrown)
         .around(jsr)
         .around(jlr)
+        .around(new JenkinsCredentialsRule(this)
+            .withCredentials('CM', 'anonymous', '********'))
 
     @Before
     public void setup() {
-
-        helper.registerAllowedMethod('usernamePassword', [Map.class], {m -> return m})
-
-        helper.registerAllowedMethod('withCredentials', [List, Closure], { l, c ->
-
-            credentialsId = l[0].credentialsId
-            binding.setProperty('username', 'anonymous')
-            binding.setProperty('password', '********')
-            try {
-                c()
-            } finally {
-                binding.setProperty('username', null)
-                binding.setProperty('password', null)
-            }
-         })
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> return 0 })
 
         nullScript.commonPipelineEnvironment.configuration = [steps:
                                      [transportRequestUploadFile:

--- a/test/groovy/util/JenkinsCredentialsRule.groovy
+++ b/test/groovy/util/JenkinsCredentialsRule.groovy
@@ -1,0 +1,74 @@
+package util
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+
+import org.junit.Assert
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.not
+import static org.hamcrest.Matchers.nullValue
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Matchers
+
+/**
+ * By default a user &quot;anonymous&quot; with password &quot;********&quot;
+ * is provided.
+ *
+ */
+class JenkinsCredentialsRule implements TestRule {
+
+    Map credentials = [:]
+
+    final BasePipelineTest testInstance
+
+    JenkinsCredentialsRule(BasePipelineTest testInstance) {
+        this.testInstance = testInstance
+    }
+
+    JenkinsCredentialsRule withCredentials(String credentialsId, String user, String passwd) {
+        credentials.put(credentialsId, [user: user, passwd: passwd])
+        return this
+    }
+
+    @Override
+    Statement apply(Statement base, Description description) {
+        return statement(base)
+    }
+
+    private Statement statement(final Statement base) {
+
+        return new Statement() {
+
+            @Override
+            void evaluate() throws Throwable {
+
+                testInstance.helper.registerAllowedMethod('usernamePassword', [Map.class], {m -> return m})
+
+                testInstance.helper.registerAllowedMethod('withCredentials', [List, Closure], { l, c ->
+
+                    def credsId = l[0].credentialsId
+                    def creds = credentials.get(credsId)
+
+                    assertThat("Unexpected credentialsId received: '${credsId}'.",
+                        creds, is(not(nullValue())))
+
+                    binding.setProperty('username', creds?.user)
+                    binding.setProperty('password', creds?.passwd)
+                    try {
+                        c()
+                    } finally {
+                        binding.setProperty('username', null)
+                        binding.setProperty('password', null)
+                    }
+                })
+
+             base.evaluate()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Instead of configuring the credentials setup

  o withCredentials
  o usename

in each of our tests (for the moment change-management related)
we collect the common coding in a JUnitRule.