### PR TITLE
Pipelines - extend init conditions

### DIFF
--- a/vars/piperInitRunStageConfiguration.groovy
+++ b/vars/piperInitRunStageConfiguration.groovy
@@ -72,6 +72,17 @@ void call(Map parameters = [:]) {
                             stepActive = true
                         }
                         break
+                    case 'configKeys':
+                        if (condition.getValue() instanceof List) {
+                            condition.getValue().each {configKey ->
+                                if (script.commonPipelineEnvironment.getStepConfiguration(step.getKey(), currentStage)?.get(configKey)) {
+                                    stepActive = true
+                                }
+                            }
+                        } else if (script.commonPipelineEnvironment.getStepConfiguration(step.getKey(), currentStage)?.get(condition.getValue())) {
+                            stepActive = true
+                        }
+                        break
                     case 'filePatternFromConfig':
                         def conditionValue=script.commonPipelineEnvironment.getStepConfiguration(step.getKey(), currentStage)?.get(condition.getValue())
                         if (conditionValue && findFiles(glob: conditionValue)) {


### PR DESCRIPTION
# Changes

extends init condition with condition `configKeys`
This condition allows to specify a list of configuration keys which if any key is set will activate the respective step & stage

- [x] Tests