### PR TITLE
dockerExecute: make javadoc comment to 'normal' comment

### DIFF
--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -154,7 +154,7 @@ void call(Map parameters = [:], body) {
 
 
 
-/**
+/*
  * Returns a string with docker options containing
  * environment variables (if set).
  * Possible to extend with further options.
@@ -225,7 +225,7 @@ boolean isKubernetes() {
     return Boolean.valueOf(env.ON_K8S)
 }
 
-/**
+/*
  * Escapes blanks for values in key/value pairs
  * E.g. <code>description=Lorem ipsum</code> is
  * changed to <code>description=Lorem\ ipsum</code>.


### PR DESCRIPTION
since it is not intendend to expose the method docu as api doc.
