### PR TITLE
ConfigurationHelper: add condition to withMandatoryProperty

### DIFF
--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -162,8 +162,13 @@ class ConfigurationHelper implements Serializable {
         return paramValue
     }
 
-    def withMandatoryProperty(key, errorMessage = null){
-        getMandatoryProperty(key, null, errorMessage)
+    def withMandatoryProperty(key, errorMessage = null, condition = null){
+        if(condition){
+            if(condition(this.config))
+                getMandatoryProperty(key, null, errorMessage)
+        }else{
+            getMandatoryProperty(key, null, errorMessage)
+        }
         return this
     }
 }

--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -253,7 +253,7 @@ class ConfigurationHelperTest {
     public void testWithMandoryWithFalseCondition() {
         thrown.none()
 
-        new ConfigurationHelper([enforce: false]).withMandatoryProperty('missingKey', null, {c -> return c.enforce})
+        new ConfigurationHelper([enforce: false]).withMandatoryProperty('missingKey', null, {c -> return c.get('execute')})
     }
 
     @Test
@@ -261,7 +261,7 @@ class ConfigurationHelperTest {
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR missingKey')
         
-        new ConfigurationHelper([enforce: true]).withMandatoryProperty('missingKey', null, {c -> return c.execute})
+        new ConfigurationHelper([enforce: true]).withMandatoryProperty('missingKey', null, {c -> return c.get('execute')})
     }
 
     @Test
@@ -269,7 +269,7 @@ class ConfigurationHelperTest {
         thrown.none()
         
         def config = new ConfigurationHelper([existingKey: 'anyValue', enforce: true])
-            .withMandatoryProperty('existingKey', null, {c -> return c.execute})
+            .withMandatoryProperty('existingKey', null, {c -> return c.get('execute')})
             .use()
         
         Assert.assertThat(config.size(), is(2))

--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -251,9 +251,8 @@ class ConfigurationHelperTest {
 
     @Test
     public void testWithMandoryWithFalseCondition() {
-        thrown.none()
-
-        new ConfigurationHelper([enforce: false]).withMandatoryProperty('missingKey', null, {c -> return c.get('execute')})
+        new ConfigurationHelper([verify: false])
+            .withMandatoryProperty('missingKey', null, { c -> return c.get('verify') })
     }
 
     @Test
@@ -261,17 +260,13 @@ class ConfigurationHelperTest {
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR missingKey')
         
-        new ConfigurationHelper([enforce: true]).withMandatoryProperty('missingKey', null, {c -> return c.get('execute')})
+        new ConfigurationHelper([verify: true])
+            .withMandatoryProperty('missingKey', null, { c -> return c.get('verify') })
     }
 
     @Test
     public void testWithMandoryWithTrueConditionExistingValue() {
-        thrown.none()
-        
-        def config = new ConfigurationHelper([existingKey: 'anyValue', enforce: true])
-            .withMandatoryProperty('existingKey', null, {c -> return c.get('execute')})
-            .use()
-        
-        Assert.assertThat(config.size(), is(2))
+        new ConfigurationHelper([existingKey: 'anyValue', verify: true])
+            .withMandatoryProperty('existingKey', null, { c -> return c.get('verify') })
     }
 }

--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -248,4 +248,30 @@ class ConfigurationHelperTest {
     public void testWithMandoryParameterDefaultCustomFailureMessageNotProvidedSucceeds() {
         new ConfigurationHelper([myKey: 'myValue']).withMandatoryProperty('myKey')
     }
+
+    @Test
+    public void testWithMandoryWithFalseCondition() {
+        thrown.none()
+
+        new ConfigurationHelper([enforce: false]).withMandatoryProperty('missingKey', null, {c -> return c.enforce})
+    }
+
+    @Test
+    public void testWithMandoryWithTrueConditionMissingValue() {
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR missingKey')
+        
+        new ConfigurationHelper([enforce: true]).withMandatoryProperty('missingKey', null, {c -> return c.execute})
+    }
+
+    @Test
+    public void testWithMandoryWithTrueConditionExistingValue() {
+        thrown.none()
+        
+        def config = new ConfigurationHelper([existingKey: 'anyValue', enforce: true])
+            .withMandatoryProperty('existingKey', null, {c -> return c.execute})
+            .use()
+        
+        Assert.assertThat(config.size(), is(2))
+    }
 }


### PR DESCRIPTION
With this change we can avoid coding like [this](https://github.com/SAP/jenkins-library/pull/183/files#diff-3ce088eec8992f06ecf9eddb854fe1d8R42)

and call it like this:

```
.mixin(parameters, PARAMETER_KEYS)
// check mandatory parameters
.withMandatoryProperty('changeId', { c -> return c.get('isVoter') })
.withMandatoryProperty('githubTokenCredentialsId', { c -> return c.get('isVoter') })
.withMandatoryProperty('githubOrg', { c -> return c.get('isVoter') })
.withMandatoryProperty('githubRepo', { c -> return c.get('isVoter') })
.withMandatoryProperty('projectVersion', { c -> return !c.get('isVoter') })
.use()
```

**changes**
- [x] extend `withMandatoryProperty` with conditional callback
- [x] tests