### PR TITLE
neoDeploy with archvive from CPE

### DIFF
--- a/documentation/docs/steps/neoDeploy.md
+++ b/documentation/docs/steps/neoDeploy.md
@@ -24,7 +24,7 @@ needs to be extracted into the folder provided by `neoHome`. In case this parame
 | parameter          | mandatory | default                       | possible values                                 |
 | -------------------|-----------|-------------------------------|-------------------------------------------------|
 | `account`          | no        |                               |                                                 |
-| `archivePath`      | yes       |                               |                                                 |
+| `archivePath`      | no        |                               |                                                 |
 | `deployAccount` deprecated, use `account` | no  |              |                                                 |
 | `deployHost` deprecated, use `host` | no        |              |                                                 |
 | `deployMode`       | yes       | `'mta'`                       | `'mta'`, `'warParams'`, `'warPropertiesFile'`   |
@@ -36,7 +36,7 @@ needs to be extracted into the folder provided by `neoHome`. In case this parame
 ## Parameters when using WAR file deployment method with .properties file (WAR_PROPERTIESFILE)
 | parameter          | mandatory | default                       | possible values                                 |
 | -------------------|-----------|-------------------------------|-------------------------------------------------|
-| `archivePath`      | yes       |                               |                                                 |
+| `archivePath`      | no        |                               |                                                 |
 | `deployMode`       | yes       | `'mta'`                       | `'mta'`, `'warParams'`, `'warPropertiesFile'`   |
 | `neoCredentialsId` | no        | `'CI_CREDENTIALS_ID'`         |                                                 |
 | `neoHome`          | no        |                               |                                                 |
@@ -49,7 +49,7 @@ needs to be extracted into the folder provided by `neoHome`. In case this parame
 | -------------------|-----------|-------------------------------|-------------------------------------------------|
 | `account`          | no        |                               |                                                 |
 | `applicationName`  | yes       |                               |                                                 |
-| `archivePath`      | yes       |                               |                                                 |
+| `archivePath`      | no        |                               |                                                 |
 | `deployAccount` deprecated, use `account` | no                 |                                                 |
 | `deployHost` deprecated, use `host` | no                       |                                                 |
 | `deployMode`       | yes       | `'mta'`                       |  `'mta'`, `'warParams'`, `'warPropertiesFile'`  |
@@ -65,7 +65,7 @@ needs to be extracted into the folder provided by `neoHome`. In case this parame
 
 * `account` - The SAP Cloud Platform account to deploy to.
 * `applicationName` - Name of the application you want to manage, configure, or deploy
-* `archivePath`- The path to the archive for deployment to SAP CP.
+* `archivePath`- The path to the archive for deployment to SAP CP. If not provided `mtarFilePath` from commom pipeline environment is used instead.
 * `deployAccount` - deprecated, use `account`. The SAP Cloud Platform account to deploy to.
 * `deployHost` - deprecated, use `host`. The SAP Cloud Platform host to deploy to.
 * `deployMode` - The deployment mode which should be used. Available options are `'mta'` (default), `'warParams'` (deploying WAR file and passing all the deployment parameters via the function call) and `'warPropertiesFile'` (deploying WAR file and putting all the deployment parameters in a .properties file)

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -151,6 +151,27 @@ class NeoDeployTest extends BasePiperTest {
                                     .hasDoubleQuotedOption('source', '.*'))
     }
 
+    @Test
+    void archivePathFromCPETest() {
+        nullScript.commonPipelineEnvironment.setMtarFilePath('archive.mtar')
+        jsr.step.call(script: nullScript)
+
+        Assert.assertThat(jscr.shell,
+            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy-mta")
+                                    .hasDoubleQuotedOption('source', 'archive.mtar'))
+    }
+
+    @Test
+    void archivePathFromParamsHasHigherPrecedenceThanCPETest() {
+        nullScript.commonPipelineEnvironment.setMtarFilePath('archive2.mtar')
+        jsr.step.call(script: nullScript,
+                      archivePath: "archive.mtar")
+
+        Assert.assertThat(jscr.shell,
+            new CommandLineMatcher().hasProlog("#!/bin/bash \"/opt/neo/tools/neo.sh\" deploy-mta")
+                                    .hasDoubleQuotedOption('source', 'archive.mtar'))
+    }
+
 
     @Test
     void badCredentialsIdTest() {
@@ -274,7 +295,7 @@ class NeoDeployTest extends BasePiperTest {
 
         nullScript.commonPipelineEnvironment.configuration = [:]
 
-        jsr.step.call(archivePath: archiveName)
+        jsr.step.call(script: nullScript, archivePath: archiveName)
     }
 
     @Test

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -78,6 +78,7 @@ def call(parameters = [:]) {
             .mixin(stepCompatibilityConfiguration)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, STEP_CONFIG_KEYS)
+            .addIfEmpty('archivePath', script.commonPipelineEnvironment.getMtarFilePath())
             .mixin(parameters, PARAMETER_KEYS)
             .use()
 


### PR DESCRIPTION
neo deploy is not capable of fetching the deployable out of the common pipeline environment (parameter mta file path).

- 
- [x] add tests
- [x] add documentation
