### PR TITLE
Remove not needed merge method from ConfigurationMerger

### DIFF
--- a/src/com/sap/piper/ConfigurationMerger.groovy
+++ b/src/com/sap/piper/ConfigurationMerger.groovy
@@ -23,13 +23,4 @@ class ConfigurationMerger {
         merged = merge(parameters, parameterKeys, merged)
         return merged
     }
-
-    @NonCPS
-    static Map merge(
-        def script, def stepName,
-        Map parameters, Set parameterKeys,
-        Set stepConfigurationKeys
-    ) {
-          merge(script, stepName, parameters, parameterKeys, [:], stepConfigurationKeys)
-    }
 }


### PR DESCRIPTION
The other merge method called in the body of that method here does not exist.
So any call to this method would end up in some method not found exception or similar.
