### PR TITLE
Pr/use docker for solman and cts

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -16,6 +16,12 @@ general:
       from: 'origin/master'
       to: 'HEAD'
       format: '%b'
+    solman:
+      docker:
+        image: 'ppiper/cm-client'
+        options: []
+        envVars: {}
+        pullImage: true
     cts:
       docker:
         image: 'ppiper/cm-client'

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -16,6 +16,12 @@ general:
       from: 'origin/master'
       to: 'HEAD'
       format: '%b'
+    cts:
+      docker:
+        image: 'ppiper/cm-client'
+        options: []
+        envVars: {}
+        pullImage: true
     rfc:
       docker:
         image: 'rfc'

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -251,6 +251,9 @@ public class ChangeManagement implements Serializable {
         String clientOpts = '') {
 
         def script = this.script
+
+        docker = docker ?: [:]
+
         script.withCredentials([script.usernamePassword(
             credentialsId: credentialsId,
             passwordVariable: 'password',

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -263,6 +263,8 @@ public class ChangeManagement implements Serializable {
             else
                 shArgs.put('returnStatus', true)
 
+            Map dockerEnvVars = docker.envVars ?: [:]
+
             def result = 1
 
             switch(type) {
@@ -281,19 +283,7 @@ public class ChangeManagement implements Serializable {
                         ABAP_DEVELOPMENT_PASSWORD: script.password,
                     ])
 
-                    // user and password are masked by withCredentials
-                    script.echo """[INFO] Executing command line: "${shArgs.script}"."""
-
-                    script.dockerExecute(
-                        script: script,
-                        dockerImage: docker.image,
-                        dockerOptions: docker.options,
-                        dockerEnvVars: (docker.envVars?:[:]).plus(args),
-                        dockerPullImage: docker.pullImage) {
-
-                        result = script.sh(shArgs)
-
-                    }
+                    dockerEnvVars += args
 
                     break
 
@@ -307,13 +297,22 @@ public class ChangeManagement implements Serializable {
                         command, args,
                         clientOpts)
 
-                    // user and password are masked by withCredentials
-                    script.echo """[INFO] Executing command line: "${shArgs.script}"."""
+                    break
+            }
+
+        // user and password are masked by withCredentials
+        script.echo """[INFO] Executing command line: "${shArgs.script}"."""
+
+                script.dockerExecute(
+                    script: script,
+                    dockerImage: docker.image,
+                    dockerOptions: docker.options,
+                    dockerEnvVars: dockerEnvVars,
+                    dockerPullImage: docker.pullImage) {
 
                     result = script.sh(shArgs)
 
-                    break
-            }
+                    }
 
             return result
         }

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -89,10 +89,10 @@ public class ChangeManagement implements Serializable {
         }
     }
 
-    String createTransportRequestSOLMAN(String changeId, String developmentSystemId, String endpoint, String credentialsId, String clientOpts = '') {
+    String createTransportRequestSOLMAN(Map docker, String changeId, String developmentSystemId, String endpoint, String credentialsId, String clientOpts = '') {
 
         try {
-            def transportRequest = executeWithCredentials(BackendType.SOLMAN, [:], endpoint, credentialsId, 'create-transport', ['-cID', changeId, '-dID', developmentSystemId],
+            def transportRequest = executeWithCredentials(BackendType.SOLMAN, docker, endpoint, credentialsId, 'create-transport', ['-cID', changeId, '-dID', developmentSystemId],
                 true,
                 clientOpts)
             return (transportRequest as String)?.trim()

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -355,6 +355,7 @@ public class ChangeManagement implements Serializable {
     }
 
     void releaseTransportRequestCTS(
+        Map docker,
         String transportRequestId,
         String endpoint,
         String credentialsId,
@@ -368,7 +369,7 @@ public class ChangeManagement implements Serializable {
 
         int rc = executeWithCredentials(
             BackendType.CTS,
-            [:],
+            docker,
             endpoint,
             credentialsId,
             cmd,

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -77,9 +77,9 @@ public class ChangeManagement implements Serializable {
         }
     }
 
-    String createTransportRequestCTS(String transportType, String targetSystemId, String description, String endpoint, String credentialsId, String clientOpts = '') {
+    String createTransportRequestCTS(Map docker, String transportType, String targetSystemId, String description, String endpoint, String credentialsId, String clientOpts = '') {
         try {
-            def transportRequest = executeWithCredentials(BackendType.CTS, [:], endpoint, credentialsId, 'create-transport',
+            def transportRequest = executeWithCredentials(BackendType.CTS, docker, endpoint, credentialsId, 'create-transport',
                     ['-tt', transportType, '-ts', targetSystemId, '-d', "\"${description}\""],
                     true,
                     clientOpts)

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -63,8 +63,8 @@ public class ChangeManagement implements Serializable {
         return items[0]
     }
 
-    boolean isChangeInDevelopment(String changeId, String endpoint, String credentialsId, String clientOpts = '') {
-        int rc = executeWithCredentials(BackendType.SOLMAN, [:], endpoint, credentialsId, 'is-change-in-development', ['-cID', "'${changeId}'", '--return-code'],
+    boolean isChangeInDevelopment(Map docker, String changeId, String endpoint, String credentialsId, String clientOpts = '') {
+        int rc = executeWithCredentials(BackendType.SOLMAN, docker, endpoint, credentialsId, 'is-change-in-development', ['-cID', "'${changeId}'", '--return-code'],
             false,
             clientOpts) as int
 

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -138,6 +138,7 @@ public class ChangeManagement implements Serializable {
     }
 
     void uploadFileToTransportRequestSOLMAN(
+        Map docker,
         String changeId,
         String transportRequestId,
         String applicationId,
@@ -154,7 +155,7 @@ public class ChangeManagement implements Serializable {
 
         int rc = executeWithCredentials(
             BackendType.SOLMAN,
-            [:],
+            docker,
             endpoint,
             credentialsId,
             'upload-file-to-transport',

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -169,6 +169,7 @@ public class ChangeManagement implements Serializable {
     }
 
     void uploadFileToTransportRequestCTS(
+        Map docker,
         String transportRequestId,
         String filePath,
         String endpoint,
@@ -182,7 +183,7 @@ public class ChangeManagement implements Serializable {
 
         int rc = executeWithCredentials(
             BackendType.CTS,
-            [:],
+            docker,
             endpoint,
             credentialsId,
             'upload-file-to-transport',

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -324,6 +324,7 @@ public class ChangeManagement implements Serializable {
     }
 
     void releaseTransportRequestSOLMAN(
+        Map docker,
         String changeId,
         String transportRequestId,
         String endpoint,
@@ -340,7 +341,7 @@ public class ChangeManagement implements Serializable {
 
         int rc = executeWithCredentials(
             BackendType.SOLMAN,
-            [:],
+            docker,
             endpoint,
             credentialsId,
             cmd,

--- a/test/groovy/CheckChangeInDevelopmentTest.groovy
+++ b/test/groovy/CheckChangeInDevelopmentTest.groovy
@@ -52,6 +52,12 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
             failIfStatusIsNotInDevelopment: true)
 
         assert cmUtilReceivedParams == [
+            docker: [
+                image: 'ppiper/cm-client',
+                options:[],
+                envVars:[:],
+                pullImage:true,
+            ],
             changeId: '001',
             endpoint: 'https://example.org/cm',
             credentialsId: 'CM',
@@ -184,7 +190,8 @@ class CheckChangeInDevelopmentTest extends BasePiperTest {
                 return changeDocumentId
             }
 
-            boolean isChangeInDevelopment(String changeId, String endpoint, String credentialsId, String cmclientOpts) {
+            boolean isChangeInDevelopment(Map docker, String changeId, String endpoint, String credentialsId, String cmclientOpts) {
+                cmUtilReceivedParams.docker = docker
                 cmUtilReceivedParams.changeId = changeId
                 cmUtilReceivedParams.endpoint = endpoint
                 cmUtilReceivedParams.credentialsId = credentialsId

--- a/test/groovy/TransportRequestCreateTest.groovy
+++ b/test/groovy/TransportRequestCreateTest.groovy
@@ -94,6 +94,7 @@ public class TransportRequestCreateTest extends BasePiperTest {
         ChangeManagement cm = new ChangeManagement(nullScript) {
 
             String createTransportRequestSOLMAN(
+                                          Map docker,
                                           String changeId,
                                           String developmentSystemId,
                                           String cmEndpoint,
@@ -119,12 +120,14 @@ public class TransportRequestCreateTest extends BasePiperTest {
         ChangeManagement cm = new ChangeManagement(nullScript) {
 
             String createTransportRequestSOLMAN(
+                                          Map docker,
                                           String changeId,
                                           String developmentSystemId,
                                           String cmEndpoint,
                                           String credentialId,
                                           String clientOpts) {
 
+                result.docker = docker
                 result.changeId = changeId
                 result.developmentSystemId = developmentSystemId
                 result.cmEndpoint = cmEndpoint
@@ -137,7 +140,14 @@ public class TransportRequestCreateTest extends BasePiperTest {
         stepRule.step.transportRequestCreate(script: nullScript, changeDocumentId: '001', developmentSystemId: '001', cmUtils: cm)
 
         assert nullScript.commonPipelineEnvironment.getTransportRequestId() == '001'
-        assert result == [changeId: '001',
+        assert result == [
+                         docker: [
+                             image: 'ppiper/cm-client',
+                             pullImage: true,
+                             options: [],
+                             envVars: [:],
+                         ],
+                         changeId: '001',
                          developmentSystemId: '001',
                          cmEndpoint: 'https://example.org/cm',
                          credentialId: 'CM',

--- a/test/groovy/TransportRequestCreateTest.groovy
+++ b/test/groovy/TransportRequestCreateTest.groovy
@@ -156,12 +156,14 @@ public class TransportRequestCreateTest extends BasePiperTest {
         ChangeManagement cm = new ChangeManagement(nullScript) {
 
             String createTransportRequestCTS(
+                Map docker,
                 String transportType,
                 String targetSystemId,
                 String description,
                 String endpoint,
                 String credentialsId,
                 String clientOpts) {
+                result.docker = docker
                 result.transportType = transportType
                 result.targetSystemId = targetSystemId
                 result.description = description
@@ -180,7 +182,14 @@ public class TransportRequestCreateTest extends BasePiperTest {
                         cmUtils: cm)
 
         assert nullScript.commonPipelineEnvironment.getTransportRequestId() == '001'
-        assert result == [transportType: 'W',
+        assert result == [
+                         docker: [
+                             image: 'ppiper/cm-client',
+                             pullImage: true,
+                             envVars: [:],
+                             options: [],
+                         ],
+                         transportType: 'W',
                          targetSystemId: 'XYZ',
                          description: 'desc',
                          endpoint: 'https://example.org/cm',

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -97,6 +97,7 @@ public class TransportRequestReleaseTest extends BasePiperTest {
         ChangeManagement cm = new ChangeManagement(nullScript) {
 
             void releaseTransportRequestSOLMAN(
+                                         Map docker,
                                          String changeId,
                                          String transportRequestId,
                                          String endpoint,
@@ -374,12 +375,14 @@ public class TransportRequestReleaseTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void releaseTransportRequestSOLMAN(
+                                         Map docker,
                                          String changeId,
                                          String transportRequestId,
                                          String endpoint,
                                          String credentialsId,
                                          String clientOpts) {
 
+                receivedParams.docker = docker
                 receivedParams.changeId = changeId
                 receivedParams.transportRequestId = transportRequestId
                 receivedParams.endpoint = endpoint
@@ -391,6 +394,12 @@ public class TransportRequestReleaseTest extends BasePiperTest {
         stepRule.step.transportRequestRelease(script: nullScript, changeDocumentId: '001', transportRequestId: '002', cmUtils: cm)
 
         assert receivedParams == [
+                                  docker: [
+                                      image: 'ppiper/cm-client',
+                                      pullImage: true,
+                                      envVars: [:],
+                                      options: [],
+                                  ],
                                   changeId: '001',
                                   transportRequestId: '002',
                                   endpoint: 'https://example.org/cm',

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -127,6 +127,7 @@ public class TransportRequestReleaseTest extends BasePiperTest {
         ChangeManagement cm = new ChangeManagement(nullScript) {
 
             void releaseTransportRequestCTS(
+                                         Map docker,
                                          String transportRequestId,
                                          String endpoint,
                                          String credentialsId,
@@ -230,12 +231,14 @@ public class TransportRequestReleaseTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void releaseTransportRequestCTS(
+                Map docker,
                 String transportRequestId,
                 String endpoint,
                 String credentialsId,
                 String clientOpts = '') {
 
                 receivedParameters = [
+                    docker: docker,
                     transportRequestId: transportRequestId,
                     endpoint: endpoint,
                     credentialsId: credentialsId,
@@ -250,6 +253,12 @@ public class TransportRequestReleaseTest extends BasePiperTest {
             cmUtils: cm)
 
         assert receivedParameters == [
+                    docker: [
+                        image:'ppiper/cm-client',
+                        options:[],
+                        envVars:[:],
+                        pullImage:true,
+                    ],
                     transportRequestId: '002',
                     endpoint: 'https://example.org/cts',
                     credentialsId: 'CM',

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -130,6 +130,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void uploadFileToTransportRequestSOLMAN(
+                                              Map docker,
                                               String changeId,
                                               String transportRequestId,
                                               String applicationId,
@@ -371,6 +372,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void uploadFileToTransportRequestSOLMAN(
+                                              Map docker,
                                               String changeId,
                                               String transportRequestId,
                                               String applicationId,
@@ -379,6 +381,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
                                               String credentialsId,
                                               String cmclientOpts) {
 
+                cmUtilReceivedParams.docker = docker
                 cmUtilReceivedParams.changeId = changeId
                 cmUtilReceivedParams.transportRequestId = transportRequestId
                 cmUtilReceivedParams.applicationId = applicationId
@@ -398,6 +401,12 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         assert cmUtilReceivedParams ==
             [
+                docker: [
+                    image: 'ppiper/cm-client',
+                    pullImage: true,
+                    envVars: [:],
+                    options: [],
+                ],
                 changeId: '001',
                 transportRequestId: '002',
                 applicationId: 'app',
@@ -417,6 +426,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void uploadFileToTransportRequestSOLMAN(
+                                              Map docker,
                                               String changeId,
                                               String transportRequestId,
                                               String applicationId,
@@ -447,6 +457,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void uploadFileToTransportRequestSOLMAN(
+                                              Map docker,
                                               String changeId,
                                               String transportRequestId,
                                               String applicationId,
@@ -477,6 +488,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void uploadFileToTransportRequestSOLMAN(
+                                              Map docker,
                                               String changeId,
                                               String transportRequestId,
                                               String applicationId,
@@ -506,6 +518,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void uploadFileToTransportRequestSOLMAN(
+                                              Map docker,
                                               String changeId,
                                               String transportRequestId,
                                               String applicationId,

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -21,6 +21,7 @@ import util.JenkinsCredentialsRule
 import util.JenkinsStepRule
 import util.JenkinsLoggingRule
 import util.JenkinsReadYamlRule
+import util.JenkinsDockerExecuteRule
 import util.Rules
 
 import hudson.AbortException
@@ -159,12 +160,14 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         ChangeManagement cm = new ChangeManagement(nullScript) {
             void uploadFileToTransportRequestCTS(
+                                              Map docker,
                                               String transportRequestId,
                                               String filePath,
                                               String endpoint,
                                               String credentialsId,
                                               String cmclientOpts) {
 
+                cmUtilReceivedParams.docker = docker
                 cmUtilReceivedParams.transportRequestId = transportRequestId
                 cmUtilReceivedParams.filePath = filePath
                 cmUtilReceivedParams.endpoint = endpoint
@@ -181,12 +184,19 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         assert cmUtilReceivedParams ==
             [
+                docker: [
+                    image: 'ppiper/cm-client',
+                    options:[],
+                    envVars:[:],
+                    pullImage:true
+                ],
                 transportRequestId: '002',
                 filePath: '/path',
                 endpoint: 'https://example.org/cm',
                 credentialsId: 'CM',
                 cmclientOpts: ''
             ]
+
     }
 
     @Test

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -228,6 +228,10 @@ public void testGetCommandLineWithCMClientOpts() {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, 'cmclient.* -t CTS .*create-transport -tt W -ts XYZ -d "desc 123"$', '004')
         def transportRequestId = new ChangeManagement(nullScript)
             .createTransportRequestCTS(
+                [
+                    image: 'ppiper/cmclient',
+                    pullImage: true
+                ],
                 'W', // transport type
                 'XYZ', // target system
                 'desc 123', // description
@@ -237,6 +241,9 @@ public void testGetCommandLineWithCMClientOpts() {
         // the check for the transportRequestID is sufficient. This checks implicit the command line since that value is
         // returned only in case the shell call matches.
         assert transportRequestId == '004'
+
+        dockerExecuteRule.getDockerParams().dockerImage = 'ppiper/cmclient'
+        dockerExecuteRule.getDockerParams().dockerPullImage = true
 
     }
 

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -424,6 +424,10 @@ public void testGetCommandLineWithCMClientOpts() {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, '-t CTS export-transport.*-tID 002', 0)
 
         new ChangeManagement(nullScript).releaseTransportRequestCTS(
+            [
+                image: 'ppiper/cm-client',
+                pullImage: true,
+            ],
             '002',
             'https://example.org',
             'me',
@@ -431,6 +435,9 @@ public void testGetCommandLineWithCMClientOpts() {
 
         // no assert required here, since the regex registered above to the script rule is an implicit check for
         // the command line.
+
+        assert dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cm-client'
+        assert dockerExecuteRule.getDockerParams().dockerPullImage == true
     }
 
     @Test

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -400,6 +400,10 @@ public void testGetCommandLineWithCMClientOpts() {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, '-t SOLMAN release-transport.*-cID 001.*-tID 002', 0)
 
         new ChangeManagement(nullScript).releaseTransportRequestSOLMAN(
+            [
+                image: 'ppiper/cm-client',
+                imagePull: true,
+            ],
             '001',
             '002',
             'https://example.org',
@@ -408,6 +412,9 @@ public void testGetCommandLineWithCMClientOpts() {
 
         // no assert required here, since the regex registered above to the script rule is an implicit check for
         // the command line.
+
+        dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cm-client'
+        dockerExecuteRule.getDockerParams().pullImage == true
     }
 
     @Test
@@ -460,6 +467,10 @@ public void testGetCommandLineWithCMClientOpts() {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, 'release-transport.*-cID 001.*-tID 002', 1)
 
         new ChangeManagement(nullScript).releaseTransportRequestSOLMAN(
+            [
+                image: 'ppiper/cm-client',
+                imagePull: true,
+            ],
             '001',
             '002',
             'https://example.org',

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -265,13 +265,20 @@ public void testGetCommandLineWithCMClientOpts() {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, '-t CTS upload-file-to-transport -tID 002 "/path"', 0)
 
         new ChangeManagement(nullScript).uploadFileToTransportRequestCTS(
+            [
+                image: 'ppiper/cmclient',
+                pullImage: true
+             ],
             '002',
             '/path',
             'https://example.org/cm',
             'me')
 
-        // no assert required here, since the regex registered above to the script rule is an implicit check for
-        // the command line.
+        assert dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cmclient'
+        assert dockerExecuteRule.getDockerParams().dockerPullImage == true
+
+        // no assert for the shell command required here, since the regex registered
+        // above to the script rule is an implicit check for the command line.
     }
 
     @Test

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -96,7 +96,12 @@ public class ChangeManagementTest extends BasePiperTest {
     public void testIsChangeInDevelopmentReturnsTrueWhenChangeIsInDevelopent() {
 
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, "cmclient.*is-change-in-development -cID '001'", 0)
-        boolean inDevelopment = new ChangeManagement(nullScript, null).isChangeInDevelopment('001', 'endpoint', 'me')
+        boolean inDevelopment = new ChangeManagement(nullScript, null).isChangeInDevelopment(
+            [
+                image: 'ppiper/cm-client',
+                pullImage: true,
+            ],
+            '001', 'endpoint', 'me')
 
         assertThat(inDevelopment, is(equalTo(true)))
         assertThat(script.shell[0], allOf(containsString("cmclient"),
@@ -106,6 +111,9 @@ public class ChangeManagementTest extends BasePiperTest {
                                             containsString('is-change-in-development'),
                                             containsString("-cID '001'"),
                                             containsString("-t SOLMAN")))
+
+        assert dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cm-client'
+        assert dockerExecuteRule.getDockerParams().dockerPullImage == true
     }
 
     @Test
@@ -114,7 +122,8 @@ public class ChangeManagementTest extends BasePiperTest {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, "cmclient.*is-change-in-development -cID '001'", 3)
 
         boolean inDevelopment = new ChangeManagement(nullScript, null)
-                                    .isChangeInDevelopment('001',
+                                    .isChangeInDevelopment([:],
+                                                           '001',
                                                            'endpoint',
                                                            'me')
 
@@ -128,7 +137,7 @@ public class ChangeManagementTest extends BasePiperTest {
         thrown.expectMessage('Cannot retrieve status for change document \'001\'. Does this change exist? Return code from cmclient: 1.')
 
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, "cmclient.*is-change-in-development -cID '001'", 1)
-        new ChangeManagement(nullScript, null).isChangeInDevelopment('001', 'endpoint', 'me')
+        new ChangeManagement(nullScript, null).isChangeInDevelopment([:], '001', 'endpoint', 'me')
     }
 
     @Test

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -262,6 +262,10 @@ public void testGetCommandLineWithCMClientOpts() {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, 'upload-file-to-transport.*-cID 001 -tID 002 XXX "/path"', 0)
 
         new ChangeManagement(nullScript).uploadFileToTransportRequestSOLMAN(
+            [
+                image: 'ppiper/cm-client',
+                imagePull: true,
+            ],
             '001',
             '002',
             'XXX',
@@ -269,8 +273,12 @@ public void testGetCommandLineWithCMClientOpts() {
             'https://example.org/cm',
             'me')
 
-        // no assert required here, since the regex registered above to the script rule is an implicit check for
-        // the command line.
+        // no assert required here for the shell script, since the regex registered above
+        // to the script rule is an implicit check for the command line.
+
+        dockerExecuteRule.getDockerParams().dockerImage = 'ppiper/cmclient'
+        dockerExecuteRule.getDockerParams().dockerPullImage = true
+
     }
 
     @Test
@@ -376,6 +384,7 @@ public void testGetCommandLineWithCMClientOpts() {
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX,, 'upload-file-to-transport', 1)
 
         new ChangeManagement(nullScript).uploadFileToTransportRequestSOLMAN(
+            [:],
             '001',
             '002',
             'XXX',

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -163,11 +163,19 @@ public void testGetCommandLineWithCMClientOpts() {
     public void testCreateTransportRequestSOLMANSucceeds() {
 
         script.setReturnValue(JenkinsShellCallRule.Type.REGEX, ".*cmclient.*create-transport -cID 001 -dID 002.*", '004')
-        def transportRequestId = new ChangeManagement(nullScript).createTransportRequestSOLMAN( '001', '002', '003', 'me')
+        def transportRequestId = new ChangeManagement(nullScript).createTransportRequestSOLMAN(
+            [
+                image: 'ppiper/cm-client',
+                pullImage: true,
+            ],
+            '001', '002', '003', 'me')
 
         // the check for the transportRequestID is sufficient. This checks implicit the command line since that value is
         // returned only in case the shell call matches.
         assert transportRequestId == '004'
+
+        assert dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cm-client'
+        assert dockerExecuteRule.getDockerParams().dockerPullImage == true
 
     }
 

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -115,7 +115,9 @@ void call(parameters = [:]) {
 
         try {
 
-            isInDevelopment = cm.isChangeInDevelopment(configuration.changeDocumentId,
+            isInDevelopment = cm.isChangeInDevelopment(
+                configuration.changeManagement.solman.docker,
+                configuration.changeDocumentId,
                 configuration.changeManagement.endpoint,
                 configuration.changeManagement.credentialsId,
                 configuration.changeManagement.clientOpts)

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -97,6 +97,7 @@ void call(parameters = [:]) {
         try {
                 if(backendType == BackendType.SOLMAN) {
                     transportRequestId = cm.createTransportRequestSOLMAN(
+                                                                configuration.changeManagement.solman.docker,
                                                                configuration.changeDocumentId,
                                                                configuration.developmentSystemId,
                                                                configuration.changeManagement.endpoint,

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -104,6 +104,7 @@ void call(parameters = [:]) {
                                                                configuration.changeManagement.clientOpts)
                 } else if(backendType == BackendType.CTS) {
                     transportRequestId = cm.createTransportRequestCTS(
+                                                                configuration.changeManagement.cts.docker,
                                                                configuration.transportType,
                                                                configuration.targetSystem,
                                                                configuration.description,

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -100,6 +100,7 @@ void call(parameters = [:]) {
                     case BackendType.SOLMAN:
 
                         cm.releaseTransportRequestSOLMAN(
+                            configuration.changeManagement.solman.docker,
                             configuration.changeDocumentId,
                             configuration.transportRequestId,
                             configuration.changeManagement.endpoint,

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -111,6 +111,7 @@ void call(parameters = [:]) {
                     case BackendType.CTS:
 
                         cm.releaseTransportRequestCTS(
+                            configuration.changeManagement.cts.docker,
                             configuration.transportRequestId,
                             configuration.changeManagement.endpoint,
                             configuration.changeManagement.credentialsId,

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -139,6 +139,7 @@ void call(parameters = [:]) {
                         break
                     case BackendType.CTS:
                         cm.uploadFileToTransportRequestCTS(
+                            configuration.changeManagement.cts?.docker ?: [:],
                             configuration.transportRequestId,
                             configuration.filePath,
                             configuration.changeManagement.endpoint,

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -148,7 +148,7 @@ void call(parameters = [:]) {
                     case BackendType.RFC:
 
                         cm.uploadFileToTransportRequestRFC(
-                            configuration.changeManagement.rfc.docker ?: [],
+                            configuration.changeManagement.rfc.docker ?: [:],
                             configuration.transportRequestId,
                             configuration.applicationName,
                             configuration.applicationUrl,

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -129,6 +129,7 @@ void call(parameters = [:]) {
 
                     case BackendType.SOLMAN:
                         cm.uploadFileToTransportRequestSOLMAN(
+                            configuration.changeManagement.solman?.docker ?: [:],
                             configuration.changeDocumentId,
                             configuration.transportRequestId,
                             configuration.applicationId,


### PR DESCRIPTION
We have docker image 'ppiper/cm-client' available outside, but the piper steps for
* creating transport requests
* uploading deployables into a transport request
* releasing transport requests

does not make use of it right now. With this PR we make use of the docker image 'ppiper/cm-client'.
