### PR TITLE
Provide option to Stop and not delete old instance on BlueGreenDeploy

### DIFF
--- a/documentation/docs/steps/cloudFoundryDeploy.md
+++ b/documentation/docs/steps/cloudFoundryDeploy.md
@@ -29,6 +29,7 @@ Deployment can be done
 | cloudFoundry | yes |  |  |
 | deployTool | no | cf_native | cf_native, mtaDeployPlugin |
 | deployType | no | standard | standard, blue-green |
+| keepOldInstance | no | false | true, false |
 | dockerImage | no | s4sdk/docker-cf-cli |  |
 | dockerWorkspace | no | /home/piper |  |
 | mtaDeployParameters |  | -f |  |
@@ -65,6 +66,7 @@ Deployment can be done
 
 * `deployTool` defines the tool which should be used for deployment.
 * `deployType` defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.
+* `keepOldInstance` defines if in case of a `blue-green` deployment the old instance will be deleted or stopped
 * `dockerImage` defines the Docker image containing the deployment tools (like cf cli, ...) and `dockerWorkspace` defines the home directory of the default user of the `dockerImage`
 * `smokeTestScript` allows to specify a script which performs a check during blue-green deployment. The script gets the FQDN as parameter and returns `exit code 0` in case check returned `smokeTestStatusCode`. More details can be found [here](https://github.com/bluemixgaragelondon/cf-blue-green-deploy#how-to-use) <br /> Currently this option is only considered for deployTool `cf_native`.
 * `stashContent` defines the stash names which should be unstashed at the beginning of the step. This makes the files available in case the step is started on an empty node.

--- a/documentation/docs/steps/cloudFoundryDeploy.md
+++ b/documentation/docs/steps/cloudFoundryDeploy.md
@@ -66,7 +66,7 @@ Deployment can be done
 
 * `deployTool` defines the tool which should be used for deployment.
 * `deployType` defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.
-* `keepOldInstance` defines if in case of a `blue-green` deployment the old instance will be deleted or stopped
+* `keepOldInstance` in case of a `blue-green` deployment the old instance will be deleted by default. If this option is set to true the old instance will remain stopped in the Cloud Foundry space.
 * `dockerImage` defines the Docker image containing the deployment tools (like cf cli, ...) and `dockerWorkspace` defines the home directory of the default user of the `dockerImage`
 * `smokeTestScript` allows to specify a script which performs a check during blue-green deployment. The script gets the FQDN as parameter and returns `exit code 0` in case check returned `smokeTestStatusCode`. More details can be found [here](https://github.com/bluemixgaragelondon/cf-blue-green-deploy#how-to-use) <br /> Currently this option is only considered for deployTool `cf_native`.
 * `stashContent` defines the stash names which should be unstashed at the beginning of the step. This makes the files available in case the step is started on an empty node.

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -123,6 +123,7 @@ steps:
       apiEndpoint: 'https://api.cf.eu10.hana.ondemand.com'
     deployTool: 'cf_native'
     deployType: 'standard'
+    keepOldInstance: false
     mtaDeployParameters: '-f'
     mtaExtensionDescriptor: ''
     mtaPath: ''

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -126,6 +126,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(jedr.dockerParams.dockerEnvVars, hasEntry('STATUS_CODE', "${200}"))
         assertThat(jscr.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(jscr.shell, hasItem(containsString("cf push testAppName -f 'test.yml'")))
+        assertThat(jscr.shell, hasItem(containsString("cf logout")))
     }
 
     @Test
@@ -175,6 +176,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(jedr.dockerParams.dockerEnvVars, hasEntry('STATUS_CODE', "${200}"))
         assertThat(jscr.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(jscr.shell, hasItem(containsString("cf push testAppName -f 'test.yml'")))
+        assertThat(jscr.shell, hasItem(containsString("cf logout")))
     }
 
     @Test
@@ -198,6 +200,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         // asserts
         assertThat(jscr.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(jscr.shell, hasItem(containsString("cf push -f 'test.yml'")))
+        assertThat(jscr.shell, hasItem(containsString("cf logout")))
     }
 
     @Test
@@ -223,7 +226,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
     }
 
     @Test
-    void testCfNativeBlueGreen() {
+    void testCfNativeBlueGreenDeleteOldInstance() {
 
         jryr.registerYaml('test.yml', "applications: [[]]")
 
@@ -232,6 +235,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
             juStabUtils: utils,
             deployTool: 'cf_native',
             deployType: 'blue-green',
+            keepOldInstance: false,
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
             cfCredentialsId: 'test_cfCredentialsId',
@@ -244,6 +248,35 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
         assertThat(jscr.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(jscr.shell, hasItem(containsString("cf blue-green-deploy testAppName --delete-old-apps -f 'test.yml'")))
+        assertThat(jscr.shell, hasItem(containsString("cf logout")))
+
+    }
+
+    @Test
+    void testCfNativeBlueGreenStopOldInstance() {
+
+        jryr.registerYaml('test.yml', "applications: [[]]")
+
+        jsr.step.cloudFoundryDeploy([
+            script: nullScript,
+            juStabUtils: utils,
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            keepOldInstance: true,
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
+        ])
+
+        assertThat(jedr.dockerParams, hasEntry('dockerImage', 's4sdk/docker-cf-cli'))
+        assertThat(jedr.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))
+
+        assertThat(jscr.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
+        assertThat(jscr.shell, hasItem(containsString("cf blue-green-deploy testAppName -f 'test.yml'")))
+        assertThat(jscr.shell, hasItem(containsString("cf stop testAppName")))
+        assertThat(jscr.shell, hasItem(containsString("cf logout")))
     }
 
 
@@ -285,5 +318,6 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(jedr.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))
         assertThat(jscr.shell, hasItem(containsString('cf login -u test_cf -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(jscr.shell, hasItem(containsString('cf deploy target/test.mtar -f')))
+        assertThat(jscr.shell, hasItem(containsString('cf logout')))
     }
 }

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -275,6 +275,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
         assertThat(jscr.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(jscr.shell, hasItem(containsString("cf blue-green-deploy testAppName --delete-old-apps -f 'test.yml'")))
+        assertThat(jscr.shell, not(hasItem(containsString("cf stop testAppName-old"))))
         assertThat(jscr.shell, hasItem(containsString("cf logout")))
 
     }

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -149,7 +149,7 @@ def deployCfNative (config) {
             cf login -u \"${username}\" -p '${password}' -a ${config.cloudFoundry.apiEndpoint} -o \"${config.cloudFoundry.org}\" -s \"${config.cloudFoundry.space}\"
             cf plugins
             cf ${deployCommand} ${config.cloudFoundry.appName?:''} ${blueGreenDeployOptions} -f '${config.cloudFoundry.manifest}' ${config.smokeTest}
-            ${(config.keepOldInstance && config.deployType == 'blue-green')?"cf stop ${config.cloudFoundry.appName}":''}
+            ${(config.keepOldInstance && config.deployType == 'blue-green')?"cf stop ${config.cloudFoundry.appName}-old":''}
             """
         sh "cf logout"
     }

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -148,8 +148,8 @@ def deployCfNative (config) {
             export HOME=${config.dockerWorkspace}
             cf login -u \"${username}\" -p '${password}' -a ${config.cloudFoundry.apiEndpoint} -o \"${config.cloudFoundry.org}\" -s \"${config.cloudFoundry.space}\"
             cf plugins
-            cf ${deployCommand} ${config.cloudFoundry.appName?:''} ${blueGreenDeployOptions} -f '${config.cloudFoundry.manifest}' ${config.smokeTest}
-            ${(config.keepOldInstance && config.deployType == 'blue-green')?"cf stop ${config.cloudFoundry.appName}-old":''}
+            cf ${deployCommand} ${config.cloudFoundry.appName ?: ''} ${blueGreenDeployOptions} -f '${config.cloudFoundry.manifest}' ${config.smokeTest}
+            ${(config.keepOldInstance && config.deployType == 'blue-green') ? "cf stop ${config.cloudFoundry.appName}-old" : ''}
             """
         sh "cf logout"
     }
@@ -157,7 +157,7 @@ def deployCfNative (config) {
 
 private String getCfNativeDeployCommand(Map config) {
     if (config.deployType == 'blue-green') {
-        return  'blue-green-deploy'
+        return 'blue-green-deploy'
     } else {
         return 'push'
     }


### PR DESCRIPTION
* Added an option to keep the old instance in case of a blue-green deployment.
* check `cf logout` when testing deploy methods.
 
- [x] add tests
- [x] add documentation

related issue: #323
