### PR TITLE
docGenerator - ensure compatibility

### DIFF
--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -752,7 +752,8 @@ stages.each {key, value ->
 
     //remove details from parameter map
     stageStepKeys.each {stepKey ->
-        stageDescriptors."${key}".parameters.remove(stepKey)
+        if (stageDescriptors."${key}"?.parameters)
+            stageDescriptors."${key}".parameters.remove(stepKey)
     }
 
 

--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -695,7 +695,7 @@ def prepareDefaultValuesStep = Helper.getPrepareDefaultValuesStep(gse)
 boolean exceptionCaught = false
 
 def stepDescriptors = [:]
-DefaultValueCache.prepare(Helper.getDummyScript(prepareDefaultValuesStep,'noop'),  customDefaults)
+//DefaultValueCache.prepare(Helper.getDummyScript(prepareDefaultValuesStep,'noop'),  customDefaults)
 
 for (step in steps) {
     try {

--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -259,7 +259,7 @@ class Helper {
         return new Yaml().load(ymlContent)
     }
 
-    static getDummyScript(def prepareDefaultValuesStep, def stepName, Map prepareDefaultValuesStepParams = [:]) {
+    static Script getDummyScript(def prepareDefaultValuesStep, def stepName, Map prepareDefaultValuesStepParams = [:]) {
 
         def _prepareDefaultValuesStep = prepareDefaultValuesStep
         def _stepName = stepName

--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -5,6 +5,7 @@ import org.yaml.snakeyaml.Yaml
 import org.codehaus.groovy.control.CompilerConfiguration
 import com.sap.piper.GenerateDocumentation
 import com.sap.piper.GenerateStageDocumentation
+import com.sap.piper.DefaultValueCache
 import java.util.regex.Matcher
 import groovy.text.StreamingTemplateEngine
 
@@ -694,6 +695,7 @@ def prepareDefaultValuesStep = Helper.getPrepareDefaultValuesStep(gse)
 boolean exceptionCaught = false
 
 def stepDescriptors = [:]
+DefaultValueCache.prepare(Helper.getDummyScript('noop'),  customDefaults)
 
 for (step in steps) {
     try {

--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -259,7 +259,7 @@ class Helper {
         return new Yaml().load(ymlContent)
     }
 
-    static getDummyScript(def prepareDefaultValuesStep, def stepName, Map prepareDefaultValuesStepParams) {
+    static getDummyScript(def prepareDefaultValuesStep, def stepName, Map prepareDefaultValuesStepParams = [:]) {
 
         def _prepareDefaultValuesStep = prepareDefaultValuesStep
         def _stepName = stepName
@@ -695,7 +695,7 @@ def prepareDefaultValuesStep = Helper.getPrepareDefaultValuesStep(gse)
 boolean exceptionCaught = false
 
 def stepDescriptors = [:]
-DefaultValueCache.prepare(Helper.getDummyScript('noop'),  customDefaults)
+DefaultValueCache.prepare(Helper.getDummyScript(prepareDefaultValuesStep,'noop'),  customDefaults)
 
 for (step in steps) {
     try {

--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -695,7 +695,7 @@ def prepareDefaultValuesStep = Helper.getPrepareDefaultValuesStep(gse)
 boolean exceptionCaught = false
 
 def stepDescriptors = [:]
-//DefaultValueCache.prepare(Helper.getDummyScript(prepareDefaultValuesStep,'noop'),  customDefaults)
+DefaultValueCache.prepare(Helper.getDummyScript(prepareDefaultValuesStep,'noop'),  [customDefaults: customDefaults])
 
 for (step in steps) {
     try {


### PR DESCRIPTION
# Changes

#737 brought an incompatibility in the docGenerator to handling previous versions.
The changes aim to fix this.

It is a pure fix of the generator with no side-effect on the library as far as I can see.