### PR TITLE
transport request id also via cpe

### DIFF
--- a/documentation/docs/steps/transportRequestCreate.md
+++ b/documentation/docs/steps/transportRequestCreate.md
@@ -7,6 +7,8 @@ Creates
 * a Transport Request for a Change Document on the Solution Manager (type `SOLMAN`) or
 * a Transport Request inside an ABAP system (type`CTS`)
 
+The id of the transport request is availabe via [commonPipelineEnvironment.getTransportRequestId()](commonPipelineEnvironment.md)
+
 ## Prerequisites
 
 * **[Change Management Client 2.0.0 or compatible version](http://central.maven.org/maven2/com/sap/devops/cmclient/dist.cli/)** - available for download on Maven Central.
@@ -97,7 +99,7 @@ The parameters can also be provided when the step is invoked. For examples see b
 
 ## Return value
 
-The id of the Transport Request that has been created.
+none
 
 ## Exceptions
 

--- a/src/com/sap/piper/cm/StepHelpers.groovy
+++ b/src/com/sap/piper/cm/StepHelpers.groovy
@@ -12,27 +12,36 @@ public class StepHelpers {
         if(transportRequestId?.trim()) {
 
             step.echo "[INFO] Transport request id '${transportRequestId}' retrieved from parameters."
+            return transportRequestId
 
-        } else {
-
-            step.echo "[INFO] Retrieving transport request id from commit history [from: ${configuration.changeManagement.git.from}, to: ${configuration.changeManagement.git.to}]." +
-                        " Searching for pattern '${configuration.changeManagement.transportRequestLabel}'. Searching with format '${configuration.changeManagement.git.format}'."
-
-            try {
-                transportRequestId = cm.getTransportRequestId(
-                                                                configuration.changeManagement.git.from,
-                                                                configuration.changeManagement.git.to,
-                                                                configuration.changeManagement.transportRequestLabel,
-                                                                configuration.changeManagement.git.format
-                                                            )
-
-                step.echo "[INFO] Transport request id '${transportRequestId}' retrieved from commit history"
-
-            } catch(ChangeManagementException ex) {
-                step.echo "[WARN] Cannot retrieve transportRequestId from commit history: ${ex.getMessage()}."
-            }
         }
-        return transportRequestId
+
+        transportRequestId = step.commonPipelineEnvironment.getTransportRequestId()
+
+        if(transportRequestId?.trim()) {
+            step.echo "[INFO] Transport request id '${transportRequestId}' retrieved from common pipeline environment."
+            return transportRequestId
+        }
+
+        step.echo "[INFO] Retrieving transport request id from commit history [from: ${configuration.changeManagement.git.from}, to: ${configuration.changeManagement.git.to}]." +
+                    " Searching for pattern '${configuration.changeManagement.transportRequestLabel}'. Searching with format '${configuration.changeManagement.git.format}'."
+
+        try {
+            transportRequestId = cm.getTransportRequestId(
+                                                            configuration.changeManagement.git.from,
+                                                            configuration.changeManagement.git.to,
+                                                            configuration.changeManagement.transportRequestLabel,
+                                                            configuration.changeManagement.git.format
+                                                        )
+
+            step.commonPipelineEnvironment.setTransportRequestId(transportRequestId)
+            step.echo "[INFO] Transport request id '${transportRequestId}' retrieved from commit history"
+
+        } catch(ChangeManagementException ex) {
+            step.echo "[WARN] Cannot retrieve transportRequestId from commit history: ${ex.getMessage()}."
+        }
+
+        transportRequestId
     }
 
     @NonCPS

--- a/src/com/sap/piper/cm/StepHelpers.groovy
+++ b/src/com/sap/piper/cm/StepHelpers.groovy
@@ -4,25 +4,25 @@ import com.cloudbees.groovy.cps.NonCPS
 
 public class StepHelpers {
 
-    public static def getTransportRequestId(ChangeManagement cm, def step, Map configuration) {
+    public static def getTransportRequestId(ChangeManagement cm, def script, Map configuration) {
 
         def transportRequestId = configuration.transportRequestId
 
         if(transportRequestId?.trim()) {
 
-            step.echo "[INFO] Transport request id '${transportRequestId}' retrieved from parameters."
+            script.echo "[INFO] Transport request id '${transportRequestId}' retrieved from parameters."
             return transportRequestId
 
         }
 
-        transportRequestId = step.commonPipelineEnvironment.getTransportRequestId()
+        transportRequestId = script.commonPipelineEnvironment.getTransportRequestId()
 
         if(transportRequestId?.trim()) {
-            step.echo "[INFO] Transport request id '${transportRequestId}' retrieved from common pipeline environment."
+            script.echo "[INFO] Transport request id '${transportRequestId}' retrieved from common pipeline environment."
             return transportRequestId
         }
 
-        step.echo "[INFO] Retrieving transport request id from commit history [from: ${configuration.changeManagement.git.from}, to: ${configuration.changeManagement.git.to}]." +
+        script.echo "[INFO] Retrieving transport request id from commit history [from: ${configuration.changeManagement.git.from}, to: ${configuration.changeManagement.git.to}]." +
                     " Searching for pattern '${configuration.changeManagement.transportRequestLabel}'. Searching with format '${configuration.changeManagement.git.format}'."
 
         try {
@@ -33,35 +33,35 @@ public class StepHelpers {
                                                             configuration.changeManagement.git.format
                                                         )
 
-            step.commonPipelineEnvironment.setTransportRequestId(transportRequestId)
-            step.echo "[INFO] Transport request id '${transportRequestId}' retrieved from commit history"
+            script.commonPipelineEnvironment.setTransportRequestId(transportRequestId)
+            script.echo "[INFO] Transport request id '${transportRequestId}' retrieved from commit history"
 
         } catch(ChangeManagementException ex) {
-            step.echo "[WARN] Cannot retrieve transportRequestId from commit history: ${ex.getMessage()}."
+            script.echo "[WARN] Cannot retrieve transportRequestId from commit history: ${ex.getMessage()}."
         }
 
         transportRequestId
     }
 
-    public static getChangeDocumentId(ChangeManagement cm, def step, Map configuration) {
+    public static getChangeDocumentId(ChangeManagement cm, def script, Map configuration) {
 
         def changeDocumentId = configuration.changeDocumentId
 
         if(changeDocumentId?.trim()) {
 
-            step.echo "[INFO] ChangeDocumentId '${changeDocumentId}' retrieved from parameters."
+            script.echo "[INFO] ChangeDocumentId '${changeDocumentId}' retrieved from parameters."
             return changeDocumentId
         }
 
-        changeDocumentId = step.commonPipelineEnvironment.getChangeDocumentId()
+        changeDocumentId = script.commonPipelineEnvironment.getChangeDocumentId()
 
         if(changeDocumentId?.trim()) {
 
-            step.echo "[INFO] ChangeDocumentId '${changeDocumentId}' retrieved from common pipeline environment."
+            script.echo "[INFO] ChangeDocumentId '${changeDocumentId}' retrieved from common pipeline environment."
             return changeDocumentId
         }
 
-        step.echo "[INFO] Retrieving ChangeDocumentId from commit history [from: ${configuration.changeManagement.git.from}, to: ${configuration.changeManagement.git.to}]." +
+        script.echo "[INFO] Retrieving ChangeDocumentId from commit history [from: ${configuration.changeManagement.git.from}, to: ${configuration.changeManagement.git.to}]." +
                     "Searching for pattern '${configuration.changeManagement.changeDocumentLabel}'. Searching with format '${configuration.changeManagement.git.format}'."
 
         try {
@@ -72,31 +72,31 @@ public class StepHelpers {
                                                         configuration.changeManagement.git.format
                                                     )
 
-            step.echo "[INFO] ChangeDocumentId '${changeDocumentId}' retrieved from commit history"
-            step.commonPipelineEnvironment.setChangeDocumentId(changeDocumentId)
+            script.echo "[INFO] ChangeDocumentId '${changeDocumentId}' retrieved from commit history"
+            script.commonPipelineEnvironment.setChangeDocumentId(changeDocumentId)
 
         } catch(ChangeManagementException ex) {
-            step.echo "[WARN] Cannot retrieve changeDocumentId from commit history: ${ex.getMessage()}."
+            script.echo "[WARN] Cannot retrieve changeDocumentId from commit history: ${ex.getMessage()}."
         }
 
         return changeDocumentId
     }
 
     @NonCPS
-    static BackendType getBackendTypeAndLogInfoIfCMIntegrationDisabled(def step, Map configuration) {
+    static BackendType getBackendTypeAndLogInfoIfCMIntegrationDisabled(def script, Map configuration) {
 
         BackendType backendType
 
         try {
             backendType = configuration.changeManagement.type as BackendType
         } catch(IllegalArgumentException e) {
-            step.error "Invalid backend type: '${configuration.changeManagement.type}'. " +
+            script.error "Invalid backend type: '${configuration.changeManagement.type}'. " +
                   "Valid values: [${BackendType.values().join(', ')}]. " +
                   "Configuration: 'changeManagement/type'."
         }
 
         if (backendType == BackendType.NONE) {
-            step.echo "[INFO] Change management integration intentionally switched off. " +
+            script.echo "[INFO] Change management integration intentionally switched off. " +
                  "In order to enable it provide 'changeManagement/type with one of " +
                  "[${BackendType.values().minus(BackendType.NONE).join(', ')}] and maintain " +
                  "other required properties like 'endpoint', 'credentialsId'."

--- a/src/com/sap/piper/cm/StepHelpers.groovy
+++ b/src/com/sap/piper/cm/StepHelpers.groovy
@@ -4,7 +4,6 @@ import com.cloudbees.groovy.cps.NonCPS
 
 public class StepHelpers {
 
-    @NonCPS
     public static def getTransportRequestId(ChangeManagement cm, def step, Map configuration) {
 
         def transportRequestId = configuration.transportRequestId
@@ -44,7 +43,6 @@ public class StepHelpers {
         transportRequestId
     }
 
-    @NonCPS
     public static getChangeDocumentId(ChangeManagement cm, def step, Map configuration) {
 
         def changeDocumentId = configuration.changeDocumentId

--- a/test/groovy/CommonStepsTest.groovy
+++ b/test/groovy/CommonStepsTest.groovy
@@ -216,7 +216,6 @@ public class CommonStepsTest extends BasePiperTest{
         def stepsWithCallMethodsOtherThanVoid = []
 
         def whitelist = [
-            'transportRequestCreate',
             'durationMeasure',
             ]
 

--- a/test/groovy/TransportRequestCreateTest.groovy
+++ b/test/groovy/TransportRequestCreateTest.groovy
@@ -127,9 +127,9 @@ public class TransportRequestCreateTest extends BasePiperTest {
             }
         }
 
-        def transportId = jsr.step.call(script: nullScript, changeDocumentId: '001', developmentSystemId: '001', cmUtils: cm)
+        jsr.step.call(script: nullScript, changeDocumentId: '001', developmentSystemId: '001', cmUtils: cm)
 
-        assert transportId == '001'
+        assert nullScript.commonPipelineEnvironment.getTransportRequestId() == '001'
         assert result == [changeId: '001',
                          developmentSystemId: '001',
                          cmEndpoint: 'https://example.org/cm',
@@ -166,14 +166,14 @@ public class TransportRequestCreateTest extends BasePiperTest {
             }
         }
 
-        def transportId = jsr.step.call(script: nullScript,
-                                        transportType: 'W',
-                                        targetSystem: 'XYZ',
-                                        description: 'desc',
-                                        changeManagement: [type: 'CTS'],
-                                        cmUtils: cm)
+        jsr.step.call(script: nullScript,
+                        transportType: 'W',
+                        targetSystem: 'XYZ',
+                        description: 'desc',
+                        changeManagement: [type: 'CTS'],
+                        cmUtils: cm)
 
-        assert transportId == '001'
+        assert nullScript.commonPipelineEnvironment.getTransportRequestId() == '001'
         assert result == [transportType: 'W',
                          targetSystemId: 'XYZ',
                          description: 'desc',

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -108,6 +108,10 @@ public class TransportRequestReleaseTest extends BasePiperTest {
     @Test
     public void releaseTransportRequestSuccessTest() {
 
+        // Here we test only the case where the transportRequestId is
+        // provided via parameters. The other cases are tested by
+        // corresponding tests for StepHelpers#getTransportRequestId(./.)
+
         jlr.expect("[INFO] Closing transport request '002' for change document '001'.")
         jlr.expect("[INFO] Transport Request '002' has been successfully closed.")
 

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -194,6 +194,10 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void uploadFileToTransportRequestSOLMANSuccessTest() {
 
+        // Here we test only the case where the transportRequestId is
+        // provided via parameters. The other cases are tested by
+        // corresponding tests for StepHelpers#getTransportRequestId(./.)
+
         jlr.expect("[INFO] Uploading file '/path' to transport request '002' of change document '001'.")
         jlr.expect("[INFO] File '/path' has been successfully uploaded to transport request '002' of change document '001'.")
 

--- a/test/groovy/com/sap/piper/cm/StepHelpersTest.groovy
+++ b/test/groovy/com/sap/piper/cm/StepHelpersTest.groovy
@@ -1,0 +1,127 @@
+package com.sap.piper.cm
+
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+
+import util.BasePiperTest
+import util.JenkinsLoggingRule
+import util.Rules
+
+class StepHelpersTest extends BasePiperTest {
+
+    // Configuration is not checked by the tests here.
+    // We simply assume it fits. It is the duty of the
+    // step related tests to ensure the configuration is valid.
+    def params = [changeManagement:
+        [git: [
+                from: 'HEAD~1',
+                to: 'HEAD',
+                format: '%b'
+            ],
+            transportRequestLabel: "TransportRequest:"
+        ]
+    ]
+
+    private Map getTransportRequestIdReceivedParameters = [:]
+
+    @Before
+    public void setup() {
+        getTransportRequestIdReceivedParameters.clear()
+    }
+
+    JenkinsLoggingRule jlr = new JenkinsLoggingRule(this)
+
+    @Rule
+    public RuleChain rules = Rules.getCommonRules(this)
+                                  .around(jlr)
+
+    private ChangeManagement cm = new ChangeManagement(nullScript) {
+        String getTransportRequestId(
+                String from,
+                String to,
+                String label,
+                String format
+        ) {
+            getTransportRequestIdReceivedParameters['from'] = from
+            getTransportRequestIdReceivedParameters['to'] = to
+            getTransportRequestIdReceivedParameters['label'] = label
+            getTransportRequestIdReceivedParameters['format'] = format
+            return '097'
+        }
+    }
+
+    @Test
+    public void transportRequestIdViaCommitHistoryTest() {
+
+        def transportRequestId = StepHelpers.getTransportRequestId(cm, nullScript, params)
+
+        assert transportRequestId == '097'
+        assert getTransportRequestIdReceivedParameters ==
+        [
+            from: 'HEAD~1',
+            to: 'HEAD',
+            label: 'TransportRequest:',
+            format: '%b'
+        ]
+
+        // We cache the value. Otherwise we have to retrieve it each time from the
+        // commit history.
+        assert nullScript.commonPipelineEnvironment.getTransportRequestId() == '097'
+
+    }
+
+    @Test
+    public void transportRequestIdViaCommonPipelineEnvironmentTest() {
+
+        nullScript.commonPipelineEnvironment.setTransportRequestId('098')
+        def transportRequestId = StepHelpers.getTransportRequestId(cm, nullScript, params)
+
+        assert transportRequestId == '098'
+
+        // getTransportRequestId gets not called on ChangeManagement util class
+        // in this case.
+        assert getTransportRequestIdReceivedParameters == [:]
+    }
+
+    @Test
+    public void transportRequestIdViaParametersTest() {
+
+        params << [transportRequestId: '099']
+
+        def transportRequestId = StepHelpers.getTransportRequestId(cm, nullScript, params)
+
+        assert transportRequestId == '099'
+
+        // In case we get the transport request id via parameters we do not cache it
+        // Caller knows the transport request id anyway. So the caller can provide it with
+        // each call.
+        assert nullScript.commonPipelineEnvironment.getTransportRequestId() == null
+
+        // getTransportRequestId gets not called on ChangeManagement util class
+        // in this case.
+        assert getTransportRequestIdReceivedParameters == [:]
+    }
+
+    @Test
+    public void transportRequestIdNotProvidedTest() {
+
+        jlr.expect('Cannot retrieve transportRequestId from commit history')
+
+        def cm = new ChangeManagement(nullScript) {
+        String getTransportRequestId(
+                String from,
+                String to,
+                String label,
+                String format
+        )   {
+                throw new ChangeManagementException('Cannot retrieve transport request id')
+            }
+        }
+
+        def transportRequestId = StepHelpers.getTransportRequestId(cm, nullScript, params)
+
+        assert transportRequestId == null
+    }
+}

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -97,7 +97,7 @@ void call(parameters = [:]) {
         new Utils().pushToSWA([step: STEP_NAME,
                                 stepParam1: parameters?.script == null], configuration)
 
-        def changeId = getChangeDocumentId(cm, this, configuration)
+        def changeId = getChangeDocumentId(cm, script, configuration)
 
         configuration = configHelper.mixin([changeDocumentId: changeId?.trim() ?: null], ['changeDocumentId'] as Set)
 

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -30,6 +30,8 @@ class commonPipelineEnvironment implements Serializable {
 
     String mtarFilePath
 
+    String transportRequestId
+
     def reset() {
         appContainerProperties = [:]
         artifactVersion = null
@@ -49,6 +51,8 @@ class commonPipelineEnvironment implements Serializable {
         influxCustomDataMap = [pipeline_data: [:], step_data: [:]]
 
         mtarFilePath = null
+
+        transportRequestId = null
     }
 
     def setAppContainerProperty(property, value) {

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -68,7 +68,7 @@ void call(parameters = [:]) {
 
         if(backendType == BackendType.SOLMAN) {
 
-            changeDocumentId = getChangeDocumentId(cm, this, configuration)
+            changeDocumentId = getChangeDocumentId(cm, script, configuration)
 
             configHelper.mixin([changeDocumentId: changeDocumentId?.trim() ?: null], ['changeDocumentId'] as Set)
                         .withMandatoryProperty('developmentSystemId')

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -110,7 +110,7 @@ def call(parameters = [:]) {
 
 
         echo "[INFO] Transport Request '$transportRequestId' has been successfully created."
+        script.commonPipelineEnvironment.setTransportRequestId(transportRequestId)
     }
-
-    return transportRequestId
+    transportRequestId
 }

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -27,7 +27,7 @@ import hudson.AbortException
 
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus(['changeDocumentId'])
 
-def call(parameters = [:]) {
+void call(parameters = [:]) {
 
     def transportRequestId
 
@@ -112,5 +112,4 @@ def call(parameters = [:]) {
         echo "[INFO] Transport Request '$transportRequestId' has been successfully created."
         script.commonPipelineEnvironment.setTransportRequestId(transportRequestId)
     }
-    transportRequestId
 }

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -62,11 +62,11 @@ void call(parameters = [:]) {
                                 stepParam1: parameters?.script == null], configuration)
 
         def changeDocumentId = null
-        def transportRequestId = getTransportRequestId(cm, this, configuration)
+        def transportRequestId = getTransportRequestId(cm, script, configuration)
 
         if(backendType == BackendType.SOLMAN) {
 
-            changeDocumentId = getChangeDocumentId(cm, this, configuration)
+            changeDocumentId = getChangeDocumentId(cm, script, configuration)
 
             configHelper.mixin([changeDocumentId: changeDocumentId?.trim() ?: null], ['changeDocumentId'] as Set)
                         .withMandatoryProperty('changeDocumentId',

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -68,10 +68,10 @@ void call(parameters = [:]) {
         def changeDocumentId = null
 
         if(backendType == BackendType.SOLMAN) {
-            changeDocumentId = getChangeDocumentId(cm, this, configuration)
+            changeDocumentId = getChangeDocumentId(cm, script, configuration)
         }
 
-        def transportRequestId = getTransportRequestId(cm, this, configuration)
+        def transportRequestId = getTransportRequestId(cm, script, configuration)
 
         configHelper
             .mixin([changeDocumentId: changeDocumentId?.trim() ?: null,


### PR DESCRIPTION
Pipeline steps must not return any value from a call (return type ```void```). TransportRequestId is now handled via common pipeline environment.

```transportRequestCreate``` puts the transport request id into the common pipeline environment. Subsequent steps (```transportRequestUploadFile```, ```transportRequestRelease```) reads the transport request id from CPE if there is no value provided via parameter to these steps. If no parameters is provided to the step and if there is nothing inside CPE, the git commit history is traversed in order to lookup a transport request id.