### PR TITLE
Remove output to stdout from tests

### DIFF
--- a/test/groovy/util/BasePiperTestContext.groovy
+++ b/test/groovy/util/BasePiperTestContext.groovy
@@ -30,8 +30,8 @@ class BasePiperTestContext {
     Utils mockUtils() {
         def mockUtils = new Utils()
         mockUtils.steps = [
-            stash  : { m -> println "stash name = ${m.name}" },
-            unstash: { println "unstash called ..." }
+            stash  : {  },
+            unstash: {  }
         ]
         LibraryLoadingTestExecutionListener.prepareObjectInterceptors(mockUtils)
         return mockUtils


### PR DESCRIPTION
In fact nobody reads it, but on some IDEs it is shown when tests are executed.
In case this was some kind of 'manual' asserts: Should we replace it by real asserts?
