### PR TITLE
neo toolset not configurable

### DIFF
--- a/src/com/sap/piper/tools/neo/NeoCommandHelper.groovy
+++ b/src/com/sap/piper/tools/neo/NeoCommandHelper.groovy
@@ -9,25 +9,23 @@ class NeoCommandHelper {
     private Script step
     private DeployMode deployMode
     private Map deploymentConfiguration
-    private String pathToNeoExecutable
     private String user
     private String password
     private String source
 
     //Warning: Commands generated with this class can contain passwords and should only be used within the step withCredentials
-    NeoCommandHelper(Script step, DeployMode deployMode, Map deploymentConfiguration, String pathToNeoExecutable,
+    NeoCommandHelper(Script step, DeployMode deployMode, Map deploymentConfiguration,
                     String user, String password, String source) {
         this.step = step
         this.deployMode = deployMode
         this.deploymentConfiguration = deploymentConfiguration
-        this.pathToNeoExecutable = pathToNeoExecutable
         this.user = user
         this.password = password
         this.source = source
     }
 
     private String prolog() {
-        return "\"${pathToNeoExecutable}\""
+        return 'neo.sh'
     }
 
     String statusCommand() {

--- a/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
+++ b/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
@@ -141,7 +141,7 @@ class FioriOnCloudPlatformPipelineTest extends BasePiperTest {
         // the neo deploy call:
         Assert.assertThat(shellRule.shell,
             new CommandLineMatcher()
-                .hasProlog("\"/opt/sap/neo/tools/neo.sh\" deploy-mta")
+                .hasProlog("\"neo.sh\" deploy-mta")
                 .hasSingleQuotedOption('host', 'hana\\.example\\.com')
                 .hasSingleQuotedOption('account', 'myTestAccount')
                 .hasSingleQuotedOption('password', 'terceSpot')

--- a/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
+++ b/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
@@ -141,7 +141,7 @@ class FioriOnCloudPlatformPipelineTest extends BasePiperTest {
         // the neo deploy call:
         Assert.assertThat(shellRule.shell,
             new CommandLineMatcher()
-                .hasProlog("\"neo.sh\" deploy-mta")
+                .hasProlog("neo.sh deploy-mta")
                 .hasSingleQuotedOption('host', 'hana\\.example\\.com')
                 .hasSingleQuotedOption('account', 'myTestAccount')
                 .hasSingleQuotedOption('password', 'terceSpot')

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -106,7 +106,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("neo.sh deploy-mta")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasOption('synchronous', '')
@@ -132,7 +132,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("neo.sh deploy-mta")
                 .hasSingleQuotedOption('host', 'configuration-frwk\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'configurationFrwkUser123')
                 .hasOption('synchronous', '')
@@ -147,7 +147,7 @@ class NeoDeployTest extends BasePiperTest {
         stepRule.step.neoDeploy(script: nullScript)
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("neo.sh deploy-mta")
                 .hasSingleQuotedOption('source', 'archive.mtar'))
     }
 
@@ -158,7 +158,7 @@ class NeoDeployTest extends BasePiperTest {
             source: "archive.mtar")
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("neo.sh deploy-mta")
                 .hasSingleQuotedOption('source', 'archive.mtar'))
     }
 
@@ -183,7 +183,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("neo.sh deploy-mta")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasOption('synchronous', '')
@@ -230,7 +230,7 @@ class NeoDeployTest extends BasePiperTest {
         stepRule.step.neoDeploy(script: nullScript, source: archiveName, deployMode: 'mta')
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("neo.sh deploy-mta")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasOption('synchronous', '')
@@ -255,7 +255,7 @@ class NeoDeployTest extends BasePiperTest {
             source: warArchiveName)
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy")
+            new CommandLineMatcher().hasProlog("neo.sh deploy")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasSingleQuotedOption('application', 'testApp')
@@ -286,7 +286,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" rolling-update")
+            new CommandLineMatcher().hasProlog("neo.sh rolling-update")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasSingleQuotedOption('application', 'testApp')
@@ -316,7 +316,7 @@ class NeoDeployTest extends BasePiperTest {
 
         Assert.assertThat(shellRule.shell,
             new CommandLineMatcher()
-                .hasProlog("\"neo.sh\" deploy")
+                .hasProlog("neo.sh deploy")
                 .hasSingleQuotedOption('application', 'testApp'))
     }
 
@@ -379,7 +379,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy")
+            new CommandLineMatcher().hasProlog("neo.sh deploy")
                 .hasArgument("config.properties")
                 .hasSingleQuotedOption('user', 'defaultUser')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
@@ -404,7 +404,7 @@ class NeoDeployTest extends BasePiperTest {
             ])
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"neo.sh\" rolling-update")
+            new CommandLineMatcher().hasProlog("neo.sh rolling-update")
                 .hasArgument('config.properties')
                 .hasSingleQuotedOption('user', 'defaultUser')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -84,7 +84,6 @@ class NeoDeployTest extends BasePiperTest {
         helper.registerAllowedMethod('dockerExecute', [Map, Closure], null)
         helper.registerAllowedMethod('fileExists', [String], { s -> return new File(workspacePath, s).exists() })
         helper.registerAllowedMethod('pwd', [], { return workspacePath })
-        mockShellCommands()
 
         nullScript.commonPipelineEnvironment.configuration = [steps: [neoDeploy: [neo: [host: 'test.deploy.host.com', account: 'trialuser123']]]]
     }
@@ -107,7 +106,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasOption('synchronous', '')
@@ -133,7 +132,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
                 .hasSingleQuotedOption('host', 'configuration-frwk\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'configurationFrwkUser123')
                 .hasOption('synchronous', '')
@@ -148,7 +147,7 @@ class NeoDeployTest extends BasePiperTest {
         stepRule.step.neoDeploy(script: nullScript)
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
                 .hasSingleQuotedOption('source', 'archive.mtar'))
     }
 
@@ -159,7 +158,7 @@ class NeoDeployTest extends BasePiperTest {
             source: "archive.mtar")
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
                 .hasSingleQuotedOption('source', 'archive.mtar'))
     }
 
@@ -184,7 +183,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasOption('synchronous', '')
@@ -193,69 +192,6 @@ class NeoDeployTest extends BasePiperTest {
                 .hasSingleQuotedOption('source', '.*')
         )
     }
-
-
-    @Test
-    void neoHomeNotSetTest() {
-
-        mockHomeVariablesNotSet()
-
-        stepRule.step.neoDeploy(script: nullScript,
-            source: archiveName
-        )
-
-        assert shellRule.shell.find { c -> c.contains('"neo.sh" deploy-mta') }
-        assert loggingRule.log.contains('SAP Cloud Platform Console Client is on PATH.')
-        assert loggingRule.log.contains("Using SAP Cloud Platform Console Client 'neo.sh'.")
-    }
-
-
-    @Test
-    void neoHomeAsParameterTest() {
-
-        mockHomeVariablesNotSet()
-
-        stepRule.step.neoDeploy(script: nullScript,
-            source: archiveName,
-            neo:[credentialsId: 'myCredentialsId'],
-            neoHome: '/param/neo'
-        )
-
-        assert shellRule.shell.find { c -> c = "\"/param/neo/tools/neo.sh\" deploy-mta" }
-        assert loggingRule.log.contains("SAP Cloud Platform Console Client home '/param/neo' retrieved from configuration.")
-        assert loggingRule.log.contains("Using SAP Cloud Platform Console Client '/param/neo/tools/neo.sh'.")
-    }
-
-
-    @Test
-    void neoHomeFromEnvironmentTest() {
-
-        stepRule.step.neoDeploy(script: nullScript,
-            source: archiveName
-        )
-
-        assert shellRule.shell.find { c -> c.contains("\"/opt/neo/tools/neo.sh\" deploy-mta") }
-        assert loggingRule.log.contains("SAP Cloud Platform Console Client home '/opt/neo' retrieved from environment.")
-        assert loggingRule.log.contains("Using SAP Cloud Platform Console Client '/opt/neo/tools/neo.sh'.")
-    }
-
-
-    @Test
-    void neoHomeFromCustomStepConfigurationTest() {
-
-        mockHomeVariablesNotSet()
-
-        nullScript.commonPipelineEnvironment.configuration = [steps: [neoDeploy: [neo: [host: 'test.deploy.host.com', account: 'trialuser123'], neoHome: '/config/neo']]]
-
-        stepRule.step.neoDeploy(script: nullScript,
-            source: archiveName
-        )
-
-        assert shellRule.shell.find { c -> c = "\"/config/neo/tools/neo.sh\" deploy-mta" }
-        assert loggingRule.log.contains("SAP Cloud Platform Console Client home '/config/neo' retrieved from configuration.")
-        assert loggingRule.log.contains("Using SAP Cloud Platform Console Client '/config/neo/tools/neo.sh'.")
-    }
-
 
     @Test
     void archiveNotProvidedTest() {
@@ -294,7 +230,7 @@ class NeoDeployTest extends BasePiperTest {
         stepRule.step.neoDeploy(script: nullScript, source: archiveName, deployMode: 'mta')
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy-mta")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy-mta")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasOption('synchronous', '')
@@ -319,7 +255,7 @@ class NeoDeployTest extends BasePiperTest {
             source: warArchiveName)
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasSingleQuotedOption('application', 'testApp')
@@ -350,7 +286,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" rolling-update")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" rolling-update")
                 .hasSingleQuotedOption('host', 'test\\.deploy\\.host\\.com')
                 .hasSingleQuotedOption('account', 'trialuser123')
                 .hasSingleQuotedOption('application', 'testApp')
@@ -380,7 +316,7 @@ class NeoDeployTest extends BasePiperTest {
 
         Assert.assertThat(shellRule.shell,
             new CommandLineMatcher()
-                .hasProlog("\"/opt/neo/tools/neo.sh\" deploy")
+                .hasProlog("\"neo.sh\" deploy")
                 .hasSingleQuotedOption('application', 'testApp'))
     }
 
@@ -443,7 +379,7 @@ class NeoDeployTest extends BasePiperTest {
         )
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" deploy")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" deploy")
                 .hasArgument("config.properties")
                 .hasSingleQuotedOption('user', 'defaultUser')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
@@ -468,7 +404,7 @@ class NeoDeployTest extends BasePiperTest {
             ])
 
         Assert.assertThat(shellRule.shell,
-            new CommandLineMatcher().hasProlog("\"/opt/neo/tools/neo.sh\" rolling-update")
+            new CommandLineMatcher().hasProlog("\"neo.sh\" rolling-update")
                 .hasArgument('config.properties')
                 .hasSingleQuotedOption('user', 'defaultUser')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
@@ -555,29 +491,5 @@ class NeoDeployTest extends BasePiperTest {
                 runtimeVersion: '2.125',
                 size: 'lite'
             ])
-    }
-
-    private mockShellCommands() {
-        String javaVersion = '''openjdk version \"1.8.0_121\"
-                    OpenJDK Runtime Environment (build 1.8.0_121-8u121-b13-1~bpo8+1-b13)
-                    OpenJDK 64-Bit Server VM (build 25.121-b13, mixed mode)'''
-        shellRule.setReturnValue(Type.REGEX, '.*java -version.*', javaVersion)
-
-        String neoVersion = '''SAP Cloud Platform Console Client
-                    SDK version    : 3.39.10
-                    Runtime        : neo-java-web'''
-        shellRule.setReturnValue(Type.REGEX, '.*neo.sh version.*', neoVersion)
-
-        shellRule.setReturnValue(Type.REGEX, '.*JAVA_HOME.*', '/opt/java')
-        shellRule.setReturnValue(Type.REGEX, '.*NEO_HOME.*', '/opt/neo')
-        shellRule.setReturnValue(Type.REGEX, '.*which java.*', 0)
-        shellRule.setReturnValue(Type.REGEX, '.*which neo.*', 0)
-    }
-
-    private mockHomeVariablesNotSet() {
-        shellRule.setReturnValue(Type.REGEX, '.*JAVA_HOME.*', '')
-        shellRule.setReturnValue(Type.REGEX, '.*NEO_HOME.*', '')
-        shellRule.setReturnValue(Type.REGEX, '.*which java.*', 0)
-        shellRule.setReturnValue(Type.REGEX, '.*which neo.*', 0)
     }
 }

--- a/test/groovy/com/sap/piper/tools/neo/NeoCommandHelperTest.groovy
+++ b/test/groovy/com/sap/piper/tools/neo/NeoCommandHelperTest.groovy
@@ -34,7 +34,6 @@ class NeoCommandHelperTest extends BasePiperTest {
         String source = (deployMode == DeployMode.MTA) ? 'file.mta' : 'file.war'
         String username = 'username'
         String password = 'password'
-        String neoExecutable = '/path/tools/neo.sh';
 
         nullScript.STEP_NAME="neoDeploy"
 
@@ -42,7 +41,6 @@ class NeoCommandHelperTest extends BasePiperTest {
             nullScript,
             deployMode,
             deploymentConfiguration,
-            neoExecutable,
             username,
             password,
             source
@@ -52,7 +50,7 @@ class NeoCommandHelperTest extends BasePiperTest {
     @Test
     void testStatusCommand() {
         String actual = getTestFixture(DeployMode.WAR_PARAMS).statusCommand()
-        String expected = "\"/path/tools/neo.sh\" status --host 'host_value' --account 'account_value' " +
+        String expected = "neo.sh status --host 'host_value' --account 'account_value' " +
             "--application 'application_value' --user 'username' --password 'password'"
         Assert.assertEquals(expected, actual)
     }
@@ -60,14 +58,14 @@ class NeoCommandHelperTest extends BasePiperTest {
     @Test
     void testStatusCommandForProperties() {
         String actual = getTestFixture(DeployMode.WAR_PROPERTIES_FILE).statusCommand()
-        String expected = "\"/path/tools/neo.sh\" status file.properties --user 'username' --password 'password'"
+        String expected = "neo.sh status file.properties --user 'username' --password 'password'"
         Assert.assertEquals(expected, actual)
     }
 
     @Test
     void testRollingUpdateCommand() {
         String actual = getTestFixture(DeployMode.WAR_PARAMS).rollingUpdateCommand()
-        String basicCommand = "\"/path/tools/neo.sh\" rolling-update --host 'host_value' --account 'account_value' " +
+        String basicCommand = "neo.sh rolling-update --host 'host_value' --account 'account_value' " +
             "--application 'application_value' --user 'username' --password 'password' --source 'file.war'"
 
         Assert.assertTrue(actual.contains(basicCommand))
@@ -81,14 +79,14 @@ class NeoCommandHelperTest extends BasePiperTest {
     @Test
     void testRollingUpdateCommandForProperties() {
         String actual = getTestFixture(DeployMode.WAR_PROPERTIES_FILE).rollingUpdateCommand()
-        String expected = "\"/path/tools/neo.sh\" rolling-update file.properties --user 'username' --password 'password' --source 'file.war' "
+        String expected = "neo.sh rolling-update file.properties --user 'username' --password 'password' --source 'file.war' "
         Assert.assertEquals(expected, actual)
     }
 
     @Test
     void testDeployCommand() {
         String actual = getTestFixture(DeployMode.WAR_PARAMS).deployCommand()
-        String basicCommand = "\"/path/tools/neo.sh\" deploy --host 'host_value' --account 'account_value' " +
+        String basicCommand = "neo.sh deploy --host 'host_value' --account 'account_value' " +
             "--application 'application_value' --user 'username' --password 'password' --source 'file.war'"
 
         Assert.assertTrue(actual.contains(basicCommand))
@@ -102,14 +100,14 @@ class NeoCommandHelperTest extends BasePiperTest {
     @Test
     void testDeployCommandForProperties() {
         String actual = getTestFixture(DeployMode.WAR_PROPERTIES_FILE).deployCommand()
-        String expected = "\"/path/tools/neo.sh\" deploy file.properties --user 'username' --password 'password' --source 'file.war' "
+        String expected = "neo.sh deploy file.properties --user 'username' --password 'password' --source 'file.war' "
         Assert.assertEquals(expected, actual)
     }
 
     @Test
     void testRestartCommand() {
         String actual = getTestFixture(DeployMode.WAR_PARAMS).restartCommand()
-        String expected = "\"/path/tools/neo.sh\" restart --synchronous --host 'host_value' --account 'account_value' " +
+        String expected = "neo.sh restart --synchronous --host 'host_value' --account 'account_value' " +
             "--application 'application_value' --user 'username' --password 'password'"
         Assert.assertEquals(expected, actual)
     }
@@ -117,14 +115,14 @@ class NeoCommandHelperTest extends BasePiperTest {
     @Test
     void testRestartCommandForProperties() {
         String actual = getTestFixture(DeployMode.WAR_PROPERTIES_FILE).restartCommand()
-        String expected = "\"/path/tools/neo.sh\" restart --synchronous file.properties --user 'username' --password 'password'"
+        String expected = "neo.sh restart --synchronous file.properties --user 'username' --password 'password'"
         Assert.assertEquals(expected, actual)
     }
 
     @Test
     void deployMta() {
         String actual = getTestFixture(DeployMode.MTA).deployMta()
-        String expected = "\"/path/tools/neo.sh\" deploy-mta --synchronous --host 'host_value' --account 'account_value' " +
+        String expected = "neo.sh deploy-mta --synchronous --host 'host_value' --account 'account_value' " +
             "--user 'username' --password 'password' --source 'file.mta'"
         Assert.assertEquals(expected, actual)
     }

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -58,7 +58,6 @@ void call(parameters = [:]) {
         ], configuration)
 
         ToolDescriptor neo = new ToolDescriptor('SAP Cloud Platform Console Client', 'NEO_HOME', 'neoHome', '/tools/', 'neo.sh', null, 'version')
-        ToolDescriptor java = new ToolDescriptor('Java', 'JAVA_HOME', '', '/bin/', 'java', '1.8.0', '-version 2>&1')
 
         if (configuration.neo.credentialsId) {
             withCredentials([usernamePassword(
@@ -74,9 +73,6 @@ void call(parameters = [:]) {
                     dockerEnvVars: configuration.dockerEnvVars,
                     dockerOptions: configuration.dockerOptions
                 ) {
-
-                    neo.verify(this, configuration)
-                    java.verify(this, configuration)
 
                     String neoExecutable = neo.getToolExecutable(script, configuration)
 

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -1,6 +1,5 @@
 import com.sap.piper.ConfigurationHelper
 import com.sap.piper.Utils
-import com.sap.piper.tools.ToolDescriptor
 import com.sap.piper.tools.neo.DeployMode
 import com.sap.piper.tools.neo.NeoCommandHelper
 import com.sap.piper.tools.neo.WarAction
@@ -57,8 +56,6 @@ void call(parameters = [:]) {
             stepParam3: parameters?.script == null,
         ], configuration)
 
-        ToolDescriptor neo = new ToolDescriptor('SAP Cloud Platform Console Client', 'NEO_HOME', 'neoHome', '/tools/', 'neo.sh', null, 'version')
-
         if (configuration.neo.credentialsId) {
             withCredentials([usernamePassword(
                 credentialsId: configuration.neo.credentialsId,
@@ -74,7 +71,7 @@ void call(parameters = [:]) {
                     dockerOptions: configuration.dockerOptions
                 ) {
 
-                    String neoExecutable = neo.getToolExecutable(script, configuration)
+                    String neoExecutable = 'neo.sh'
 
                     DeployMode deployMode = DeployMode.fromString(configuration.deployMode)
 

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -71,15 +71,12 @@ void call(parameters = [:]) {
                     dockerOptions: configuration.dockerOptions
                 ) {
 
-                    String neoExecutable = 'neo.sh'
-
                     DeployMode deployMode = DeployMode.fromString(configuration.deployMode)
 
                     NeoCommandHelper neoCommandHelper = new NeoCommandHelper(
                         this,
                         deployMode,
                         configuration.neo,
-                        neoExecutable,
                         NEO_USERNAME,
                         NEO_PASSWORD,
                         configuration.source


### PR DESCRIPTION
No configuration options anymore for `neo.sh`. It is expected that neo is configured properly on the system or in the docker container (folder containing `neo.sh` is in path or symbolic link to neo.sh from `/usr/local/bin`, environment variables set accordingly (if any)).
