### PR TITLE
Avoid unwanted behavior when using resilience options

### DIFF
--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -110,7 +110,7 @@ import groovy.transform.Field
  */
 @GenerateDocumentation
 void call(Map parameters = [:], body) {
-    handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters) {
+    handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters, failOnError: true) {
 
         final script = checkScript(this, parameters) ?: this
 

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -102,7 +102,7 @@ import hudson.AbortException
  */
 @GenerateDocumentation
 void call(Map parameters = [:], body) {
-    handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters) {
+    handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters, failOnError: true) {
 
         final script = checkScript(this, parameters) ?: this
 

--- a/vars/pipelineExecute.groovy
+++ b/vars/pipelineExecute.groovy
@@ -36,7 +36,7 @@ void call(Map parameters = [:]) {
 
         def path
 
-        handlePipelineStepErrors (stepName: 'pipelineExecute', stepParameters: parameters) {
+        handlePipelineStepErrors (stepName: 'pipelineExecute', stepParameters: parameters, failOnError: true) {
 
             def utils = new Utils()
 

--- a/vars/pipelineRestartSteps.groovy
+++ b/vars/pipelineRestartSteps.groovy
@@ -12,7 +12,7 @@ import groovy.transform.Field
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
 
 void call(Map parameters = [:], body) {
-    handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
+    handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters, failOnError: true) {
         def script = checkScript(this, parameters) ?: this
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
         // load default & individual configuration


### PR DESCRIPTION
Certain steps should always fail, even though resilience option `failOnError=false` is used.

# Changes

* Docker execution typically happens in another step. We should not hide errors here but rather handle their resilience in the step which uses `dockerExecute` and `dockerExecuteOnKubernetes`.
* Wrapper steps like `pipelineExecute`, `pipelineRestartSteps` should not hide errors. If an error occured this has to be considered as **intentional** and not hidden accidentially in case resilience option is switched on.

