### PR TITLE
exclude images and key file from Code Climate editorConfig scan

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,4 @@
+version: "2"
 plugins:
   codenarc:
     enabled: true
@@ -17,6 +18,6 @@ plugins:
     enabled: true
 # https://docs.codeclimate.com/docs/advanced-configuration#section-exclude-patterns
 exclude_patterns:
-- 'documentation/docs/images/*.png'
-- 'documentation/docs/images/*.ico'
-- 'cfg/id_rsa.enc'
+- "documentation/docs/images/*.png"
+- "documentation/docs/images/*.ico"
+- "cfg/id_rsa.enc"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,6 +5,7 @@ plugins:
     enabled: true
     config:
       editorconfig: .editorconfig
+    # https://docs.codeclimate.com/docs/advanced-configuration#section-exclude-patterns
     exclude_patterns:
     - "documentation/docs/images/"
     - "cfg/id_rsa.enc"
@@ -18,6 +19,3 @@ plugins:
     enabled: true
   shellcheck:
     enabled: true
-# https://docs.codeclimate.com/docs/advanced-configuration#section-exclude-patterns
-exclude_patterns:
-- "test/resources/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,3 +15,8 @@ plugins:
     enabled: true
   shellcheck:
     enabled: true
+# https://docs.codeclimate.com/docs/advanced-configuration#section-exclude-patterns
+exclude_patterns:
+- 'documentation/docs/images/*.png'
+- 'documentation/docs/images/*.ico'
+- 'cfg/id_rsa.enc'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,3 @@
-version: "2"
 plugins:
   codenarc:
     enabled: true
@@ -6,6 +5,9 @@ plugins:
     enabled: true
     config:
       editorconfig: .editorconfig
+    exclude_patterns:
+    - "documentation/docs/images/"
+    - "cfg/id_rsa.enc"
   fixme:
     enabled: true
     config:
@@ -18,6 +20,4 @@ plugins:
     enabled: true
 # https://docs.codeclimate.com/docs/advanced-configuration#section-exclude-patterns
 exclude_patterns:
-- "documentation/docs/images/*.png"
-- "documentation/docs/images/*.ico"
-- "cfg/id_rsa.enc"
+- "test/resources/"


### PR DESCRIPTION
**changes:**
- exclude `*.png` & `*.ico` files from scan
- exclude `cfg/id_rsa.enc` file from scan