### PR TITLE
Fix imagePullPolicy always being IfNotPresent when executing single container

### DIFF
--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -146,8 +146,8 @@ void call(Map parameters = [:], body) {
         if (!parameters.containerMap) {
             configHelper.withMandatoryProperty('dockerImage')
             config.containerName = 'container-exec'
-            config.containerMap = ["${config.get('dockerImage')}".toString(): config.containerName]
-            config.containerCommands = config.containerCommand ? ["${config.get('dockerImage')}".toString(): config.containerCommand] : null
+            config.containerMap = [(config.get('dockerImage')): config.containerName]
+            config.containerCommands = config.containerCommand ? [(config.get('dockerImage')): config.containerCommand] : null
         }
         executeOnPod(config, utils, body)
     }

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -146,8 +146,8 @@ void call(Map parameters = [:], body) {
         if (!parameters.containerMap) {
             configHelper.withMandatoryProperty('dockerImage')
             config.containerName = 'container-exec'
-            config.containerMap = ["${config.get('dockerImage')}": config.containerName]
-            config.containerCommands = config.containerCommand ? ["${config.get('dockerImage')}": config.containerCommand] : null
+            config.containerMap = ["${config.get('dockerImage')}".toString(): config.containerName]
+            config.containerCommands = config.containerCommand ? ["${config.get('dockerImage')}".toString(): config.containerCommand] : null
         }
         executeOnPod(config, utils, body)
     }


### PR DESCRIPTION
# Changes
When using this function with only a single container instead of a `containerMap` (e.g. from the `dockerExecute` function), the key of the resulting `containerMap` is of type `org.codehaus.groovy.runtime.GStringImpl`, not `java.lang.String`, against which it will be compared later in Line 290, when determining the `imagePullPolicy`, resulting in it being always `IfNotPresent`. 

Same with the `containerCommands` Map.

A simple `.toString()` compiles the GString to a normal Java String and therefore fixes the comparison.

- [ ] Tests
- [ ] Documentation
