### PR TITLE
Perform parameter validation early, do not truncate parameters

### DIFF
--- a/src/com/sap/piper/tools/neo/NeoCommandHelper.groovy
+++ b/src/com/sap/piper/tools/neo/NeoCommandHelper.groovy
@@ -1,7 +1,6 @@
 package com.sap.piper.tools.neo
 
 import com.sap.piper.BashUtils
-import com.sap.piper.ConfigurationHelper
 import com.sap.piper.StepAssertions
 
 class NeoCommandHelper {
@@ -58,19 +57,10 @@ class NeoCommandHelper {
                 "/acc/${properties.account}/app/${properties.application}/dashboard"
         }
 
-        ConfigurationHelper configurationHelper = ConfigurationHelper.newInstance(step, deploymentConfiguration)
-
-        configurationHelper
-            .withMandatoryProperty('host')
-            .withMandatoryProperty('account')
-
         if (deployMode == DeployMode.MTA) {
             return "https://account.${deploymentConfiguration.host}/cockpit#" +
                 "/acc/${deploymentConfiguration.account}/mtas"
         }
-
-        configurationHelper
-            .withMandatoryProperty('application')
 
         return "https://account.${deploymentConfiguration.host}/cockpit#" +
             "/acc/${deploymentConfiguration.account}/app/${deploymentConfiguration.application}/dashboard"
@@ -82,17 +72,9 @@ class NeoCommandHelper {
             return "${properties.host}/${properties.account}/${properties.application}"
         }
 
-        ConfigurationHelper configurationHelper = ConfigurationHelper.newInstance(step, deploymentConfiguration)
-        configurationHelper
-            .withMandatoryProperty('host')
-            .withMandatoryProperty('account')
-
-
         String resource = "${deploymentConfiguration.host}/${deploymentConfiguration.account}"
 
         if (deployMode == DeployMode.WAR_PARAMS) {
-            configurationHelper
-                .withMandatoryProperty('application')
 
             resource += "/${deploymentConfiguration.application}"
         }
@@ -113,17 +95,10 @@ class NeoCommandHelper {
             return "${deploymentConfiguration.propertiesFile} ${usernamePassword}"
         }
 
-        ConfigurationHelper configurationHelper = ConfigurationHelper.newInstance(step, deploymentConfiguration)
-        configurationHelper
-            .withMandatoryProperty('host')
-            .withMandatoryProperty('account')
-
         String targetArgs = "--host ${BashUtils.quoteAndEscape(deploymentConfiguration.host)}"
         targetArgs += " --account ${BashUtils.quoteAndEscape(deploymentConfiguration.account)}"
 
         if (deployMode == DeployMode.WAR_PARAMS) {
-            configurationHelper
-                .withMandatoryProperty('application')
 
             targetArgs += " --application ${BashUtils.quoteAndEscape(deploymentConfiguration.application)}"
         }
@@ -136,13 +111,8 @@ class NeoCommandHelper {
             return ""
         }
 
-        ConfigurationHelper configurationHelper = ConfigurationHelper.newInstance(step, deploymentConfiguration)
-
         String args = ""
-        configurationHelper.withMandatoryProperty('runtime')
         args += " --runtime ${BashUtils.quoteAndEscape(deploymentConfiguration.runtime)}"
-
-        configurationHelper.withMandatoryProperty('runtimeVersion')
         args += " --runtime-version ${BashUtils.quoteAndEscape(deploymentConfiguration.runtimeVersion)}"
 
         if (deploymentConfiguration.size) {

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -217,7 +217,7 @@ class NeoDeployTest extends BasePiperTest {
     void scriptNotProvidedTest() {
 
         thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR host')
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/host')
 
         nullScript.commonPipelineEnvironment.configuration = [:]
 
@@ -415,7 +415,7 @@ class NeoDeployTest extends BasePiperTest {
     void applicationNameNotProvidedTest() {
 
         thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR application')
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/application')
 
         stepRule.step.neoDeploy(script: nullScript,
             source: warArchiveName,
@@ -431,7 +431,7 @@ class NeoDeployTest extends BasePiperTest {
     void runtimeNotProvidedTest() {
 
         thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR runtime')
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/runtime')
 
         stepRule.step.neoDeploy(script: nullScript,
             source: warArchiveName,
@@ -446,7 +446,7 @@ class NeoDeployTest extends BasePiperTest {
     void runtimeVersionNotProvidedTest() {
 
         thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR runtimeVersion')
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/runtimeVersion')
 
         stepRule.step.neoDeploy(script: nullScript,
             source: warArchiveName,

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -34,18 +34,30 @@ void call(parameters = [:]) {
         prepareDefaultValues script: script
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName ?: env.STAGE_NAME, STEP_CONFIG_KEYS)
             .addIfEmpty('source', script.commonPipelineEnvironment.getMtarFilePath())
             .mixin(parameters, PARAMETER_KEYS)
-            .withMandatoryProperty('neo')
+            .withMandatoryProperty('neo/host')
+            .withMandatoryProperty('neo/account')
             .withMandatoryProperty('source')
             .withMandatoryProperty('neo/credentialsId')
             .withPropertyInValues('deployMode', DeployMode.stringValues())
-            .use()
+
+        Map configuration = configHelper.use()
+
+        DeployMode deployMode = DeployMode.fromString(configuration.deployMode)
+
+        def isWarParamsDeployMode = { deployMode == DeployMode.WAR_PARAMS }
+
+        configHelper
+            .withMandatoryProperty('neo/application', null, isWarParamsDeployMode)
+            .withMandatoryProperty('neo/runtime', null, isWarParamsDeployMode)
+            .withMandatoryProperty('neo/runtimeVersion', null, isWarParamsDeployMode)
+
 
         utils.pushToSWA([
             step: STEP_NAME,
@@ -71,8 +83,6 @@ void call(parameters = [:]) {
                 dockerEnvVars: configuration.dockerEnvVars,
                 dockerOptions: configuration.dockerOptions
             ) {
-                DeployMode deployMode = DeployMode.fromString(configuration.deployMode)
-
                 NeoCommandHelper neoCommandHelper = new NeoCommandHelper(
                     this,
                     deployMode,


### PR DESCRIPTION
In case of a mis-configuration we get a hint like "host is missing".
Actually it should be "neo/host is missing" since the parameter "host" is nested inside "neo".

Having simply "host" confuses the person troubleshooting this issue.

With this change the input validation is performed right at the beginning of the step.
The NeoCommandLine helper does not check a second time now.

