### PR TITLE
[refactoring] streamline git calls

### DIFF
--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -79,9 +79,8 @@ class ArtifactSetVersionTest extends BasePiperTest {
         assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
         assertThat(jscr.shell, hasItem('git add .'))
         assertThat(jscr.shell, hasItem("git commit -m 'update version 1.2.3-20180101010203_testCommitId'"))
-        assertThat(jscr.shell, hasItems(containsString('git remote set-url origin myGitSshUrl'),
-                                        containsString('git tag build_1.2.3-20180101010203_testCommitId'),
-                                        containsString('git push origin build_1.2.3-20180101010203_testCommitId')))
+        assertThat(jscr.shell, hasItems(containsString('git tag build_1.2.3-20180101010203_testCommitId'),
+                                        containsString('git push myGitSshUrl build_1.2.3-20180101010203_testCommitId')))
     }
 
     @Test

--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -15,7 +15,11 @@ import util.JenkinsWriteFileRule
 import util.Rules
 
 import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.hasItems
+import static org.hamcrest.Matchers.notNullValue
+import static org.hamcrest.Matchers.containsString
 import static org.junit.Assert.assertThat
+
 import static org.junit.Assert.assertEquals
 
 class ArtifactSetVersionTest extends BasePiperTest {
@@ -75,9 +79,9 @@ class ArtifactSetVersionTest extends BasePiperTest {
         assertThat(jscr.shell, hasItem("mvn --file 'pom.xml' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101010203_testCommitId"))
         assertThat(jscr.shell, hasItem('git add .'))
         assertThat(jscr.shell, hasItem("git commit -m 'update version 1.2.3-20180101010203_testCommitId'"))
-        assertThat(jscr.shell, hasItem("git remote set-url origin myGitSshUrl"))
-        assertThat(jscr.shell, hasItem("git tag build_1.2.3-20180101010203_testCommitId"))
-        assertThat(jscr.shell, hasItem("git push origin build_1.2.3-20180101010203_testCommitId"))
+        assertThat(jscr.shell, hasItems(containsString('git remote set-url origin myGitSshUrl'),
+                                        containsString('git tag build_1.2.3-20180101010203_testCommitId'),
+                                        containsString('git push origin build_1.2.3-20180101010203_testCommitId')))
     }
 
     @Test

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -96,9 +96,10 @@ def call(Map parameters = [:], Closure body = null) {
                 } catch (e) {
                     error "[${STEP_NAME}]git commit failed: ${e}"
                 }
-                sh "git remote set-url origin ${config.gitSshUrl}"
-                sh "git tag ${config.tagPrefix}${newVersion}"
-                sh "git push origin ${config.tagPrefix}${newVersion}"
+                sh """#!/bin/bash
+                      git remote set-url origin ${config.gitSshUrl}
+                      git tag ${config.tagPrefix}${newVersion}
+                      git push origin ${config.tagPrefix}${newVersion}"""
 
                 config.gitCommitId = gitUtils.getGitCommitIdOrNull()
             }

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -97,9 +97,8 @@ def call(Map parameters = [:], Closure body = null) {
                     error "[${STEP_NAME}]git commit failed: ${e}"
                 }
                 sh """#!/bin/bash
-                      git remote set-url origin ${config.gitSshUrl}
                       git tag ${config.tagPrefix}${newVersion}
-                      git push origin ${config.tagPrefix}${newVersion}"""
+                      git push ${config.gitSshUrl} ${config.tagPrefix}${newVersion}"""
 
                 config.gitCommitId = gitUtils.getGitCommitIdOrNull()
             }


### PR DESCRIPTION
* Only one sh statement instead of three.
* No need to change the origin url and with that no footprint on the build servers git repo.

Integration test not performed so far, hence status is "in progress"

- [x] add tests: Tests adjusted according to refactoring
- [ ] add documentation: not needed, refactoring only
