### PR TITLE
Take mtarFilePath in commonPipelineEnviroment into account

### DIFF
--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -182,6 +182,65 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     }
 
     @Test
+    public void uploadFileToTransportRequestFilePathFromParameters() {
+
+        // this one is not used when file path is provided via signature
+        nullScript.commonPipelineEnvironment.setMtarFilePath('/path2')
+
+        ChangeManagement cm = new ChangeManagement(nullScript) {
+            void uploadFileToTransportRequest(String changeId,
+                                              String transportRequestId,
+                                              String applicationId,
+                                              String filePath,
+                                              String endpoint,
+                                              String username,
+                                              String password,
+                                              String cmclientOpts) {
+
+                cmUtilReceivedParams.filePath = filePath
+            }
+        }
+
+        jsr.step.call(script: nullScript,
+                      changeDocumentId: '001',
+                      transportRequestId: '002',
+                      applicationId: 'app',
+                      filePath: '/path',
+                      cmUtils: cm)
+
+        assert cmUtilReceivedParams.filePath == '/path'
+    }
+
+    @Test
+    public void uploadFileToTransportRequestFilePathFromCommonPipelineEnvironment() {
+
+        // this one is used since there is nothing in the signature
+        nullScript.commonPipelineEnvironment.setMtarFilePath('/path2')
+
+        ChangeManagement cm = new ChangeManagement(nullScript) {
+            void uploadFileToTransportRequest(String changeId,
+                                              String transportRequestId,
+                                              String applicationId,
+                                              String filePath,
+                                              String endpoint,
+                                              String username,
+                                              String password,
+                                              String cmclientOpts) {
+
+                cmUtilReceivedParams.filePath = filePath
+            }
+        }
+
+        jsr.step.call(script: nullScript,
+                      changeDocumentId: '001',
+                      transportRequestId: '002',
+                      applicationId: 'app',
+                      cmUtils: cm)
+
+        assert cmUtilReceivedParams.filePath == '/path2'
+    }
+
+    @Test
     public void uploadFileToTransportRequestUploadFailureTest() {
 
         thrown.expect(AbortException)

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -37,6 +37,7 @@ def call(parameters = [:]) {
                                .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, stepConfigurationKeys)
                                .mixinStepConfig(script.commonPipelineEnvironment, stepConfigurationKeys)
                                .mixin(parameters, parameterKeys)
+                               .addIfEmpty('filePath', script.commonPipelineEnvironment.getMtarFilePath())
                                .withMandatoryProperty('applicationId')
                                .withMandatoryProperty('changeManagement/changeDocumentLabel')
                                .withMandatoryProperty('changeManagement/clientOpts')


### PR DESCRIPTION
This allows the steps to interact without using return values (which is not possible in
declarative pipelines). On the other hand we have depencencies between the steps based
on the status of the commonPipelineEnvironment.