### PR TITLE
Honor maven user-settings file for mta build

### DIFF
--- a/test/groovy/MtaBuildTest.groovy
+++ b/test/groovy/MtaBuildTest.groovy
@@ -182,6 +182,14 @@ public class MtaBuildTest extends BasePiperTest {
     }
 
     @Test
+    void canConfigureMavenUserSettings() {
+
+        stepRule.step.mtaBuild(script: nullScript, projectSettingsFile: 'settings.xml')
+
+        assert shellRule.shell.find(){ c -> c.contains('cp settings.xml /home/mta/.m2/settings.xml')}
+    }
+
+    @Test
     void buildTargetFromDefaultStepConfigurationTest() {
 
         nullScript.commonPipelineEnvironment.defaultConfiguration = [steps:[mtaBuild:[buildTarget: 'NEO']]]

--- a/test/groovy/MtaBuildTest.groovy
+++ b/test/groovy/MtaBuildTest.groovy
@@ -186,7 +186,7 @@ public class MtaBuildTest extends BasePiperTest {
 
         stepRule.step.mtaBuild(script: nullScript, projectSettingsFile: 'settings.xml')
 
-        assert shellRule.shell.find(){ c -> c.contains('cp settings.xml /home/mta/.m2/settings.xml')}
+        assert shellRule.shell.find(){ c -> c.contains('cp settings.xml $HOME/.m2/settings.xml')}
     }
 
     @Test

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -26,7 +26,11 @@ import groovy.transform.Field
      * The location of the SAP Multitarget Application Archive Builder jar file, including file name and extension.
      * If it is not provided, the SAP Multitarget Application Archive Builder is expected on PATH.
      */
-    'mtaJarLocation'
+    'mtaJarLocation',
+    /** Path or url to the mvn settings file that should be used as global settings file.*/
+    'globalSettingsFile',
+    /** Path or url to the mvn settings file that should be used as project settings file.*/
+    'projectSettingsFile'
 ]
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus([
     /** @see dockerExecute */
@@ -58,6 +62,12 @@ void call(Map parameters = [:]) {
         ], configuration)
 
         dockerExecute(script: script, dockerImage: configuration.dockerImage, dockerOptions: configuration.dockerOptions) {
+
+            //fixme
+            sh "mkdir -p /home/mta/.m2"
+            sh "cp ${configuration.projectSettingsFile} /home/mta/.m2/settings.xml"
+            sh "cp ${configuration.globalSettingsFile} /opt/maven/apache-maven-3.6.0/conf/settings.xml"
+
 
             def mtaYamlName = "mta.yaml"
             def applicationName = configuration.applicationName

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -67,9 +67,9 @@ void call(Map parameters = [:]) {
             sh "mkdir -p /home/mta/.m2"
             sh "cp ${configuration.projectSettingsFile} /home/mta/.m2/settings.xml"
 
-            if (configuration.globalSettingsFile) {
-                sh "cp ${configuration.globalSettingsFile} /opt/maven/apache-maven-3.6.0/conf/settings.xml"
-            }
+//            if (configuration.globalSettingsFile) {
+//                sh "cp ${configuration.globalSettingsFile} /opt/maven/apache-maven-3.6.0/conf/settings.xml"
+//            }
 
 
             def mtaYamlName = "mta.yaml"

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -66,7 +66,10 @@ void call(Map parameters = [:]) {
             //fixme
             sh "mkdir -p /home/mta/.m2"
             sh "cp ${configuration.projectSettingsFile} /home/mta/.m2/settings.xml"
-            sh "cp ${configuration.globalSettingsFile} /opt/maven/apache-maven-3.6.0/conf/settings.xml"
+
+            if (configuration.globalSettingsFile) {
+                sh "cp ${configuration.globalSettingsFile} /opt/maven/apache-maven-3.6.0/conf/settings.xml"
+            }
 
 
             def mtaYamlName = "mta.yaml"

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -27,8 +27,6 @@ import groovy.transform.Field
      * If it is not provided, the SAP Multitarget Application Archive Builder is expected on PATH.
      */
     'mtaJarLocation',
-    /** Path or url to the mvn settings file that should be used as global settings file.*/
-    'globalSettingsFile',
     /** Path or url to the mvn settings file that should be used as project settings file.*/
     'projectSettingsFile'
 ]
@@ -63,14 +61,11 @@ void call(Map parameters = [:]) {
 
         dockerExecute(script: script, dockerImage: configuration.dockerImage, dockerOptions: configuration.dockerOptions) {
 
-            //fixme
-            sh "mkdir -p /home/mta/.m2"
-            sh "cp ${configuration.projectSettingsFile} /home/mta/.m2/settings.xml"
-
-//            if (configuration.globalSettingsFile) {
-//                sh "cp ${configuration.globalSettingsFile} /opt/maven/apache-maven-3.6.0/conf/settings.xml"
-//            }
-
+            // Apply maven user-settings (for custom repositories, etc)
+            if (configuration.projectSettingsFile) {
+                sh "mkdir -p /home/mta/.m2"
+                sh "cp ${configuration.projectSettingsFile} /home/mta/.m2/settings.xml"
+            }
 
             def mtaYamlName = "mta.yaml"
             def applicationName = configuration.applicationName

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -63,8 +63,8 @@ void call(Map parameters = [:]) {
 
             // Apply maven user-settings (for custom repositories, etc)
             if (configuration.projectSettingsFile) {
-                sh "mkdir -p /home/mta/.m2"
-                sh "cp ${configuration.projectSettingsFile} /home/mta/.m2/settings.xml"
+                sh 'mkdir -p $HOME/.m2'
+                sh "cp ${configuration.projectSettingsFile} \$HOME/.m2/settings.xml"
             }
 
             def mtaYamlName = "mta.yaml"


### PR DESCRIPTION
# Changes

Allow setting custom settings file for maven in mta build, which is for example required if a custom maven repo needs to be used.

- [x] Tests
- [x] Documentation
