### PR TITLE
Streamline setting build to unstable

### DIFF
--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -86,11 +86,7 @@ void call(Map parameters = [:], body) {
             //use new unstable feature if available: see https://jenkins.io/blog/2019/07/05/jenkins-pipeline-stage-result-visualization-improvements/
             unstable(failureMessage)
         } catch (java.lang.NoSuchMethodError nmEx) {
-            if (config.stepParameters?.script) {
-                config.stepParameters?.script.currentBuild.result = 'UNSTABLE'
-            } else {
-                currentBuild.result = 'UNSTABLE'
-            }
+            currentBuild.result = 'UNSTABLE'
             echo failureMessage
         }
 


### PR DESCRIPTION
@OliverNocon : I would like to simplify the code for setting the build to unstable. I saw that `config.stepParameters?.script.currentBuild` is another instance than `currentBuild`. But from reviwing the [code](https://github.com/jenkinsci/workflow-support-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.java) I think all the RunWrappers ( ==> currentBuild) forward the status to a common `Run` instance. I also verified that setting the build status through one `RunWrapper` is reflected by other `RunWrappers`. Hence the effect of the new code here should be the same like the old one.

Is there any special reason why you implemented it in the way it is currently implemented? Did you find some situations where simply using currentBuild (from the current step) does not do the job?