### PR TITLE
Disable check for Boolean.getBoolean()

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,9 @@
 plugins:
   codenarc:
     enabled: true
+    checks:
+      BooleanGetBoolean:
+        enabled: false
   editorconfig:
     enabled: true
     checks:


### PR DESCRIPTION
Is it IMO completly normal to use Boolean.getBoolean(./.).

What is stated in the rule description

>  It is often mistakenly used to attempt to read user input or parse

is not a cool reason for having that rule. With such an approach we
can knock out a lot of APIs which can be misunderstood. It is the
duty of the developer to understand the API s?he is using.

The alternate way would be

'Boolean.parseBoolean(System.getProperty('xxx'))'

which is not that convenient like Boolean.getBoolean('xxx').

**changes:**

- 
- [ ] add tests
- [ ] add documentation
