### PR TITLE
Remove template docu page for piperPipelinStagePost

### DIFF
--- a/documentation/docs/steps/piperPipelineStagePost.md
+++ b/documentation/docs/steps/piperPipelineStagePost.md
@@ -1,9 +1,0 @@
-# ${docGenStepName}
-
-## ${docGenDescription}
-
-## ${docGenParameters}
-
-## ${docGenConfiguration}
-
-## ${docJenkinsPluginDependencies}


### PR DESCRIPTION
There are at the moment no stage docu pages. I guess this has been added too early
by mistake. Maybe we should remove this for now since it triggers a warning during docu generation.

