### PR TITLE
Fix sanity checks for warPropertiesFile deploy mode.

### DIFF
--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -1,10 +1,16 @@
 import com.sap.piper.Utils
 import hudson.AbortException
+
+import static org.hamcrest.Matchers.allOf
+import static org.hamcrest.Matchers.containsString
+
+import org.hamcrest.Matchers
 import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
 import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.ClassRule
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
@@ -197,16 +203,6 @@ class NeoDeployTest extends BasePiperTest {
     }
 
     @Test
-    void archiveNotProvidedTest() {
-
-        thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR source')
-
-        stepRule.step.neoDeploy(script: nullScript)
-    }
-
-
-    @Test
     void wrongArchivePathProvidedTest() {
 
         thrown.expect(AbortException)
@@ -217,14 +213,51 @@ class NeoDeployTest extends BasePiperTest {
 
 
     @Test
-    void scriptNotProvidedTest() {
+    void sanityChecksDeployModeMTATest() {
 
         thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/host')
+        thrown.expectMessage(
+            allOf(
+                containsString('ERROR - NO VALUE AVAILABLE FOR:'),
+                containsString('neo/host'),
+                containsString('neo/account'),
+                containsString('source')))
 
         nullScript.commonPipelineEnvironment.configuration = [:]
 
-        stepRule.step.neoDeploy(script: nullScript, source: archiveName)
+        // deployMode mta is the default, but for the sake of transparency it is better to repeat it.
+        stepRule.step.neoDeploy(script: nullScript, deployMode: 'mta')
+    }
+
+    @Test
+    public void sanityChecksDeployModeWarPropertiesFileTest() {
+
+        thrown.expect(IllegalArgumentException)
+        // using this deploy mode account and host are provided by the properties file
+        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR source')
+
+        nullScript.commonPipelineEnvironment.configuration = [:]
+
+        stepRule.step.neoDeploy(script: nullScript, deployMode: 'warPropertiesFile')
+    }
+
+    @Test
+    public void sanityChecksDeployModeWarParamsTest() {
+
+        thrown.expect(IllegalArgumentException)
+        thrown.expectMessage(
+            allOf(
+                containsString('ERROR - NO VALUE AVAILABLE FOR:'),
+                containsString('source'),
+                containsString('neo/application'),
+                containsString('neo/runtime'),
+                containsString('neo/runtimeVersion'),
+                containsString('neo/host'),
+                containsString('neo/account')))
+
+        nullScript.commonPipelineEnvironment.configuration = [:]
+
+        stepRule.step.neoDeploy(script: nullScript, deployMode: 'warParams')
     }
 
     @Test
@@ -412,52 +445,6 @@ class NeoDeployTest extends BasePiperTest {
                 .hasSingleQuotedOption('user', 'defaultUser')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
                 .hasSingleQuotedOption('source', '.*\\.war'))
-    }
-
-    @Test
-    void applicationNameNotProvidedTest() {
-
-        thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/application')
-
-        stepRule.step.neoDeploy(script: nullScript,
-            source: warArchiveName,
-            deployMode: 'warParams',
-            neo: [
-                runtime: 'neo-javaee6-wp',
-                runtimeVersion: '2.125'
-            ]
-        )
-    }
-
-    @Test
-    void runtimeNotProvidedTest() {
-
-        thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/runtime')
-
-        stepRule.step.neoDeploy(script: nullScript,
-            source: warArchiveName,
-            neo: [
-                application: 'testApp',
-                runtimeVersion: '2.125'
-            ],
-            deployMode: 'warParams')
-    }
-
-    @Test
-    void runtimeVersionNotProvidedTest() {
-
-        thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR neo/runtimeVersion')
-
-        stepRule.step.neoDeploy(script: nullScript,
-            source: warArchiveName,
-            neo: [
-                application: 'testApp',
-                runtime: 'neo-javaee6-wp'
-            ],
-            deployMode: 'warParams')
     }
 
     @Test

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -3,6 +3,7 @@ import hudson.AbortException
 
 import static org.hamcrest.Matchers.allOf
 import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.not
 
 import org.hamcrest.Matchers
 import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
@@ -10,7 +11,6 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.ClassRule
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
@@ -233,8 +233,12 @@ class NeoDeployTest extends BasePiperTest {
     public void sanityChecksDeployModeWarPropertiesFileTest() {
 
         thrown.expect(IllegalArgumentException)
-        // using this deploy mode account and host are provided by the properties file
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR source')
+        // using this deploy mode 'account' and 'host' are provided by the properties file
+        thrown.expectMessage(
+            allOf(
+                containsString('ERROR - NO VALUE AVAILABLE FOR source'),
+                not(containsString('neo/host')),
+                not(containsString('neo/account'))))
 
         nullScript.commonPipelineEnvironment.configuration = [:]
 

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -41,8 +41,6 @@ void call(parameters = [:]) {
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName ?: env.STAGE_NAME, STEP_CONFIG_KEYS)
             .addIfEmpty('source', script.commonPipelineEnvironment.getMtarFilePath())
             .mixin(parameters, PARAMETER_KEYS)
-            .withMandatoryProperty('neo/host')
-            .withMandatoryProperty('neo/account')
             .withMandatoryProperty('source')
             .withMandatoryProperty('neo/credentialsId')
             .withPropertyInValues('deployMode', DeployMode.stringValues())
@@ -51,12 +49,15 @@ void call(parameters = [:]) {
 
         DeployMode deployMode = DeployMode.fromString(configuration.deployMode)
 
-        def isWarParamsDeployMode = { deployMode == DeployMode.WAR_PARAMS }
+        def isWarParamsDeployMode = { deployMode == DeployMode.WAR_PARAMS },
+            isNotWarPropertiesDeployMode = {deployMode != DeployMode.WAR_PROPERTIES_FILE}
 
         configHelper
             .withMandatoryProperty('neo/application', null, isWarParamsDeployMode)
             .withMandatoryProperty('neo/runtime', null, isWarParamsDeployMode)
             .withMandatoryProperty('neo/runtimeVersion', null, isWarParamsDeployMode)
+            .withMandatoryProperty('neo/host', null, isNotWarPropertiesDeployMode)
+            .withMandatoryProperty('neo/account', null, isNotWarPropertiesDeployMode)
 
 
         utils.pushToSWA([

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -41,8 +41,7 @@ void call(parameters = [:]) {
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName ?: env.STAGE_NAME, STEP_CONFIG_KEYS)
             .addIfEmpty('source', script.commonPipelineEnvironment.getMtarFilePath())
             .mixin(parameters, PARAMETER_KEYS)
-            .withMandatoryProperty('source')
-            .withMandatoryProperty('neo/credentialsId')
+            .collectValidationFailures()
             .withPropertyInValues('deployMode', DeployMode.stringValues())
 
         Map configuration = configHelper.use()
@@ -53,12 +52,17 @@ void call(parameters = [:]) {
             isNotWarPropertiesDeployMode = {deployMode != DeployMode.WAR_PROPERTIES_FILE}
 
         configHelper
+            .withMandatoryProperty('source')
+            .withMandatoryProperty('neo/credentialsId')
             .withMandatoryProperty('neo/application', null, isWarParamsDeployMode)
             .withMandatoryProperty('neo/runtime', null, isWarParamsDeployMode)
             .withMandatoryProperty('neo/runtimeVersion', null, isWarParamsDeployMode)
             .withMandatoryProperty('neo/host', null, isNotWarPropertiesDeployMode)
             .withMandatoryProperty('neo/account', null, isNotWarPropertiesDeployMode)
-
+            //
+            // call 'use()' a second time in order to get the collected validation failures
+            // since the map did not change, it is not required to replace the previous configuration map.
+            .use()
 
         utils.pushToSWA([
             step: STEP_NAME,


### PR DESCRIPTION
With #561 sanity checks at beginning of neoDeploy covers also neo host and account.
But for deploy mode `warProperties` these values are expected in the corresponding properties file. Hence we must not check that with the sanity checks.
