### PR TITLE
Fix typo in yaml

### DIFF
--- a/documentation/docs/scenarios/CAP_Scenario.md
+++ b/documentation/docs/scenarios/CAP_Scenario.md
@@ -47,7 +47,7 @@ node(){
 
 ```yaml
 steps:
-  mtaBuild
+  mtaBuild:
     buildTarget: 'CF'
   cloudFoundryDeploy:
     cloudFoundry:


### PR DESCRIPTION
# Changes

Missing colon in yaml example.
