### PR TITLE
decouple tests

### DIFF
--- a/test/groovy/TransportRequestCreateTest.groovy
+++ b/test/groovy/TransportRequestCreateTest.groovy
@@ -45,8 +45,6 @@ public class TransportRequestCreateTest extends BasePiperTest {
             }
          })
 
-        helper.registerAllowedMethod('sh', [Map], { Map m -> return 0 })
-
         nullScript.commonPipelineEnvironment.configuration = [steps:
                                      [transportRequestCreate:
                                          [

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -42,8 +42,6 @@ public class TransportRequestReleaseTest extends BasePiperTest {
             }
          })
 
-        helper.registerAllowedMethod('sh', [Map], { Map m -> return 0 })
-
         nullScript.commonPipelineEnvironment.configuration = [steps:
                                      [transportRequestRelease:
                                          [

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -45,8 +45,6 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
             }
          })
 
-        helper.registerAllowedMethod('sh', [Map], { Map m -> return 0 })
-
         nullScript.commonPipelineEnvironment.configuration = [steps:
                                      [transportRequestUploadFile:
                                          [

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -134,7 +134,11 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         helper.registerAllowedMethod('sh', [Map], { Map m -> return 0 })
 
-        jsr.step.call(script: nullScript, changeDocumentId: '001', transportRequestId: '001', applicationId: 'app', filePath: '/path')
+        jsr.step.call(script: nullScript,
+                      changeDocumentId: '001',
+                      transportRequestId: '001',
+                      applicationId: 'app',
+                      filePath: '/path')
 
         assert jlr.log.contains("[INFO] Uploading file '/path' to transport request '001' of change document '001'.")
         assert jlr.log.contains("[INFO] File '/path' has been successfully uploaded to transport request '001' of change document '001'.")

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -202,6 +202,24 @@ public void testGetCommandLineWithCMClientOpts() {
         // the command line.
     }
 
+    @Test
+    public void testUploadFileToTransportFails() {
+
+        thrown.expect(ChangeManagementException)
+        thrown.expectMessage("Cannot upload file '/path' for change document '001' with transport request '002'. " +
+            "Return code from cmclient: 1.")
+
+        script.setReturnValue(JenkinsShellCallRule.Type.REGEX,, 'upload-file-to-transport', 1)
+
+        new ChangeManagement(nullScript).uploadFileToTransportRequest('001',
+            '002',
+            'XXX',
+            '/path',
+            'https://example.org/cm',
+            'me',
+            'openSesame')
+    }
+
     private GitUtils gitUtilsMock(boolean insideWorkTree, String[] changeIds) {
         return new GitUtils() {
             public boolean insideWorkTree() {


### PR DESCRIPTION
Up to now the upload file to transport step tested the step itself and also the ChangeManagment utils class. With that change we ensure a clear focus to one class under test. There are the tests in the default package testing the step itself. Beside that there is a dedicated test class for the ChangeManagment utils class.