### PR TITLE
[fix] remove inapproriate package statement

### DIFF
--- a/test/groovy/UiVeri5ExecuteTestsTest.groovy
+++ b/test/groovy/UiVeri5ExecuteTestsTest.groovy
@@ -1,5 +1,4 @@
 #!groovy
-package steps
 
 import static org.hamcrest.Matchers.*
 


### PR DESCRIPTION
The test class is in the default package and not in a package 'steps'.