### PR TITLE
whiteSourceExecuteScan - allow passing projects via cpe

### DIFF
--- a/test/groovy/CommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/CommonPipelineEnvironmentTest.groovy
@@ -1,0 +1,37 @@
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import util.BasePiperTest
+import util.JenkinsReadYamlRule
+import util.Rules
+
+import static org.hamcrest.CoreMatchers.is
+import static org.hamcrest.Matchers.hasItem
+import static org.junit.Assert.assertThat
+
+class CommonPipelineEnvironmentTest extends BasePiperTest {
+
+    @Rule
+    public RuleChain rules = Rules
+        .getCommonRules(this)
+        .around(new JenkinsReadYamlRule(this)
+    )
+
+    @Test
+    void testCustomValueList() {
+        nullScript.commonPipelineEnvironment.setValue('myList', [])
+        nullScript.commonPipelineEnvironment.getValue('myList').add('item1')
+        nullScript.commonPipelineEnvironment.getValue('myList').add('item2')
+        assertThat(nullScript.commonPipelineEnvironment.getValue('myList'), hasItem('item1'))
+        assertThat(nullScript.commonPipelineEnvironment.getValue('myList'), hasItem('item2'))
+    }
+
+    @Test
+    void testCustomValueMap() {
+        nullScript.commonPipelineEnvironment.setValue('myList', [:])
+        nullScript.commonPipelineEnvironment.getValue('myList').key1 = 'val1'
+        nullScript.commonPipelineEnvironment.getValue('myList').key2 = 'val2'
+        assertThat(nullScript.commonPipelineEnvironment.getValue('myList').key1, is('val1'))
+        assertThat(nullScript.commonPipelineEnvironment.getValue('myList').key2, is('val2'))
+    }
+}

--- a/vars/whitesourceExecuteScan.groovy
+++ b/vars/whitesourceExecuteScan.groovy
@@ -227,6 +227,11 @@ void call(Map parameters = [:]) {
         def descriptorUtils = parameters.descriptorUtilsStub ?: new DescriptorUtils()
         def statusCode = 1
 
+        //initialize CPE for passing whiteSourceProjects
+        if(script.commonPipelineEnvironment.getValue('whitesourceProjectNames') == null) {
+            script.commonPipelineEnvironment.setValue('whitesourceProjectNames', [])
+        }
+
         // load default & individual configuration
         Map config = ConfigurationHelper.newInstance(this)
             .loadStepDefaults(CONFIG_KEY_COMPATIBILITY)
@@ -357,6 +362,10 @@ private def triggerWhitesourceScanWithUserKey(script, config, utils, descriptorU
                 def projectName = "${config.whitesource.projectName}${config.whitesource.productVersion?' - ':''}${config.whitesource.productVersion?:''}".toString()
                 if(!config.whitesource['projectNames'].contains(projectName))
                     config.whitesource['projectNames'].add(projectName)
+
+                //share projectNames with other steps
+                if(!script.commonPipelineEnvironment.getValue('whitesourceProjectNames').contains(projectName))
+                    script.commonPipelineEnvironment.getValue('whitesourceProjectNames').add(projectName)
 
                 WhitesourceConfigurationHelper.extendUAConfigurationFile(script, utils, config, path)
                 dockerExecute(script: script, dockerImage: config.dockerImage, dockerWorkspace: config.dockerWorkspace, stashContent: config.stashContent) {


### PR DESCRIPTION
# Changes

Having the executed WhiteSource project names in `commonPipelineEnvironment` will help downstream steps to re-use these names for example to conduct further checks against these projects.

- [x] Tests
- [ ] ~Documentation~ not relevant for documentation
