### PR TITLE
Revert "Remove explict getters and setters from common pipeline envir…

### DIFF
--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -5,8 +5,8 @@ class commonPipelineEnvironment implements Serializable {
     def artifactVersion
 
     //stores the gitCommitId as well as additional git information for the build during pipeline run
-    String gitCommitId
-    String gitSshUrl
+    private String gitCommitId
+    private String gitSshUrl
 
     //stores properties for a pipeline which build an artifact and then bundles it into a container
     private Map appContainerProperties = [:]
@@ -19,7 +19,7 @@ class commonPipelineEnvironment implements Serializable {
     //influxCustomData represents measurement jenkins_custom_data in Influx. Metrics can be written into this map
     private Map influxCustomData = [:]
 
-    String mtarFilePath
+    private String mtarFilePath
 
     def reset() {
         appContainerProperties = [:]
@@ -45,6 +45,22 @@ class commonPipelineEnvironment implements Serializable {
         return appContainerProperties[property]
     }
 
+    def setArtifactVersion(version) {
+        artifactVersion = version
+    }
+
+    def getArtifactVersion() {
+        return artifactVersion
+    }
+
+    def setConfigProperties(map) {
+        configProperties = map
+    }
+
+    def getConfigProperties() {
+        return configProperties
+    }
+
     def setConfigProperty(property, value) {
         configProperties[property] = value
     }
@@ -54,6 +70,22 @@ class commonPipelineEnvironment implements Serializable {
             return configProperties[property].trim()
         else
             return configProperties[property]
+    }
+
+    def setGitCommitId(commitId) {
+        gitCommitId = commitId
+    }
+
+    def getGitCommitId() {
+        return gitCommitId
+    }
+
+    def setGitSshUrl(url) {
+        gitSshUrl = url
+    }
+
+    def getGitSshUrl() {
+        return gitSshUrl
     }
 
     def getInfluxCustomData() {
@@ -69,6 +101,15 @@ class commonPipelineEnvironment implements Serializable {
     }
     def getInfluxStepData (dataKey) {
         return influxCustomDataMap.step_data[dataKey]
+    }
+
+
+    def getMtarFilePath() {
+        return mtarFilePath
+    }
+
+    void setMtarFilePath(mtarFilePath) {
+        this.mtarFilePath = mtarFilePath
     }
 
     def setPipelineMeasurement (measurementName, value) {


### PR DESCRIPTION
…onment"

This reverts commit d22af0f9d465153ee472cd48b3d4f95852d35eda.

Since there are complains about non-running pipelines due to missing getters and setters.
We should revert that change first and check afterwards why the change causes trouble.

**changes:**

- 
- [ ] add tests
- [ ] add documentation
