### PR TITLE
Remove println statements from tests

### DIFF
--- a/test/groovy/MailSendNotificationTest.groovy
+++ b/test/groovy/MailSendNotificationTest.groovy
@@ -72,8 +72,6 @@ user3@domain.com noreply+github@domain.com'''
             ],
             'master',
             2)
-        println("LOGS: ${loggingRule.log}")
-        println("RESULT: ${result}")
         // asserts
         assertThat(result, containsString('user2@domain.com'))
         assertThat(result, containsString('user3@domain.com'))


### PR DESCRIPTION
Nobody will have a look at println statements emitted by tests. Proper way is to assert.

* log is empty, not sure if it makes sense to assert that the log is empty.
* result is already asserted, so everything is fine there ...