### PR TITLE
Lookup mtar in the whole workspace

### DIFF
--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -37,9 +37,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
 
-        def script = checkScript(this, parameters)
-        if (script == null)
-            script = this
+        final script = checkScript(this, parameters) ?: this
 
         Map config = ConfigurationHelper.newInstance(this)
             .loadStepDefaults()
@@ -124,7 +122,7 @@ void call(Map parameters = [:]) {
 
 def findMtar(){
     def mtarPath = ''
-    def mtarFiles = findFiles(glob: '**/target/*.mtar')
+    def mtarFiles = findFiles(glob: '**/*.mtar')
 
     if(mtarFiles.length > 1){
         error 'Found multiple *.mtar files, please specify file via mtaPath parameter! ${mtarFiles}'

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -125,7 +125,7 @@ def findMtar(){
     def mtarFiles = findFiles(glob: '**/*.mtar')
 
     if(mtarFiles.length > 1){
-        error 'Found multiple *.mtar files, please specify file via mtaPath parameter! ${mtarFiles}'
+        error "Found multiple *.mtar files, please specify file via mtaPath parameter! ${mtarFiles}"
     }
     if(mtarFiles.length == 1){
         return mtarFiles[0].path

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -121,7 +121,6 @@ void call(Map parameters = [:]) {
 }
 
 def findMtar(){
-    def mtarPath = ''
     def mtarFiles = findFiles(glob: '**/*.mtar')
 
     if(mtarFiles.length > 1){


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation

Widens the lookup space for an mtar file to the whole workspace. Necessary because mta build tool creates mtar in workspace root.
Still includes the target folder and reuses the existing solution for multiple mtars giving a hint to specify a concrete mtaPath.