### PR TITLE
return deployable from mta build step

### DIFF
--- a/test/groovy/MtaBuildTest.groovy
+++ b/test/groovy/MtaBuildTest.groovy
@@ -88,6 +88,15 @@ public class MtaBuildTest extends BasePiperTest {
     }
 
     @Test
+    void deployablePathIsReturnedFromStepTest() {
+
+        def deployable = jsr.step.call(script: nullScript,
+                                       buildTarget: 'NEO')
+
+        assert deployable == 'com.mycompany.northwind.mtar'
+    }
+
+    @Test
     void mtaJarLocationAsParameterTest() {
 
         jsr.step.call(mtaJarLocation: '/mylocation/mta/mta.jar', buildTarget: 'NEO')

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -78,8 +78,7 @@ def call(Map parameters = [:]) {
             $mtaCall
             """
 
-            def mtarFilePath = "${mtarFileName}"
-            script?.commonPipelineEnvironment?.setMtarFilePath(mtarFilePath)
+            script?.commonPipelineEnvironment?.setMtarFilePath(mtarFileName)
         }
     }
 }

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -35,6 +35,8 @@ def call(Map parameters = [:]) {
 
         new Utils().pushToSWA([step: STEP_NAME], configuration)
 
+        def mtarFileName
+
         dockerExecute(script: script, dockerImage: configuration.dockerImage, dockerOptions: configuration.dockerOptions) {
             def java = new ToolDescriptor('Java', 'JAVA_HOME', '', '/bin/', 'java', '1.8.0', '-version 2>&1')
             java.verify(this, configuration)
@@ -64,7 +66,7 @@ def call(Map parameters = [:]) {
                 error "Property 'ID' not found in ${mtaYamlName} file."
             }
 
-            def mtarFileName = "${id}.mtar"
+            mtarFileName = "${id}.mtar"
             def mtaJar = mta.getCall(this, configuration)
             def buildTarget = configuration.buildTarget
 
@@ -80,5 +82,6 @@ def call(Map parameters = [:]) {
 
             script?.commonPipelineEnvironment?.setMtarFilePath(mtarFileName)
         }
+        return mtarFileName
     }
 }


### PR DESCRIPTION
Return mta file name from step.

- [x] add tests: we have now a test asserting that mtaBuild returns the mtaFileName
- [x] add documentation: was already present, but coding behaved in a different way
