### PR TITLE
more precise param handover (gitUrl) in piperPipelineStageInit

### DIFF
--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -149,7 +149,7 @@ class PiperPipelineStageInitTest extends BasePiperTest {
         ]
 
         scmInfoTestList.each {scmInfoTest ->
-            jsr.step.piperPipelineStageInit.setScmInfoOnCommonPipelineEnvironment(nullScript, scmInfoTest)
+            jsr.step.piperPipelineStageInit.setGitUrlsOnCommonPipelineEnvironment(nullScript, scmInfoTest.GIT_URL)
             assertThat(nullScript.commonPipelineEnvironment.getGitSshUrl(), is(scmInfoTest.expectedSsh))
             assertThat(nullScript.commonPipelineEnvironment.getGitHttpsUrl(), is(scmInfoTest.expectedHttp))
             assertThat(nullScript.commonPipelineEnvironment.getGithubOrg(), is(scmInfoTest.expectedOrg))

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -63,7 +63,7 @@ void call(Map parameters = [:]) {
         //perform stashing based on libray resource piper-stash-settings.yml if not configured otherwise
         initStashConfiguration(script, config)
 
-        setScmInfoOnCommonPipelineEnvironment(script, scmInfo)
+        setGitUrlsOnCommonPipelineEnvironment(script, scmInfo.GIT_URL)
         script.commonPipelineEnvironment.setGitCommitId(scmInfo.GIT_COMMIT)
 
         if (config.verbose) {
@@ -131,9 +131,7 @@ private void initStashConfiguration (script, config) {
     script.commonPipelineEnvironment.configuration.stageStashes = stashConfiguration
 }
 
-private void setScmInfoOnCommonPipelineEnvironment(script, scmInfo) {
-
-    def gitUrl = scmInfo.GIT_URL
+private void setGitUrlsOnCommonPipelineEnvironment(script, String gitUrl) {
 
     def gitPath = ''
     if (gitUrl.startsWith('http')) {


### PR DESCRIPTION
Before: complete scmInfo was handed over via method signature.

After: Only the relevant part (GIT_URL from scmInfo) is handed over.

All the other properties from scmInfo are not used in the method body.
With this appraoch it is more obvious what is used inside the method.

# Changes

- [ ] Tests
- [ ] Documentation
