### PR TITLE
Do not fail immediatly in case commit history does not contain a chan…

### DIFF
--- a/test/groovy/CheckChangeInDevelopmentTest.groovy
+++ b/test/groovy/CheckChangeInDevelopmentTest.groovy
@@ -103,8 +103,9 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
     @Test
     public void changeDocumentIdRetrievalFailsTest() {
 
-        thrown.expect(AbortException)
-        thrown.expectMessage('Something went wrong')
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage("No changeDocumentId provided. Neither via parameter 'changeDocumentId' nor via " +
+                             "label 'ChangeDocument\\s?:' in commit range [from: origin/master, to: HEAD].")
 
         ChangeManagement cm = new ChangeManagement(nullScript, null) {
 

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -65,7 +65,7 @@ def call(parameters = [:]) {
                     echo "[INFO] ChangeDocumentId '${changeId}' retrieved from commit history"
                 }
             } catch(ChangeManagementException ex) {
-                throw new AbortException(ex.getMessage())
+                echo "[WARN] Cannot retrieve changeDocumentId from commit history: ${ex.getMessage()}."
             }
         }
 


### PR DESCRIPTION
…geDocumentId

we emit a log message and fail later at withManadotoryProperty check.