### PR TITLE
cloudFoundryDeploy - add deployment reporting to Influx

### DIFF
--- a/src/com/sap/piper/JenkinsUtils.groovy
+++ b/src/com/sap/piper/JenkinsUtils.groovy
@@ -18,3 +18,32 @@ def nodeAvailable() {
     }
     return true
 }
+
+@NonCPS
+def getCurrentBuildInstance() {
+    return currentBuild
+}
+
+@NonCPS
+def getRawBuild() {
+    return getCurrentBuildInstance().rawBuild
+}
+
+def isJobStartedByTimer() {
+    return isJobStartedByCause(hudson.triggers.TimerTrigger.TimerTriggerCause.class)
+}
+
+def isJobStartedByUser() {
+    return isJobStartedByCause(hudson.model.Cause.UserIdCause.class)
+}
+
+@NonCPS
+def isJobStartedByCause(Class cause) {
+    def startedByGivenCause = false
+    def detectedCause = getRawBuild().getCause(cause)
+    if (null != detectedCause) {
+        startedByGivenCause = true
+        echo "Found build cause ${detectedCause}"
+    }
+    return startedByGivenCause
+}

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -1,10 +1,10 @@
 #!groovy
+import com.sap.piper.JenkinsUtils
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
-import org.yaml.snakeyaml.Yaml
 import util.BasePiperTest
 import util.JenkinsCredentialsRule
 import util.JenkinsEnvironmentRule
@@ -19,6 +19,7 @@ import util.Rules
 import static org.junit.Assert.assertThat
 
 import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.is
 import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.hasEntry
 import static org.hamcrest.Matchers.containsString
@@ -34,6 +35,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
     private JenkinsEnvironmentRule jer = new JenkinsEnvironmentRule(this)
     private JenkinsReadYamlRule jryr = new JenkinsReadYamlRule(this)
 
+    private writeInfluxMap = [:]
+
+    class JenkinsUtilsMock extends JenkinsUtils {
+        def isJobStartedByUser() {
+            return true
+        }
+    }
+
     @Rule
     public RuleChain rules = Rules
         .getCommonRules(this)
@@ -46,6 +55,13 @@ class CloudFoundryDeployTest extends BasePiperTest {
         .around(jer)
         .around(new JenkinsCredentialsRule(this).withCredentials('test_cfCredentialsId', 'test_cf', '********'))
         .around(jsr) // needs to be activated after jedr, otherwise executeDocker is not mocked
+
+    @Before
+    void init() {
+        helper.registerAllowedMethod('writeInflux', [Map.class], {m ->
+            writeInfluxMap = m
+        })
+    }
 
     @Test
     void testNoTool() throws Exception {
@@ -69,6 +85,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: '',
             stageName: 'acceptance',
         ])
@@ -97,6 +114,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'notAvailable',
             stageName: 'acceptance'
         ])
@@ -114,6 +132,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
@@ -140,6 +159,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             cfApiEndpoint: 'https://customApi',
             cfOrg: 'testOrg',
@@ -162,6 +182,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             cloudFoundry: [
                 org: 'testOrg',
@@ -192,6 +213,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
@@ -218,6 +240,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
@@ -234,6 +257,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             deployType: 'blue-green',
             cfOrg: 'testOrg',
@@ -260,6 +284,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             deployType: 'blue-green',
             keepOldInstance: false,
@@ -288,6 +313,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             deployType: 'blue-green',
             keepOldInstance: true,
@@ -315,6 +341,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             deployType: 'standard',
             keepOldInstance: true,
@@ -340,6 +367,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             deployTool: 'cf_native',
             deployType: 'blue-green',
             cfOrg: 'testOrg',
@@ -355,6 +383,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         jsr.step.cloudFoundryDeploy([
             script: nullScript,
             juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
             cfCredentialsId: 'test_cfCredentialsId',
@@ -368,4 +397,37 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(jscr.shell, hasItem(containsString('cf deploy target/test.mtar -f')))
         assertThat(jscr.shell, hasItem(containsString('cf logout')))
     }
+
+    @Test
+    void testInfluxReporting() {
+        jryr.registerYaml('test.yml', "applications: [[name: 'manifestAppName']]")
+        helper.registerAllowedMethod('writeYaml', [Map], { Map parameters ->
+            generatedFile = parameters.file
+            data = parameters.data
+        })
+        nullScript.commonPipelineEnvironment.setArtifactVersion('1.2.3')
+        jsr.step.cloudFoundryDeploy([
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
+        ])
+        // asserts
+        assertThat(writeInfluxMap.customDataMap.deployment_data.artifactUrl, is('n/a'))
+        assertThat(writeInfluxMap.customDataMap.deployment_data.deployTime, containsString(new Date().format( 'MMM dd, yyyy')))
+        assertThat(writeInfluxMap.customDataMap.deployment_data.jobTrigger, is('USER'))
+
+        assertThat(writeInfluxMap.customDataMapTags.deployment_data.artifactVersion, is('1.2.3'))
+        assertThat(writeInfluxMap.customDataMapTags.deployment_data.deployUser, is('test_cf'))
+        assertThat(writeInfluxMap.customDataMapTags.deployment_data.deployResult, is('SUCCESS'))
+        assertThat(writeInfluxMap.customDataMapTags.deployment_data.cfApiEndpoint, is('https://api.cf.eu10.hana.ondemand.com'))
+        assertThat(writeInfluxMap.customDataMapTags.deployment_data.cfOrg, is('testOrg'))
+        assertThat(writeInfluxMap.customDataMapTags.deployment_data.cfSpace, is('testSpace'))
+    }
+
 }

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -1,3 +1,5 @@
+import com.sap.piper.JenkinsUtils
+
 import static com.sap.piper.Prerequisites.checkScript
 
 import com.sap.piper.Utils
@@ -32,10 +34,8 @@ void call(Map parameters = [:]) {
 
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
 
-        def utils = parameters.juStabUtils
-        if (utils == null) {
-            utils = new Utils()
-        }
+        def utils = parameters.juStabUtils ?: new Utils()
+        def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
 
         def script = checkScript(this, parameters)
         if (script == null)
@@ -63,42 +63,54 @@ void call(Map parameters = [:]) {
         //make sure that for further execution whole workspace, e.g. also downloaded artifacts are considered
         config.stashContent = []
 
-        if (config.deployTool == 'mtaDeployPlugin') {
-            // set default mtar path
-            config = ConfigurationHelper.newInstance(this, config)
-                .addIfEmpty('mtaPath', config.mtaPath?:findMtar())
-                .use()
+        boolean deploy = false
+        boolean deploySuccess = true
+        try {
+            if (config.deployTool == 'mtaDeployPlugin') {
+                deploy = true
+                // set default mtar path
+                config = ConfigurationHelper.newInstance(this, config)
+                    .addIfEmpty('mtaPath', config.mtaPath?:findMtar())
+                    .use()
 
-            dockerExecute(script: script, dockerImage: config.dockerImage, dockerWorkspace: config.dockerWorkspace, stashContent: config.stashContent) {
-                deployMta(config)
+                dockerExecute(script: script, dockerImage: config.dockerImage, dockerWorkspace: config.dockerWorkspace, stashContent: config.stashContent) {
+                    deployMta(config)
+                }
             }
-            return
+
+            if (config.deployTool == 'cf_native') {
+                deploy = true
+                config.smokeTest = ''
+
+                if (config.smokeTestScript == 'blueGreenCheckScript.sh') {
+                    writeFile file: config.smokeTestScript, text: libraryResource(config.smokeTestScript)
+                }
+
+                config.smokeTest = '--smoke-test $(pwd)/' + config.smokeTestScript
+                sh "chmod +x ${config.smokeTestScript}"
+
+                echo "[${STEP_NAME}] CF native deployment (${config.deployType}) with cfAppName=${config.cloudFoundry.appName}, cfManifest=${config.cloudFoundry.manifest}, smokeTestScript=${config.smokeTestScript}"
+
+                dockerExecute (
+                    script: script,
+                    dockerImage: config.dockerImage,
+                    dockerWorkspace: config.dockerWorkspace,
+                    stashContent: config.stashContent,
+                    dockerEnvVars: [CF_HOME:"${config.dockerWorkspace}", CF_PLUGIN_HOME:"${config.dockerWorkspace}", STATUS_CODE: "${config.smokeTestStatusCode}"]
+                ) {
+                    deployCfNative(config)
+                }
+            }
+        } catch (err) {
+            deploySuccess = false
+            throw err
+        } finally {
+            if (deploy) {
+                reportToInflux(script, config, deploySuccess, jenkinsUtils)
+            }
+
         }
 
-        if (config.deployTool == 'cf_native') {
-            config.smokeTest = ''
-
-            if (config.smokeTestScript == 'blueGreenCheckScript.sh') {
-                writeFile file: config.smokeTestScript, text: libraryResource(config.smokeTestScript)
-            }
-
-            config.smokeTest = '--smoke-test $(pwd)/' + config.smokeTestScript
-            sh "chmod +x ${config.smokeTestScript}"
-
-            echo "[${STEP_NAME}] CF native deployment (${config.deployType}) with cfAppName=${config.cloudFoundry.appName}, cfManifest=${config.cloudFoundry.manifest}, smokeTestScript=${config.smokeTestScript}"
-
-            dockerExecute (
-                script: script,
-                dockerImage: config.dockerImage,
-                dockerWorkspace: config.dockerWorkspace,
-                stashContent: config.stashContent,
-                dockerEnvVars: [CF_HOME:"${config.dockerWorkspace}", CF_PLUGIN_HOME:"${config.dockerWorkspace}", STATUS_CODE: "${config.smokeTestStatusCode}"]
-            ) {
-                deployCfNative(config)
-            }
-
-            return
-        }
     }
 }
 
@@ -221,4 +233,34 @@ Transformed manifest file content: $transformedManifest"""
         sh "rm ${config.cloudFoundry.manifest}"
         writeYaml file: config.cloudFoundry.manifest, data: manifest
     }
+}
+
+
+private void reportToInflux(script, config, deploySuccess, JenkinsUtils jenkinsUtils) {
+    def deployUser = ''
+    withCredentials([usernamePassword(
+        credentialsId: config.cloudFoundry.credentialsId,
+        passwordVariable: 'password',
+        usernameVariable: 'username'
+    )]) {
+        deployUser = username
+    }
+
+    def timeFinished = new Date().format( 'MMM dd, yyyy - HH:mm:ss' )
+    def triggerCause = jenkinsUtils.isJobStartedByUser()?'USER':(jenkinsUtils.isJobStartedByTimer()?'TIMER': 'OTHER')
+
+    def deploymentData = [deployment_data: [
+        artifactUrl: 'n/a', //might be added later on during pipeline run (written to commonPipelineEnvironment)
+        deployTime: timeFinished,
+        jobTrigger: triggerCause
+    ]]
+    def deploymentDataTags = [deployment_data: [
+        artifactVersion: script.commonPipelineEnvironment.getArtifactVersion(),
+        deployUser: deployUser,
+        deployResult: deploySuccess?'SUCCESS':'FAILURE',
+        cfApiEndpoint: config.cloudFoundry.apiEndpoint,
+        cfOrg: config.cloudFoundry.org,
+        cfSpace: config.cloudFoundry.space,
+    ]]
+    writeInflux script: script, customData: [:], customDataTags: [:], customDataMap: deploymentData, customDataMapTags: deploymentDataTags
 }


### PR DESCRIPTION
**changes:**

Add reporting of operations-related data to Influx (if configured), like:
* Version of deployed artifact
* Deployment time
* Target infrastructure for deployment

Other tasks:
- [x] add tests
- ~add documentation~ no documentation update required

In order to be fully functional this requires #420 to be merged.
