### PR TITLE
cloudFoundryDeploy - patch mta blue-green deployment

### DIFF
--- a/documentation/docs/steps/cloudFoundryDeploy.md
+++ b/documentation/docs/steps/cloudFoundryDeploy.md
@@ -32,7 +32,7 @@ Deployment can be done
 | keepOldInstance | no | false | true, false |
 | dockerImage | no | s4sdk/docker-cf-cli |  |
 | dockerWorkspace | no | /home/piper |  |
-| mtaDeployParameters |  | -f |  |
+| mtaDeployParameters |  | for _deployType:standard_ `-f`<br />for _deployType:blue-green_ `-f --no-confirm` |  |
 | mtaExtensionDescriptor | no | '' |  |
 | mtaPath | no | '' |  |
 | smokeTestScript | no | blueGreenCheckScript.sh (provided by library). <br />Can be overwritten using config property 'smokeTestScript' |  |

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -16,6 +16,7 @@ import util.JenkinsWriteFileRule
 import util.JenkinsReadYamlRule
 import util.Rules
 
+import static org.hamcrest.Matchers.stringContainsInOrder
 import static org.junit.Assert.assertThat
 
 import static org.hamcrest.Matchers.hasItem
@@ -396,6 +397,24 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(jscr.shell, hasItem(containsString('cf login -u test_cf -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(jscr.shell, hasItem(containsString('cf deploy target/test.mtar -f')))
         assertThat(jscr.shell, hasItem(containsString('cf logout')))
+    }
+
+    @Test
+    void testMtaBlueGreen() {
+
+        jsr.step.cloudFoundryDeploy([
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            deployType: 'blue-green',
+            mtaPath: 'target/test.mtar'
+        ])
+
+        assertThat(jscr.shell, hasItem(stringContainsInOrder(["cf login -u test_cf", 'cf bg-deploy', '-f', '--no-confirm'])))
     }
 
     @Test

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -209,8 +209,12 @@ def deployMta (config) {
     if (!config.mtaExtensionDescriptor.isEmpty() && !config.mtaExtensionDescriptor.startsWith('-e ')) config.mtaExtensionDescriptor = "-e ${config.mtaExtensionDescriptor}"
 
     def deployCommand = 'deploy'
-    if (config.deployType == 'blue-green')
+    if (config.deployType == 'blue-green') {
         deployCommand = 'bg-deploy'
+        if (config.mtaDeployParameters.indexOf('--no-confirm') < 0) {
+            config.mtaDeployParameters += ' --no-confirm'
+        }
+    }
 
     withCredentials([usernamePassword(
         credentialsId: config.cloudFoundry.credentialsId,


### PR DESCRIPTION
# Changes
mta deploy plugin has flag:
` --no-confirm` which is described as _"Do not require confirmation for deleting the previously deployed MTA apps"_

This flag is essentials for performing fully automated blue-green deployments.

- [x] Tests
- [x] Documentation
