### PR TITLE
Project configuration as singleton

### DIFF
--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -5,10 +5,12 @@ import com.cloudbees.groovy.cps.NonCPS
 class DefaultValueCache implements Serializable {
     private static DefaultValueCache instance
 
-    private Map defaultValues
+    enum Level { DEFAULTS }
+
+    private Map<Level, Map> configurations = [:]
 
     private DefaultValueCache(Map defaultValues){
-        this.defaultValues = defaultValues
+        this.configurations.put(Level.DEFAULTS, defaultValues)
     }
 
     @NonCPS
@@ -22,7 +24,7 @@ class DefaultValueCache implements Serializable {
 
     @NonCPS
     Map getDefaultValues(){
-        return defaultValues
+        return configurations.get(Level.DEFAULTS)
     }
 
     static reset(){

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -5,12 +5,13 @@ import com.cloudbees.groovy.cps.NonCPS
 class DefaultValueCache implements Serializable {
     private static DefaultValueCache instance
 
-    enum Level { DEFAULTS }
+    enum Level { DEFAULTS, PROJECT }
 
     private Map<Level, Map> configurations = [:]
 
-    private DefaultValueCache(Map defaultValues){
+    private DefaultValueCache(Map defaultValues, Map projectConfiguration){
         this.configurations.put(Level.DEFAULTS, defaultValues)
+        this.configurations.put(Level.PROJECT, projectConfiguration)
     }
 
     @NonCPS
@@ -18,14 +19,20 @@ class DefaultValueCache implements Serializable {
         return instance
     }
 
-    static createInstance(Map defaultValues){
-        instance = new DefaultValueCache(defaultValues)
+    static createInstance(Map defaultValues, Map projectConfiguration){
+        instance = new DefaultValueCache(defaultValues, projectConfiguration)
     }
 
     @NonCPS
     Map getDefaultValues(){
         return configurations.get(Level.DEFAULTS)
     }
+
+    @NonCPS
+    Map getProjectConfiguration(){
+        return configurations.get(Level.PROJECT)
+    }
+
 
     static reset(){
         instance = null

--- a/test/groovy/PrepareDefaultValuesTest.groovy
+++ b/test/groovy/PrepareDefaultValuesTest.groovy
@@ -54,7 +54,7 @@ public class PrepareDefaultValuesTest extends BasePiperTest {
     @Test
     public void testReInitializeOnCustomConfig() {
 
-        DefaultValueCache.createInstance([key:'value'])
+        DefaultValueCache.createInstance([key:'value'], null)
 
         // existing instance is dropped in case a custom config is provided.
         jsr.step.call(script: nullScript, customDefaults: 'custom.yml')
@@ -67,7 +67,7 @@ public class PrepareDefaultValuesTest extends BasePiperTest {
     @Test
     public void testNoReInitializeWithoutCustomConfig() {
 
-        DefaultValueCache.createInstance([key:'value'])
+        DefaultValueCache.createInstance([key:'value'], null)
 
         jsr.step.call(script: nullScript)
 

--- a/test/groovy/com/sap/piper/ConfigurationLoaderTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationLoaderTest.groovy
@@ -18,7 +18,7 @@ class ConfigurationLoaderTest {
         defaultConfiguration.stages = [staticCodeChecks: [pmdExcludes: '*.java']]
 
         def pipelineEnvironment = [configuration: configuration]
-        DefaultValueCache.createInstance(defaultConfiguration)
+        DefaultValueCache.createInstance(defaultConfiguration, null)
         return [commonPipelineEnvironment: pipelineEnvironment]
     }
 

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -44,7 +44,6 @@ def call(Map parameters = [:]) {
 
             def mtaYamlName = "mta.yaml"
             def applicationName = configuration.applicationName
-
             if (!fileExists(mtaYamlName)) {
                 if (!applicationName) {
                     echo "'applicationName' not provided as parameter - will not try to generate ${mtaYamlName} file"

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -19,7 +19,7 @@ def call(Map parameters = [:]) {
                         MapUtils.pruneNulls(defaultValues),
                         MapUtils.pruneNulls(configuration))
             }
-            DefaultValueCache.createInstance(defaultValues)
+            DefaultValueCache.createInstance(defaultValues, null)
         }
     }
 }

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -19,7 +19,10 @@ def call(Map parameters = [:]) {
                         MapUtils.pruneNulls(defaultValues),
                         MapUtils.pruneNulls(configuration))
             }
-            DefaultValueCache.createInstance(defaultValues, null)
+
+            def projectConfig = readYaml(file: '.pipeline/config.yml')
+
+            DefaultValueCache.createInstance(defaultValues, MapUtils.pruneNulls(projectConfig))
         }
     }
 }


### PR DESCRIPTION
Follow up to for #255. There we recognized that the approach with ```script: parameters.script ? [commonPipelineEnvironment:commonPipelineEnvironment]``` is bogus since the defaults are not initialized on the step specific instances.

Here I try to provide the project configuration in a very similar way like the default configuration.

The general idea is to provide the project configuration via a singleton. All instances of the commonPipelineEnvironment are able to access the configuration via the singleton.

This is only a first step. All the properties of the commonPipelineEnvironment must be handled in a different way. Proposal: yet another map in the DefaultValueCache instance providing all the values retrieved during a pipeline run. But one step after the other ...

Just a proposal, other approaches welcome.