### PR TITLE
return type related updates

### DIFF
--- a/documentation/docs/steps/checkChangeInDevelopment.md
+++ b/documentation/docs/steps/checkChangeInDevelopment.md
@@ -82,10 +82,6 @@ The properties can also be configured on a per-step basis:
 
 The parameters can also be provided when the step is invoked. For examples see below.
 
-## Return value
-`true` in case the change document is in status 'in development'. Otherwise an hudson.AbortException is thrown. In case `failIfStatusIsNotInDevelopment`
-is set to `false`, `false` is returned in case the change document is not in status 'in development'
-
 ## Exceptions
 * `AbortException`:
     * If the change id is not provided via parameter and if the change document id cannot be retrieved from the commit history.

--- a/documentation/docs/steps/checksPublishResults.md
+++ b/documentation/docs/steps/checksPublishResults.md
@@ -139,9 +139,6 @@ checksPublishResults(
 
 ![StaticChecks Thresholds](../images/StaticChecks_Threshold.png)
 
-## Return value
-none
-
 ## Side effects
 If both ESLint and PyLint results are published, they are not correctly aggregated in the aggregator plugin.
 

--- a/documentation/docs/steps/dockerExecute.md
+++ b/documentation/docs/steps/dockerExecute.md
@@ -29,9 +29,6 @@ If the Jenkins is setup on a Kubernetes cluster, then you can execute the closur
 ## Step configuration
 none
 
-## Return value
-none
-
 ## Side effects
 none
 

--- a/documentation/docs/steps/dockerExecuteOnKubernetes.md
+++ b/documentation/docs/steps/dockerExecuteOnKubernetes.md
@@ -28,9 +28,6 @@ Executes a closure inside a container in a kubernetes pod. Proxy environment var
 ## Step configuration
 none
 
-## Return value
-none
-
 ## Side effects
 none
 

--- a/documentation/docs/steps/handlePipelineStepErrors.md
+++ b/documentation/docs/steps/handlePipelineStepErrors.md
@@ -41,9 +41,6 @@ none
 ## Step configuration
 none
 
-## Return value
-none
-
 ## Side effects
 none
 

--- a/documentation/docs/steps/mtaBuild.md
+++ b/documentation/docs/steps/mtaBuild.md
@@ -1,7 +1,8 @@
 # mtaBuild
 
 ## Description
-Executes the SAP Multitarget Application Archive Builder to create an mtar archive of the application.
+Executes the SAP Multitarget Application Archive Builder to create an mtar archive of the application. The path
+relative to the workspace root is exposed via property `mtarFilePath` in the common pipeline environment.
 
 Before doing this, validates that SAP Multitarget Application Archive Builder exists and the version is compatible.
 
@@ -44,11 +45,8 @@ The following parameters can also be specified as step parameters using the glob
 * `mtaJarLocation`
 * `applicationName`
 
-## Return value
-The file name of the resulting archive is returned with this step. The file name is extracted from the key `ID` defined in `mta.yaml`.
-
 ## Side effects
-1. The file name of the resulting archive is written to the `commonPipelineEnvironment` with variable name `mtarFileName`.
+1. The file name of the resulting archive is written to the `commonPipelineEnvironment` with variable name `mtarFilePath`.
 
 ## Exceptions
 * `AbortException`:

--- a/documentation/docs/steps/neoDeploy.md
+++ b/documentation/docs/steps/neoDeploy.md
@@ -92,9 +92,6 @@ The following parameters can also be specified as step parameters using the glob
 * `neoCredentialsId`
 * `neoHome`
 
-## Return value
-none
-
 ## Side effects
 none
 

--- a/documentation/docs/steps/pipelineExecute.md
+++ b/documentation/docs/steps/pipelineExecute.md
@@ -29,10 +29,6 @@ none
 
 none
 
-## Return value
-
-none
-
 ## Side effects
 
 none

--- a/documentation/docs/steps/setupCommonPipelineEnvironment.md
+++ b/documentation/docs/steps/setupCommonPipelineEnvironment.md
@@ -23,9 +23,6 @@ Initializes the [`commonPipelineEnvironment`](commonPipelineEnvironment.md), whi
 ## Step configuration
 none
 
-## Return value
-none
-
 ## Side effects
 none
 

--- a/documentation/docs/steps/testsPublishResults.md
+++ b/documentation/docs/steps/testsPublishResults.md
@@ -100,9 +100,6 @@ Following parameters can also be specified as step parameters using the global c
 * `cobertura`
 * `jmeter`
 
-## Return value
-none
-
 ## Side effects
 none
 

--- a/documentation/docs/steps/toolValidate.md
+++ b/documentation/docs/steps/toolValidate.md
@@ -19,9 +19,6 @@ none
 ## Step configuration
 none
 
-## Return value
-none
-
 ## Side effects
 none
 

--- a/documentation/docs/steps/transportRequestCreate.md
+++ b/documentation/docs/steps/transportRequestCreate.md
@@ -1,7 +1,8 @@
 # transportRequestCreate
 
 ## Description
-Creates a Transport Request for a Change Document on the Solution Manager.
+Creates a Transport Request for a Change Document on the Solution Manager The ID of the
+Transport Request that has been created is written into the common pipeline environment (property `transportRequestId`)
 
 ## Prerequisites
 * **[Change Management Client 2.0.0 or compatible version](http://central.maven.org/maven2/com/sap/devops/cmclient/dist.cli/)** - available for download on Maven Central.
@@ -78,8 +79,9 @@ The properties can also be configured on a per-step basis:
 
 The parameters can also be provided when the step is invoked. For examples see below.
 
-## Return value
-The id of the Transport Request that has been created.
+## Side effect
+The ID of the Transport Request that has been created is written into the common pipeline environment
+(property `transportRequestId`)
 
 ## Exceptions
 * `AbortException`:

--- a/documentation/docs/steps/transportRequestRelease.md
+++ b/documentation/docs/steps/transportRequestRelease.md
@@ -79,9 +79,6 @@ The properties can also be configured on a per-step basis:
 
 The parameters can also be provided when the step is invoked. For examples see below.
 
-## Return value
-None.
-
 ## Exceptions
 * `IllegalArgumentException`:
     * If the change id is not provided.

--- a/documentation/docs/steps/transportRequestUploadFile.md
+++ b/documentation/docs/steps/transportRequestUploadFile.md
@@ -84,9 +84,6 @@ The properties can also be configured on a per-step basis:
 
 The parameters can also be provided when the step is invoked. For examples see below.
 
-## Return value
-None.
-
 ## Exceptions
 * `IllegalArgumentException`:
     * If the change id is not provided.

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -103,14 +103,12 @@ void call(parameters = [:]) {
 
         if(isInDevelopment) {
             echo "[INFO] Change '${changeId}' is in status 'in development'."
-            return true
         } else {
             if(configuration.failIfStatusIsNotInDevelopment.toBoolean()) {
                 throw new AbortException("Change '${changeId}' is not in status 'in development'.")
 
             } else {
                 echo "[WARNING] Change '${changeId}' is not in status 'in development'. Failing the pipeline has been explicitly disabled."
-                return false
             }
         }
     }


### PR DESCRIPTION
**changes:**

* checkChangeInDevelopment without return values since call method has return value 'void'
* Remove paragraphes for return values from the step documentation, since it does make no sense to have a paragraph for return values when the steps all have return value 'void'.
