### PR TITLE
remove non cps

### DIFF
--- a/src/com/sap/piper/ConfigurationLoader.groovy
+++ b/src/com/sap/piper/ConfigurationLoader.groovy
@@ -41,7 +41,6 @@ class ConfigurationLoader implements Serializable {
         return loadConfiguration(script, 'postActions', actionName, ConfigurationType.CUSTOM_CONFIGURATION)
     }
 
-    @NonCPS
     private static Map loadConfiguration(script, String type, String entryName, ConfigurationType configType){
         switch (configType) {
             case ConfigurationType.CUSTOM_CONFIGURATION:

--- a/src/com/sap/piper/ConfigurationLoader.groovy
+++ b/src/com/sap/piper/ConfigurationLoader.groovy
@@ -14,7 +14,6 @@ class ConfigurationLoader implements Serializable {
         return loadConfiguration(script, 'stages', stageName, ConfigurationType.CUSTOM_CONFIGURATION)
     }
 
-    @NonCPS
     static Map defaultStepConfiguration(script, String stepName) {
         return loadConfiguration(script, 'steps', stepName, ConfigurationType.DEFAULT_CONFIGURATION)
     }

--- a/src/com/sap/piper/ConfigurationLoader.groovy
+++ b/src/com/sap/piper/ConfigurationLoader.groovy
@@ -1,15 +1,11 @@
 package com.sap.piper
 
-import com.cloudbees.groovy.cps.NonCPS
-
 @API(deprecated = true)
 class ConfigurationLoader implements Serializable {
-    @NonCPS
     static Map stepConfiguration(script, String stepName) {
         return loadConfiguration(script, 'steps', stepName, ConfigurationType.CUSTOM_CONFIGURATION)
     }
 
-    @NonCPS
     static Map stageConfiguration(script, String stageName) {
         return loadConfiguration(script, 'stages', stageName, ConfigurationType.CUSTOM_CONFIGURATION)
     }
@@ -18,12 +14,10 @@ class ConfigurationLoader implements Serializable {
         return loadConfiguration(script, 'steps', stepName, ConfigurationType.DEFAULT_CONFIGURATION)
     }
 
-    @NonCPS
     static Map defaultStageConfiguration(script, String stageName) {
         return loadConfiguration(script, 'stages', stageName, ConfigurationType.DEFAULT_CONFIGURATION)
     }
 
-    @NonCPS
     static Map generalConfiguration(script){
         try {
             return script?.commonPipelineEnvironment?.configuration?.general ?: [:]
@@ -36,7 +30,6 @@ class ConfigurationLoader implements Serializable {
         return DefaultValueCache.getInstance()?.getDefaultValues()?.general ?: [:]
     }
 
-    @NonCPS
     static Map postActionConfiguration(script, String actionName){
         return loadConfiguration(script, 'postActions', actionName, ConfigurationType.CUSTOM_CONFIGURATION)
     }

--- a/src/com/sap/piper/ConfigurationLoader.groovy
+++ b/src/com/sap/piper/ConfigurationLoader.groovy
@@ -33,7 +33,6 @@ class ConfigurationLoader implements Serializable {
         }
     }
 
-    @NonCPS
     static Map defaultGeneralConfiguration(script){
         return DefaultValueCache.getInstance()?.getDefaultValues()?.general ?: [:]
     }

--- a/src/com/sap/piper/ConfigurationMerger.groovy
+++ b/src/com/sap/piper/ConfigurationMerger.groovy
@@ -1,10 +1,7 @@
 package com.sap.piper
 
-import com.cloudbees.groovy.cps.NonCPS
-
 @API(deprecated = true)
 class ConfigurationMerger {
-    @NonCPS
     static Map merge(Map configs, Set configKeys, Map defaults) {
         Map filteredConfig = configKeys?configs.subMap(configKeys):configs
 
@@ -12,7 +9,6 @@ class ConfigurationMerger {
                               MapUtils.pruneNulls(filteredConfig))
     }
 
-    @NonCPS
     static Map merge(
         Map parameters, Set parameterKeys,
         Map configuration, Set configurationKeys,

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -2,8 +2,6 @@ package com.sap.piper
 
 import com.sap.piper.MapUtils
 
-import com.cloudbees.groovy.cps.NonCPS
-
 @API
 class DefaultValueCache implements Serializable {
     private static DefaultValueCache instance
@@ -14,7 +12,6 @@ class DefaultValueCache implements Serializable {
         this.defaultValues = defaultValues
     }
 
-    @NonCPS
     static getInstance(){
         return instance
     }
@@ -23,7 +20,6 @@ class DefaultValueCache implements Serializable {
         instance = new DefaultValueCache(defaultValues)
     }
 
-    @NonCPS
     Map getDefaultValues(){
         return defaultValues
     }

--- a/src/com/sap/piper/MapUtils.groovy
+++ b/src/com/sap/piper/MapUtils.groovy
@@ -8,7 +8,6 @@ class MapUtils implements Serializable {
         return object in Map
     }
 
-    @NonCPS
     static Map pruneNulls(Map m) {
 
         Map result = [:]
@@ -24,7 +23,6 @@ class MapUtils implements Serializable {
     }
 
 
-    @NonCPS
     static Map merge(Map base, Map overlay) {
 
         Map result = [:]


### PR DESCRIPTION
We have issues with coding annotated with `@NonCPS`:

* #788 
* #786 

Maybe we can get ride of some '@NonCPS` annotations wnich seems to be present for `historical reasons`.

Needs to be carefully integration tested since we do not get a clear picture wrt that annotation based on the unit tests.
