### PR TITLE
Improve check for batch mode in mavenExecute

### DIFF
--- a/test/groovy/MavenExecuteTest.groovy
+++ b/test/groovy/MavenExecuteTest.groovy
@@ -9,10 +9,12 @@ import util.Rules
 
 import static org.hamcrest.Matchers.allOf
 import static org.hamcrest.Matchers.containsString
-import static org.hamcrest.Matchers.not
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertTrue
+
+import org.hamcrest.Matchers
+import org.junit.Assert
 
 class MavenExecuteTest extends BasePiperTest {
 
@@ -89,17 +91,5 @@ class MavenExecuteTest extends BasePiperTest {
         assertThat(jscr.shell[0],
             allOf(containsString('-Blah'),
                   containsString('--batch-mode')))
-    }
-
-    @Test
-    void testMavenCommandWithMultiLineFlags() throws Exception {
-        jsr.step.mavenExecute(script: nullScript, goals: 'clean install', flags: '-B\n--version')
-        assertEquals('maven:3.5-jdk-7', jder.dockerParams.dockerImage)
-
-        assertThat(jscr.shell[0],
-            allOf(containsString('-B'),
-                containsString('--version')))
-
-        assertThat(jscr.shell[0], not(containsString('--batch-mode')))
     }
 }

--- a/test/groovy/MavenExecuteTest.groovy
+++ b/test/groovy/MavenExecuteTest.groovy
@@ -63,10 +63,17 @@ class MavenExecuteTest extends BasePiperTest {
 
     @Test
     void testMavenCommandForwardsDockerOptions() throws Exception {
-
         jsr.step.mavenExecute(script: nullScript, goals: 'clean install')
         assertEquals('maven:3.5-jdk-7', jder.dockerParams.dockerImage)
 
-        assert jscr.shell[0] == 'mvn --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install'
+        assertEquals('mvn --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install', jscr.shell[0])
+    }
+
+    @Test
+    void testMavenCommandWithShortBatchModeFlag() throws Exception {
+        jsr.step.mavenExecute(script: nullScript, goals: 'clean install', flags: '-B')
+        assertEquals('maven:3.5-jdk-7', jder.dockerParams.dockerImage)
+
+        assertEquals('mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install', jscr.shell[0])
     }
 }

--- a/test/groovy/MavenExecuteTest.groovy
+++ b/test/groovy/MavenExecuteTest.groovy
@@ -9,12 +9,10 @@ import util.Rules
 
 import static org.hamcrest.Matchers.allOf
 import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.not
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertTrue
-
-import org.hamcrest.Matchers
-import org.junit.Assert
 
 class MavenExecuteTest extends BasePiperTest {
 
@@ -91,5 +89,17 @@ class MavenExecuteTest extends BasePiperTest {
         assertThat(jscr.shell[0],
             allOf(containsString('-Blah'),
                   containsString('--batch-mode')))
+    }
+
+    @Test
+    void testMavenCommandWithMultiLineFlags() throws Exception {
+        jsr.step.mavenExecute(script: nullScript, goals: 'clean install', flags: '-B\n--version')
+        assertEquals('maven:3.5-jdk-7', jder.dockerParams.dockerImage)
+
+        assertThat(jscr.shell[0],
+            allOf(containsString('-B'),
+                containsString('--version')))
+
+        assertThat(jscr.shell[0], not(containsString('--batch-mode')))
     }
 }

--- a/vars/mavenExecute.groovy
+++ b/vars/mavenExecute.groovy
@@ -67,7 +67,7 @@ def call(Map parameters = [:]) {
         }
 
         // Always use Maven's batch mode
-        if (!(command.contains('-B') || command.contains('--batch-mode'))){
+        if (!(command =~ /--batch-mode|-B(?=\s)|-B$/)) {
             command += ' --batch-mode'
         }
 


### PR DESCRIPTION
The old naive check fails if an argument starts with '-B'. Now we use a
regular expression, which should correctly match if batch mode was
already supplied, and add it if not.