### PR TITLE
setupCommonPipelineEnvironment: support yaml config file ending

### DIFF
--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -55,5 +55,20 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
         assertEquals('develop', nullScript.commonPipelineEnvironment.configuration.general.productiveBranch)
         assertEquals('my-maven-docker', nullScript.commonPipelineEnvironment.configuration.steps.mavenExecute.dockerImage)
     }
+
+    @Test
+    void testWorksAlsoWithYamlFileEnding() throws Exception {
+
+        helper.registerAllowedMethod("fileExists", [String], { String path ->
+            return path.endsWith('.pipeline/config.yaml')
+        })
+
+        stepRule.step.setupCommonPipelineEnvironment(script: nullScript)
+
+        assertEquals('.pipeline/config.yaml', usedConfigFile)
+        assertNotNull(nullScript.commonPipelineEnvironment.configuration)
+        assertEquals('develop', nullScript.commonPipelineEnvironment.configuration.general.productiveBranch)
+        assertEquals('my-maven-docker', nullScript.commonPipelineEnvironment.configuration.steps.mavenExecute.dockerImage)
+    }
 }
 

--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -3,17 +3,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.yaml.snakeyaml.Yaml
-
-import com.sap.piper.Utils
-
 import util.BasePiperTest
-import util.Rules
-import util.JenkinsReadYamlRule
 import util.JenkinsStepRule
+import util.Rules
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
-
 
 class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
 
@@ -33,7 +28,7 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
 
         helper.registerAllowedMethod("readYaml", [Map], { Map parameters ->
             Yaml yamlParser = new Yaml()
-            if(parameters.text) {
+            if (parameters.text) {
                 return yamlParser.load(parameters.text)
             }
             usedConfigFile = parameters.file

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -60,10 +60,13 @@ void call(Map parameters = [:]) {
 private loadConfigurationFromFile(script, String configFile) {
 
     String defaultYmlConfigFile = '.pipeline/config.yml'
+    String defaultYamlConfigFile = '.pipeline/config.yaml'
 
     if (configFile) {
         script.commonPipelineEnvironment.configuration = readYaml(file: configFile)
     } else if (fileExists(defaultYmlConfigFile)) {
         script.commonPipelineEnvironment.configuration = readYaml(file: defaultYmlConfigFile)
+    } else if (fileExists(defaultYamlConfigFile)) {
+        script.commonPipelineEnvironment.configuration = readYaml(file: defaultYamlConfigFile)
     }
 }


### PR DESCRIPTION
# Changes

Allows the default configuration file to be `config.yaml` instead of `config.yml`. When I have made this mistake in the past it has taken me a long time to understand what I did wrong, why the config was not loaded properly.

- [x] Tests
