### PR TITLE
Pipeline steps are expected not to return a return value

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Implementation of a functionality and its documentation shall happen within the 
 
 ### Coding pattern
 
-Pipeline steps must not make use of return values. The pattern for sharing parameters between pipeline steps or between a pipeline step and a pipeline script is sharing values via the common pipeline environment. Since there is no return value from a pipeline step the return value of a pipeline step is already `void` rather than `def`.
+Pipeline steps must not make use of return values. The pattern for sharing parameters between pipeline steps or between a pipeline step and a pipeline script is sharing values via the [`commonPipelineEnvironment`](../vars/commonPipelineEnvironment.groovy). Since there is no return value from a pipeline step the return value of a pipeline step is already `void` rather than `def`.
 
 ### Code Style
 The code should follow any stylistic and architectural guidelines prescribed by the project. In the absence of guidelines, mimic the styles and patterns in the existing code-base.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,6 +25,10 @@ All pipeline library coding _must_ come with automated unit tests.
 The contract of functionality exposed by a library functionality needs to be documented, so it can be properly used.
 Implementation of a functionality and its documentation shall happen within the same commit(s).
 
+### Coding pattern
+
+Pipeline steps must not make use of return values. The pattern for sharing parameters between pipeline steps or between a pipeline step and a pipeline script is sharing values via the common pipeline environment. Since there is no return value from a pipeline step the return value of a pipeline step is already `void` rather than `def`.
+
 ### Code Style
 The code should follow any stylistic and architectural guidelines prescribed by the project. In the absence of guidelines, mimic the styles and patterns in the existing code-base.
 


### PR DESCRIPTION
There is no official advice that our pipeline steps must use ```void``` as a return type as discussed yesterday with @OliverNocon @CCFenner @rodibrin @thorstenwillenbacher .

Especially feedback from the colleagues not involved in that face-to-face discussion is appreciated: @daniel-kurzynski (Daniel, please share with more colleagues if there is a need for further discussions).
