### PR TITLE
Add Notify object for pipeline issue management

### DIFF
--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -1,0 +1,51 @@
+package com.sap.piper
+
+import groovy.text.SimpleTemplateEngine
+
+class Notify implements Serializable {
+    private static enum Severity { ERROR, WARNING }
+    private final static String LIBRARY_NAME = 'piper-lib-os'
+    private final static String MESSAGE_PATTERN = '[${severity}] ${message} (${libName}/${stepName})'
+
+    protected static Utils instance = null
+
+    protected static Utils getUtilsInstance(){
+        instance = instance ?: new Utils()
+        return instance
+    }
+
+    static void warning(Map config, Script step, String msg, String stepName = null){
+        log(config, step, msg, stepName)
+    }
+
+    static void error(Map config, Script step, String msg, String stepName = null) {
+        log(config, step, msg, stepName, Severity.ERROR)
+    }
+
+    private static void log(Map config, Script step, String msg, String stepName, Severity severity = Severity.WARNING){
+        stepName = stepName ?: step.STEP_NAME
+        getUtilsInstance().pushToSWA([
+            folder: '',
+            repository: '',
+            step: 'Notify',
+            eventType: 'notification',
+            stepParam1: LIBRARY_NAME,
+            stepParam2: stepName,
+            stepParam3: msg,
+            stepParam4: severity
+        ], config)
+        def logEntry = SimpleTemplateEngine.newInstance().createTemplate(
+            MESSAGE_PATTERN
+        ).make([
+            libName: LIBRARY_NAME,
+            stepName: stepName,
+            message: msg,
+            severity: severity
+        ]).toString()
+
+        if (severity == Severity.ERROR){
+            step.error(logEntry)
+        }
+        step.echo(logEntry)
+    }
+}

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -4,11 +4,11 @@ class Notify implements Serializable {
     private static enum Severity { ERROR, WARNING }
     private final static String LIBRARY_NAME = 'piper-lib-os'
 
-    protected static Utils instance = null
+    protected static Utils utils = null
 
     protected static Utils getUtilsInstance(){
-        instance = instance ?: new Utils()
-        return instance
+        this.utils = this.utils ?: new Utils()
+        return this.utils
     }
 
     static void warning(Map config, Script step, String message, String stepName = null){

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -1,9 +1,9 @@
 package com.sap.piper
 
 class Notify implements Serializable {
-    private static enum Severity { ERROR, WARNING }
-    private final static String LIBRARY_NAME = 'piper-lib-os'
+    protected static enum Severity { ERROR, WARNING }
 
+    protected final static String LIBRARY_NAME = 'piper-lib-os'
     protected static Utils utils = null
 
     protected static Utils getUtilsInstance(){

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -1,5 +1,7 @@
 package com.sap.piper
 
+import com.sap.piper.analytics.Telemetry
+
 class Notify implements Serializable {
     protected static enum Severity { ERROR, WARNING }
 
@@ -21,22 +23,27 @@ class Notify implements Serializable {
 
     private static void log(Map config, Script step, String message, String stepName, Severity severity){
         stepName = stepName ?: step.STEP_NAME
-        getUtilsInstance().pushToSWA([
+
+        Telemetry.notify(step, config, [
             folder: '',
             repository: '',
             step: 'Notify',
+            actionName: 'Piper Library OS',
             eventType: 'notification',
+            jobUrlSha1: Utils.generateSha1(env.JOB_URL),
+            buildUrlSha1: Utils.generateSha1(env.BUILD_URL),
             stepParam1: LIBRARY_NAME,
             stepParam2: stepName,
             stepParam3: message,
             stepParam4: severity
-        ], config)
+        ])
 
         def notification = "[${severity}] ${message} (${LIBRARY_NAME}/${stepName})"
 
         if (severity == Severity.ERROR){
             step.error(notification)
+        } else{
+            step.echo(notification)
         }
-        step.echo(notification)
     }
 }

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -28,7 +28,7 @@ class Notify implements Serializable {
             eventType: 'notification',
             stepParam1: LIBRARY_NAME,
             stepParam2: stepName,
-            stepParam3: msg,
+            stepParam3: message,
             stepParam4: severity
         ], config)
 

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -14,14 +14,14 @@ class Notify implements Serializable {
     }
 
     static void warning(Map config, Script step, String message, String stepName = null){
-        log(config, step, message, stepName, Severity.WARNING)
+        notify(config, step, message, stepName, Severity.WARNING)
     }
 
     static void error(Map config, Script step, String message, String stepName = null) {
-        log(config, step, message, stepName, Severity.ERROR)
+        notify(config, step, message, stepName, Severity.ERROR)
     }
 
-    private static void log(Map config, Script step, String message, String stepName, Severity severity){
+    private static void notify(Map config, Script step, String message, String stepName, Severity severity){
         stepName = stepName ?: step.STEP_NAME
 
         Telemetry.notify(step, config, [

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -1,11 +1,8 @@
 package com.sap.piper
 
-import groovy.text.SimpleTemplateEngine
-
 class Notify implements Serializable {
     private static enum Severity { ERROR, WARNING }
     private final static String LIBRARY_NAME = 'piper-lib-os'
-    private final static String MESSAGE_PATTERN = '[${severity}] ${message} (${libName}/${stepName})'
 
     protected static Utils instance = null
 
@@ -14,15 +11,15 @@ class Notify implements Serializable {
         return instance
     }
 
-    static void warning(Map config, Script step, String msg, String stepName = null){
-        log(config, step, msg, stepName)
+    static void warning(Map config, Script step, String message, String stepName = null){
+        log(config, step, message, stepName)
     }
 
-    static void error(Map config, Script step, String msg, String stepName = null) {
-        log(config, step, msg, stepName, Severity.ERROR)
+    static void error(Map config, Script step, String message, String stepName = null) {
+        log(config, step, message, stepName, Severity.ERROR)
     }
 
-    private static void log(Map config, Script step, String msg, String stepName, Severity severity = Severity.WARNING){
+    private static void log(Map config, Script step, String message, String stepName, Severity severity = Severity.WARNING){
         stepName = stepName ?: step.STEP_NAME
         getUtilsInstance().pushToSWA([
             folder: '',
@@ -34,18 +31,12 @@ class Notify implements Serializable {
             stepParam3: msg,
             stepParam4: severity
         ], config)
-        def logEntry = SimpleTemplateEngine.newInstance().createTemplate(
-            MESSAGE_PATTERN
-        ).make([
-            libName: LIBRARY_NAME,
-            stepName: stepName,
-            message: msg,
-            severity: severity
-        ]).toString()
+
+        def notification = "[${severity}] ${message} (${LIBRARY_NAME}/${stepName})"
 
         if (severity == Severity.ERROR){
-            step.error(logEntry)
+            step.error(notification)
         }
-        step.echo(logEntry)
+        step.echo(notification)
     }
 }

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -6,37 +6,17 @@ class Notify implements Serializable {
     protected static enum Severity { ERROR, WARNING }
 
     protected final static String LIBRARY_NAME = 'piper-lib-os'
-    protected static Utils utils = null
 
-    protected static Utils getUtilsInstance(){
-        this.utils = this.utils ?: new Utils()
-        return this.utils
+    static void warning(Script step, String message, String stepName = null){
+        notify(step, message, stepName, Severity.WARNING)
     }
 
-    static void warning(Map config, Script step, String message, String stepName = null){
-        notify(config, step, message, stepName, Severity.WARNING)
+    static void error(Script step, String message, String stepName = null) {
+        notify(step, message, stepName, Severity.ERROR)
     }
 
-    static void error(Map config, Script step, String message, String stepName = null) {
-        notify(config, step, message, stepName, Severity.ERROR)
-    }
-
-    private static void notify(Map config, Script step, String message, String stepName, Severity severity){
+    private static void notify(Script step, String message, String stepName, Severity severity){
         stepName = stepName ?: step.STEP_NAME
-
-        Telemetry.notify(step, config, [
-            folder: '',
-            repository: '',
-            step: 'Notify',
-            actionName: 'Piper Library OS',
-            eventType: 'notification',
-            jobUrlSha1: Utils.generateSha1(env.JOB_URL),
-            buildUrlSha1: Utils.generateSha1(env.BUILD_URL),
-            stepParam1: LIBRARY_NAME,
-            stepParam2: stepName,
-            stepParam3: message,
-            stepParam4: severity
-        ])
 
         def notification = "[${severity}] ${message} (${LIBRARY_NAME}/${stepName})"
 

--- a/src/com/sap/piper/Notify.groovy
+++ b/src/com/sap/piper/Notify.groovy
@@ -12,14 +12,14 @@ class Notify implements Serializable {
     }
 
     static void warning(Map config, Script step, String message, String stepName = null){
-        log(config, step, message, stepName)
+        log(config, step, message, stepName, Severity.WARNING)
     }
 
     static void error(Map config, Script step, String message, String stepName = null) {
         log(config, step, message, stepName, Severity.ERROR)
     }
 
-    private static void log(Map config, Script step, String message, String stepName, Severity severity = Severity.WARNING){
+    private static void log(Map config, Script step, String message, String stepName, Severity severity){
         stepName = stepName ?: step.STEP_NAME
         getUtilsInstance().pushToSWA([
             folder: '',

--- a/test/groovy/com/sap/piper/NotifyTest.groovy
+++ b/test/groovy/com/sap/piper/NotifyTest.groovy
@@ -1,0 +1,66 @@
+package com.sap.piper
+
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.not
+
+import static org.junit.Assert.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.rules.RuleChain
+
+import util.BasePiperTest
+import util.JenkinsLoggingRule
+import util.JenkinsShellCallRule
+import util.Rules
+
+class NotifyTest extends BasePiperTest {
+    private ExpectedException thrown = ExpectedException.none()
+    private JenkinsLoggingRule jlr = new JenkinsLoggingRule(this)
+    private JenkinsShellCallRule jscr = new JenkinsShellCallRule(this)
+
+    private Map config
+
+    @Rule
+    public RuleChain rules = Rules
+        .getCommonRules(this)
+        .around(jlr)
+        .around(jscr)
+        .around(thrown)
+
+    @Before
+    void init() throws Exception {
+        // prepare
+        config = [collectTelemetryData: true]
+        nullScript.STEP_NAME = 'anyStep'
+        utils.env.JOB_NAME = 'testJob'
+        Notify.instance = utils
+    }
+
+    @Test
+    void testWarning() {
+        // execute test
+        Notify.warning(config, nullScript, "test message")
+        // asserts
+        assertThat(jlr.log, containsString('[WARNING] test message (piper-lib-os/anyStep)'))
+        assertThat(jscr.shell, hasItem(containsString('curl -G -v "https://webanalytics.cfapps.eu10.hana.ondemand.com/tracker/log"')))
+        assertThat(jscr.shell, hasItem(containsString('--data-urlencode "custom14=WARNING"')))
+    }
+
+    @Test
+    void testError() {
+        thrown.expect(hudson.AbortException)
+        thrown.expectMessage('[ERROR] test message (piper-lib-os/anyOtherStep)')
+        // execute test
+        try{
+            Notify.error(config, nullScript, "test message", "anyOtherStep")
+        }finally{
+            // asserts
+            assertThat(jscr.shell, hasItem(containsString('curl -G -v "https://webanalytics.cfapps.eu10.hana.ondemand.com/tracker/log"')))
+            assertThat(jscr.shell, hasItem(containsString('--data-urlencode "custom14=ERROR"')))
+        }
+    }
+}

--- a/test/groovy/com/sap/piper/NotifyTest.groovy
+++ b/test/groovy/com/sap/piper/NotifyTest.groovy
@@ -14,27 +14,21 @@ import org.junit.rules.RuleChain
 
 import util.BasePiperTest
 import util.JenkinsLoggingRule
-import util.JenkinsShellCallRule
 import util.Rules
 
 class NotifyTest extends BasePiperTest {
     private ExpectedException thrown = ExpectedException.none()
     private JenkinsLoggingRule jlr = new JenkinsLoggingRule(this)
-    private JenkinsShellCallRule jscr = new JenkinsShellCallRule(this)
-
-    private Map config
 
     @Rule
     public RuleChain rules = Rules
         .getCommonRules(this)
         .around(jlr)
-        .around(jscr)
         .around(thrown)
 
     @Before
     void init() throws Exception {
         // prepare
-        config = [collectTelemetryData: true]
         nullScript.STEP_NAME = 'anyStep'
         utils.env.JOB_NAME = 'testJob'
         Notify.instance = utils
@@ -43,11 +37,9 @@ class NotifyTest extends BasePiperTest {
     @Test
     void testWarning() {
         // execute test
-        Notify.warning(config, nullScript, "test message")
+        Notify.warning(nullScript, "test message")
         // asserts
         assertThat(jlr.log, containsString('[WARNING] test message (piper-lib-os/anyStep)'))
-        assertThat(jscr.shell, hasItem(containsString('curl -G -v "https://webanalytics.cfapps.eu10.hana.ondemand.com/tracker/log"')))
-        assertThat(jscr.shell, hasItem(containsString('--data-urlencode "custom14=WARNING"')))
     }
 
     @Test
@@ -55,12 +47,6 @@ class NotifyTest extends BasePiperTest {
         thrown.expect(hudson.AbortException)
         thrown.expectMessage('[ERROR] test message (piper-lib-os/anyOtherStep)')
         // execute test
-        try{
-            Notify.error(config, nullScript, "test message", "anyOtherStep")
-        }finally{
-            // asserts
-            assertThat(jscr.shell, hasItem(containsString('curl -G -v "https://webanalytics.cfapps.eu10.hana.ondemand.com/tracker/log"')))
-            assertThat(jscr.shell, hasItem(containsString('--data-urlencode "custom14=ERROR"')))
-        }
+        Notify.error(nullScript, "test message", "anyOtherStep")
     }
 }

--- a/test/groovy/com/sap/piper/NotifyTest.groovy
+++ b/test/groovy/com/sap/piper/NotifyTest.groovy
@@ -31,7 +31,6 @@ class NotifyTest extends BasePiperTest {
         // prepare
         nullScript.STEP_NAME = 'anyStep'
         utils.env.JOB_NAME = 'testJob'
-        Notify.instance = utils
     }
 
     @Test

--- a/test/groovy/util/BasePiperTestContext.groovy
+++ b/test/groovy/util/BasePiperTestContext.groovy
@@ -32,6 +32,7 @@ class BasePiperTestContext {
     @Bean
     Utils mockUtils() {
         def mockUtils = new Utils()
+        mockUtils.env = [:]
         mockUtils.steps = [
             stash  : {  },
             unstash: {  }


### PR DESCRIPTION
Create `Notify` class to raise warnings and errors in an aligned format that they can be picked up by custom log parser via the [`warnings` plugin](https://wiki.jenkins.io/display/JENKINS/Warnings+Plugin). 

![Bildschirmfoto 2019-05-20 um 15 14 40](https://user-images.githubusercontent.com/26137398/58024233-03822780-7b12-11e9-8a64-43abf43b362d.png)

related to #652 