### PR TITLE
cloudFoundryDeploy: fix naming of Influx step 

### DIFF
--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -58,7 +58,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
     @Before
     void init() {
-        helper.registerAllowedMethod('writeInflux', [Map.class], {m ->
+        helper.registerAllowedMethod('influxWriteData', [Map.class], {m ->
             writeInfluxMap = m
         })
     }

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -264,5 +264,5 @@ private void reportToInflux(script, config, deploySuccess, JenkinsUtils jenkinsU
         cfOrg: config.cloudFoundry.org,
         cfSpace: config.cloudFoundry.space,
     ]]
-    writeInflux script: script, customData: [:], customDataTags: [:], customDataMap: deploymentData, customDataMapTags: deploymentDataTags
+    influxWriteData script: script, customData: [:], customDataTags: [:], customDataMap: deploymentData, customDataMapTags: deploymentDataTags
 }


### PR DESCRIPTION
# Changes
Internal name was used: writeInflux -> influxWriteData