### PR TITLE
cloudFoundryDeploy - fix stashing behavior

### DIFF
--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -58,7 +58,10 @@ void call(Map parameters = [:]) {
 
         echo "[${STEP_NAME}] General parameters: deployTool=${config.deployTool}, deployType=${config.deployType}, cfApiEndpoint=${config.cloudFoundry.apiEndpoint}, cfOrg=${config.cloudFoundry.org}, cfSpace=${config.cloudFoundry.space}, cfCredentialsId=${config.cloudFoundry.credentialsId}, deployUser=${config.deployUser}"
 
-        config.stashContent = utils.unstashAll(config.stashContent)
+        //make sure that all relevant descriptors, are available in workspace
+        utils.unstashAll(config.stashContent)
+        //make sure that for further execution whole workspace, e.g. also downloaded artifacts are considered
+        config.stashContent = [:]
 
         if (config.deployTool == 'mtaDeployPlugin') {
             // set default mtar path


### PR DESCRIPTION
**changes:**

This change fixes an error which only occurs in a Kubernetes landscape.
When only initial stashes are passed, the deployment will fail since it misses the artifact to be deployed.

Solution: pass empty stash map thus Docker execution on Kubernetes will respect all content in the current workspace.
