### PR TITLE
fix general config for parameter changeManagement

### DIFF
--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -16,17 +16,13 @@ import static com.sap.piper.cm.StepHelpers.getBackendTypeAndLogInfoIfCMIntegrati
 
 @Field def STEP_NAME = getClass().getName()
 
-@Field Set GENERAL_CONFIG_KEYS = STEP_CONFIG_KEYS
-
-@Field Set STEP_CONFIG_KEYS = [
-    'changeManagement',
+@Field Set GENERAL_CONFIG_KEYS = ['changeManagement']
+@Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS.plus(
     /**
       * When set to `false` the step will not fail in case the step is not in status 'in development'.
       * @possibleValues `true`, `false`
       */
-    'failIfStatusIsNotInDevelopment'
-  ]
-
+    'failIfStatusIsNotInDevelopment')
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus('changeDocumentId')
 
 /**


### PR DESCRIPTION
According to the documentation the parameter ```changeManagement``` should be configurable with general scope.
