### PR TITLE
piperStageWrapper: remove misleading log message

### DIFF
--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -96,7 +96,6 @@ private void executeStage(script, originalStage, stageName, config, utils) {
         }
 
     } finally {
-        echo "Current build result in stage $stageName is ${script.currentBuild.currentResult}."
         //Perform stashing of selected files in workspace
         utils.stashList(script, script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.stashes ?: [])
         deleteDir()


### PR DESCRIPTION
If an error occurs in a `piperStageWrapper`, the message `Current build result in stage xyz is SUCCESS.` is logged.

```
17:11:52  ----------------------------------------------------------
17:11:52  --- An error occurred in the library step: runBuild
17:11:52  ----------------------------------------------------------
...
17:11:52  ----------------------------------------------------------
17:11:52  --- End library step of: runBuild ---
[Pipeline] }
[Pipeline] // parallel
[Pipeline] echo
17:11:54  Current build result in stage xyz is SUCCESS.
...
```

The used Jenkins variable `currentBuild.currentResult` is not yet updated and therefore this misleading status is logged.