### PR TITLE
fetch possible values from @see

### DIFF
--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -448,6 +448,8 @@ for(step in stepDescriptors) {
                 def otherStep = param.value.docu.replaceAll('@see', '').trim()
                 param.value.docu = fetchTextFrom(otherStep, param.key, stepDescriptors)
                 param.value.mandatory = fetchMandatoryFrom(otherStep, param.key, stepDescriptors)
+                if(! param.value.value)
+                    param.value.value = fetchPossibleValuesFrom(otherStep, param.key, stepDescriptors)
             }
         }
     }
@@ -509,6 +511,10 @@ def fetchMandatoryFrom(def step, def parameterName, def steps) {
         System.err << "[ERROR] Cannot retrieve docu for parameter ${parameterName} from step ${step}.\n"
         throw e
     }
+}
+
+def fetchPossibleValuesFrom(def step, def parameterName, def steps) {
+        return steps[step]?.parameters[parameterName]?.value ?: ''
 }
 
 def handleStep(stepName, prepareDefaultValuesStep, gse) {


### PR DESCRIPTION
In case there is a @see tag provided for a parameter in the description,
the possible values are only fetched from the corresponding source in
case there is no explict value provided for the possible values.

In case the source does not contain a possible value tag nothing is
transfered.