### PR TITLE
Prerequisite check for availability of Jenkins plugins

### DIFF
--- a/src/com/sap/piper/Dependencies.groovy
+++ b/src/com/sap/piper/Dependencies.groovy
@@ -1,0 +1,14 @@
+package com.sap.piper
+
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+import java.lang.annotation.ElementType
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface Dependencies {
+    String[] requiredPlugins() default []
+    String[] optionalPlugin() default []
+    String[] requiredShellCommands() default []
+}

--- a/src/com/sap/piper/Prerequisites.groovy
+++ b/src/com/sap/piper/Prerequisites.groovy
@@ -2,6 +2,10 @@ package com.sap.piper
 
 import static java.lang.Boolean.getBoolean
 
+import static com.sap.piper.JenkinsUtils.isPluginActive
+
+import com.sap.piper.Dependencies
+
 static checkScript(def step, Map params) {
 
     def script = params?.script
@@ -19,4 +23,16 @@ static checkScript(def step, Map params) {
     }
 
     return script
+}
+
+static void checkRequiredPlugins(step) {
+
+    def requiredPlugins = step.getClass().getDeclaredMethod('call')?.getAnnotation(Dependencies)?.requiredPlugins() ?: []
+
+    def missingPlugins = []
+
+    for (plugin in requiredPlugins)
+        if(! isPluginActive(plugin)) missingPlugins << plugin
+
+    if(missingPlugins) step.error "The following plugins are required for step '${step.STEP_NAME}', but they are not available: ${missingPlugins}."
 }

--- a/test/groovy/util/JenkinsDependenciesRule.groovy
+++ b/test/groovy/util/JenkinsDependenciesRule.groovy
@@ -1,0 +1,40 @@
+package util
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+
+import util.JenkinsShellCallRule.Type
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+import com.sap.piper.JenkinsUtils
+
+class JenkinsDependenciesRule implements TestRule {
+
+    JenkinsDependenciesRule(BasePipelineTest testInstance) {
+    }
+
+    @Override
+    Statement apply(Statement base, Description description) {
+        return statement(base)
+    }
+
+    private Statement statement(final Statement base) {
+        return new Statement() {
+            @Override
+            void evaluate() throws Throwable {
+
+                def preserved = JenkinsUtils.metaClass.static.isPluginActive
+
+                JenkinsUtils.metaClass.static.isPluginActive = { true }
+
+                try {
+                    base.evaluate()
+                } finally {
+                    JenkinsUtils.metaClass.static.isPluginActive = preserved
+                }
+            }
+        }
+    }
+}

--- a/test/groovy/util/Rules.groovy
+++ b/test/groovy/util/Rules.groovy
@@ -15,6 +15,7 @@ public class Rules {
         return RuleChain.outerRule(new JenkinsSetupRule(testCase, libConfig))
             .around(new JenkinsResetDefaultCacheRule())
             .around(new JenkinsErrorRule(testCase))
-			.around(new JenkinsEnvironmentRule(testCase))
+            .around(new JenkinsEnvironmentRule(testCase))
+            .around(new JenkinsDependenciesRule(testCase))
     }
 }

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -1,4 +1,5 @@
 import static com.sap.piper.Prerequisites.checkScript
+import static com.sap.piper.Prerequisites.checkRequiredPlugins
 
 import com.sap.piper.GitUtils
 import com.sap.piper.Utils
@@ -7,6 +8,7 @@ import hudson.AbortException
 
 import com.sap.piper.ConfigurationHelper
 import com.sap.piper.ConfigurationMerger
+import com.sap.piper.Dependencies
 import com.sap.piper.cm.BackendType
 import com.sap.piper.cm.ChangeManagement
 import com.sap.piper.cm.ChangeManagementException
@@ -37,11 +39,13 @@ import static com.sap.piper.cm.StepHelpers.getBackendTypeAndLogInfoIfCMIntegrati
  * range and the pattern can be configured. For details see 'parameters' table.
  *
  */
+@Dependencies(requiredPlugins=['workflow-basic-steps'])
 void call(parameters = [:]) {
 
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
 
         def script = checkScript(this, parameters) ?: this
+        checkRequiredPlugins(this)
 
         GitUtils gitUtils = parameters?.gitUtils ?: new GitUtils()
 


### PR DESCRIPTION
Currently we have dependencies from our pipeline steps to
- Jenkins plugins
- shell commands

These dependencies are implicit, they are not written down in the piper lib. Somewhere else we have a plugin vector, but far, far away. It is the scope of this PR to make the dependencies transparent for the Jenkins plugins. And also for other shell tools (e.g. `curl`) we use.

PluginDependenies (and in principle also dependencies to shell commands) are written down in the step using a `@Dependencies` annotation on the level of the call method. A corresponding prerequisite check is also which can/should be called right at the beginning of the step body.

Right now this is an early draft. _Feedback welcome, especially in case you think this is the wrong way to go_.

Why I think we should have more transparency on the plugins and shell calls we rely on:

* When we describe the plugins on the level of the steps we are able to create the plugin vector out of this.
* From the security point of view it is desirable to have the minimal set of required plugins installed on a Jenkins in order to reduce the attack vector. In case a user of the piper lib uses only a subset of the pipeline steps s?he would be able to reduce the full set of the Jenkins plugins according to what is really neeed.
* With regards to the shell calls: we know in a more direct way what tools we have to include in case we provide a docker image or in case we prepare a Jenkins in another way.
* Transparency wrt Plugins and shell tools we use it a value "as it", since it creates awareness for the developers. The plugins and the shell tools does not fall from sky.

Since we have the case of fallback in case of a non existing plugin (`dockerExecute` which simply falls back to local execution) there are the properties `requiredPlugins` and `optionsPlugins`.

Currently there is no check for the required shell tools (e.g. curl). I guess the most suibable way to implement this would be via `which -q <tool`. Here we have to keep in mind that it matters where/when that check is executed since on different nodes there might be different tools installed.

Not sure if we should also take the versions of the plugin into account. I personally think we should start without, and adapt later on if we see the need. In case we would like to take the version into account we can reuse the `<pluginId>:<version>` syntax from the `plugins.txt` used by the Jenkins docker image.

Of course only direct dependencies should be listed. The set of transitive dependencies can be calculated.

Since a lot of plugins uses in fact the same JenkinsPlugins (e.g. `workflow-basic-steps`) it makes sense to provide a collection of common prerequisites (applies maybe also for the shell tools, e.g. `curl`). This is not implemented right now in this PR.