### PR TITLE
Remove println statements from default registered sh closure

### DIFF
--- a/test/groovy/util/LibraryLoadingTestExecutionListener.groovy
+++ b/test/groovy/util/LibraryLoadingTestExecutionListener.groovy
@@ -152,11 +152,9 @@ class LibraryLoadingTestExecutionListener extends AbstractTestExecutionListener 
         helper.registerAllowedMethod("node", [String.class, Closure.class], null)
         helper.registerAllowedMethod("node", [Closure.class], null)
         helper.registerAllowedMethod( method('sh', Map.class), {m ->
-            println "sh-command: $m.script"
             return ""
         } )
         helper.registerAllowedMethod( method('sh', String.class), {s ->
-            println "sh-command: $s"
             return ""
         } )
         helper.registerAllowedMethod("checkout", [Map.class], null)


### PR DESCRIPTION
We should try to avoid promting statements to the log during tests. This is basically
some kind of manual/visual checking of conditions. This does not work since in most cases
nobody scans test logs manually/visually. I think this is often a smell for missing assertions.
