### PR TITLE
[refactoring] artifactSetVersion: use gitUtils#insideWorkTree

### DIFF
--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -31,7 +31,7 @@ def call(Map parameters = [:], Closure body = null) {
 
         def gitUtils = parameters.juStabGitUtils ?: new GitUtils()
 
-        if (fileExists('.git')) {
+        if (gitUtils.insideWorkTree()) {
             if (sh(returnStatus: true, script: 'git diff --quiet HEAD') != 0)
                 error "[${STEP_NAME}] Files in the workspace have been changed previously - aborting ${STEP_NAME}"
         }


### PR DESCRIPTION
rather than checking for existing .git folder. An existing .git folder is a necessarry, but not a sufficient
condition here.

Adapting the test is not necessary. The gitUtil itself is not mocked, but the underlying sh calls are
already mocked accordingly.



- 
- [ ] add tests pure refactoring, no new tests
- [ ] add documentation, refactoring only
