### PR TITLE
[fix] Remove early check for mandatory param 'changeDocumentId'

### DIFF
--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -57,7 +57,7 @@ public class TransportRequestReleaseTest extends BasePiperTest {
         }
 
         thrown.expect(IllegalArgumentException)
-        thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR changeDocumentId")
+        thrown.expectMessage("Change document id not provided (parameter: 'changeDocumentId' or via commit history).")
 
         jsr.step.call(script: nullScript, transportRequestId: '001', cmUtils: cm)
     }

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -43,7 +43,6 @@ def call(parameters = [:]) {
                             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, stepConfigurationKeys)
                             .mixinStepConfig(script.commonPipelineEnvironment, stepConfigurationKeys)
                             .mixin(parameters, parameterKeys)
-                            .withMandatoryProperty('changeDocumentId')
                             .withMandatoryProperty('endpoint')
 
         Map configuration = configHelper.use()


### PR DESCRIPTION
otherwise we will never try to read the change document id from commit history.