### PR TITLE
mtaBuild inside docker

### DIFF
--- a/documentation/docs/steps/mtaBuild.md
+++ b/documentation/docs/steps/mtaBuild.md
@@ -14,13 +14,19 @@ Note that a version is formed by `major.minor.patch`, and a version is compatibl
   * **SAP MTA Archive Builder 1.0.6 or compatible version** - can be downloaded from [SAP Development Tools](https://tools.hana.ondemand.com/#cloud).
   * **Java 8 or compatible version** - necessary to run the `mta.jar` file.
   * **NodeJS installed** - the MTA Builder uses `npm` to download node module dependencies such as `grunt`.
+  * We are migrating our build tools into docker containers. In case you do not use our default docker image for performing mta builds there must
+    be a script file named `mtaBuild` in the path. This script file performs the mta call and looks basically like this:
+
+    ```
+    java -jar <PATH TO MTA.JAR> $@
+    ```
 
 ## Parameters
 
 | parameter        | mandatory | default                                                | possible values    |
 | -----------------|-----------|--------------------------------------------------------|--------------------|
 | `script`         | yes       |                                                        |                    |
-| `dockerImage`    | yes       |                                                        |                    |
+| `dockerImage`    | yes       | `mta:latest`                                           |                    |
 | `dockerOptions`  | no        | ''                                                     |                    |
 | `buildTarget`    | yes       | `'NEO'`                                                | 'CF', 'NEO', 'XSA' |
 | `extension`    | no       |                                                            |                    |

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -215,6 +215,7 @@ steps:
   mtaBuild:
     buildTarget: 'NEO'
     mtaJarLocation: 'mta.jar'
+    dockerImage: 'mta:latest'
   neoDeploy:
     dockerImage: 's4sdk/docker-neo-cli'
     deployMode: 'mta'

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -41,10 +41,7 @@ void call(Map parameters = [:]) {
 
         dockerExecute(script: script, dockerImage: configuration.dockerImage, dockerOptions: configuration.dockerOptions) {
             def java = new ToolDescriptor('Java', 'JAVA_HOME', '', '/bin/', 'java', '1.8.0', '-version 2>&1')
-            java.verify(this, configuration)
-
             def mta = new JavaArchiveDescriptor('SAP Multitarget Application Archive Builder', 'MTA_JAR_LOCATION', 'mtaJarLocation', '1.0.6', '-v', java)
-            mta.verify(this, configuration)
 
             def mtaYamlName = "mta.yaml"
             def applicationName = configuration.applicationName

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -70,9 +70,8 @@ void call(Map parameters = [:]) {
 
             def mtarFileName = "${id}.mtar"
             def mtaJar = mta.getCall(this, configuration)
-            def buildTarget = configuration.buildTarget
 
-            def mtaCall = "${mtaJar} --mtar ${mtarFileName} --build-target=${buildTarget}"
+            def mtaCall = "${mtaJar} --mtar ${mtarFileName} --build-target=${configuration.buildTarget}"
 
             if (configuration.extension) mtaCall += " --extension=$configuration.extension"
             mtaCall += ' build'


### PR DESCRIPTION
mtaBuild is by default executed inside docker

**Before merging the script we need to ensure that the docker image is avialable**.

* a docker image mta:latest is provided **the name of the image needs to be adjusted in order to fit into some naming conventions**.
* inside mta docker image there is a script in the path hiding the details wrt jar file location. When working without docker (fallback to Jenkins) there should be a similar script in the path. If not we issue a warning to the log and set the build to unstable.