### PR TITLE
enhance prepare stage with cleanup and checkout

### DIFF
--- a/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
+++ b/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
@@ -93,6 +93,8 @@ class FioriOnCloudPlatformPipelineTest extends BasePiperTest {
             it == 'test.mtar'
         })
 
+        helper.registerAllowedMethod("deleteDir",[], null)
+
         //
         // the properties below we read out of the yaml file
         readYamlRule.registerYaml('mta.yaml', ('''
@@ -104,6 +106,8 @@ class FioriOnCloudPlatformPipelineTest extends BasePiperTest {
         // we need the path variable since we extend the path in the mtaBuild step. In order
         // to be able to extend the path we have to have some initial value.
         binding.setVariable('PATH', '/usr/bin')
+
+        binding.setVariable('scm', null)
 
         helper.registerAllowedMethod('pwd', [], { return "./" })
     }

--- a/vars/fioriOnCloudPlatformPipeline.groovy
+++ b/vars/fioriOnCloudPlatformPipeline.groovy
@@ -31,6 +31,8 @@ void call(parameters = [:]) {
 
         stage('prepare') {
 
+            deleteDir()
+            checkout scm
             setupCommonPipelineEnvironment(parameters)
         }
 


### PR DESCRIPTION
Reading the documentation, it is sufficient to use fioriOnCloudPlatformPipeline to build and deploy SAPUI5 application. However, in the prepare step only the parameters were set. The user has to explicitly checkout the sources of the project.

- [ ] Tests
- [ ] Documentation
