### PR TITLE
dockerExecute - fix issue when image does not contain which

### DIFF
--- a/test/groovy/DockerExecuteTest.groovy
+++ b/test/groovy/DockerExecuteTest.groovy
@@ -31,7 +31,7 @@ class DockerExecuteTest extends BasePiperTest {
         .around(jlr)
         .around(jsr)
 
-    int whichDockerReturnValue = 0
+    int dockerPsReturnValue = 0
     def bodyExecuted
     def containerName
 
@@ -41,7 +41,7 @@ class DockerExecuteTest extends BasePiperTest {
         docker = new DockerMock()
         JenkinsUtils.metaClass.static.isPluginActive = {def s -> new PluginMock(s).isActive()}
         binding.setVariable('docker', docker)
-        helper.registerAllowedMethod('sh', [Map.class], {return whichDockerReturnValue})
+        helper.registerAllowedMethod('sh', [Map.class], {return dockerPsReturnValue})
     }
 
     @Test
@@ -168,12 +168,12 @@ class DockerExecuteTest extends BasePiperTest {
 
     @Test
     void testDockerNotInstalledResultsInLocalExecution() throws Exception {
-        whichDockerReturnValue = 1
+        dockerPsReturnValue = 1
         jsr.step.dockerExecute(script: nullScript,
             dockerOptions: '-it') {
             bodyExecuted = true
         }
-        assertTrue(jlr.log.contains('No docker environment found'))
+        assertTrue(jlr.log.contains('Cannot connect to docker daemon'))
         assertTrue(jlr.log.contains('Running on local environment'))
         assertTrue(bodyExecuted)
         assertFalse(docker.isImagePulled())

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -106,12 +106,6 @@ void call(Map parameters = [:], body) {
                 executeInsideDocker = false
             }
 
-            def returnCode = sh script: 'which docker > /dev/null', returnStatus: true
-            if (returnCode != 0) {
-                echo "[WARNING][${STEP_NAME}] No docker environment found (command 'which docker' did not return with '0'). Configured docker image '${config.dockerImage}' will not be used."
-                executeInsideDocker = false
-            }
-
             returnCode = sh script: 'docker ps -q > /dev/null', returnStatus: true
             if (returnCode != 0) {
                 echo "[WARNING][$STEP_NAME] Cannot connect to docker daemon (command 'docker ps' did not return with '0'). Configured docker image '${config.dockerImage}' will not be used."


### PR DESCRIPTION
# Changes

command `which` requires a dedicated OS package to be installed.
In case a Jenkins Master or Jenkins Slave Image does not contain `which`, although `docker` command is available the step took a wrong turn.

This removes the check using `which` since checking `docker ps` is sufficient.

- [x] Tests
- [x] ~Documentation~ not relevant
