### PR TITLE
Implement workaround for incompatible change in cloud foundry API

### DIFF
--- a/documentation/docs/steps/cloudFoundryDeploy.md
+++ b/documentation/docs/steps/cloudFoundryDeploy.md
@@ -63,7 +63,7 @@ Deployment can be done
 
 !!! note
     Due to [an incompatible change](https://github.com/cloudfoundry/cli/issues/1445) in the Cloud Foundry CLI, multiple buildpacks are not supported by this step.
-    If your `application` contains a list of `buildpacks` instead a single `buildpack`, this will be automatically re-written by the step.
+    If your `application` contains a list of `buildpacks` instead a single `buildpack`, this will be automatically re-written by the step when blue-green deployment is used.
 
 * `deployTool` defines the tool which should be used for deployment.
 * `deployType` defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.

--- a/documentation/docs/steps/cloudFoundryDeploy.md
+++ b/documentation/docs/steps/cloudFoundryDeploy.md
@@ -61,6 +61,10 @@ Deployment can be done
     - cfOrg
     - cfSpace
 
+!!! note
+    Due to [an incompatible change](https://github.com/cloudfoundry/cli/issues/1445) in the Cloud Foundry CLI, multiple buildpacks are not supported by this step.
+    If your `application` contains a list of `buildpacks` instead a single `buildpack`, this will be automatically re-written by the step.
+
 * `deployTool` defines the tool which should be used for deployment.
 * `deployType` defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.
 * `dockerImage` defines the Docker image containing the deployment tools (like cf cli, ...) and `dockerWorkspace` defines the home directory of the default user of the `dockerImage`
@@ -109,7 +113,7 @@ The following parameters can also be specified as step/stage/general parameters 
 cloudFoundryDeploy(
     script: script,
     deployType: 'blue-green',
-    cloudFoundry: target,
+    cloudFoundry: [apiEndpoint: 'https://test.server.com', appName:'cfAppName', credentialsId: 'cfCredentialsId', manifest: 'cfManifest', org: 'cfOrg', space: 'cfSpace'],
     deployTool: 'cf_native'
 )
 ```

--- a/documentation/docs/steps/cloudFoundryDeploy.md
+++ b/documentation/docs/steps/cloudFoundryDeploy.md
@@ -106,7 +106,11 @@ The following parameters can also be specified as step/stage/general parameters 
 ## Example
 
 ```groovy
-artifactSetVersion script: this, buildTool: 'maven'
+cloudFoundryDeploy(
+    script: script,
+    deployType: 'blue-green',
+    cloudFoundry: target,
+    deployTool: 'cf_native'
+)
 ```
-
 

--- a/src/com/sap/piper/CfManifestUtils.groovy
+++ b/src/com/sap/piper/CfManifestUtils.groovy
@@ -1,0 +1,24 @@
+package com.sap.piper
+
+import com.cloudbees.groovy.cps.NonCPS
+
+class CfManifestUtils {
+    @NonCPS
+    static Map transform(Map manifest) {
+        if (manifest.applications[0].buildpacks) {
+            manifest['applications'].each { Map application ->
+                def buildpacks = application['buildpacks']
+                if (buildpacks) {
+                    if (buildpacks instanceof List) {
+                        if (buildpacks.size > 1) {
+                            throw new RuntimeException('More than one Cloud Foundry Buildpack is not supported. Please check your manifest.yaml file.')
+                        }
+                        application['buildpack'] = buildpacks[0]
+                    }
+                    application.remove('buildpacks')
+                }
+            }
+        }
+        return manifest
+    }
+}

--- a/src/com/sap/piper/CfManifestUtils.groovy
+++ b/src/com/sap/piper/CfManifestUtils.groovy
@@ -14,8 +14,10 @@ class CfManifestUtils {
                             throw new RuntimeException('More than one Cloud Foundry Buildpack is not supported. Please check your manifest.yaml file.')
                         }
                         application['buildpack'] = buildpacks[0]
+                        application.remove('buildpacks')
+                    } else {
+                        throw new RuntimeException('"buildpacks" in manifest.yaml is not a list. Please check your manifest.yaml file.')
                     }
-                    application.remove('buildpacks')
                 }
             }
         }

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -105,6 +105,11 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
     @Test
     void testCfNativeWithAppName() {
+        jryr.registerYaml('test.yml', "applications: [[name: 'manifestAppName']]")
+        helper.registerAllowedMethod('writeYaml', [Map], { Map parameters ->
+            generatedFile = parameters.file
+            data = parameters.data
+        })
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
@@ -125,6 +130,11 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
     @Test
     void testCfNativeWithAppNameCustomApi() {
+        jryr.registerYaml('test.yml', "applications: [[name: 'manifestAppName']]")
+        helper.registerAllowedMethod('writeYaml', [Map], { Map parameters ->
+            generatedFile = parameters.file
+            data = parameters.data
+        })
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
@@ -142,6 +152,11 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
     @Test
     void testCfNativeWithAppNameCompatible() {
+        jryr.registerYaml('test.yml', "applications: [[name: 'manifestAppName']]")
+        helper.registerAllowedMethod('writeYaml', [Map], { Map parameters ->
+            generatedFile = parameters.file
+            data = parameters.data
+        })
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
@@ -165,7 +180,11 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void testCfNativeAppNameFromManifest() {
         helper.registerAllowedMethod('fileExists', [String.class], { s -> return true })
-        jryr.registerYaml('test.yml', "[applications: [[name: 'manifestAppName']]]")
+        jryr.registerYaml('test.yml', "applications: [[name: 'manifestAppName']]")
+        helper.registerAllowedMethod('writeYaml', [Map], { Map parameters ->
+            generatedFile = parameters.file
+            data = parameters.data
+        })
 
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
@@ -185,6 +204,10 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testCfNativeWithoutAppName() {
         helper.registerAllowedMethod('fileExists', [String.class], { s -> return true })
         jryr.registerYaml('test.yml', "applications: [[]]")
+        helper.registerAllowedMethod('writeYaml', [Map], { Map parameters ->
+            generatedFile = parameters.file
+            data = parameters.data
+        })
         thrown.expect(hudson.AbortException)
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: No appName available in manifest test.yml.')
 

--- a/test/groovy/com/sap/piper/CfManifestUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/CfManifestUtilsTest.groovy
@@ -1,15 +1,30 @@
 package com.sap.piper
 
-import org.junit.Assert
 import org.junit.Test
 
+import static org.junit.Assert.*
+
 class CfManifestUtilsTest {
-    Map testFixture = [applications: [[buildpacks: ['sap_java_buildpack']]]]
 
     @Test
     void testManifestTransform() {
+        Map testFixture = [applications: [[buildpacks: ['sap_java_buildpack']]]]
         Map expected = [applications: [[buildpack: 'sap_java_buildpack']]]
         def actual = CfManifestUtils.transform(testFixture)
-        Assert.assertEquals(expected, actual)
+        assertEquals(expected, actual)
+    }
+
+    @Test(expected = RuntimeException)
+    void testManifestTransformMultipleBuildpacks() {
+        Map testFixture = [applications: [[buildpacks: ['sap_java_buildpack', 'another_buildpack']]]]
+        CfManifestUtils.transform(testFixture)
+    }
+
+    @Test
+    void testManifestTransformShouldNotChange() {
+        Map testFixture = [applications: [[buildpack: 'sap_java_buildpack']]]
+        Map expected = [applications: [[buildpack: 'sap_java_buildpack']]]
+        def actual = CfManifestUtils.transform(testFixture)
+        assertEquals(expected, actual)
     }
 }

--- a/test/groovy/com/sap/piper/CfManifestUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/CfManifestUtilsTest.groovy
@@ -1,0 +1,15 @@
+package com.sap.piper
+
+import org.junit.Assert
+import org.junit.Test
+
+class CfManifestUtilsTest {
+    Map testFixture = [applications: [[buildpacks: ['sap_java_buildpack']]]]
+
+    @Test
+    void testManifestTransform() {
+        Map expected = [applications: [[buildpack: 'sap_java_buildpack']]]
+        def actual = CfManifestUtils.transform(testFixture)
+        Assert.assertEquals(expected, actual)
+    }
+}

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -171,7 +171,17 @@ def deployMta (config) {
 
 def handleLegacyCfManifest(config) {
     def manifest = readYaml file: config.cloudFoundry.manifest
+    String originalManifest = manifest.toString()
     manifest = CfManifestUtils.transform(manifest)
-    sh "rm ${config.cloudFoundry.manifest}"
-    writeYaml file: config.cloudFoundry.manifest, data: manifest
+    String transformedManifest = manifest.toString()
+    sh "echo $originalManifest" //todo
+    sh "echo $transformedManifest" //todo
+    if (originalManifest != transformedManifest) {
+        echo "The file ${config.cloudFoundry.manifest} is not compatible with the Cloud Foundry blue-green deployment plugin. Re-writing inline."
+        echo "See this issue if you are interested in the background: https://github.com/cloudfoundry/cli/issues/1445"
+        echo "Original manifest file content: $originalManifest"
+        echo "Transformed manifest file content: $transformedManifest"
+        sh "rm ${config.cloudFoundry.manifest}"
+        writeYaml file: config.cloudFoundry.manifest, data: manifest
+    }
 }

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -175,10 +175,10 @@ def handleLegacyCfManifest(config) {
     manifest = CfManifestUtils.transform(manifest)
     String transformedManifest = manifest.toString()
     if (originalManifest != transformedManifest) {
-        echo "The file ${config.cloudFoundry.manifest} is not compatible with the Cloud Foundry blue-green deployment plugin. Re-writing inline."
-        echo "See this issue if you are interested in the background: https://github.com/cloudfoundry/cli/issues/1445"
-        echo "Original manifest file content: $originalManifest"
-        echo "Transformed manifest file content: $transformedManifest"
+        echo """The file ${config.cloudFoundry.manifest} is not compatible with the Cloud Foundry blue-green deployment plugin. Re-writing inline.
+See this issue if you are interested in the background: https://github.com/cloudfoundry/cli/issues/1445.\n
+Original manifest file content: $originalManifest\n
+Transformed manifest file content: $transformedManifest"""
         sh "rm ${config.cloudFoundry.manifest}"
         writeYaml file: config.cloudFoundry.manifest, data: manifest
     }

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -174,8 +174,6 @@ def handleLegacyCfManifest(config) {
     String originalManifest = manifest.toString()
     manifest = CfManifestUtils.transform(manifest)
     String transformedManifest = manifest.toString()
-    sh "echo $originalManifest" //todo
-    sh "echo $transformedManifest" //todo
     if (originalManifest != transformedManifest) {
         echo "The file ${config.cloudFoundry.manifest} is not compatible with the Cloud Foundry blue-green deployment plugin. Re-writing inline."
         echo "See this issue if you are interested in the background: https://github.com/cloudfoundry/cli/issues/1445"


### PR DESCRIPTION
**changes:**

Handle the case when cloud foundry manifest follows the new format (list of buildpacks) and transform to a single buildpack, since the blue-green plugin can't handle the new API.

- [x] add tests
- [ ] add documentation
