### PR TITLE
Docker Pipeline - fixes and small adoptions

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -56,7 +56,7 @@ nav:
             - 'Stages':
                 - 'Init Stage': stages/init.md
                 - 'Pull-Request Voting Stage': stages/prvoting.md
-                - 'Central Build Stage': stages/build.md
+                - 'Build Stage': stages/build.md
                 - 'Additional Unit Test Stage': stages/additionalunittests.md
                 - 'Integration Stage': stages/integration.md
                 - 'Acceptance Stage': stages/acceptance.md

--- a/resources/com.sap.piper/pipeline/stageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/stageDefaults.yml
@@ -52,9 +52,6 @@ stages:
       healthExecuteCheck:
         configKeys:
           - 'testServerUrl'
-      neoDeploy:
-        configKeys:
-          - 'neo/credentialsId'
       githubPublishRelease:
         configKeys:
           - 'githubTokenCredentialsId'

--- a/resources/com.sap.piper/pipeline/stageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/stageDefaults.yml
@@ -2,27 +2,71 @@ stages:
   Init:
     stepConditions:
       slackSendNotification:
-        config: 'channel'
+        configKeys:
+          - 'channel'
   'Pull-Request Voting': {}
   Build: {}
-  'Additional Unit Tests': {}
+  'Additional Unit Tests': {
+    stepConditions:
+      batsExecuteTests:
+        filePattern: '**/*.bats'
+      karmaExecuteTests:
+        filePattern: '**/karma.conf.js'
+  }
   Integration: {}
   Acceptance:
     stepConditions:
       cloudFoundryDeploy:
-        config: 'cfSpace'
+        configKeys:
+          - 'cfSpace'
+      healthExecuteCheck:
+        configKeys:
+          - 'testServerUrl'
+      neoDeploy:
+        configKeys:
+          - 'neo/credentialsId'
       newmanExecute:
         filePatternFromConfig: 'newmanCollection'
-        config: 'testRepository'
+        configKeys:
+          - 'testRepository'
       uiVeri5ExecuteTests:
         filePattern: '**/conf.js'
-        config: 'testRepository'
-  Security: {}
+        configKeys:
+          - 'testRepository'
+  Security: {
+    stepConditions:
+      whitesourceExecuteScan:
+        configKeys:
+          - 'userTokenCredentialsId'
+          - 'whitesource/userTokenCredentialsId'
+          - 'whitesourceUserTokenCredentialsId'
+  }
   Performance: {}
   Compliance: {}
-  Promote: {}
-  Release: {}
+  Promote: {
+    stepConditions:
+      containerPushToRegistry:
+        configKeys:
+          - 'dockerRegistryUrl'
+  }
+  Release: {
+    stepConditions:
+      cloudFoundryDeploy:
+        configKeys:
+          - 'cfSpace'
+          - 'cloudFoundry/space'
+      healthExecuteCheck:
+        configKeys:
+          - 'testServerUrl'
+      neoDeploy:
+        configKeys:
+          - 'neo/credentialsId'
+      githubPublishRelease:
+        configKeys:
+          - 'githubTokenCredentialsId'
+  }
   'Post Actions':
     stepConditions:
       slackSendNotification:
-        config: 'channel'
+        configKeys:
+          - 'channel'

--- a/resources/com.sap.piper/pipeline/stageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/stageDefaults.yml
@@ -21,9 +21,6 @@ stages:
       healthExecuteCheck:
         configKeys:
           - 'testServerUrl'
-      neoDeploy:
-        configKeys:
-          - 'neo/credentialsId'
       newmanExecute:
         filePatternFromConfig: 'newmanCollection'
         configKeys:

--- a/resources/com.sap.piper/pipeline/stageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/stageDefaults.yml
@@ -6,13 +6,12 @@ stages:
           - 'channel'
   'Pull-Request Voting': {}
   Build: {}
-  'Additional Unit Tests': {
+  'Additional Unit Tests':
     stepConditions:
       batsExecuteTests:
         filePattern: '**/*.bats'
       karmaExecuteTests:
         filePattern: '**/karma.conf.js'
-  }
   Integration: {}
   Acceptance:
     stepConditions:
@@ -33,23 +32,21 @@ stages:
         filePattern: '**/conf.js'
         configKeys:
           - 'testRepository'
-  Security: {
+  Security:
     stepConditions:
       whitesourceExecuteScan:
         configKeys:
           - 'userTokenCredentialsId'
           - 'whitesource/userTokenCredentialsId'
           - 'whitesourceUserTokenCredentialsId'
-  }
   Performance: {}
   Compliance: {}
-  Promote: {
+  Promote:
     stepConditions:
       containerPushToRegistry:
         configKeys:
           - 'dockerRegistryUrl'
-  }
-  Release: {
+  Release:
     stepConditions:
       cloudFoundryDeploy:
         configKeys:
@@ -64,7 +61,6 @@ stages:
       githubPublishRelease:
         configKeys:
           - 'githubTokenCredentialsId'
-  }
   'Post Actions':
     stepConditions:
       slackSendNotification:

--- a/resources/com.sap.piper/pipeline/stageOrdinals.yml
+++ b/resources/com.sap.piper/pipeline/stageOrdinals.yml
@@ -1,22 +1,23 @@
-Init:
-  ordinal: 1
-'Pull-Request Voting':
-  ordinal: 5
-Build:
-  ordinal: 10
-'Additional Unit Tests':
-  ordinal: 20
-Integration:
-  ordinal: 30
-Acceptance:
-  ordinal: 40
-Security:
-  ordinal: 50
-Performance:
-  ordinal: 60
-Compliance:
-  ordinal: 70
-Promote:
-  ordinal: 80
-Release:
-  ordinal: 90
+stages:
+  Init:
+    ordinal: 1
+  'Pull-Request Voting':
+    ordinal: 5
+  Build:
+    ordinal: 10
+  'Additional Unit Tests':
+    ordinal: 20
+  Integration:
+    ordinal: 30
+  Acceptance:
+    ordinal: 40
+  Security:
+    ordinal: 50
+  Performance:
+    ordinal: 60
+  Compliance:
+    ordinal: 70
+  Promote:
+    ordinal: 80
+  Release:
+    ordinal: 90

--- a/resources/com.sap.piper/pipeline/stageOrdinals.yml
+++ b/resources/com.sap.piper/pipeline/stageOrdinals.yml
@@ -1,0 +1,22 @@
+Init:
+  ordinal: 1
+'Pull-Request Voting':
+  ordinal: 5
+Build:
+  ordinal: 10
+'Additional Unit Tests':
+  ordinal: 20
+Integration:
+  ordinal: 30
+Acceptance:
+  ordinal: 40
+Security:
+  ordinal: 50
+Performance:
+  ordinal: 60
+Compliance:
+  ordinal: 70
+Promote:
+  ordinal: 80
+Release:
+  ordinal: 90

--- a/test/groovy/BatsExecuteTestsTest.groovy
+++ b/test/groovy/BatsExecuteTestsTest.groovy
@@ -64,8 +64,8 @@ class BatsExecuteTestsTest extends BasePiperTest {
         assertThat(dockerExecuteRule.dockerParams.dockerImage, is('node:8-stretch'))
         assertThat(dockerExecuteRule.dockerParams.dockerWorkspace, is('/home/node'))
 
-        assertThat(shellRule.shell, hasItem('npm install tap-xunit -g'))
-        assertThat(shellRule.shell, hasItem('cat \'TEST-testPackage.tap\' | tap-xunit --package=\'testPackage\' > TEST-testPackage.xml'))
+        assertThat(shellRule.shell, hasItem('NPM_CONFIG_PREFIX=~/.npm-global npm install tap-xunit -g'))
+        assertThat(shellRule.shell, hasItem('cat \'TEST-testPackage.tap\' | PATH=\$PATH:~/.npm-global/bin tap-xunit --package=\'testPackage\' > TEST-testPackage.xml'))
 
         assertJobStatusSuccess()
     }

--- a/test/groovy/templates/PiperPipelineStageAdditionalUnitTestsTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageAdditionalUnitTestsTest.groovy
@@ -39,6 +39,10 @@ class PiperPipelineStageAdditionalUnitTestsTest extends BasePiperTest {
             return body()
         })
 
+        helper.registerAllowedMethod('batsExecuteTests', [Map.class], {m ->
+            stepsCalled.add('batsExecuteTests')
+        })
+
         helper.registerAllowedMethod('karmaExecuteTests', [Map.class], {m ->
             stepsCalled.add('karmaExecuteTests')
         })
@@ -53,7 +57,7 @@ class PiperPipelineStageAdditionalUnitTestsTest extends BasePiperTest {
 
         jsr.step.piperPipelineStageAdditionalUnitTests(script: nullScript, juStabUtils: utils)
 
-        assertThat(stepsCalled, not(hasItems('karmaExecuteTests', 'testsPublishResults')))
+        assertThat(stepsCalled, not(hasItems('batsExecuteTests', 'karmaExecuteTests', 'testsPublishResults')))
     }
 
     @Test
@@ -64,5 +68,15 @@ class PiperPipelineStageAdditionalUnitTestsTest extends BasePiperTest {
         jsr.step.piperPipelineStageAdditionalUnitTests(script: nullScript, juStabUtils: utils)
 
         assertThat(stepsCalled, hasItems('karmaExecuteTests', 'testsPublishResults'))
+    }
+
+    @Test
+    void testAdditionalUnitTestsWithBats() {
+
+        nullScript.commonPipelineEnvironment.configuration = [runStep: ['Additional Unit Tests': [batsExecuteTests: true]]]
+
+        jsr.step.piperPipelineStageAdditionalUnitTests(script: nullScript, juStabUtils: utils)
+
+        assertThat(stepsCalled, hasItems('batsExecuteTests', 'testsPublishResults'))
     }
 }

--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -139,17 +139,22 @@ class PiperPipelineStageInitTest extends BasePiperTest {
     void testSetScmInfoOnCommonPipelineEnvironment() {
         //currently supported formats
         def scmInfoTestList = [
-            [GIT_URL: 'https://github.com/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git'],
-            [GIT_URL: 'https://github.com:7777/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com:7777/testOrg/testRepo.git'],
-            [GIT_URL: 'git@github.com:testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git'],
-            [GIT_URL: 'ssh://git@github.com/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git'],
-            [GIT_URL: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git'],
+            [GIT_URL: 'https://github.com/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'https://github.com:7777/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com:7777/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'git@github.com:testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedHttp: 'https://github.com/path/to/testOrg/testRepo.git', expectedOrg: 'path/to/testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com/testRepo.git', expectedSsh: 'ssh://git@github.com/testRepo.git', expectedHttp: 'https://github.com/testRepo.git', expectedOrg: 'N/A', expectedRepo: 'testRepo'],
         ]
 
         scmInfoTestList.each {scmInfoTest ->
             jsr.step.piperPipelineStageInit.setScmInfoOnCommonPipelineEnvironment(nullScript, scmInfoTest)
+            println(scmInfoTest.GIT_URL)
             assertThat(nullScript.commonPipelineEnvironment.getGitSshUrl(), is(scmInfoTest.expectedSsh))
             assertThat(nullScript.commonPipelineEnvironment.getGitHttpsUrl(), is(scmInfoTest.expectedHttp))
+            assertThat(nullScript.commonPipelineEnvironment.getGithubOrg(), is(scmInfoTest.expectedOrg))
+            assertThat(nullScript.commonPipelineEnvironment.getGithubRepo(), is(scmInfoTest.expectedRepo))
         }
     }
 

--- a/vars/batsExecuteTests.groovy
+++ b/vars/batsExecuteTests.groovy
@@ -25,7 +25,7 @@ import groovy.transform.Field
     'failOnError',
     /**
      * Defines the format of the test result output. `junit` would be the standard for automated build environments but you could use also the option `tap`.
-     * @possibleValues `tap`
+     * @possibleValues `junit`, `tap`
      */
     'outputFormat',
     /**

--- a/vars/batsExecuteTests.groovy
+++ b/vars/batsExecuteTests.groovy
@@ -98,8 +98,8 @@ void call(Map parameters = [:]) {
                 sh "cat 'TEST-${config.testPackage}.tap'"
                 if (config.outputFormat == 'junit') {
                     dockerExecute(script: script, dockerImage: config.dockerImage, dockerWorkspace: config.dockerWorkspace, stashContent: config.stashContent) {
-                        sh "npm install tap-xunit -g"
-                        sh "cat 'TEST-${config.testPackage}.tap' | tap-xunit --package='${config.testPackage}' > TEST-${config.testPackage}.xml"
+                        sh "NPM_CONFIG_PREFIX=~/.npm-global npm install tap-xunit -g"
+                        sh "cat 'TEST-${config.testPackage}.tap' | PATH=\$PATH:~/.npm-global/bin tap-xunit --package='${config.testPackage}' > TEST-${config.testPackage}.xml"
                     }
                 }
             }

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -93,7 +93,7 @@ void call(Map parameters = [:]) {
                     def containerImageNameAndTag = config.dockerRegistryUrl ? "${dockerUtils.getRegistryFromUrl(config.dockerRegistryUrl)}/${dockerImageNameAndTag}" : ''
                     kanikoExecute script: script, containerImageNameAndTag: containerImageNameAndTag
                 } else {
-                    def dockerBuildImage = docker.build(dockerImageNameAndTag, "${config.containerBuildOptions} .")
+                    def dockerBuildImage = docker.build(dockerImageNameAndTag, "${config.containerBuildOptions ?: ''} .")
                     //only push if registry is defined
                     if (config.dockerRegistryUrl) {
                         containerPushToRegistry script: this, dockerBuildImage: dockerBuildImage, dockerRegistryUrl: config.dockerRegistryUrl

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -96,7 +96,7 @@ void call(Map parameters = [:]) {
                     def dockerBuildImage = docker.build(dockerImageNameAndTag, "${config.containerBuildOptions ?: ''} .")
                     //only push if registry is defined
                     if (config.dockerRegistryUrl) {
-                        containerPushToRegistry script: this, dockerBuildImage: dockerBuildImage, dockerRegistryUrl: config.dockerRegistryUrl
+                        containerPushToRegistry script: script, dockerBuildImage: dockerBuildImage, dockerRegistryUrl: config.dockerRegistryUrl
                     }
                 }
                 script.commonPipelineEnvironment.setValue('containerImage', dockerImageNameAndTag)

--- a/vars/piperPipeline.groovy
+++ b/vars/piperPipeline.groovy
@@ -12,7 +12,7 @@ void call(parameters) {
             stage('Init') {
                 steps {
                     library 'piper-lib-os'
-                    piperPipelineStageInit script: parameters.script, customDefaults: ['com.sap.piper/pipeline/stageOrdinals.yml'].plus(parameters.customDefaults)
+                    piperPipelineStageInit script: parameters.script, customDefaults: ['com.sap.piper/pipeline/stageOrdinals.yml'].plus(parameters.customDefaults ?: [])
                 }
             }
             stage('Pull-Request Voting') {

--- a/vars/piperPipeline.groovy
+++ b/vars/piperPipeline.groovy
@@ -12,7 +12,7 @@ void call(parameters) {
             stage('Init') {
                 steps {
                     library 'piper-lib-os'
-                    piperPipelineStageInit script: parameters.script, customDefaults: parameters.customDefaults
+                    piperPipelineStageInit script: parameters.script, customDefaults: ['com.sap.piper/pipeline/stageOrdinals.yml'].plus(parameters.customDefaults)
                 }
             }
             stage('Pull-Request Voting') {

--- a/vars/piperPipelineStageBuild.groovy
+++ b/vars/piperPipelineStageBuild.groovy
@@ -32,7 +32,7 @@ import static com.sap.piper.Prerequisites.checkScript
  * They type of build is defined using the configuration `buildTool`, see also step [buildExecute](../steps/buildExecute.md)
  *
  */
-@GenerateStageDocumentation(defaultStageName = 'Central Build')
+@GenerateStageDocumentation(defaultStageName = 'Build')
 void call(Map parameters = [:]) {
 
     def script = checkScript(this, parameters) ?: this

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -56,8 +56,8 @@ void call(Map parameters = [:]) {
             .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)
             .mixin(parameters, PARAMETER_KEYS)
             .addIfEmpty('stageConfigResource', 'com.sap.piper/pipeline/stageDefaults.yml')
-            .addIfEmpty('stageOrdinals', 'com.sap.piper/pipeline/stageOrdinals.yml')
-            //.addIfEmpty('stashSettings', 'com.sap.piper/pipeline/stashSettings.yml')
+            //.addIfEmpty('stageOrdinals', 'com.sap.piper/pipeline/stageOrdinals.yml')
+            .addIfEmpty('stashSettings', 'com.sap.piper/pipeline/stashSettings.yml')
             .withMandatoryProperty('buildTool')
             .use()
 

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -138,7 +138,7 @@ private void initStashConfiguration (script, config) {
 private void initStageOrdinalConfiguration (script, config) {
     Map stageOrdinals = readYaml(text: libraryResource(config.stageOrdinals))
     if (config.verbose) echo "Stage ordinals: ${stageOrdinals}"
-    script.commonPipelineEnvironment.configuration.general = stageOrdinals
+    script.commonPipelineEnvironment.configuration.general += stageOrdinals
 }
 
 private void setScmInfoOnCommonPipelineEnvironment(script, scmInfo) {

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -127,7 +127,7 @@ private void checkBuildTool(config) {
 
 private void initStashConfiguration (script, config) {
     Map stashConfiguration = readYaml(text: libraryResource(config.stashSettings))
-    echo "Stash config: stashConfiguration"
+    if (config.verbose) echo "Stash config: ${stashConfiguration}"
     script.commonPipelineEnvironment.configuration.stageStashes = stashConfiguration
 }
 

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -57,7 +57,7 @@ void call(Map parameters = [:]) {
             .mixin(parameters, PARAMETER_KEYS)
             .addIfEmpty('stageConfigResource', 'com.sap.piper/pipeline/stageDefaults.yml')
             .addIfEmpty('stageOrdinals', 'com.sap.piper/pipeline/stageOrdinals.yml')
-            .addIfEmpty('stashSettings', 'com.sap.piper/pipeline/stashSettings.yml')
+            //.addIfEmpty('stashSettings', 'com.sap.piper/pipeline/stashSettings.yml')
             .withMandatoryProperty('buildTool')
             .use()
 
@@ -65,7 +65,7 @@ void call(Map parameters = [:]) {
         initStashConfiguration(script, config)
 
         //provide the correct ordinals for stage locking in piperStageWrapper
-        initStageOrdinalConfiguration (script, config)
+       // initStageOrdinalConfiguration (script, config)
 
         setScmInfoOnCommonPipelineEnvironment(script, scmInfo)
         script.commonPipelineEnvironment.setGitCommitId(scmInfo.GIT_COMMIT)
@@ -138,6 +138,7 @@ private void initStashConfiguration (script, config) {
 private void initStageOrdinalConfiguration (script, config) {
     Map stageOrdinals = readYaml(text: libraryResource(config.stageOrdinals))
     if (config.verbose) echo "Stage ordinals: ${stageOrdinals}"
+    if (script.commonPipelineEnvironment.configuration.general == null) script.commonPipelineEnvironment.configuration.general = [:]
     script.commonPipelineEnvironment.configuration.general += stageOrdinals
 }
 

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -56,16 +56,12 @@ void call(Map parameters = [:]) {
             .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)
             .mixin(parameters, PARAMETER_KEYS)
             .addIfEmpty('stageConfigResource', 'com.sap.piper/pipeline/stageDefaults.yml')
-            //.addIfEmpty('stageOrdinals', 'com.sap.piper/pipeline/stageOrdinals.yml')
             .addIfEmpty('stashSettings', 'com.sap.piper/pipeline/stashSettings.yml')
             .withMandatoryProperty('buildTool')
             .use()
 
         //perform stashing based on libray resource piper-stash-settings.yml if not configured otherwise
         initStashConfiguration(script, config)
-
-        //provide the correct ordinals for stage locking in piperStageWrapper
-       // initStageOrdinalConfiguration (script, config)
 
         setScmInfoOnCommonPipelineEnvironment(script, scmInfo)
         script.commonPipelineEnvironment.setGitCommitId(scmInfo.GIT_COMMIT)
@@ -133,13 +129,6 @@ private void initStashConfiguration (script, config) {
     Map stashConfiguration = readYaml(text: libraryResource(config.stashSettings))
     if (config.verbose) echo "Stash config: ${stashConfiguration}"
     script.commonPipelineEnvironment.configuration.stageStashes = stashConfiguration
-}
-
-private void initStageOrdinalConfiguration (script, config) {
-    Map stageOrdinals = readYaml(text: libraryResource(config.stageOrdinals))
-    if (config.verbose) echo "Stage ordinals: ${stageOrdinals}"
-    if (script.commonPipelineEnvironment.configuration.general == null) script.commonPipelineEnvironment.configuration.general = [:]
-    script.commonPipelineEnvironment.configuration.general += stageOrdinals
 }
 
 private void setScmInfoOnCommonPipelineEnvironment(script, scmInfo) {

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -135,11 +135,13 @@ private void setScmInfoOnCommonPipelineEnvironment(script, scmInfo) {
 
     def gitUrl = scmInfo.GIT_URL
 
+    def gitPath = ''
     if (gitUrl.startsWith('http')) {
         def httpPattern = /(https?):\/\/([^:\/]+)(?:[:\d\/]*)(.*)/
         def gitMatcher = gitUrl =~ httpPattern
         if (!gitMatcher.hasGroup() && gitMatcher.groupCount() != 3) return
         script.commonPipelineEnvironment.setGitSshUrl("git@${gitMatcher[0][2]}:${gitMatcher[0][3]}")
+        gitPath = gitMatcher[0][3]
         script.commonPipelineEnvironment.setGitHttpsUrl(gitUrl)
     } else if (gitUrl.startsWith('ssh')) {
         //(.*)@([^:\/]*)(?:[:\d\/]*)(.*)
@@ -148,11 +150,33 @@ private void setScmInfoOnCommonPipelineEnvironment(script, scmInfo) {
         if (!gitMatcher.hasGroup() && gitMatcher.groupCount() != 3) return
         script.commonPipelineEnvironment.setGitSshUrl(gitUrl)
         script.commonPipelineEnvironment.setGitHttpsUrl("https://${gitMatcher[0][2]}/${gitMatcher[0][3]}")
+        gitPath = gitMatcher[0][3]
     }
     else if (gitUrl.indexOf('@') > 0) {
         script.commonPipelineEnvironment.setGitSshUrl(gitUrl)
+        gitPath = gitUrl.split(':')[1]
         script.commonPipelineEnvironment.setGitHttpsUrl("https://${(gitUrl.split('@')[1]).replace(':', '/')}")
     }
+
+    List gitPathParts = gitPath.split('/')
+    def gitFolder = 'N/A'
+    def gitRepo = 'N/A'
+    switch (gitPathParts.size()) {
+        case 1:
+            gitRepo = gitPathParts[0].replaceAll('.git', '')
+            break
+        case 2:
+            gitFolder = gitPathParts[0]
+            gitRepo = gitPathParts[1].replaceAll('.git', '')
+            break
+        case { it > 3 }:
+            gitRepo = gitPathParts[gitPathParts.size()-1].replaceAll('.git', '')
+            gitPathParts.remove(gitPathParts.size()-1)
+            gitFolder = gitPathParts.join('/')
+            break
+    }
+    script.commonPipelineEnvironment.setGithubOrg(gitFolder)
+    script.commonPipelineEnvironment.setGithubRepo(gitRepo)
 }
 
 private void setPullRequestStageStepActivation(script, config, List actions) {

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -56,12 +56,16 @@ void call(Map parameters = [:]) {
             .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)
             .mixin(parameters, PARAMETER_KEYS)
             .addIfEmpty('stageConfigResource', 'com.sap.piper/pipeline/stageDefaults.yml')
+            .addIfEmpty('stageOrdinals', 'com.sap.piper/pipeline/stageOrdinals.yml')
             .addIfEmpty('stashSettings', 'com.sap.piper/pipeline/stashSettings.yml')
             .withMandatoryProperty('buildTool')
             .use()
 
         //perform stashing based on libray resource piper-stash-settings.yml if not configured otherwise
         initStashConfiguration(script, config)
+
+        //provide the correct ordinals for stage locking in piperStageWrapper
+        initStageOrdinalConfiguration (script, config)
 
         setScmInfoOnCommonPipelineEnvironment(script, scmInfo)
         script.commonPipelineEnvironment.setGitCommitId(scmInfo.GIT_COMMIT)
@@ -129,6 +133,12 @@ private void initStashConfiguration (script, config) {
     Map stashConfiguration = readYaml(text: libraryResource(config.stashSettings))
     if (config.verbose) echo "Stash config: ${stashConfiguration}"
     script.commonPipelineEnvironment.configuration.stageStashes = stashConfiguration
+}
+
+private void initStageOrdinalConfiguration (script, config) {
+    Map stageOrdinals = readYaml(text: libraryResource(config.stageOrdinals))
+    if (config.verbose) echo "Stage ordinals: ${stageOrdinals}"
+    script.commonPipelineEnvironment.configuration.general = stageOrdinals
 }
 
 private void setScmInfoOnCommonPipelineEnvironment(script, scmInfo) {

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -1,4 +1,5 @@
 import com.sap.piper.ConfigurationHelper
+import com.sap.piper.GenerateStageDocumentation
 import com.sap.piper.Utils
 import groovy.transform.Field
 
@@ -15,6 +16,7 @@ import static com.sap.piper.Prerequisites.checkScript
  * The stage allows to execute project-specific integration tests.<br />
  * Typically, integration tests are very project-specific, thus they can be defined here using the [stage extension mechanism](../extensibility.md).
  */
+@GenerateStageDocumentation(defaultStageName = 'Integration')
 void call(Map parameters = [:]) {
 
     def script = checkScript(this, parameters) ?: this

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -61,7 +61,6 @@ private void executeStage(script, originalStage, stageName, config, utils) {
     try {
         //Add general stage stashes to config.stashContent
         config.stashContent += script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.unstash ?: []
-        echo "[${STAGE_NAME}] StashContent: ${config.stashContent}"
 
         utils.unstashAll(config.stashContent)
 

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -61,6 +61,7 @@ private void executeStage(script, originalStage, stageName, config, utils) {
     try {
         //Add general stage stashes to config.stashContent
         config.stashContent += script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.unstash ?: []
+        echo "[${STAGE_NAME}] StashContent: ${config.stashContent}"
 
         utils.unstashAll(config.stashContent)
 


### PR DESCRIPTION
# Changes

* fix stage name in documentation
* fix doc generation for integration stage
* verbose output
* add default stage ordinals
* `buildExecute`, properly handle empty `containerBuildOptions`
* `buildExecute` fix wrong script reference
* make usage of `batsExecuteTests` possible

- [x] Tests
- [x] Documentation
