### PR TITLE
Introduce 'skip' flag for neoDeploy

### DIFF
--- a/documentation/docs/steps/neoDeploy.md
+++ b/documentation/docs/steps/neoDeploy.md
@@ -33,6 +33,7 @@ Note that a version is formed by `major.minor.patch`, and a version is compatibl
 | `neoCredentialsId` | no        | `'CI_CREDENTIALS_ID'`         |                                                 |
 | `neoHome`          | no        |                               |                                                 |
 | `script`           | yes       |                               |                                                 |
+| `skip`             | yes       | false                         | boolean value: `true`, `false`                  |
 
 ## Parameters when using WAR file deployment method with .properties file (WAR_PROPERTIESFILE)
 
@@ -44,6 +45,7 @@ Note that a version is formed by `major.minor.patch`, and a version is compatibl
 | `neoHome`          | no        |                               |                                                 |
 | `propertiesFile`   | yes       |                               |                                                 |
 | `script`           | yes       |                               |                                                 |
+| `skip`             | yes       | `false`                       | boolean value: `true`, `false`                  |
 | `warAction`        | yes       | `'deploy'`                    | `'deploy'`, `'rolling-update'`                  |
 
 ## Parameters when using WAR file deployment method witout .properties file - with parameters (WAR_PARAMS)
@@ -62,6 +64,7 @@ Note that a version is formed by `major.minor.patch`, and a version is compatibl
 | `runtime`          | yes       |                               |                                                 |
 | `runtime-version`  | yes       |                               |                                                 |
 | `script`           | yes       |                               |                                                 |
+| `skip`             | yes       | `false`                       | boolean value: `true`, `false`                  |
 | `vmSize`           | no        | `'lite'`                      | `'lite'`, `'pro'`, `'prem'`, `'prem-plus'`      |
 | `warAction`        | yes       | `'deploy'`                    | `'deploy'`, `'rolling-update'`                  |
 
@@ -78,6 +81,7 @@ Note that a version is formed by `major.minor.patch`, and a version is compatibl
 * `runtime` - Name of SAP Cloud Platform application runtime
 * `runtime-version` - Version of SAP Cloud Platform application runtime
 * `script` - The common script environment of the Jenkinsfile run. Typically `this` is passed to this parameter. This allows the function to access the [`commonPipelineEnvironment`](commonPipelineEnvironment.md) for retrieving e.g. configuration parameters.
+* skip - Set this to `true` to bypass artifact deploy.
 * `vmSize` - Compute unit (VM) size. Acceptable values: lite, pro, prem, prem-plus.
 * `warAction` - Action mode when using WAR file mode. Available options are `deploy` (default) and `rolling-update` which performs update of an application without downtime in one go.
 

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -221,6 +221,7 @@ steps:
     warAction: 'deploy'
     vmSize: 'lite'
     neoCredentialsId: 'CI_CREDENTIALS_ID'
+    skip: false
   newmanExecute:
     dockerImage: 'node:8-stretch'
     failOnError: true

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -568,6 +568,22 @@ class NeoDeployTest extends BasePiperTest {
         assert jlr.log.contains("Deprecated parameter 'deployAccount' is used. This will not work anymore in future versions. Use parameter 'account' instead.")
     }
 
+    @Test
+    void skipNeoDeploymentTest() {
+
+        jlr.expect('[INFO][neoDeploy] Neo deployment will be skipped since flag \'skip\' was provided with value \'true\'.')
+
+        jsr.step.neoDeploy(
+            script: nullScript,
+            skip: true,
+        )
+
+        //
+        // basically we have to ensure neo neo call has been emitted via sh.
+        // In fact no sh call at all happens in this case. Hence we
+        // simply check that there was not sh call ...
+        jscr.shell.isEmpty()
+    }
 
     private getVersionWithEnvVars(Map m) {
 

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -16,7 +16,8 @@ import groovy.transform.Field
     'dockerOptions',
     'host',
     'neoCredentialsId',
-    'neoHome'
+    'neoHome',
+    'skip'
 ]
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus([
     'applicationName',
@@ -101,6 +102,11 @@ void call(parameters = [:]) {
             .addIfEmpty('archivePath', script.commonPipelineEnvironment.getMtarFilePath())
             .mixin(parameters, PARAMETER_KEYS)
             .use()
+
+        if(configuration.skip) {
+            echo "[INFO][${STEP_NAME}] Neo deployment will be skipped since flag 'skip' was provided with value '${configuration.skip}'."
+            return
+        }
 
         utils.pushToSWA([
             step: STEP_NAME,


### PR DESCRIPTION
In case we provide larger scenario steps it is required to be
able to switch off a step. Otherwise the scenario step cannot
be used in case on step, which is not switchoffable, should
not be used.
