### PR TITLE
dockerExecuteOnKubernetes - revert #739

### DIFF
--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -373,6 +373,8 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
         assertThat(securityContext, is(equalTo(expectedSecurityContext)))
     }
 
+    /*
+    Due to negative side-effect of full git stashing
     @Test
     void testDockerExecuteOnKubernetesWorkspaceStashing() {
 
@@ -384,6 +386,7 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
         assertTrue(bodyExecuted)
         assertThat(stashMap.useDefaultExcludes, is(false))
     }
+    */
 
 
     private container(options, body) {

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -226,7 +226,8 @@ chown -R ${runAsUser}:${fsGroup} ."""
             name: stashName,
             includes: config.stashIncludes.workspace,
             excludes: config.stashExcludes.workspace,
-            useDefaultExcludes: false
+            //inactive due to negative side-effects, we may require a dedicated git stash to be used
+            //useDefaultExcludes: false
         )
         return stashName
     } catch (AbortException | IOException e) {


### PR DESCRIPTION
stashing .git directory had negative side-effects.
Solution would be to stash `.git` folder and unstash in `dockerExecuteOnKubernetes` only if required for a dedicated scenario.


