### PR TITLE
cmclient call needs to quote the file path

### DIFF
--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -91,7 +91,7 @@ public class ChangeManagement implements Serializable {
     void uploadFileToTransportRequest(String changeId, String transportRequestId, String applicationId, String filePath, String endpoint, String credentialsId, String cmclientOpts = '') {
         int rc = executeWithCredentials(endpoint, credentialsId, 'upload-file-to-transport', ['-cID', changeId,
                                                                                                  '-tID', transportRequestId,
-                                                                                                 applicationId, filePath],
+                                                                                                 applicationId, "\"$filePath\""],
             cmclientOpts) as int
 
         if(rc == 0) {

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -186,7 +186,7 @@ public void testGetCommandLineWithCMClientOpts() {
     public void testUploadFileToTransportSucceeds() {
 
         // the regex provided below is an implicit check that the command line is fine.
-        script.setReturnValue(JenkinsShellCallRule.Type.REGEX,, 'upload-file-to-transport.*-cID 001 -tID 002 XXX /path', 0)
+        script.setReturnValue(JenkinsShellCallRule.Type.REGEX,, 'upload-file-to-transport.*-cID 001 -tID 002 XXX "/path"', 0)
 
         new ChangeManagement(nullScript).uploadFileToTransportRequest('001',
             '002',


### PR DESCRIPTION
the call of the cmclient command 'upload-file-to-transport' with a file path containing spaces fails. Since getCMCommandLine does not quote the option values the shell ignores anything after the first space of the file path found.

[workspace] Running shell script Exception in thread "main" java.lang.IllegalArgumentException: Cannot read upload file '/var/jenkins_home/jobs/copy'. at com.google.common.base.Preconditions.checkArgument(Preconditions.java:122)

hudson.AbortException: Cannot upload file '/var/jenkins_home/jobs/copy of solution teched 2018/workspace/com.sap.teched2018.cna370.fiori.mtar' for change document '8000000225' with transport request 'SCDK900002'. Return code from cmclient: 1. ***