### PR TITLE
consumer tests only in master repo for master or integration branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ jobs:
         documentation/bin/createDocu.sh vars documentation/docs-tmp/steps
         docker run --rm -it -v ${TRAVIS_BUILD_DIR}:/docs -w /docs/documentation squidfunk/mkdocs-material:3.0.4 build --clean --verbose --strict
     - name: Consumer Tests for s4sdk pipeline (CloudFoundry)
-      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^integration\/.*$/
+      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
-      if: repo = "SAP/jenkins-library" AND (branch = master OR branch = integration)
+      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^integration\/.*$/
       script: cd consumer-test/s4sdk/NeoEnvironment && chmod +x runTests.sh && ./runTests.sh
 
     - stage: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
         documentation/bin/createDocu.sh vars documentation/docs-tmp/steps
         docker run --rm -it -v ${TRAVIS_BUILD_DIR}:/docs -w /docs/documentation squidfunk/mkdocs-material:3.0.4 build --clean --verbose --strict
     - name: Consumer Tests for s4sdk pipeline (CloudFoundry)
-      if: repo = "SAP/jenkins-library" AND (branch = master OR branch = integration)
+      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^integration\/.*$/
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
       if: repo = "SAP/jenkins-library" AND (branch = master OR branch = integration)

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ jobs:
         documentation/bin/createDocu.sh vars documentation/docs-tmp/steps
         docker run --rm -it -v ${TRAVIS_BUILD_DIR}:/docs -w /docs/documentation squidfunk/mkdocs-material:3.0.4 build --clean --verbose --strict
     - name: Consumer Tests for s4sdk pipeline (CloudFoundry)
-      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/
+      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/ AND NOT type = pull_request
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
-      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^integration\/.*$/
+      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/
       script: cd consumer-test/s4sdk/NeoEnvironment && chmod +x runTests.sh && ./runTests.sh
 
     - stage: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   only:
   - master
+  - /^it\/.*$/
 language: groovy
 sudo: required
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ jobs:
         documentation/bin/createDocu.sh vars documentation/docs-tmp/steps
         docker run --rm -it -v ${TRAVIS_BUILD_DIR}:/docs -w /docs/documentation squidfunk/mkdocs-material:3.0.4 build --clean --verbose --strict
     - name: Consumer Tests for s4sdk pipeline (CloudFoundry)
-      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND head_repo = "SAP/jenkins-library" AND head_branch =~ /^it\/.*$/) )
+      if: repo = "SAP/jenkins-library" && ( (type != pull_request && branch =~ /^master$|^it\/.*$/) || (type == pull_request && head_repo = "SAP/jenkins-library" && head_branch =~ /^it\/.*$/) )
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
-      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND head_repo = "SAP/jenkins-library" AND head_branch =~ /^it\/.*$/) )
+      if: repo = "SAP/jenkins-library" && ( (type != pull_request && branch =~ /^master$|^it\/.*$/) || (type == pull_request && head_repo = "SAP/jenkins-library" && head_branch =~ /^it\/.*$/) )
       script: cd consumer-test/s4sdk/NeoEnvironment && chmod +x runTests.sh && ./runTests.sh
 
     - stage: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ jobs:
         documentation/bin/createDocu.sh vars documentation/docs-tmp/steps
         docker run --rm -it -v ${TRAVIS_BUILD_DIR}:/docs -w /docs/documentation squidfunk/mkdocs-material:3.0.4 build --clean --verbose --strict
     - name: Consumer Tests for s4sdk pipeline (CloudFoundry)
+      if: repo = "SAP/jenkins-library" AND (branch = master OR branch = integration)
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
+      if: repo = "SAP/jenkins-library" AND (branch = master OR branch = integration)
       script: cd consumer-test/s4sdk/NeoEnvironment && chmod +x runTests.sh && ./runTests.sh
 
     - stage: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ jobs:
         documentation/bin/createDocu.sh vars documentation/docs-tmp/steps
         docker run --rm -it -v ${TRAVIS_BUILD_DIR}:/docs -w /docs/documentation squidfunk/mkdocs-material:3.0.4 build --clean --verbose --strict
     - name: Consumer Tests for s4sdk pipeline (CloudFoundry)
-      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/ AND NOT type = pull_request
+      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND branch =~ /^it\/.*$/) )
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
-      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/
+      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/ AND NOT type = pull_request
       script: cd consumer-test/s4sdk/NeoEnvironment && chmod +x runTests.sh && ./runTests.sh
 
     - stage: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ jobs:
         documentation/bin/createDocu.sh vars documentation/docs-tmp/steps
         docker run --rm -it -v ${TRAVIS_BUILD_DIR}:/docs -w /docs/documentation squidfunk/mkdocs-material:3.0.4 build --clean --verbose --strict
     - name: Consumer Tests for s4sdk pipeline (CloudFoundry)
-      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND branch =~ /^it\/.*$/) )
+      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND head_repo = "SAP/jenkins-library" AND head_branch =~ /^it\/.*$/) )
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
-      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND branch =~ /^it\/.*$/) )
+      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND head_repo = "SAP/jenkins-library" AND head_branch =~ /^it\/.*$/) )
       script: cd consumer-test/s4sdk/NeoEnvironment && chmod +x runTests.sh && ./runTests.sh
 
     - stage: Docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND branch =~ /^it\/.*$/) )
       script: cd consumer-test/s4sdk/CloudFoundry && chmod +x runTests.sh && ./runTests.sh
     - name: Consumer Tests for s4sdk pipeline (Neo Environment)
-      if: repo = "SAP/jenkins-library" AND branch =~ /^master$|^it\/.*$/ AND NOT type = pull_request
+      if: repo = "SAP/jenkins-library" && ( (type != pull_request AND  branch =~ /^master$|^it\/.*$/) || (type == pull_request AND branch =~ /^it\/.*$/) )
       script: cd consumer-test/s4sdk/NeoEnvironment && chmod +x runTests.sh && ./runTests.sh
 
     - stage: Docs


### PR DESCRIPTION
@fwilhe : this is more a propsal for further discussions rather than something ready to merge.

We have the issue that for security reasons the consumer test can't work in case there are credentials involved.

--> this proposal cuts off the consumer tests for the forks.

Furthermore we will end up in long running tests having the consumer tests. It is more the less the nature of the consumer test to run quite long ... In order to address this issue the execution of theses tests is limited to a certain branch ("integration", currently also master ...).

The idea is to push from time to time (... with `-f`, of course) into this branch in order to trigger these tests as a deliberate action.

Feedback welcome ...

