### PR TITLE
Enable configuration of npm registry for mtaBuild

### DIFF
--- a/test/groovy/MtaBuildTest.groovy
+++ b/test/groovy/MtaBuildTest.groovy
@@ -211,6 +211,14 @@ public class MtaBuildTest extends BasePiperTest {
     }
 
     @Test
+    void canConfigureNpmRegistry() {
+
+        stepRule.step.mtaBuild(script: nullScript, defaultNpmRegistry: 'myNpmRegistry.com')
+
+        assert shellRule.shell.find(){ c -> c.contains('npm config set registry myNpmRegistry.com')}
+    }
+
+    @Test
     void canConfigureMavenGlobalSettingsFromRemoteSource() {
 
         stepRule.step.mtaBuild(script: nullScript, globalSettingsFile: 'https://some.host/my-settings.xml')

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -35,7 +35,9 @@ import static com.sap.piper.Utils.downloadSettingsFromUrl
 ]
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus([
     /** @see dockerExecute */
-    'dockerOptions'
+    'dockerOptions',
+    /** Url to the npm registry that should be used for installing npm dependencies.*/
+    'defaultNpmRegistry'
 ])
 
 /**
@@ -79,6 +81,11 @@ void call(Map parameters = [:]) {
                     globalSettingsFile = downloadSettingsFromUrl(this, globalSettingsFile, 'global-settings.xml')
                 }
                 sh "cp ${globalSettingsFile} \$M2_HOME/conf/settings.xml"
+            }
+
+            String defaultNpmRegistry = configuration.defaultNpmRegistry?.trim()
+            if (defaultNpmRegistry) {
+                sh "npm config set registry $defaultNpmRegistry"
             }
 
             def mtaYamlName = "mta.yaml"


### PR DESCRIPTION
# Changes

To allow users to use other registries than npmjs.com this change makes the npm registry used in a mtaBuild configurable.

- [x] Tests
- [x] Documentation
