### PR TITLE
Document MTA Deployment Limitation

### DIFF
--- a/documentation/docs/steps/neoDeploy.md
+++ b/documentation/docs/steps/neoDeploy.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-* **SAP CP account** - the account to where the application is deployed.
+* **SAP CP account** - the account to where the application is deployed. To deploy MTA (`deployMode: MTA`) an over existing application you need a _Java Quota_ of at least 2.
 * **SAP CP user for deployment** - a user with deployment permissions in the given account.
 * **Jenkins credentials for deployment** - must be configured in Jenkins credentials with a dedicated Id.
 


### PR DESCRIPTION
Inform users that you can not deploy over an existing Java application (`deploymode: MTA`) unless there's at least 2 Java compute units available.

#845 