### PR TITLE
Remove the NEO version check

### DIFF
--- a/src/com/sap/piper/VersionUtils.groovy
+++ b/src/com/sap/piper/VersionUtils.groovy
@@ -35,13 +35,31 @@ class VersionUtils implements Serializable {
         script.echo "Verification success. $name version ${installedVersion.toString()} is installed."
     }
 
+    def static verifyVersion(script, name, String versionDesc, String versionExpected) {
+      
+        script.echo "Verifying $name version $versionExpected or compatible version."
+      
+        Version versionAvailable = new Version(versionDesc)
+        
+        if  (!versionAvailable.isCompatibleVersion(new Version(versionExpected))) {
+            throw new AbortException("The installed version of $name is ${versionAvailable.toString()}. Please install version $versionExpected or a compatible version.")
+        }
+        script.echo "Verification success. $name version ${versionAvailable.toString()} is installed."
+    }
+      
+      
     def static verifyVersion(script, name, executable, Map versions, versionOption) {
 
-        def toolVersion = getVersionDesc(script, name, executable, versionOption)
+        def versionDesc = getVersionDesc(script, name, executable, versionOption)
           
+        verifyVersion(script, name, versionDesc, versions)
+    }
+    
+    def static verifyVersion(script, name, String versionDesc, Map versions) {
+
         for (def entry : versions) {
-            if (toolVersion.contains(entry.getKey())) {
-                def installedVersion = new Version(toolVersion)
+            if (versionDesc.contains(entry.getKey())) {
+                def installedVersion = new Version(versionDesc)
                 def expectedVersion = entry.getValue()
                 script.echo "Verifying $name version $expectedVersion or compatible version."
                 if (!installedVersion.isCompatibleVersion(new Version(expectedVersion))) {

--- a/src/com/sap/piper/tools/ToolDescriptor.groovy
+++ b/src/com/sap/piper/tools/ToolDescriptor.groovy
@@ -108,8 +108,9 @@ class ToolDescriptor implements Serializable {
     def verifyVersion(script, configuration) {
 
         def executable = getToolExecutable(script, configuration, false)
-        if (singleVersion) VersionUtils.verifyVersion(script, name, executable, singleVersion, versionOption)
-        if (multipleVersions) VersionUtils.verifyVersion(script, name, executable, multipleVersions, versionOption)
+        def versionDesc = VersionUtils.getVersionDesc(script, name, executable, versionOption)
+        if (singleVersion) VersionUtils.verifyVersion(script, name, versionDesc, singleVersion)
+        if (multipleVersions) VersionUtils.verifyVersion(script, name, versionDesc, multipleVersions)
     }
 
     def getMessage() {

--- a/test/groovy/ToolValidateTest.groovy
+++ b/test/groovy/ToolValidateTest.groovy
@@ -145,17 +145,6 @@ class ToolValidateTest extends BasePiperTest {
     }
 
     @Test
-    void validateNeoIncompatibleVersionTest() {
-
-        thrown.expect(AbortException)
-        thrown.expectMessage('The installed version of SAP Cloud Platform Console Client is 1.126.51.')
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> getIncompatibleVersion(m) })
-
-        jsr.step.call(tool: 'neo', home: home)
-    }
-
-    @Test
     void validateCmIncompatibleVersionTest() {
 
         thrown.expect(AbortException)
@@ -195,9 +184,6 @@ class ToolValidateTest extends BasePiperTest {
         helper.registerAllowedMethod('sh', [Map], { Map m -> getVersion(m) })
 
         jsr.step.call(tool: 'neo', home: home)
-
-        assert jlr.log.contains('Verifying SAP Cloud Platform Console Client version 3.39.10 or compatible version.')
-        assert jlr.log.contains('SAP Cloud Platform Console Client version 3.39.10 is installed.')
     }
 
     @Test

--- a/test/groovy/com/sap/piper/VersionUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/VersionUtilsTest.groovy
@@ -1,0 +1,83 @@
+package com.sap.piper
+
+import hudson.AbortException
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.rules.RuleChain
+import util.BasePiperTest
+import util.JenkinsShellCallRule
+import util.Rules
+
+import static org.junit.Assert.assertEquals
+import static org.hamcrest.Matchers.equalTo
+import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.notNullValue
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertThat
+
+class VersionUtilsTest extends BasePiperTest {
+
+    ExpectedException thrown = ExpectedException.none()
+
+    @Rule
+    public RuleChain ruleChain = Rules.getCommonRules(this).around(thrown)
+
+    @Before
+    void init() throws Exception {
+    }
+
+    @Test
+    void test_if_getVersionDesc_returns_desc() {
+        helper.registerAllowedMethod('sh', [Map], { Map m -> return 'SAP Cloud Platform Console Client\n\n\nSDK version    : 2.129.5.1\nRuntime        : neo-javaee6-wp\n'}) 
+       
+        assertEquals('SAP Cloud Platform Console Client\n\n\nSDK version    : 2.129.5.1\nRuntime        : neo-javaee6-wp\n',VersionUtils.getVersionDesc(nullScript, "test", "test.sh", "version"))
+    }
+
+    @Test
+    void test_if_getVersion_returns_version() {
+        helper.registerAllowedMethod('sh', [Map], { Map m -> return 'SAP Cloud Platform Console Client\n\n\nSDK version    : 2.129.5.1\nRuntime        : neo-javaee6-wp\n'}) 
+       
+        assertEquals(new Version('2.129.5.1'),VersionUtils.getVersion(nullScript, "test", "test.sh", "version"))
+    }
+
+    @Test
+    void test_if_verifyVersion_succeeds_compatible() {
+        helper.registerAllowedMethod('sh', [Map], { Map m -> return 'version : 1.0.0\runtime: key' })
+        VersionUtils.verifyVersion(nullScript, "test", "test.sh", '1.0.0', "version")
+    }
+    
+    @Test
+    void test_if_verifyVersion_fails_incompatible() {
+        helper.registerAllowedMethod('sh', [Map], { Map m -> return 'version : 1.0.0\runtime: key' })
+        
+        thrown.expect(AbortException)
+        thrown.expectMessage("The installed version of test is 1.0.0. Please install version 1.0.1 or a compatible version.")
+
+        VersionUtils.verifyVersion(nullScript, "test", "test.sh", '1.0.1', "version")
+    }
+
+    @Test
+    void test_if_verifyVersion_map_succeeds_compatible() {
+        Map versionMap = ['key1': '1.0.0', 'key2': '2.0.0', 'key3': '3.0.0']
+        helper.registerAllowedMethod('sh', [Map], { Map m -> return 'version : 1.0.0\runtime: key1' })
+        VersionUtils.verifyVersion(nullScript, "test", "test.sh", versionMap, "version")
+    }
+    
+    @Test
+    void test_if_verifyVersion_map_fails_incompatible() {
+        Map versionMap = ['key1': '1.0.1', 'key2': '2.0.1', 'key3': '3.0.1']
+        helper.registerAllowedMethod('sh', [Map], { Map m -> return 'version : 1.0.0\runtime: key1' })
+        
+        thrown.expect(AbortException)
+        thrown.expectMessage("The installed version of test is 1.0.0. Please install version 1.0.1 or a compatible version.")
+        
+        VersionUtils.verifyVersion(nullScript, "test", "test.sh", versionMap, "version")
+    }
+    
+
+}

--- a/test/groovy/com/sap/piper/tools/ToolDescriptorTest.groovy
+++ b/test/groovy/com/sap/piper/tools/ToolDescriptorTest.groovy
@@ -193,6 +193,17 @@ class ToolDescriptorTest extends BasePiperTest {
         tool.verifyVersion(script, configuration)
     }
 
+    @Test
+    void verifyToolVersion_without_version_check() {
+
+        def tool = new ToolDescriptor('SAP Cloud Platform Console Client', 'NEO_HOME', 'neoHome', '/tools/', 'neo.sh', null, 'version')
+
+        helper.registerAllowedMethod('sh', [Map], { Map m -> getVersion(m) })
+
+        tool.verifyVersion(script, configuration)
+    }
+
+
 
     private getEnvVars(Map m) {
 

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -148,8 +148,7 @@ def call(parameters = [:]) {
             deployAccount = utils.getMandatoryParameter(configuration, 'account')
         }
 
-        def neoVersions = ['neo-java-web': '3.39.10', 'neo-javaee6-wp': '2.132.6', 'neo-javaee7-wp': '1.21.13']
-        def neo = new ToolDescriptor('SAP Cloud Platform Console Client', 'NEO_HOME', 'neoHome', '/tools/', 'neo.sh', neoVersions, 'version')
+        def neo = new ToolDescriptor('SAP Cloud Platform Console Client', 'NEO_HOME', 'neoHome', '/tools/', 'neo.sh', null, 'version')
         def neoExecutable = neo.getToolExecutable(this, configuration)
         def neoDeployScript = """#!/bin/bash
                                  "${neoExecutable}" ${warAction} \

--- a/vars/toolValidate.groovy
+++ b/vars/toolValidate.groovy
@@ -31,8 +31,7 @@ def call(Map parameters = [:]) {
                 mta.verifyVersion(this, [mtaJarLocation: home])
                 return
             case 'neo':
-                def neoVersions = ['neo-java-web': '3.39.10', 'neo-javaee6-wp': '2.132.6', 'neo-javaee7-wp': '1.21.13']
-                def neo = new ToolDescriptor('SAP Cloud Platform Console Client', 'NEO_HOME', 'neoHome', '/tools/', 'neo.sh', neoVersions, 'version')
+                def neo = new ToolDescriptor('SAP Cloud Platform Console Client', 'NEO_HOME', 'neoHome', '/tools/', 'neo.sh', null, 'version')
                 neo.verifyVersion(this, [neoHome: home])
                 return
             case 'cm':


### PR DESCRIPTION
We agreed that the version of the neo image we are going to use (latest) will be compatible per definition. If not, the customer can configure a certain version.
#26

