### PR TITLE
executeDockerOnKubernetes - specify custom shell

### DIFF
--- a/documentation/docs/steps/dockerExecuteOnKubernetes.md
+++ b/documentation/docs/steps/dockerExecuteOnKubernetes.md
@@ -21,6 +21,7 @@ Executes a closure inside a container in a kubernetes pod. Proxy environment var
 |containerMap|no|`[:]`||
 |containerName|no|||
 |containerPortMappings|no|||
+|containerShell|no|||
 |containerWorkspaces|no|||
 |dockerEnvVars|no|`[:]`||
 |dockerImage|yes|||
@@ -37,6 +38,7 @@ Executes a closure inside a container in a kubernetes pod. Proxy environment var
 
 * `containerName`: optional configuration in combination with containerMap to define the container where the commands should be executed in
 * `containerPortMappings`: Map which defines per docker image the port mappings, like `containerPortMappings: ['selenium/standalone-chrome': [[name: 'selPort', containerPort: 4444, hostPort: 4444]]]`
+* `containerShell` allows to specify the shell to be executed for container with containerName
 * `containerWorkspaces` specifies workspace (=home directory of user) per container. If not provided `dockerWorkspace` will be used. If empty, home directory will not be set.
 * `dockerImage` Name of the docker image that should be used. If empty, Docker is not used.
 * `dockerEnvVars` Environment variables to set in the container, e.g. [http_proxy:'proxy:8080']

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -49,6 +49,7 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
     def containersList = []
     def imageList = []
     def containerName = ''
+    def containerShell = ''
     def envList = []
     def portList = []
     def containerCommands = []
@@ -260,9 +261,23 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
         assertThat(envList, hasItem(hasItem(allOf(hasEntry('key', 'customEnvKey'), hasEntry ('value','customEnvValue')))))
     }
 
+    @Test
+    void testDockerExecuteOnKubernetesWithCustomShell() {
+        jsr.step.dockerExecuteOnKubernetes(
+            script: nullScript,
+            juStabUtils: utils,
+            dockerImage: 'maven:3.5-jdk-8-alpine',
+            containerShell: '/busybox/sh'
+        ) {
+            //nothing to exeute
+        }
+        assertThat(containerShell, is('/busybox/sh'))
+    }
+
 
     private container(options, body) {
         containerName = options.name
+        containerShell = options.shell
         body()
     }
 }

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -16,6 +16,7 @@ import hudson.AbortException
     'containerMap', //specify multiple images which then form a kubernetes pod, example: containerMap: ['maven:3.5-jdk-8-alpine': 'mavenexecute','selenium/standalone-chrome': 'selenium']
     'containerName', //optional configuration in combination with containerMap to define the container where the commands should be executed in
     'containerPortMappings', //map which defines per docker image the port mappings, like containerPortMappings: ['selenium/standalone-chrome': [[name: 'selPort', containerPort: 4444, hostPort: 4444]]]
+    'containerShell', // allows to specify the shell to be executed for container with containerName
     'containerWorkspaces', //specify workspace (=home directory of user) per container. If not provided dockerWorkspace will be used. If empty, home directory will not be set.
     'dockerImage',
     'dockerWorkspace',
@@ -77,7 +78,11 @@ void executeOnPod(Map config, utils, Closure body) {
         podTemplate(getOptions(config)) {
             node(config.uniqueId) {
                 if (config.containerName) {
-                    container(name: config.containerName){
+                    Map containerParams = [name: config.containerName]
+                    if (config.containerShell) {
+                        containerParams.shell = config.containerShell
+                    }
+                    container(containerParams){
                         try {
                             utils.unstashAll(config.stashContent)
                             body()


### PR DESCRIPTION
Depending on the Docker image used the default shell will not work in certain cases.

**changes:**

This extends the executeDockerOnKubernetes step to be able to use a custom shell according to https://github.com/jenkinsci/kubernetes-plugin#specifying-a-different-shell-command-other-than-binsh
 
- [x] add tests
- [x] add documentation
