### PR TITLE
piperStageWrapper - add script as parameter for extensions

### DIFF
--- a/test/groovy/PiperStageWrapperTest.groovy
+++ b/test/groovy/PiperStageWrapperTest.groovy
@@ -54,7 +54,7 @@ class PiperStageWrapperTest extends BasePiperTest {
 
     @Test
     void testDefault() {
-        def testInt = 1
+        def executed = false
         jsr.step.piperStageWrapper(
             script: nullScript,
             juStabUtils: utils,
@@ -62,16 +62,16 @@ class PiperStageWrapperTest extends BasePiperTest {
             stageName: 'test'
 
         ) {
-            testInt ++
+            executed = true
         }
-        assertThat(testInt, is(2))
+        assertThat(executed, is(true))
         assertThat(lockMap.size(), is(2))
         assertThat(countNodeUsage, is(1))
     }
 
     @Test
     void testNoLocking() {
-        def testInt = 1
+        def executed = false
         jsr.step.piperStageWrapper(
             script: nullScript,
             juStabUtils: utils,
@@ -81,9 +81,9 @@ class PiperStageWrapperTest extends BasePiperTest {
             stageName: 'test'
 
         ) {
-            testInt ++
+            executed = true
         }
-        assertThat(testInt, is(2))
+        assertThat(executed, is(true))
         assertThat(lockMap.size(), is(0))
         assertThat(countNodeUsage, is(1))
         assertThat(nodeLabel, is('testLabel'))
@@ -98,21 +98,23 @@ class PiperStageWrapperTest extends BasePiperTest {
         helper.registerAllowedMethod('load', [String.class], {
             return helper.loadScript('test/resources/stages/test.groovy')
         })
+        nullScript.commonPipelineEnvironment.gitBranch = 'testBranch'
 
-        def testInt = 1
+        def executed = false
         jsr.step.piperStageWrapper(
             script: nullScript,
             juStabUtils: utils,
             ordinal: 10,
             stageName: 'test'
         ) {
-            testInt ++
+            executed = true
         }
 
-        assertThat(testInt, is(2))
+        assertThat(executed, is(true))
         assertThat(jlr.log, containsString('[piperStageWrapper] Running project interceptor \'.pipeline/extensions/test.groovy\' for test.'))
         assertThat(jlr.log, containsString('Stage Name: test'))
-        assertThat(jlr.log, containsString('Config:'))
+        assertThat(jlr.log, containsString('Config: [productiveBranch:master,'))
+        assertThat(jlr.log, containsString('testBranch'))
     }
 }
 

--- a/test/resources/stages/test.groovy
+++ b/test/resources/stages/test.groovy
@@ -1,6 +1,7 @@
-void call(body, stageName, config) {
+void call(script, body, stageName, config) {
     echo "Stage Name: ${stageName}"
     echo "Config: ${config}"
     body()
+    echo "Branch: ${script.commonPipelineEnvironment.gitBranch}"
 }
 return this

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -81,7 +81,7 @@ private void executeStage(script, originalStage, stageName, config, utils) {
             echo "[${STEP_NAME}] Found global interceptor '${globalInterceptorFile}' for ${stageName}."
             // If we call the global interceptor, we will pass on originalStage as parameter
             body = {
-                globalInterceptorScript(body, stageName, config)
+                globalInterceptorScript(script, body, stageName, config)
             }
         }
 
@@ -90,7 +90,7 @@ private void executeStage(script, originalStage, stageName, config, utils) {
             Script projectInterceptorScript = load(projectInterceptorFile)
             echo "[${STEP_NAME}] Running project interceptor '${projectInterceptorFile}' for ${stageName}."
             // If we call the project interceptor, we will pass on body as parameter which contains either originalStage or the repository interceptor
-            projectInterceptorScript(body, stageName, config)
+            projectInterceptorScript(script, body, stageName, config)
         } else {
             //TODO: assign projectInterceptorScript to body as done for globalInterceptorScript, currently test framework does not seem to support this case. Further investigations needed.
             body()


### PR DESCRIPTION
Based on interactions with teams we saw that the current extension mechanism is insufficient.

When calling other library steps we need to have the current `script` available. One reason is to be able to properly pass the context. This is for example required to resolve step configuration. Currently, the config parameter only contains the general as well as the relevant stage section of the configuration since at this point no information is available about which steps are executed in the extension.

This PR aims to add the functionality of having the main script context inside an extension.

An alternative solution would be to change the extension syntax to only pass a Map instead of multiple parameters.
This way we would be save with potential future adaptions and can stay compatible.

Personally, I opt for choosing a map. If this was common agreement I would adapt this PR accordingly.
