### PR TITLE
githubPublishRelease - ensure proper JSON encoding

### DIFF
--- a/src/com/sap/piper/JsonUtils.groovy
+++ b/src/com/sap/piper/JsonUtils.groovy
@@ -8,6 +8,11 @@ String groovyObjectToPrettyJsonString(object) {
 }
 
 @NonCPS
+String groovyObjectToJsonString(object) {
+    return groovy.json.JsonOutput.toJson(object)
+}
+
+@NonCPS
 def jsonStringToGroovyObject(text) {
     return new groovy.json.JsonSlurperClassic().parseText(text)
 }

--- a/test/groovy/GithubPublishReleaseTest.groovy
+++ b/test/groovy/GithubPublishReleaseTest.groovy
@@ -213,4 +213,5 @@ class GithubPublishReleaseTest extends BasePiperTest {
         assertThat(stepRule.step.isExcluded(item, ['won\'t fix']), is(false))
         assertJobStatusSuccess()
     }
+
 }

--- a/vars/githubPublishRelease.groovy
+++ b/vars/githubPublishRelease.groovy
@@ -1,3 +1,5 @@
+import com.sap.piper.JsonUtils
+
 import static com.sap.piper.Prerequisites.checkScript
 
 import com.sap.piper.GenerateDocumentation
@@ -146,9 +148,15 @@ String addDeltaToLastRelease(config, latestTag){
 }
 
 void postNewRelease(config, TOKEN, releaseBody){
-    releaseBody = releaseBody.replace('"', '\\"')
-    //write release information
-    def data = "{\"tag_name\": \"${config.version}\",\"target_commitish\": \"master\",\"name\": \"${config.version}\",\"body\": \"${releaseBody}\",\"draft\": false,\"prerelease\": false}"
+    Map messageBody = [
+        tag_name: "${config.version}",
+        target_commitish: 'master',
+        name: "${config.version}",
+        body: releaseBody,
+        draft: false,
+        prerelease: false
+    ]
+    def data =  new JsonUtils().groovyObjectToJsonString(messageBody)
     try {
         httpRequest httpMode: 'POST', requestBody: data, url: "${config.githubApiUrl}/repos/${config.githubOrg}/${config.githubRepo}/releases?access_token=${TOKEN}"
     } catch (e) {


### PR DESCRIPTION
# Changes

So far some special characters have not been properly encoded when creating a release.
This is addressed by using a new JsonUtils method now.

