### PR TITLE
use new unstable step to better visualize pipeline errors

### DIFF
--- a/test/groovy/HandlePipelineStepErrorsTest.groovy
+++ b/test/groovy/HandlePipelineStepErrorsTest.groovy
@@ -86,6 +86,9 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
     @Test
     void testHandleErrorsIgnoreFailure() {
         def errorOccured = false
+        helper.registerAllowedMethod('unstable', [String.class], {s ->
+            nullScript.currentBuild.result = 'UNSTABLE'
+        })
         try {
             stepRule.step.handlePipelineStepErrors([
                 stepName: 'test',
@@ -127,6 +130,10 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
     @Test
     void testHandleErrorsIgnoreFailureNoScript() {
         def errorOccured = false
+        helper.registerAllowedMethod('unstable', [String.class], {s ->
+            //test behavior in case plugina are not yet up to date
+            throw new java.lang.NoSuchMethodError('No such DSL method \'unstable\' found')
+        })
         try {
             stepRule.step.handlePipelineStepErrors([
                 stepName: 'test',
@@ -148,6 +155,11 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
             timeout = m.time
             throw new org.jenkinsci.plugins.workflow.steps.FlowInterruptedException(hudson.model.Result.ABORTED, new jenkins.model.CauseOfInterruption.UserInterruption('Test'))
         })
+        String errorMsg
+        helper.registerAllowedMethod('unstable', [String.class], {s ->
+            nullScript.currentBuild.result = 'UNSTABLE'
+            errorMsg = s
+        })
 
         stepRule.step.handlePipelineStepErrors([
             stepName: 'test',
@@ -159,5 +171,6 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
         }
         assertThat(timeout, is(10))
         assertThat(nullScript.currentBuild.result, is('UNSTABLE'))
+        assertThat(errorMsg, is('[handlePipelineStepErrors] Error in step test - Build result set to \'UNSTABLE\''))
     }
 }

--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -81,13 +81,18 @@ void call(Map parameters = [:], body) {
             throw ex
         }
 
-        if (config.stepParameters?.script) {
-            config.stepParameters?.script.currentBuild.result = 'UNSTABLE'
-        } else {
-            currentBuild.result = 'UNSTABLE'
+        def failureMessage = "[${STEP_NAME}] Error in step ${config.stepName} - Build result set to 'UNSTABLE'"
+        try {
+            //use new unstable feature if available: see https://jenkins.io/blog/2019/07/05/jenkins-pipeline-stage-result-visualization-improvements/
+            unstable(failureMessage)
+        } catch (java.lang.NoSuchMethodError nmEx) {
+            if (config.stepParameters?.script) {
+                config.stepParameters?.script.currentBuild.result = 'UNSTABLE'
+            } else {
+                currentBuild.result = 'UNSTABLE'
+            }
+            echo failureMessage
         }
-
-        echo "[${STEP_NAME}] Error in step ${config.stepName} - Build result set to 'UNSTABLE'"
 
         List unstableSteps = cpe?.getValue('unstableSteps') ?: []
         if(!unstableSteps) {


### PR DESCRIPTION
# Changes

With https://jenkins.io/blog/2019/07/05/jenkins-pipeline-stage-result-visualization-improvements/ it has been made possible to allow for a better visualization in case certain pipeline stages are 'UNSTABLE'

This is about using the new feature if available with a fall-back to old behavior.

- [x] Tests
- ~[ ] Documentation~ not applicable
