### PR TITLE
Remove generic gitUtils from BasePiperTest

### DIFF
--- a/test/groovy/com/sap/piper/GitUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/GitUtilsTest.groovy
@@ -19,7 +19,12 @@ import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
 import static org.junit.Assert.assertThat
 
+import org.springframework.beans.factory.annotation.Autowired
+
 class GitUtilsTest extends BasePiperTest {
+
+    @Autowired
+    GitUtils gitUtils
 
     JenkinsShellCallRule jscr = new JenkinsShellCallRule(this)
     ExpectedException thrown = ExpectedException.none()

--- a/test/groovy/util/BasePiperTest.groovy
+++ b/test/groovy/util/BasePiperTest.groovy
@@ -21,9 +21,6 @@ abstract class BasePiperTest extends BasePipelineTest {
     Script nullScript
 
     @Autowired
-    GitUtils gitUtils
-
-    @Autowired
     Utils utils
 
     @Override


### PR DESCRIPTION
there is only one test class making use of it left. This test class is the
GitUtilsTest itself.

Hence moving this member downwards in the test class hierarchy into GitUtilsTest.

I doubt it makes sense to make use of a generic git utils mock somewhere else since this basically
means to test the GitUtils class in the conxtext of other examinees. For that there is no need.
The GitUtils class should be tested by the corresponding test class, but not in a transive manner
by other tests. For all other tests a specific git utils mock should be provided mocking the corresponding
method class. This is already the case today, otherwise we would have more test classes making use
of the generic git utils mock.

**changes:**

- 
- [ ] add tests
- [ ] add documentation
