### PR TITLE
mock GitUtils

### DIFF
--- a/test/groovy/ArtifactSetVersionTest.groovy
+++ b/test/groovy/ArtifactSetVersionTest.groovy
@@ -1,9 +1,13 @@
 #!groovy
+
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
+
+import com.sap.piper.GitUtils
+
 import util.BasePiperTest
 import util.JenkinsDockerExecuteRule
 import util.JenkinsEnvironmentRule
@@ -25,6 +29,16 @@ import static org.junit.Assert.assertEquals
 
 class ArtifactSetVersionTest extends BasePiperTest {
     Map dockerParameters
+
+    def GitUtils gitUtils = new GitUtils() {
+        boolean insideWorkTree() {
+            return true
+        }
+
+        String getGitCommitIdOrNull() {
+            return 'testCommitId'
+        }
+    }
 
     def sshAgentList = []
 
@@ -61,10 +75,8 @@ class ArtifactSetVersionTest extends BasePiperTest {
             return closure()
         })
 
-        jscr.setReturnValue('git rev-parse HEAD', 'testCommitId')
         jscr.setReturnValue("date --universal +'%Y%m%d%H%M%S'", '20180101010203')
         jscr.setReturnValue('git diff --quiet HEAD', 0)
-        jscr.setReturnValue('git rev-parse --is-inside-work-tree 1>/dev/null 2>&1', 0)
 
         helper.registerAllowedMethod('fileExists', [String.class], {true})
     }


### PR DESCRIPTION
if we don't mock the GitUtils here changes inside GitUtils affecting the git commands
issued at the command line requires changes here. In fact we have to react on
implementation details of the GitUtils here. It is better to be independent from that
implementation details here since this leads to more focused and smaller commits.

The quint-essence is: Up to now we described what should happen on the ```GitUtils``` layer via mocking some shell calls. Now we describe what should happen on the ```GitUtils``` layer by directly mocking this.