### PR TITLE
pipeline initialization - support nested keys

### DIFF
--- a/documentation/docs/steps/slackSendNotification.md
+++ b/documentation/docs/steps/slackSendNotification.md
@@ -4,7 +4,9 @@
 
 ## Prerequisites
 
-* Installed and configured [Jenkins Slack plugin](https://github.com/jenkinsci/slack-plugin).
+* Installed and configured [Slack JenkinsCI integration](https://my.slack.com/services/new/jenkins-ci)
+* *secret text* Jenkins credentials with the Slack token
+* Installed and configured [Jenkins Slack plugin](https://github.com/jenkinsci/slack-plugin#install-instructions-for-slack).
 
 ## ${docGenParameters}
 

--- a/test/groovy/templates/PiperInitRunStageConfigurationTest.groovy
+++ b/test/groovy/templates/PiperInitRunStageConfigurationTest.groovy
@@ -451,4 +451,27 @@ steps: {}
         assertThat(nullScript.commonPipelineEnvironment.configuration.runStage.Acceptance, is(true))
 
     }
+
+    @Test
+    void testGetConfigValue() {
+
+        def config = [
+            invalidKey: 'invalidValue',
+            stringKey: 'stringValue',
+            listKey: [
+                'listValue1',
+                'listValue2'
+            ],
+            nested: [
+                key: 'nestedValue'
+            ]
+        ]
+
+        assertThat(jsr.step.piperInitRunStageConfiguration.getConfigValue(config, 'stringKey'), is('stringValue'))
+        assertThat(jsr.step.piperInitRunStageConfiguration.getConfigValue(config, 'listKey'), is(['listValue1','listValue2']))
+        assertThat(jsr.step.piperInitRunStageConfiguration.getConfigValue(config, 'nested/key'), is('nestedValue'))
+        assertThat(jsr.step.piperInitRunStageConfiguration.getConfigValue(config, 'invalidKey/key'), is(nullValue()))
+
+        //assertThat(jsr.step.piperInitRunStageConfiguration.getConfigValue(config, 'nested/key'), is('nestedValue'))
+    }
 }

--- a/vars/piperInitRunStageConfiguration.groovy
+++ b/vars/piperInitRunStageConfiguration.groovy
@@ -85,7 +85,7 @@ void call(Map parameters = [:]) {
                         }
                         break
                     case 'filePatternFromConfig':
-                        def conditionValue=getConfigValue(stepConfig, condition.getValue())
+                        def conditionValue = getConfigValue(stepConfig, condition.getValue())
                         if (conditionValue && findFiles(glob: conditionValue)) {
                             stepActive = true
                         }
@@ -114,18 +114,12 @@ void call(Map parameters = [:]) {
 private def getConfigValue(Map stepConfig, def configKey) {
     if (stepConfig == null) return null
 
-    List configPath
-    if (configKey instanceof String) {
-        configPath = configKey.tokenize('/')
-    } else {
-        configPath = configKey
-    }
+    List configPath = configKey instanceof String ? configKey.tokenize('/') : configKey
 
     def configValue = stepConfig[configPath.head()]
+
     if (configPath.size() == 1) return configValue
-    if (configValue in Map) {
-        return getConfigValue(configValue, configPath.tail())
-    } else {
-        return null
-    }
+    if (configValue in Map) return getConfigValue(configValue, configPath.tail())
+
+    return null
 }


### PR DESCRIPTION
# Changes

support a nested structure for config keys for initialization conditions, like

```
Acceptance:
    stepConditions:
      cloudFoundryDeploy:
        configKeys:
          - 'cfSpace'
          - 'cloudFoundry/space'
```

- [x] Tests


