### PR TITLE
streamline env usage.

### DIFF
--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -135,7 +135,7 @@ private String formatErrorMessage(Map config, error){
 private void writeErrorToInfluxData(Map config, error){
     if(InfluxData.getInstance().getFields().pipeline_data?.build_error_message == null){
         InfluxData.addTag('pipeline_data', 'build_error_step', config.stepName)
-        InfluxData.addTag('pipeline_data', 'build_error_stage', config.stepParameters.script?.env?.STAGE_NAME)
+        InfluxData.addTag('pipeline_data', 'build_error_stage', env?.STAGE_NAME)
         InfluxData.addField('pipeline_data', 'build_error_message', error.getMessage())
     }
 }


### PR DESCRIPTION
@CCFenner : I saw that `config.stepParameters.script?.env` is the same instance of `EnvActionImpl` like simply `env` (as associated with the current step (`handlePipelineStepErrors`).

Is there from you point of view a special reason for accessing the env via `config.stepParameters.script` rather than using `this.env`?


