### PR TITLE
Provide docu metadata in gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,10 @@ jobs:
       name: Create Documentation
       install: docker pull squidfunk/mkdocs-material:3.0.4
       before_script: documentation/bin/createDocu.sh
-      script: docker run --rm -it -v ${TRAVIS_BUILD_DIR}/documentation:/docs squidfunk/mkdocs-material:3.0.4 build --clean --strict
+      script:
+        - docker run -u `id -u`:`id -g` --rm -it -v ${TRAVIS_BUILD_DIR}/documentation:/docs squidfunk/mkdocs-material:3.0.4 build --clean --strict
+        - mkdir -p documentation/docs-gen/misc
+        - cp target/docuMetaData.json documentation/docs-gen/misc
       deploy:
         on:
           branch: master


### PR DESCRIPTION
Since some weeks we create a docu metadata.json file which contains the same information we use for rendering the md files - and finally the published documention.

That docuMetadata.yml is intended to be used as input for wizzard generators.

In order to simplify the consumption of that file we have the requirement to include this file in the gh-pages branch  - that branch holds also the generated docu.
