### PR TITLE
deactivate MD013 - line length

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,6 +3,10 @@ plugins:
     enabled: true
   editorconfig:
     enabled: true
+    checks:
+      # https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013---line-length
+      MD013:
+        enabled: false
     config:
       editorconfig: .editorconfig
     # https://docs.codeclimate.com/docs/advanced-configuration#section-exclude-patterns


### PR DESCRIPTION
**changes:**
- deactivate Markdown rule [MD013](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013---line-length) - *Line length*

Line length limit is not applicable for generated docs (automatic line breaking).