### PR TITLE
Make library versioning more flexible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.sap.cp.jenkins</groupId>
     <artifactId>jenkins-library</artifactId>
-    <version>0.11</version>
+    <version>${revision}</version>
 
     <name>SAP CP Piper Library</name>
     <description>Shared library containing steps and utilities to set up continuous deployment processes for SAP technologies.</description>
@@ -40,13 +40,13 @@
     </pluginRepositories>
 
     <properties>
+        <revision>0-SNAPSHOT</revision>
         <findbugs.skip>true</findbugs.skip>
         <jenkins.version>2.32.3</jenkins.version>
         <pipeline.version>2.5</pipeline.version>
         <cps.global.lib.version>2.6</cps.global.lib.version>
         <java.level>8</java.level>
     </properties>
-
 
     <dependencies>
 


### PR DESCRIPTION
# Changes

There is a possibility with maven to inject the version number into the build (see https://maven.apache.org/maven-ci-friendly.html).

This will allow us to publish regular releases without permanent PRs for version updates.


- ~[ ] Tests~ not relevant
- ~[ ] Documentation~ not relevant
