### PR TITLE
Make K8S integration more configurable

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -27,6 +27,9 @@ general:
   gitSshKeyCredentialsId: '' #needed to allow sshagent to run with local ssh key
   jenkinsKubernetes:
     jnlpAgent: 's4sdk/jenkins-agent-k8s:latest'
+    securityContext:
+      runAsUser: 1000
+      fsGroup: 1000
   manualConfirmation: true
   productiveBranch: 'master'
 

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -28,8 +28,9 @@ general:
   jenkinsKubernetes:
     jnlpAgent: 's4sdk/jenkins-agent-k8s:latest'
     securityContext:
-      runAsUser: 1000
-      fsGroup: 1000
+    # Setting security context globally is currently not working with jaas
+    #  runAsUser: 1000
+    #  fsGroup: 1000
   manualConfirmation: true
   productiveBranch: 'master'
 

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -264,7 +264,7 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
             hasItem('maven:3.5-jdk-8-alpine'),
             hasItem('selenium/standalone-chrome'),
         ))
-        assertThat(portList, hasItem(hasItem([name: 'selenium0', port: 4444, hostPort: 4444])))
+        assertThat(portList, hasItem(hasItem([name: 'selenium0', containPort: 4444, hostPort: 4444])))
         assertThat(containerCommands.size(), is(1))
         assertThat(envList, hasItem(hasItem(allOf(hasEntry('name', 'customEnvKey'), hasEntry ('value','customEnvValue')))))
     }

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -82,7 +82,9 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
                 containersList.add(container.name)
                 imageList.add(container.image.toString())
                 envList.add(container.env)
-                portList.add(container.ports)
+                if(container.ports) {
+                    portList.add(container.ports)
+                }
                 if (container.command) {
                     containerCommands.add(container.command)
                 }
@@ -90,9 +92,6 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
             }
             body()
         })
-        helper.registerAllowedMethod('node', [String.class, Closure.class], { String nodeName, Closure body -> body() })
-        helper.registerAllowedMethod('envVar', [Map.class], { Map option -> return option })
-        helper.registerAllowedMethod('containerTemplate', [Map.class], { Map option -> return option })
     }
 
     @Test
@@ -264,7 +263,8 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
             hasItem('maven:3.5-jdk-8-alpine'),
             hasItem('selenium/standalone-chrome'),
         ))
-        assertThat(portList, hasItem(hasItem([name: 'selenium0', containPort: 4444, hostPort: 4444])))
+        // assertThat(portList, is(null))
+        assertThat(portList, hasItem([[name: 'selenium0', containerPort: 4444, hostPort: 4444]]))
         assertThat(containerCommands.size(), is(1))
         assertThat(envList, hasItem(hasItem(allOf(hasEntry('name', 'customEnvKey'), hasEntry ('value','customEnvValue')))))
     }

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -265,7 +265,7 @@ private List getContainerList(config) {
             def portMapping = { m ->
                 [
                     name: m.name,
-                    port: m.containerPort,
+                    containerPort: m.containerPort,
                     hostPort: m.hostPort
                 ]
             }

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -138,7 +138,7 @@ def getOptions(config) {
             yaml      : generatePodSpec(config)
     ]
     if (namespace) {
-      options.namespace = namespace
+        options.namespace = namespace
     }
     return options
 }
@@ -188,18 +188,18 @@ void executeOnPod(Map config, utils, Closure body) {
 def generatePodSpec(Map config) {
     def containers = getContainerList(config)
     def podSpec = [
-      apiVersion: "v1",
-      kind: "Pod",
-      metadata: [
-        lables: config.uniqueId
-      ],
-      spec: [
-        containers: containers
-      ]
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: [
+            lables: config.uniqueId
+        ],
+        spec: [
+            containers: containers
+        ]
     ]
     def securityContext = config.jenkinsKubernetes.securityContext
     if (securityContext) {
-      podSpec.spec.securityContext = securityContext
+        podSpec.spec.securityContext = securityContext
     }
     return new JsonBuilder(podSpec).toPrettyString()
 }
@@ -236,10 +236,10 @@ private void unstashWorkspace(config, prefix) {
 
 private List getContainerList(config) {
     def result = [
-      [
-        name: 'jnlp',
-        image: config.jenkinsKubernetes.jnlpAgent
-      ]
+        [
+            name: 'jnlp',
+            image: config.jenkinsKubernetes.jnlpAgent
+        ]
     ]
     config.containerMap.each { imageName, containerName ->
         def containerPullImage = config.containerPullImageFlags?.get(imageName)
@@ -256,7 +256,7 @@ private List getContainerList(config) {
             containerSpec['command'] = ['/usr/bin/tail', '-f', '/dev/null']
         } else {
             containerSpec['command'] =
-              (configuredCommand in List) ? configuredCommand : [shell, '-c', configuredCommand]
+                (configuredCommand in List) ? configuredCommand : [shell, '-c', configuredCommand]
         }
 
         if (config.containerPortMappings?.get(imageName)) {
@@ -292,7 +292,7 @@ private List getContainerEnvs(config, imageName) {
     def dockerWorkspace = config.containerWorkspaces?.get(imageName) != null ? config.containerWorkspaces?.get(imageName) : config.dockerWorkspace ?: ''
 
     def envVar = { e ->
-      [ name: e.key, value: e.value ]
+        [ name: e.key, value: e.value ]
     }
 
     if (dockerEnvVars) {

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -5,8 +5,8 @@ import com.sap.piper.GenerateDocumentation
 import com.sap.piper.JenkinsUtils
 import com.sap.piper.Utils
 import com.sap.piper.k8s.SystemEnv
+import com.sap.piper.JsonUtils
 
-import groovy.json.JsonBuilder
 import groovy.transform.Field
 import hudson.AbortException
 
@@ -200,8 +200,9 @@ private String generatePodSpec(Map config) {
     ]
     podSpec.spec.securityContext = getSecurityContext(config)
 
-    return new JsonBuilder(podSpec).toPrettyString()
+    return new JsonUtils().getPrettyJsonString(podSpec)
 }
+
 
 private String stashWorkspace(config, prefix, boolean chown = false) {
     def stashName = "${prefix}-${config.uniqueId}"


### PR DESCRIPTION
# Changes

*  Make the Kubernetes ns configurable

    If one Jenkins Master is used by multiple Teams, it is desirable to
    schedule K8S workloads in separate workspaces.

*  Add securityContext to define uid and fsGroup

   In the context of the Jenkins k8s plugin it is uids and fsGroups play an
   important role, because the containers share a common file system.

    Therefore it is beneficial to configure this data centrally.

To achieve this, we change the way pods are defined. Instead of using the DSL provided by the Kubernetes plugin, we specify pods directly as Kubernetes Objects.

This has the advantage of unlocking Kubernetes features which are not
exposed via the Kubernetes plugin, including all Kubernetes security
features.