### PR TITLE
testsPublishResults: Make jUnit pattern more universal

### DIFF
--- a/documentation/docs/steps/testsPublishResults.md
+++ b/documentation/docs/steps/testsPublishResults.md
@@ -54,7 +54,7 @@ Each of the parameters `junit`, `jacoco`, `cobertura` and `jmeter` can be set to
 
 | parameter | mandatory | default | possible values |
 | ----------|-----------|---------|-----------------|
-| pattern | no | `'**/target/surefire-reports/*.xml'` |  |
+| pattern | no | `'**/TEST-*.xml'` |  |
 | archive | no | `false` | true, false |
 | updateResults | no | `false` | true, false |
 | allowEmptyResults | no | `true` | true, false |

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -287,7 +287,7 @@ steps:
     toHtml: false
   testsPublishResults:
     junit:
-      pattern: '**/target/surefire-reports/*.xml'
+      pattern: '**/TEST-*.xml'
       updateResults: false
       allowEmptyResults: true
       archive: false

--- a/test/groovy/TestsPublishResultsTest.groovy
+++ b/test/groovy/TestsPublishResultsTest.groovy
@@ -75,7 +75,7 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('JUnit options are empty', publisherStepOptions.junit != null)
         // ensure default patterns are set
         assertEquals('JUnit default pattern not set correct',
-            '**/target/surefire-reports/*.xml', publisherStepOptions.junit.testResults)
+            '**/TEST-*.xml', publisherStepOptions.junit.testResults)
         // ensure nothing else is published
         assertTrue('JaCoCo options are not empty', publisherStepOptions.jacoco == null)
         assertTrue('Cobertura options are not empty', publisherStepOptions.cobertura == null)


### PR DESCRIPTION
**changes:**

- update jUnit pattern to work also for projects which do not use surefire plugin.

- [x] Tests updated
- [x] Documentation updated