### PR TITLE
Implement hashCode/equals/toString for JenkinsShellCallRule

### DIFF
--- a/test/groovy/util/JenkinsShellCallRule.groovy
+++ b/test/groovy/util/JenkinsShellCallRule.groovy
@@ -21,6 +21,23 @@ class JenkinsShellCallRule implements TestRule {
             this.type = type
             this.script = script
         }
+
+        String toString() {
+            return "${type} : ${script}"
+        }
+
+        @Override
+        public int hashCode() {
+            return type.hashCode() * script.hashCode()
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+
+            if (obj == null || !obj instanceof Key) return false;
+            Key other = (Key) obj;
+            return type == other.type && script == other.script
+        }
     }
 
     final BasePipelineTest testInstance


### PR DESCRIPTION
* toString is helpful for troubleshooting during developing tests
* equals/hashCode are required in case somebody would like to register
  some responses again (e.g. register something valid almost all the time, and
  register something more specific for a certain test).