### PR TITLE
Remove tool descriptor from neo deploy and config the neo docker image

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -85,6 +85,7 @@ steps:
     buildTarget: 'NEO'
     mtaJarLocation: 'mta.jar'
   neoDeploy:
+    dockerImage: 's4sdk/docker-neo-cli'
     deployMode: 'mta'
     warAction: 'deploy'
     vmSize: 'lite'

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -100,7 +100,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh deploy-mta")
                                     .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                                     .hasSingleQuotedOption('account', 'trialuser123')
                                     .hasOption('synchronous', '')
@@ -118,7 +118,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh deploy-mta")
                                     .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                                     .hasSingleQuotedOption('account', 'trialuser123')
                                     .hasOption('synchronous', '')
@@ -142,7 +142,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh deploy-mta")
                                     .hasSingleQuotedOption('host', 'configuration-frwk\\.deploy\\.host\\.com')
                                     .hasSingleQuotedOption('account', 'configurationFrwkUser123')
                                     .hasOption('synchronous', '')
@@ -173,75 +173,13 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh deploy-mta")
                                     .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                                     .hasSingleQuotedOption('account', 'trialuser123')
                                     .hasOption('synchronous', '')
                                     .hasSingleQuotedOption('user', 'defaultUser')
                                     .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
                                     .hasDoubleQuotedOption('source', '.*'))
-    }
-
-
-    @Test
-    void neoHomeNotSetTest() {
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> getVersionWithPath(m) })
-
-        jsr.step.call(script: nullScript,
-                       archivePath: archiveName
-        )
-
-        assert jscr.shell.find { c -> c.contains('"neo.sh" deploy-mta') }
-        assert jlr.log.contains('SAP Cloud Platform Console Client is on PATH.')
-        assert jlr.log.contains("Using SAP Cloud Platform Console Client 'neo.sh'.")
-    }
-
-
-    @Test
-    void neoHomeAsParameterTest() {
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> getVersionWithPath(m) })
-
-        jsr.step.call(script: nullScript,
-                       archivePath: archiveName,
-                       neoCredentialsId: 'myCredentialsId',
-                       neoHome: '/param/neo'
-        )
-
-        assert jscr.shell.find{ c -> c = "\"/param/neo/tools/neo.sh\" deploy-mta" }
-        assert jlr.log.contains("SAP Cloud Platform Console Client home '/param/neo' retrieved from configuration.")
-        assert jlr.log.contains("Using SAP Cloud Platform Console Client '/param/neo/tools/neo.sh'.")
-    }
-
-
-    @Test
-    void neoHomeFromEnvironmentTest() {
-
-        jsr.step.call(script: nullScript,
-                       archivePath: archiveName
-        )
-
-        assert jscr.shell.find { c -> c.contains("\"/opt/neo/tools/neo.sh\" deploy-mta")}
-        assert jlr.log.contains("SAP Cloud Platform Console Client home '/opt/neo' retrieved from environment.")
-        assert jlr.log.contains("Using SAP Cloud Platform Console Client '/opt/neo/tools/neo.sh'.")
-    }
-
-
-    @Test
-    void neoHomeFromCustomStepConfigurationTest() {
-
-        helper.registerAllowedMethod('sh', [Map], { Map m -> getVersionWithPath(m) })
-
-        nullScript.commonPipelineEnvironment.configuration = [steps:[neoDeploy: [host: 'test.deploy.host.com', account: 'trialuser123', neoHome: '/config/neo']]]
-
-        jsr.step.call(script: nullScript,
-                       archivePath: archiveName
-        )
-
-        assert jscr.shell.find { c -> c = "\"/config/neo/tools/neo.sh\" deploy-mta"}
-        assert jlr.log.contains("SAP Cloud Platform Console Client home '/config/neo' retrieved from configuration.")
-        assert jlr.log.contains("Using SAP Cloud Platform Console Client '/config/neo/tools/neo.sh'.")
     }
 
 
@@ -283,7 +221,7 @@ class NeoDeployTest extends BasePiperTest {
         jsr.step.call(script: nullScript, archivePath: archiveName, deployMode: 'mta')
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh deploy-mta")
                                     .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                                     .hasSingleQuotedOption('account', 'trialuser123')
                                     .hasOption('synchronous', '')
@@ -306,7 +244,7 @@ class NeoDeployTest extends BasePiperTest {
                              archivePath: warArchiveName)
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh deploy")
                                     .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                                     .hasSingleQuotedOption('account', 'trialuser123')
                                     .hasSingleQuotedOption('application', 'testApp')
@@ -332,7 +270,7 @@ class NeoDeployTest extends BasePiperTest {
                              vmSize: 'lite')
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" rolling-update")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh rolling-update")
                                     .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                                     .hasSingleQuotedOption('account', 'trialuser123')
                                     .hasSingleQuotedOption('application', 'testApp')
@@ -358,7 +296,7 @@ class NeoDeployTest extends BasePiperTest {
                              vmSize: 'lite')
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh deploy")
                                     .hasArgument("config.properties")
                                     .hasSingleQuotedOption('user', 'defaultUser')
                                     .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
@@ -379,7 +317,7 @@ class NeoDeployTest extends BasePiperTest {
                              vmSize: 'lite')
 
         Assert.assertThat(jscr.shell,
-            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" rolling-update")
+            new CommandLineMatcher().hasProlog("#!/bin/bash neo.sh rolling-update")
                                     .hasArgument('config.properties')
                                     .hasSingleQuotedOption('user', 'defaultUser')
                                     .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
@@ -536,11 +474,7 @@ class NeoDeployTest extends BasePiperTest {
 
         if(m.script.contains('JAVA_HOME')) {
             return '/opt/java'
-        } else if(m.script.contains('NEO_HOME')) {
-            return '/opt/neo'
         } else if (m.script.contains('which java')) {
-            return 0
-        } else if (m.script.contains('which neo')) {
             return 0
         } else {
             return 0
@@ -551,11 +485,7 @@ class NeoDeployTest extends BasePiperTest {
 
         if(m.script.contains('JAVA_HOME')) {
             return ''
-        } else if(m.script.contains('NEO_HOME')) {
-            return ''
         } else if (m.script.contains('which java')) {
-            return 0
-        } else if (m.script.contains('which neo')) {
             return 0
         } else {
             return 0


### PR DESCRIPTION
The implementation of neo as a ToolDescriptor is not necessary. The version check was already dropped, so only the creation of the executable path remained. Since the neo executable is expected on the path it can be dropped too.  
