### PR TITLE
Add myOwnJenkins to docu index

### DIFF
--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
         - 'Build and Deploy Applications with Jenkins and the SAP Cloud Application Programming Model': scenarios/CAP_Scenario.md
     - Resources:
         - 'Required Plugins': jenkins/requiredPlugins.md
+        - 'My Own Jenkins': myownjenkins.md
 
 theme:
     name: 'material'


### PR DESCRIPTION
Don't know if the `myOwnJenkins.md` was intentionally not added to the documentation index.
