### PR TITLE
Format neo deploy test

### DIFF
--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -124,7 +124,9 @@ class NeoDeployTest extends BasePiperTest {
 
     @Test
     void archivePathFromCPETest() {
+
         nullScript.commonPipelineEnvironment.setMtarFilePath('archive.mtar')
+
         stepRule.step.neoDeploy(script: nullScript)
 
         Assert.assertThat(shellRule.shell,
@@ -134,7 +136,9 @@ class NeoDeployTest extends BasePiperTest {
 
     @Test
     void archivePathFromParamsHasHigherPrecedenceThanCPETest() {
+
         nullScript.commonPipelineEnvironment.setMtarFilePath('archive2.mtar')
+
         stepRule.step.neoDeploy(script: nullScript,
             source: "archive.mtar")
 

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -79,14 +79,6 @@ class NeoDeployTest extends BasePiperTest {
     @Test
     void straightForwardTestConfigViaParameters() {
 
-        boolean notifyOldConfigFrameworkUsed = true
-
-        def utils = new Utils() {
-            void pushToSWA(Map parameters, Map config) {
-                notifyOldConfigFrameworkUsed = parameters.stepParam4
-            }
-        }
-
         stepRule.step.neoDeploy(script: nullScript,
             source: archiveName,
             neo:[credentialsId: 'myCredentialsId'],
@@ -101,8 +93,6 @@ class NeoDeployTest extends BasePiperTest {
                 .hasSingleQuotedOption('user', 'anonymous')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
                 .hasSingleQuotedOption('source', '.*'))
-
-        assert !notifyOldConfigFrameworkUsed
     }
 
     @Test

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -47,7 +47,7 @@ class NeoDeployTest extends BasePiperTest {
     public RuleChain ruleChain = Rules
         .getCommonRules(this)
         .around(new JenkinsReadYamlRule(this))
-        .around(new JenkinsPropertiesRule(this, propertiesFileName, configProperties))
+        .around(new JenkinsPropertiesRule(this, warPropertiesFileName, warProperties))
         .around(thrown)
         .around(loggingRule)
         .around(shellRule)
@@ -61,9 +61,9 @@ class NeoDeployTest extends BasePiperTest {
 
     private static workspacePath
     private static warArchiveName
-    private static propertiesFileName
+    private static warPropertiesFileName
     private static archiveName
-    private static configProperties
+    private static warProperties
 
 
     @BeforeClass
@@ -71,16 +71,16 @@ class NeoDeployTest extends BasePiperTest {
 
         workspacePath = "${tmp.getRoot()}"
         warArchiveName = 'warArchive.war'
-        propertiesFileName = 'config.properties'
         archiveName = 'archive.mtar'
+        warPropertiesFileName = 'war.properties'
 
-        configProperties = new Properties()
-        configProperties.put('account', 'trialuser123')
-        configProperties.put('host', 'test.deploy.host.com')
-        configProperties.put('application', 'testApp')
+        warProperties = new Properties()
+        warProperties.put('account', 'trialuser123')
+        warProperties.put('host', 'test.deploy.host.com')
+        warProperties.put('application', 'testApp')
 
         tmp.newFile(warArchiveName) << 'dummy war archive'
-        tmp.newFile(propertiesFileName) << 'dummy properties file'
+        tmp.newFile(warPropertiesFileName) << 'dummy war properties file'
         tmp.newFile(archiveName) << 'dummy archive'
     }
 
@@ -410,7 +410,7 @@ class NeoDeployTest extends BasePiperTest {
             deployMode: 'warPropertiesFile',
             warAction: 'deploy',
             neo: [
-                propertiesFile: propertiesFileName,
+                propertiesFile: warPropertiesFileName,
                 application: 'testApp',
                 runtime: 'neo-javaee6-wp',
                 runtimeVersion: '2.125',
@@ -420,7 +420,7 @@ class NeoDeployTest extends BasePiperTest {
 
         Assert.assertThat(shellRule.shell,
             new CommandLineMatcher().hasProlog("neo.sh deploy")
-                .hasArgument("config.properties")
+                .hasArgument('war.properties')
                 .hasSingleQuotedOption('user', 'defaultUser')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
                 .hasSingleQuotedOption('source', '.*\\.war'))
@@ -436,7 +436,7 @@ class NeoDeployTest extends BasePiperTest {
             deployMode: 'warPropertiesFile',
             warAction: 'rolling-update',
             neo: [
-                propertiesFile: propertiesFileName,
+                propertiesFile: warPropertiesFileName,
                 application: 'testApp',
                 runtime: 'neo-javaee6-wp',
                 runtimeVersion: '2.125',
@@ -445,7 +445,7 @@ class NeoDeployTest extends BasePiperTest {
 
         Assert.assertThat(shellRule.shell,
             new CommandLineMatcher().hasProlog("neo.sh rolling-update")
-                .hasArgument('config.properties')
+                .hasArgument('war.properties')
                 .hasSingleQuotedOption('user', 'defaultUser')
                 .hasSingleQuotedOption('password', '\\*\\*\\*\\*\\*\\*\\*\\*')
                 .hasSingleQuotedOption('source', '.*\\.war'))

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -9,13 +9,10 @@ import org.hamcrest.Matchers
 import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException
 import org.junit.Assert
 import org.junit.Before
-import org.junit.BeforeClass
-import org.junit.ClassRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
-import org.junit.rules.TemporaryFolder
 import util.BasePiperTest
 import util.CommandLineMatcher
 import util.JenkinsCredentialsRule
@@ -27,20 +24,19 @@ import util.JenkinsShellCallRule
 import util.JenkinsShellCallRule.Type
 import util.JenkinsStepRule
 import util.JenkinsWithEnvRule
+import util.JenkinsFileExistsRule
 import util.Rules
 
 class NeoDeployTest extends BasePiperTest {
 
     def toolJavaValidateCalled = false
 
-    @ClassRule
-    public static TemporaryFolder tmp = new TemporaryFolder()
-
     private ExpectedException thrown = new ExpectedException().none()
     private JenkinsLoggingRule loggingRule = new JenkinsLoggingRule(this)
     private JenkinsShellCallRule shellRule = new JenkinsShellCallRule(this)
     private JenkinsStepRule stepRule = new JenkinsStepRule(this)
     private JenkinsLockRule lockRule = new JenkinsLockRule(this)
+    private JenkinsFileExistsRule fileExistsRule = new JenkinsFileExistsRule(this, ['warArchive.war', 'archive.mtar', 'war.properties'])
 
 
     @Rule
@@ -57,39 +53,25 @@ class NeoDeployTest extends BasePiperTest {
         .around(stepRule)
         .around(lockRule)
         .around(new JenkinsWithEnvRule(this))
+        .around(fileExistsRule)
 
 
-    private static workspacePath
-    private static warArchiveName
-    private static warPropertiesFileName
-    private static archiveName
+    private static warArchiveName = 'warArchive.war'
+    private static warPropertiesFileName = 'war.properties'
+    private static archiveName = 'archive.mtar'
     private static warProperties
 
 
-    @BeforeClass
-    static void createTestFiles() {
-
-        workspacePath = "${tmp.getRoot()}"
-        warArchiveName = 'warArchive.war'
-        archiveName = 'archive.mtar'
-        warPropertiesFileName = 'war.properties'
+    @Before
+    void init() {
 
         warProperties = new Properties()
         warProperties.put('account', 'trialuser123')
         warProperties.put('host', 'test.deploy.host.com')
         warProperties.put('application', 'testApp')
 
-        tmp.newFile(warArchiveName) << 'dummy war archive'
-        tmp.newFile(warPropertiesFileName) << 'dummy war properties file'
-        tmp.newFile(archiveName) << 'dummy archive'
-    }
-
-    @Before
-    void init() {
-
         helper.registerAllowedMethod('dockerExecute', [Map, Closure], null)
-        helper.registerAllowedMethod('fileExists', [String], { s -> return new File(workspacePath, s).exists() })
-        helper.registerAllowedMethod('pwd', [], { return workspacePath })
+        helper.registerAllowedMethod('pwd', [], { return './' })
 
         nullScript.commonPipelineEnvironment.configuration = [steps: [neoDeploy: [neo: [host: 'test.deploy.host.com', account: 'trialuser123']]]]
     }


### PR DESCRIPTION
- Renames configProperties to warProperties since the name is misleading.

-  Adds JenkinsFileExistsRule in order to follow rules format.

- Removes deprecated check related to the old config framework.