### PR TITLE
Remove explict getters and setters from common pipeline environment

### DIFF
--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -5,8 +5,8 @@ class commonPipelineEnvironment implements Serializable {
     def artifactVersion
 
     //stores the gitCommitId as well as additional git information for the build during pipeline run
-    private String gitCommitId
-    private String gitSshUrl
+    String gitCommitId
+    String gitSshUrl
 
     //stores properties for a pipeline which build an artifact and then bundles it into a container
     private Map appContainerProperties = [:]
@@ -19,7 +19,7 @@ class commonPipelineEnvironment implements Serializable {
     //influxCustomData represents measurement jenkins_custom_data in Influx. Metrics can be written into this map
     private Map influxCustomData = [:]
 
-    private String mtarFilePath
+    String mtarFilePath
 
     def reset() {
         appContainerProperties = [:]
@@ -45,22 +45,6 @@ class commonPipelineEnvironment implements Serializable {
         return appContainerProperties[property]
     }
 
-    def setArtifactVersion(version) {
-        artifactVersion = version
-    }
-
-    def getArtifactVersion() {
-        return artifactVersion
-    }
-
-    def setConfigProperties(map) {
-        configProperties = map
-    }
-
-    def getConfigProperties() {
-        return configProperties
-    }
-
     def setConfigProperty(property, value) {
         configProperties[property] = value
     }
@@ -70,22 +54,6 @@ class commonPipelineEnvironment implements Serializable {
             return configProperties[property].trim()
         else
             return configProperties[property]
-    }
-
-    def setGitCommitId(commitId) {
-        gitCommitId = commitId
-    }
-
-    def getGitCommitId() {
-        return gitCommitId
-    }
-
-    def setGitSshUrl(url) {
-        gitSshUrl = url
-    }
-
-    def getGitSshUrl() {
-        return gitSshUrl
     }
 
     def getInfluxCustomData() {
@@ -101,15 +69,6 @@ class commonPipelineEnvironment implements Serializable {
     }
     def getInfluxStepData (dataKey) {
         return influxCustomDataMap.step_data[dataKey]
-    }
-
-
-    def getMtarFilePath() {
-        return mtarFilePath
-    }
-
-    void setMtarFilePath(mtarFilePath) {
-        this.mtarFilePath = mtarFilePath
     }
 
     def setPipelineMeasurement (measurementName, value) {


### PR DESCRIPTION
We get getters and setters generated automatically.

IMO we should be able to explain each line of code. For me it is hard do explain why we have getters and setters, since groovy is able to automagically create getters and setters. Does anybody know a good reason for writing down the getters and setters explictly?

See:
* [here](https://github.com/SAP/jenkins-library/pull/298#issuecomment-421981041)
* and [here](https://en.wikipedia.org/wiki/Occam%27s_razor)
