### PR TITLE
piperPipeline: handle build result correctly

### DIFF
--- a/test/groovy/CommonStepsTest.groovy
+++ b/test/groovy/CommonStepsTest.groovy
@@ -46,13 +46,14 @@ public class CommonStepsTest extends BasePiperTest{
 
         // all steps not adopting the usual pattern of working with the script.
         def whitelistScriptReference = [
-               'commonPipelineEnvironment',
-               'handlePipelineStepErrors',
-               'pipelineExecute',
-               'piperPipeline',
-               'prepareDefaultValues',
-               'setupCommonPipelineEnvironment'
-           ]
+            'commonPipelineEnvironment',
+            'handlePipelineStepErrors',
+            'pipelineExecute',
+            'piperPipeline',
+            'prepareDefaultValues',
+            'setupCommonPipelineEnvironment',
+            'buildSetResult'
+        ]
 
         List steps = getSteps().stream()
             .filter {! whitelistScriptReference.contains(it)}
@@ -102,17 +103,18 @@ public class CommonStepsTest extends BasePiperTest{
     }
 
     private static fieldRelatedWhitelist = [
-            'durationMeasure', // only expects parameters via signature
-            'prepareDefaultValues', // special step (infrastructure)
-            'piperPipeline', // special step (infrastructure)
-            'pipelineStashFilesAfterBuild', // intended to be called from pipelineStashFiles
-            'pipelineStashFilesBeforeBuild', // intended to be called from pipelineStashFiles
-            'pipelineStashFiles', // only forwards to before/after step
-            'pipelineExecute', // special step (infrastructure)
-            'commonPipelineEnvironment', // special step (infrastructure)
-            'handlePipelineStepErrors', // special step (infrastructure)
-            'piperStageWrapper' //intended to be called from within stages
-            ]
+        'durationMeasure', // only expects parameters via signature
+        'prepareDefaultValues', // special step (infrastructure)
+        'piperPipeline', // special step (infrastructure)
+        'pipelineStashFilesAfterBuild', // intended to be called from pipelineStashFiles
+        'pipelineStashFilesBeforeBuild', // intended to be called from pipelineStashFiles
+        'pipelineStashFiles', // only forwards to before/after step
+        'pipelineExecute', // special step (infrastructure)
+        'commonPipelineEnvironment', // special step (infrastructure)
+        'handlePipelineStepErrors', // special step (infrastructure)
+        'piperStageWrapper', //intended to be called from within stages
+        'buildSetResult'
+    ]
 
     @Test
     public void generalConfigKeysSetPresentTest() {
@@ -170,7 +172,8 @@ public class CommonStepsTest extends BasePiperTest{
 
         def whitelist = [
             'commonPipelineEnvironment',
-            'piperPipeline'
+            'piperPipeline',
+            'buildSetResult'
         ]
 
         def stepsWithWrongStepName = []

--- a/test/groovy/templates/PiperPipelineTest.groovy
+++ b/test/groovy/templates/PiperPipelineTest.groovy
@@ -109,7 +109,11 @@ class PiperPipelineTest extends BasePiperTest {
 
         helper.registerAllowedMethod('steps', [Closure], null)
         helper.registerAllowedMethod('post', [Closure], null)
-        helper.registerAllowedMethod('always', [Closure], null)
+        helper.registerAllowedMethod('success', [Closure], {c -> c()})
+        helper.registerAllowedMethod('failure', [Closure], {c -> c()})
+        helper.registerAllowedMethod('aborted', [Closure], {c -> c()})
+        helper.registerAllowedMethod('unstable', [Closure], {c -> c()})
+        helper.registerAllowedMethod('cleanup', [Closure], {c -> c()})
 
         helper.registerAllowedMethod('input', [Map], {m -> return null})
 
@@ -155,6 +159,9 @@ class PiperPipelineTest extends BasePiperTest {
         })
         helper.registerAllowedMethod('piperPipelineStageRelease', [Map.class], {m ->
             stepsCalled.add('piperPipelineStageRelease')
+        })
+        helper.registerAllowedMethod('piperPipelineStagePost', [Map.class], {m ->
+            stepsCalled.add('piperPipelineStagePost')
         })
 
         nullScript.prepareDefaultValues(script: nullScript)
@@ -227,7 +234,8 @@ class PiperPipelineTest extends BasePiperTest {
             'piperPipelineStageCompliance',
             'input',
             'piperPipelineStagePromote',
-            'piperPipelineStageRelease'
+            'piperPipelineStageRelease',
+            'piperPipelineStagePost'
         ))
     }
 }

--- a/test/groovy/templates/PiperPipelineTest.groovy
+++ b/test/groovy/templates/PiperPipelineTest.groovy
@@ -108,7 +108,7 @@ class PiperPipelineTest extends BasePiperTest {
         })
 
         helper.registerAllowedMethod('steps', [Closure], null)
-        helper.registerAllowedMethod('post', [Closure], null)
+        helper.registerAllowedMethod('post', [Closure], {c -> c()})
         helper.registerAllowedMethod('success', [Closure], {c -> c()})
         helper.registerAllowedMethod('failure', [Closure], {c -> c()})
         helper.registerAllowedMethod('aborted', [Closure], {c -> c()})
@@ -159,9 +159,6 @@ class PiperPipelineTest extends BasePiperTest {
         })
         helper.registerAllowedMethod('piperPipelineStageRelease', [Map.class], {m ->
             stepsCalled.add('piperPipelineStageRelease')
-        })
-        helper.registerAllowedMethod('piperPipelineStagePost', [Map.class], {m ->
-            stepsCalled.add('piperPipelineStagePost')
         })
 
         nullScript.prepareDefaultValues(script: nullScript)
@@ -234,8 +231,7 @@ class PiperPipelineTest extends BasePiperTest {
             'piperPipelineStageCompliance',
             'input',
             'piperPipelineStagePromote',
-            'piperPipelineStageRelease',
-            'piperPipelineStagePost'
+            'piperPipelineStageRelease'
         ))
     }
 }

--- a/vars/buildSetResult.groovy
+++ b/vars/buildSetResult.groovy
@@ -1,0 +1,4 @@
+void call(currentBuild, result = 'SUCCESS') {
+    echo "Current build result is ${currentBuild.result}, setting it to ${result}."
+    currentBuild.result = result
+}

--- a/vars/piperPipeline.groovy
+++ b/vars/piperPipeline.groovy
@@ -81,7 +81,12 @@ void call(parameters) {
             }
         }
         post {
-            always {
+            /* https://jenkins.io/doc/book/pipeline/syntax/#post */
+            success {buildSetResult(currentBuild)}
+            aborted {buildSetResult(currentBuild, 'ABORTED')}
+            failure {buildSetResult(currentBuild, 'FAILURE')}
+            unstable {buildSetResult(currentBuild, 'UNSTABLE')}
+            cleanup {
                 influxWriteData script: parameters.script, wrapInNode: true
                 mailSendNotification script: parameters.script, wrapInNode: true
             }


### PR DESCRIPTION
**changes:**
- add convenient step to adjust the build result
- set `currentBuild.result` accordingly to the executed post stage
