### PR TITLE
Explicitly call `toString()` on `stepParameters`

### DIFF
--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -27,7 +27,7 @@ def call(Map parameters = [:], body) {
 
 FOLLOWING PARAMETERS WERE AVAILABLE TO THIS STEP:
 ***
-${stepParameters}
+${stepParameters?.toString()}
 ***
 
 ERROR WAS:


### PR DESCRIPTION
**changes:**

Explicitly call (null-safe) `toString()` on `stepParameters` to avoid errors such as

```
11:04:06 ERROR WAS:
11:04:06 ***
11:04:06 groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.codehaus.groovy.runtime.GStringImpl(java.lang.String, [Ljava.lang.String;)
11:04:06 ***
```

- 
- [ ] add tests
- [ ] add documentation
