### PR TITLE
Provide a deep config copy from ConfigHelper.use()

### DIFF
--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -127,8 +127,10 @@ class ConfigurationHelper implements Serializable {
         handleValidationFailures()
         MapUtils.traverse(config, { v -> (v instanceof GString) ? v.toString() : v })
         if(config.verbose) step.echo "[${name}] Configuration: ${config}"
-        return config
+        return MapUtils.deepCopy(config)
     }
+
+
 
     /* private */ def getConfigPropertyNested(key) {
         return getConfigPropertyNested(config, key)

--- a/src/com/sap/piper/MapUtils.groovy
+++ b/src/com/sap/piper/MapUtils.groovy
@@ -62,4 +62,38 @@ class MapUtils implements Serializable {
         }
         m.putAll(updates)
     }
+
+    static deepCopy(Map original) {
+        Map copy = [:]
+        for (def e : original.entrySet()) {
+            if(e.value == null) {
+                copy.put(e.key, e.value)
+            } else {
+                copy.put(e.key, deepCopy(e.value))
+            }
+        }
+        copy
+    }
+
+    static deepCopy(Set original) {
+        Set copy = []
+        for(def e : original)
+            copy << deepCopy(e)
+        copy
+    }
+
+    static deepCopy(List original) {
+        List copy = []
+        for(def e : original)
+            copy << deepCopy(e)
+        copy
+    }
+
+    /*
+     * In fact not a copy, but a catch all for everything not matching
+     * with the other signatures
+     */
+    static deepCopy(def original) {
+        original
+    }
 }

--- a/src/com/sap/piper/MapUtils.groovy
+++ b/src/com/sap/piper/MapUtils.groovy
@@ -63,6 +63,13 @@ class MapUtils implements Serializable {
         m.putAll(updates)
     }
 
+    /*
+     * Provides a new map with the same content like the original map.
+     * Nested Collections and Maps are copied. Values with are not
+     * Collections/Maps are not copied/cloned.
+     * &lt;paranoia&gt;&/ltThe keys are also not copied/cloned, even if they are
+     * Maps or Collections;paranoia&gt;
+     */
     static deepCopy(Map original) {
         Map copy = [:]
         for (def e : original.entrySet()) {
@@ -75,14 +82,14 @@ class MapUtils implements Serializable {
         copy
     }
 
-    static deepCopy(Set original) {
+    /* private */ static deepCopy(Set original) {
         Set copy = []
         for(def e : original)
             copy << deepCopy(e)
         copy
     }
 
-    static deepCopy(List original) {
+    /* private */ static deepCopy(List original) {
         List copy = []
         for(def e : original)
             copy << deepCopy(e)
@@ -93,7 +100,7 @@ class MapUtils implements Serializable {
      * In fact not a copy, but a catch all for everything not matching
      * with the other signatures
      */
-    static deepCopy(def original) {
+    /* private */ static deepCopy(def original) {
         original
     }
 }

--- a/test/groovy/com/sap/piper/MapUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/MapUtilsTest.groovy
@@ -50,4 +50,35 @@ class MapUtilsTest {
         MapUtils.traverse(m, { s -> (s.startsWith('x')) ? "replaced" : s})
         assert m == [a: 'replaced', m: [b: 'replaced', c: 'otherString']]
     }
+
+    @Test
+    void testDeepCopy() {
+
+        List l = ['a', 'b', 'c']
+
+        def original = [
+                list: l,
+                set: (Set)['1', '2'],
+                nextLevel: [
+                    list: ['x', 'y'],
+                    duplicate: l,
+                    set: (Set)[9, 8, 7]
+                ]
+            ]
+
+        def copy = MapUtils.deepCopy(original)
+
+        assert ! copy.is(original)
+        assert ! copy.list.is(original.list)
+        assert ! copy.set.is(original.set)
+        assert ! copy.nextLevel.list.is(original.nextLevel.list)
+        assert ! copy.nextLevel.set.is(original.nextLevel.set)
+        assert ! copy.nextLevel.duplicate.is(original.nextLevel.duplicate)
+
+        // Within the original identical list is used twice, but the
+        // assuption is that there are different lists in the copy.
+        assert ! copy.nextLevel.duplicate.is(copy.list)
+
+        assert copy == original
+    }
 }


### PR DESCRIPTION
The config map prepared by `ConfigHelper` is a mix from several configuration levels. The lowest config level (`DefaultValueCache`) is shared between several `ConfigHelper`/step invocations. In case a Map or Collection which is inherited from the `DefaultValueCache` level gets modified, this is also visible for all subsequent steps. This causes trouble and situations which are hard to debug (See e.g. https://github.com/SAP/jenkins-pipelines/issues/16).

With this change here each invocation of ConfigHelper.use() provides a deep defensive copy. With that we can ensure that there is no configuration update from one step to another.

There is another related pull request making the DefaultValueCache immutable (#642). This PR is not superseded by thisone. This two PRs complements each other.

Currently #642 fails since there is an update performed the the config map from one of the steps (hitting finally an unmodifiable Map). With is resolved with the PR here since the immutable map is replaced by another (mutable) map when creating the defensive copy.
