### PR TITLE
Fix PATH substitution

### DIFF
--- a/test/groovy/MtaBuildTest.groovy
+++ b/test/groovy/MtaBuildTest.groovy
@@ -52,7 +52,6 @@ public class MtaBuildTest extends BasePiperTest {
                     OpenJDK 64-Bit Server VM (build 25.121-b13, mixed mode)''')
         shellRule.setReturnValue(JenkinsShellCallRule.Type.REGEX, '.*mta\\.jar -v.*', '1.0.6')
 
-        binding.setVariable('PATH', '/usr/bin')
     }
 
 

--- a/test/groovy/MtaBuildTest.groovy
+++ b/test/groovy/MtaBuildTest.groovy
@@ -61,7 +61,7 @@ public class MtaBuildTest extends BasePiperTest {
 
         stepRule.step.mtaBuild(script: nullScript, buildTarget: 'NEO')
 
-        assert shellRule.shell.find { c -> c.contains('PATH=./node_modules/.bin:/usr/bin')}
+        assert shellRule.shell.find { c -> c.contains('PATH=./node_modules/.bin:$PATH')}
     }
 
 

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -127,7 +127,7 @@ void call(Map parameters = [:]) {
             echo "[INFO] Executing mta build call: '${mtaCall}'."
 
             sh """#!/bin/bash
-            export PATH=./node_modules/.bin:${PATH}
+            export PATH=./node_modules/.bin:\$PATH
             $mtaCall
             """
 


### PR DESCRIPTION
# Changes
The PATH is now correctly substituted. 
- [x] Tests
- [x] Documentation
