### PR TITLE
ConfigHelper: handle also keys provided as GString to withMandProp

### DIFF
--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -117,16 +117,15 @@ class ConfigurationHelper implements Serializable {
         this.config = config
     }
 
-    /* private */ def getConfigPropertyNested(key) {
+    /* private */ def getConfigPropertyNested(CharSequence key) {
         return getConfigPropertyNested(config, key)
     }
 
-    /* private */ static getConfigPropertyNested(Map config, key) {
+    /* private */ static getConfigPropertyNested(Map config, CharSequence key) {
 
         def separator = '/'
 
-        // reason for cast to CharSequence: String#tokenize(./.) causes a deprecation warning.
-        List parts = (key in String) ? (key as CharSequence).tokenize(separator) : ([key] as List)
+        List parts = key.tokenize(separator)
 
         if(config[parts.head()] != null) {
 
@@ -142,7 +141,7 @@ class ConfigurationHelper implements Serializable {
         return config[parts.head()]
     }
 
-     private void existsMandatoryProperty(key, errorMessage) {
+     private void existsMandatoryProperty(CharSequence key, errorMessage) {
 
         def paramValue = getConfigPropertyNested(config, key)
 
@@ -157,7 +156,7 @@ class ConfigurationHelper implements Serializable {
         }
     }
 
-    ConfigurationHelper withMandatoryProperty(key, errorMessage = null, condition = null){
+    ConfigurationHelper withMandatoryProperty(CharSequence key, errorMessage = null, condition = null){
         if(condition){
             if(condition(this.config))
                 existsMandatoryProperty(key, errorMessage)

--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -233,6 +233,22 @@ class ConfigurationHelperTest {
     }
 
     @Test
+    public void testWithMandoryParameterParameterExistsAndEverythingIsFine() {
+        def  b = 'b'
+        new ConfigurationHelper([a: [b: 'v']])
+            .withMandatoryProperty('a/b')
+    }
+
+    @Test
+    public void testWithMandoryParameterParameterExistsWithKeyAsGString() {
+        def  b = 'b'
+        def key = "a/${b}"
+        assert key in GString
+        new ConfigurationHelper([a: [b: 'v']])
+            .withMandatoryProperty(key)
+    }
+
+    @Test
     public void testTelemetryConfigurationAvailable() {
         Set filter = ['test']
         def configuration = new ConfigurationHelper([test: 'testValue'])


### PR DESCRIPTION
`ConfigurationHelper#withMandatoryProperty(key)` works up no now only fine if the key provided to that method is a string. However we accept `def` for the `key`.

Now we are more precise with the type of `key` and we require `Charsequence`. This covers `String` as well as `GString`.

Up to now there a no issues with the old approach, but the new one suggested here is more robust. We have also no downcasting inside the method due to accepting `def` but having stronger assumptions in the corresponding method body for the tokenization.

Nota bene: We still might have issues in case a key in the config map is provided as `GString`. But in such a case the root case is providing a mutable key in the map ... Any caller should have sufficient knowledge not to do this. The hard version whould be to check all they keys for being a `String`.  