### PR TITLE
[fix] Make regex in test Operating System independent.

### DIFF
--- a/test/groovy/CommonStepsTest.groovy
+++ b/test/groovy/CommonStepsTest.groovy
@@ -237,7 +237,7 @@ public class CommonStepsTest extends BasePiperTest{
     private static getSteps() {
         List steps = []
         new File('vars').traverse(type: FileType.FILES, maxDepth: 0)
-            { if(it.getName().endsWith('.groovy')) steps << (it =~ /vars\/(.*)\.groovy/)[0][1] }
+            { if(it.getName().endsWith('.groovy')) steps << (it =~ /vars[\\\/](.*)\.groovy/)[0][1] }
         return steps
     }
 }


### PR DESCRIPTION
We searched for the slash, but on win like operating system we have of course a backslash.
