### PR TITLE
pipelineStashFiles: Add *.d, *.di

### DIFF
--- a/documentation/docs/steps/pipelineStashFiles.md
+++ b/documentation/docs/steps/pipelineStashFiles.md
@@ -15,7 +15,7 @@ The step is stashing files before and after the build. This is due to the fact, 
 | stash name | mandatory | prerequisite | pattern |
 |---|---|---|---|
 |buildDescriptor|no| |includes: `**/pom.xml, **/.mvn/**, **/assembly.xml, **/.swagger-codegen-ignore, **/package.json, **/requirements.txt, **/setup.py, **/whitesource_config.py, **/mta*.y*ml, **/.npmrc, **/whitesource.*.json, **/whitesource-fs-agent.config, Dockerfile, **/VERSION, **/version.txt, **/Gopkg.*, **/dub.json, **/dub.sdl, **/build.sbt, **/sbtDescriptor.json, **/project/*`<br /> excludes: `**/node_modules/**/package.json`|
-|checkmarx|no|Checkmarx is enabled|includes: `**/*.js, **/*.scala, **/*.go`<br /> excludes: `**/*.mockserver.js, node_modules/**/*.js`|
+|checkmarx|no|Checkmarx is enabled|includes: `**/*.js, **/*.scala, **/*.go, **/*.d, **/*.di`<br /> excludes: `**/*.mockserver.js, node_modules/**/*.js`|
 |classFiles|no| |includes: `**/target/classes/**/*.class, **/target/test-classes/**/*.class` <br />excludes: `''`|
 |deployDescriptor|no| |includes: `**/manifest*.y*ml, **/*.mtaext.y*ml, **/*.mtaext, **/xs-app.json, helm/**, *.y*ml`<br />exclude: `''`|
 |git|no| |includes: `**/gitmetadata/**`<br />exludes: `''`|

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -414,7 +414,7 @@ steps:
   pipelineStashFilesAfterBuild:
     stashIncludes:
       buildResult: '**/target/*.jar, **/*.mtar'
-      checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.xml, **/*.html'
+      checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html'
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
       sonar: '**/jacoco*.exec, **/sonar-project.properties'
     stashExcludes:


### PR DESCRIPTION
# Changes
While D source code files not used in checkmarx, the stash ```checkmarx``` is used for various purposes (e.g. in step detectExecuteScan). Therefore added D source code files to stash ```checkmarx```.
Maybe an additional stash ```additionalSourceFiles``` makes sense in general?

- [X] Documentation
