### PR TITLE
Retrieve used steps from test run

### DIFF
--- a/test/groovy/util/LibraryLoadingTestExecutionListener.groovy
+++ b/test/groovy/util/LibraryLoadingTestExecutionListener.groovy
@@ -1,5 +1,7 @@
 package util
 
+import groovy.json.JsonOutput
+
 import com.lesfurets.jenkins.unit.InterceptingGCL
 import com.lesfurets.jenkins.unit.MethodSignature
 import com.lesfurets.jenkins.unit.PipelineTestHelper
@@ -11,6 +13,8 @@ import org.springframework.test.context.support.DependencyInjectionTestExecution
 import static com.lesfurets.jenkins.unit.MethodSignature.method
 
 class LibraryLoadingTestExecutionListener extends AbstractTestExecutionListener {
+
+    static StepTracker stepTracker = new StepTracker()
 
     static PipelineTestHelper singletonInstance
 
@@ -100,6 +104,9 @@ class LibraryLoadingTestExecutionListener extends AbstractTestExecutionListener 
         super.afterTestClass(testContext)
         PipelineTestHelper helper = LibraryLoadingTestExecutionListener.getSingletonInstance()
         helper.clearAllowedMethodCallbacks(LibraryLoadingTestExecutionListener.TRACKED_ON_CLASS)
+
+        stepTracker.add(testContext.testClass.getSimpleName(), LibraryLoadingTestExecutionListener.TRACKED_ON_CLASS)
+
         LibraryLoadingTestExecutionListener.TRACKED_ON_CLASS.clear()
 
         helper.putAllAllowedMethodCallbacks(LibraryLoadingTestExecutionListener.RESTORE_ON_CLASS)
@@ -135,6 +142,9 @@ class LibraryLoadingTestExecutionListener extends AbstractTestExecutionListener 
         PipelineTestHelper helper = LibraryLoadingTestExecutionListener.getSingletonInstance()
 
         helper.clearCallStack()
+
+        stepTracker.add(testInstance.getClass().getSimpleName(), LibraryLoadingTestExecutionListener.TRACKED_ON_METHODS)
+
         helper.clearAllowedMethodCallbacks(LibraryLoadingTestExecutionListener.TRACKED_ON_METHODS)
         LibraryLoadingTestExecutionListener.TRACKED_ON_METHODS.clear()
 

--- a/test/groovy/util/StepTracker.groovy
+++ b/test/groovy/util/StepTracker.groovy
@@ -1,0 +1,42 @@
+package util
+
+import groovy.json.JsonBuilder
+
+class StepTracker {
+
+        final static filePath = 'target/trackedCalls.json'
+
+    final static trackedCalls = [:]
+
+    def add(String testClass, Collection steps) {
+
+        def stepName = stepName(testClass)
+
+        if(trackedCalls[stepName] == null)
+            trackedCalls[stepName] = (Set)[]
+
+        steps.each { c -> trackedCalls[stepName] << c.name }
+
+        persist()
+    }
+
+    private persist() {
+        new File(filePath).write(new JsonBuilder(trackedCalls).toPrettyString())
+    }
+
+    // we expect a naming convention between test class and step under test:
+    // "<step>Test", where the first char of the test is transformed to upper case.
+    private static stepName(CharSequence testClass) {
+        firstCharToLowerCase(stripTrailingTest(testClass))
+    }
+
+    private static stripTrailingTest(CharSequence testClass) {
+        testClass.replaceAll('Test$', '')
+    }
+
+    private static firstCharToLowerCase(CharSequence cs) {
+        char[] c = cs.getChars()
+        c[0] = Character.toLowerCase(c[0])
+        return new String(c)
+    }
+}


### PR DESCRIPTION
We would like to have a where-use-list which contains the
directly required plugins for a step.

With this change we keep track which steps are called from a pipeline
step test. This can be used an input for making queries on a Jenkins
which plugins provides the steps in question.

Better approach would be to hook into PipelineTestHelper#methodInterceptor
(... a closure). But this is not that easy and directly modiyfing the
code in the JenkinsPipelineTesting framework is IMO also not a cool
option.

# Changes

- [ ] Tests
- [ ] Documentation
