### PR TITLE
Remove size property for neoDeploy from default pipeline environment

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -225,7 +225,6 @@ steps:
     deployMode: 'mta'
     warAction: 'deploy'
     neo:
-      size: 'lite'
       credentialsId: 'CI_CREDENTIALS_ID'
 
   newmanExecute:


### PR DESCRIPTION
since this property is not used anymore.

