### PR TITLE
disable download logs in maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: groovy
 sudo: required
 services:
   - docker
+env:
+  global:
+    MAVEN_OPTS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
**changes:**
- disable maven log infos like:
  ```
  Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/org/eluder/coveralls/coveralls-maven-plugin/4.3.0/coveralls-maven-plugin-4.3.0.jar
  ```