### PR TITLE
Pass configured env vars to docker execution in existing container

### DIFF
--- a/test/groovy/DockerExecuteTest.groovy
+++ b/test/groovy/DockerExecuteTest.groovy
@@ -48,8 +48,13 @@ class DockerExecuteTest extends BasePiperTest {
 
     @Test
     void testExecuteInsideContainerOfExistingPod() throws Exception {
+        List usedDockerEnvVars
         helper.registerAllowedMethod('container', [String.class, Closure.class], { String container, Closure body ->
             containerName = container
+            body()
+        })
+        helper.registerAllowedMethod('withEnv',[List.class, Closure.class], { List envVars, Closure body ->
+            usedDockerEnvVars = envVars
             body()
         })
         binding.setVariable('env', [POD_NAME: 'testpod', ON_K8S: 'true'])
@@ -61,6 +66,7 @@ class DockerExecuteTest extends BasePiperTest {
         }
         assertTrue(loggingRule.log.contains('Executing inside a Kubernetes Container'))
         assertEquals('mavenexec', containerName)
+        assertEquals(usedDockerEnvVars[0].toString(), "http_proxy=http://proxy:8000")
         assertTrue(bodyExecuted)
      }
 

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -133,11 +133,17 @@ void call(Map parameters = [:], body) {
         ], config)
 
         if (isKubernetes() && config.dockerImage) {
+            List dockerEnvVars = []
+            config.dockerEnvVars.each { key, value ->
+                dockerEnvVars << "$key=$value"
+            }
             if (env.POD_NAME && isContainerDefined(config)) {
                 container(getContainerDefined(config)) {
-                    echo "[INFO][${STEP_NAME}] Executing inside a Kubernetes Container."
-                    body()
-                    sh "chown -R 1000:1000 ."
+                    withEnv(dockerEnvVars) {
+                        echo "[INFO][${STEP_NAME}] Executing inside a Kubernetes Container."
+                        body()
+                        sh "chown -R 1000:1000 ."
+                    }
                 }
             } else {
                 if (!config.sidecarImage) {

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -134,7 +134,7 @@ void call(Map parameters = [:], body) {
 
         if (isKubernetes() && config.dockerImage) {
             List dockerEnvVars = []
-            config?.dockerEnvVars?.each { key, value ->
+            config.dockerEnvVars?.each { key, value ->
                 dockerEnvVars << "$key=$value"
             }
             if (env.POD_NAME && isContainerDefined(config)) {

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -134,7 +134,7 @@ void call(Map parameters = [:], body) {
 
         if (isKubernetes() && config.dockerImage) {
             List dockerEnvVars = []
-            config.dockerEnvVars.each { key, value ->
+            config?.dockerEnvVars?.each { key, value ->
                 dockerEnvVars << "$key=$value"
             }
             if (env.POD_NAME && isContainerDefined(config)) {


### PR DESCRIPTION
# Changes

* At the moment the configured env vars passed to `dockerExecute` are not used when executing inside an already created pod

* This change creates a list from `config.dockerEnvVars` which will then be used as env vars for the execution inside a docker container, inside an already created pod of Kubernetes

- [x] Tests
