### PR TITLE
[docu] fix markup

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -60,7 +60,7 @@ steps:
     newmanCollection: 'myNewmanCollection.file'
     newmanEnvironment: 'myNewmanEnvironment'
     newmanGlobals: 'myNewmanGlobals'
- ```
+```
 
 ## Access to configuration from custom scripts
 


### PR DESCRIPTION
The coding box was too long since the closing markup for the code box
had a leading blank, hence the end of the code box was not properly detected.