### PR TITLE
Fix exception list for step neoDeploy

### DIFF
--- a/documentation/docs/steps/neoDeploy.md
+++ b/documentation/docs/steps/neoDeploy.md
@@ -25,15 +25,15 @@ none
 ## Exceptions
 
 * `Exception`:
-  * If `source` is not provided.
-  * If `propertiesFile` is not provided (when using `'WAR_PROPERTIESFILE'` deployment mode).
-  * If `application` is not provided (when using `'WAR_PARAMS'` deployment mode).
-  * If `runtime` is not provided (when using `'WAR_PARAMS'` deployment mode).
-  * If `runtimeVersion` is not provided (when using `'WAR_PARAMS'` deployment mode).
+    * If `source` is not provided.
+    * If `propertiesFile` is not provided (when using `'WAR_PROPERTIESFILE'` deployment mode).
+    * If `application` is not provided (when using `'WAR_PARAMS'` deployment mode).
+    * If `runtime` is not provided (when using `'WAR_PARAMS'` deployment mode).
+    * If `runtimeVersion` is not provided (when using `'WAR_PARAMS'` deployment mode).
 * `AbortException`:
-  * If neo-java-web-sdk is not installed, or `neoHome`is wrong.
+    * If neo-java-web-sdk is not installed, or `neoHome`is wrong.
 * `CredentialNotFoundException`:
-  * If the credentials cannot be resolved.
+    * If the credentials cannot be resolved.
 
 ## Example
 


### PR DESCRIPTION
due to wrong indentation in the md file the excpetions are not rendered as expected. The reasons
why an exception occures is on the same level like the exception, but should have only level more.

Fixes #692.
