### PR TITLE
Handle sidecar parameters in dockerExecuteOnKubernetes

### DIFF
--- a/src/com/sap/piper/k8s/SidecarUtils.groovy
+++ b/src/com/sap/piper/k8s/SidecarUtils.groovy
@@ -1,0 +1,34 @@
+package com.sap.piper.k8s
+
+class SidecarUtils {
+
+
+    static waitForSidecarReadyOnDocker(String containerId, String command, Script script){
+        String dockerCommand = "docker exec ${containerId} ${command}"
+        waitForSidecarReady(dockerCommand, script)
+    }
+
+    static waitForSidecarReadyOnKubernetes(String containerName, String command, Script script){
+        script.container(name: containerName){
+            waitForSidecarReady(command, script)
+        }
+    }
+
+    static waitForSidecarReady(String command, Script script){
+        int sleepTimeInSeconds = 10
+        int timeoutInSeconds = 5 * 60
+        int maxRetries = timeoutInSeconds / sleepTimeInSeconds
+        int retries = 0
+        while(true){
+            script.echo "Waiting for sidecar container"
+            String status = script.sh script:command, returnStatus:true
+            if(status == "0") return
+            if(retries > maxRetries){
+                script.error("Timeout while waiting for sidecar container to be ready")
+            }
+
+            sleep sleepTimeInSeconds
+            retries++
+        }
+    }
+}

--- a/test/groovy/DockerExecuteTest.groovy
+++ b/test/groovy/DockerExecuteTest.groovy
@@ -1,6 +1,6 @@
 import com.sap.piper.k8s.ContainerMap
 import com.sap.piper.JenkinsUtils
-
+import com.sap.piper.k8s.SidecarUtils
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -41,7 +41,7 @@ class DockerExecuteTest extends BasePiperTest {
     void init() {
         bodyExecuted = false
         docker = new DockerMock()
-        JenkinsUtils.metaClass.static.isPluginActive = {def s -> new PluginMock(s).isActive()}
+        JenkinsUtils.metaClass.static.isPluginActive = { def s -> new PluginMock(s).isActive() }
         binding.setVariable('docker', docker)
         shellRule.setReturnValue(JenkinsShellCallRule.Type.REGEX, "docker .*", 0)
     }
@@ -53,7 +53,7 @@ class DockerExecuteTest extends BasePiperTest {
             containerName = container
             body()
         })
-        helper.registerAllowedMethod('withEnv',[List.class, Closure.class], { List envVars, Closure body ->
+        helper.registerAllowedMethod('withEnv', [List.class, Closure.class], { List envVars, Closure body ->
             usedDockerEnvVars = envVars
             body()
         })
@@ -68,7 +68,7 @@ class DockerExecuteTest extends BasePiperTest {
         assertEquals('mavenexec', containerName)
         assertEquals(usedDockerEnvVars[0].toString(), "http_proxy=http://proxy:8000")
         assertTrue(bodyExecuted)
-     }
+    }
 
     @Test
     void testExecuteInsideNewlyCreatedPod() throws Exception {
@@ -102,7 +102,7 @@ class DockerExecuteTest extends BasePiperTest {
     void testExecuteInsidePodWithStageKeyEmptyValue() throws Exception {
         helper.registerAllowedMethod('dockerExecuteOnKubernetes', [Map.class, Closure.class], { Map config, Closure body -> body() })
         binding.setVariable('env', [POD_NAME: 'testpod', ON_K8S: 'true'])
-        ContainerMap.instance.setMap(['testpod':[:]])
+        ContainerMap.instance.setMap(['testpod': [:]])
         stepRule.step.dockerExecute(script: nullScript,
             dockerImage: 'maven:3.5-jdk-8-alpine',
             dockerEnvVars: ['http_proxy': 'http://proxy:8000']) {
@@ -115,7 +115,7 @@ class DockerExecuteTest extends BasePiperTest {
     @Test
     void testExecuteInsidePodWithCustomCommandAndShell() throws Exception {
         Map kubernetesConfig = [:]
-        helper.registerAllowedMethod('dockerExecuteOnKubernetes', [Map.class, Closure.class], {Map config, Closure body ->
+        helper.registerAllowedMethod('dockerExecuteOnKubernetes', [Map.class, Closure.class], { Map config, Closure body ->
             kubernetesConfig = config
             return body()
         })
@@ -125,12 +125,12 @@ class DockerExecuteTest extends BasePiperTest {
             containerCommand: '/busybox/tail -f /dev/null',
             containerShell: '/busybox/sh',
             dockerImage: 'maven:3.5-jdk-8-alpine'
-        ){
+        ) {
             bodyExecuted = true
         }
         assertTrue(loggingRule.log.contains('Executing inside a Kubernetes Pod'))
-        assertThat(kubernetesConfig.containerCommand, is('/busybox/tail -f /dev/null'))
-        assertThat(kubernetesConfig.containerShell, is('/busybox/sh'))
+        assertThat(kubernetesConfig.containerCommands['maven:3.5-jdk-8-alpine'], is('/busybox/tail -f /dev/null'))
+        assertThat(kubernetesConfig.containerShell['maven:3.5-jdk-8-alpine'], is('/busybox/sh'))
         assertTrue(bodyExecuted)
     }
 
@@ -147,7 +147,7 @@ class DockerExecuteTest extends BasePiperTest {
 
     @Test
     void testSkipDockerImagePull() throws Exception {
-        nullScript.commonPipelineEnvironment.configuration = [steps:[dockerExecute:[dockerPullImage: false]]]
+        nullScript.commonPipelineEnvironment.configuration = [steps: [dockerExecute: [dockerPullImage: false]]]
         stepRule.step.dockerExecute(
             script: nullScript,
             dockerImage: 'maven:3.5-jdk-8-alpine'
@@ -164,11 +164,11 @@ class DockerExecuteTest extends BasePiperTest {
             script: nullScript,
             dockerName: 'maven',
             dockerImage: 'maven:3.5-jdk-8-alpine',
-            sidecarEnvVars: ['testEnv':'testVal'],
+            sidecarEnvVars: ['testEnv': 'testVal'],
             sidecarImage: 'selenium/standalone-chrome',
-            sidecarVolumeBind: ['/dev/shm':'/dev/shm'],
+            sidecarVolumeBind: ['/dev/shm': '/dev/shm'],
             sidecarName: 'testAlias',
-            sidecarPorts: ['4444':'4444', '1111':'1111'],
+            sidecarPorts: ['4444': '4444', '1111': '1111'],
             sidecarPullImage: false
         ) {
             bodyExecuted = true
@@ -180,10 +180,10 @@ class DockerExecuteTest extends BasePiperTest {
     @Test
     void testExecuteInsideDockerContainerWithParameters() throws Exception {
         stepRule.step.dockerExecute(script: nullScript,
-                      dockerImage: 'maven:3.5-jdk-8-alpine',
-                      dockerOptions: '-description=lorem ipsum',
-                      dockerVolumeBind: ['my_vol': '/my_vol'],
-                      dockerEnvVars: ['http_proxy': 'http://proxy:8000']) {
+            dockerImage: 'maven:3.5-jdk-8-alpine',
+            dockerOptions: '-description=lorem ipsum',
+            dockerVolumeBind: ['my_vol': '/my_vol'],
+            dockerEnvVars: ['http_proxy': 'http://proxy:8000']) {
             bodyExecuted = true
         }
         assertTrue(docker.getParameters().contains('--env https_proxy '))
@@ -221,16 +221,16 @@ class DockerExecuteTest extends BasePiperTest {
     }
 
     @Test
-    void testSidecarDefault(){
+    void testSidecarDefault() {
         stepRule.step.dockerExecute(
             script: nullScript,
             dockerName: 'maven',
             dockerImage: 'maven:3.5-jdk-8-alpine',
-            sidecarEnvVars: ['testEnv':'testVal'],
+            sidecarEnvVars: ['testEnv': 'testVal'],
             sidecarImage: 'selenium/standalone-chrome',
-            sidecarVolumeBind: ['/dev/shm':'/dev/shm'],
+            sidecarVolumeBind: ['/dev/shm': '/dev/shm'],
             sidecarName: 'testAlias',
-            sidecarPorts: ['4444':'4444', '1111':'1111']
+            sidecarPorts: ['4444': '4444', '1111': '1111']
         ) {
             bodyExecuted = true
         }
@@ -250,7 +250,7 @@ class DockerExecuteTest extends BasePiperTest {
     }
 
     @Test
-    void testSidecarHealthCheck(){
+    void testSidecarHealthCheck() {
         stepRule.step.dockerExecute(
             script: nullScript,
             dockerImage: 'maven:3.5-jdk-8-alpine',
@@ -262,18 +262,18 @@ class DockerExecuteTest extends BasePiperTest {
     }
 
     @Test
-    void testSidecarKubernetes(){
+    void testSidecarKubernetes() {
         boolean dockerExecuteOnKubernetesCalled = false
         binding.setVariable('env', [ON_K8S: 'true'])
         helper.registerAllowedMethod('dockerExecuteOnKubernetes', [Map.class, Closure.class], { params, body ->
             dockerExecuteOnKubernetesCalled = true
-            assertThat(params.containerCommands['selenium/standalone-chrome'], is(''))
-            assertThat(params.containerEnvVars, allOf(hasEntry('selenium/standalone-chrome', ['testEnv': 'testVal']),hasEntry('maven:3.5-jdk-8-alpine', null)))
-            assertThat(params.containerMap, allOf(hasEntry('maven:3.5-jdk-8-alpine', 'maven'), hasEntry('selenium/standalone-chrome', 'selenium')))
+            assertThat(params.containerMap, allOf(hasEntry('maven:3.5-jdk-8-alpine', 'maven')))
+            assertThat(params.containerEnvVars, allOf(hasEntry('maven:3.5-jdk-8-alpine', null)))
+            assertThat(params.sidecarEnvVars, is(['testEnv': 'testVal']))
+            assertThat(params.sidecarName, is('selenium'))
             assertThat(params.containerName, is('maven'))
             assertThat(params.containerPortMappings['selenium/standalone-chrome'], hasItem(allOf(hasEntry('containerPort', 4444), hasEntry('hostPort', 4444))))
             assertThat(params.containerWorkspaces['maven:3.5-jdk-8-alpine'], is('/home/piper'))
-            assertThat(params.containerWorkspaces['selenium/standalone-chrome'], is(''))
             body()
         })
         stepRule.step.dockerExecute(
@@ -284,10 +284,10 @@ class DockerExecuteTest extends BasePiperTest {
             dockerImage: 'maven:3.5-jdk-8-alpine',
             dockerName: 'maven',
             dockerWorkspace: '/home/piper',
-            sidecarEnvVars: ['testEnv':'testVal'],
+            sidecarEnvVars: ['testEnv': 'testVal'],
             sidecarImage: 'selenium/standalone-chrome',
             sidecarName: 'selenium',
-            sidecarVolumeBind: ['/dev/shm':'/dev/shm']
+            sidecarVolumeBind: ['/dev/shm': '/dev/shm']
         ) {
             bodyExecuted = true
         }
@@ -296,11 +296,11 @@ class DockerExecuteTest extends BasePiperTest {
     }
 
     @Test
-    void testSidecarKubernetesHealthCheck(){
+    void testSidecarKubernetesHealthCheck() {
         binding.setVariable('env', [ON_K8S: 'true'])
 
         helper.registerAllowedMethod('dockerExecuteOnKubernetes', [Map.class, Closure.class], { params, body ->
-            body()
+            SidecarUtils.waitForSidecarReadyOnKubernetes(params.sidecarName, params.sidecarReadyCommand, nullScript)
         })
 
         def containerCalled = false

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -1,3 +1,5 @@
+import com.sap.piper.k8s.SidecarUtils
+
 import static com.sap.piper.Prerequisites.checkScript
 
 import com.cloudbees.groovy.cps.NonCPS
@@ -120,16 +122,16 @@ void call(Map parameters = [:], body) {
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
-            .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, STEP_CONFIG_KEYS)
+            .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName ?: env.STAGE_NAME, STEP_CONFIG_KEYS)
             .mixin(parameters, PARAMETER_KEYS)
             .use()
 
         new Utils().pushToSWA([
-            step: STEP_NAME,
+            step         : STEP_NAME,
             stepParamKey1: 'scriptMissing',
-            stepParam1: parameters?.script == null,
+            stepParam1   : parameters?.script == null,
             stepParamKey2: 'kubernetes',
-            stepParam2: isKubernetes()
+            stepParam2   : isKubernetes()
         ], config)
 
         if (isKubernetes() && config.dockerImage) {
@@ -146,60 +148,40 @@ void call(Map parameters = [:], body) {
                     }
                 }
             } else {
-                if (!config.sidecarImage) {
-                    dockerExecuteOnKubernetes(
-                        script: script,
-                        containerCommand: config.containerCommand,
-                        containerShell: config.containerShell,
-                        dockerImage: config.dockerImage,
-                        dockerPullImage: config.dockerPullImage,
-                        dockerEnvVars: config.dockerEnvVars,
-                        dockerWorkspace: config.dockerWorkspace,
-                        stashContent: config.stashContent
-                    ){
-                        echo "[INFO][${STEP_NAME}] Executing inside a Kubernetes Pod"
-                        body()
-                    }
-                } else {
-                    if(!config.dockerName){
-                        config.dockerName = UUID.randomUUID().toString()
-                    }
+                if (!config.dockerName) {
+                    config.dockerName = UUID.randomUUID().toString()
+                }
 
-                    Map paramMap = [
-                        script: script,
-                        containerCommands: [:],
-                        containerEnvVars: [:],
-                        containerPullImageFlags: [:],
-                        containerMap: [:],
-                        containerName: config.dockerName,
-                        containerPortMappings: [:],
-                        containerWorkspaces: [:],
-                        stashContent: config.stashContent
-                    ]
+                Map paramMap = [
+                    script                 : script,
+                    containerCommands      : [:],
+                    containerShell         : [:],
+                    containerEnvVars       : [:],
+                    containerPullImageFlags: [:],
+                    containerMap           : [:],
+                    containerName          : config.dockerName,
+                    containerPortMappings  : [:],
+                    containerWorkspaces    : [:],
+                    stashContent           : config.stashContent
+                ]
 
-                    paramMap.containerCommands[config.sidecarImage] = ''
+                paramMap.containerEnvVars[config.dockerImage] = config.dockerEnvVars
+                paramMap.containerPullImageFlags[config.dockerImage] = config.dockerPullImage
+                paramMap.containerMap[config.dockerImage] = config.dockerName
+                paramMap.containerPortMappings = config.containerPortMappings
+                paramMap.containerWorkspaces[config.dockerImage] = config.dockerWorkspace
+                paramMap.containerCommands[config.dockerImage] = config.containerCommand
+                paramMap.containerShell[config.dockerImage] = config.containerShell
 
-                    paramMap.containerEnvVars[config.dockerImage] = config.dockerEnvVars
-                    paramMap.containerEnvVars[config.sidecarImage] = config.sidecarEnvVars
+                paramMap.sidecarName = parameters.sidecarName
+                paramMap.sidecarImage = parameters.sidecarImage
+                paramMap.sidecarPullImage = parameters.sidecarPullImage
+                paramMap.sidecarReadyCommand = parameters.sidecarReadyCommand
+                paramMap.sidecarEnvVars = parameters.sidecarEnvVars
 
-                    paramMap.containerPullImageFlags[config.dockerImage] = config.dockerPullImage
-                    paramMap.containerPullImageFlags[config.sidecarImage] = config.sidecarPullImage
-
-                    paramMap.containerMap[config.dockerImage] = config.dockerName
-                    paramMap.containerMap[config.sidecarImage] = config.sidecarName
-
-                    paramMap.containerPortMappings = config.containerPortMappings
-
-                    paramMap.containerWorkspaces[config.dockerImage] = config.dockerWorkspace
-                    paramMap.containerWorkspaces[config.sidecarImage] = ''
-
-                    dockerExecuteOnKubernetes(paramMap){
-                        echo "[INFO][${STEP_NAME}] Executing inside a Kubernetes Pod with sidecar container"
-                        if(config.sidecarReadyCommand) {
-                            waitForSidecarReadyOnKubernetes(config.sidecarName, config.sidecarReadyCommand)
-                        }
-                        body()
-                    }
+                dockerExecuteOnKubernetes(paramMap) {
+                    echo "[INFO][${STEP_NAME}] Executing inside a Kubernetes Pod with sidecar container"
+                    body()
                 }
             }
         } else {
@@ -218,7 +200,7 @@ void call(Map parameters = [:], body) {
                 utils.unstashAll(config.stashContent)
                 def image = docker.image(config.dockerImage)
                 if (config.dockerPullImage) image.pull()
-                else echo"[INFO][$STEP_NAME] Skipped pull of image '${config.dockerImage}'."
+                else echo "[INFO][$STEP_NAME] Skipped pull of image '${config.dockerImage}'."
                 if (!config.sidecarImage) {
                     image.inside(getDockerOptions(config.dockerEnvVars, config.dockerVolumeBind, config.dockerOptions)) {
                         body()
@@ -226,28 +208,28 @@ void call(Map parameters = [:], body) {
                 } else {
                     def networkName = "sidecar-${UUID.randomUUID()}"
                     sh "docker network create ${networkName}"
-                    try{
+                    try {
                         def sidecarImage = docker.image(config.sidecarImage)
                         if (config.sidecarPullImage) sidecarImage.pull()
-                        else echo"[INFO][$STEP_NAME] Skipped pull of image '${config.sidecarImage}'."
-                        config.sidecarOptions = config.sidecarOptions?:[]
+                        else echo "[INFO][$STEP_NAME] Skipped pull of image '${config.sidecarImage}'."
+                        config.sidecarOptions = config.sidecarOptions ?: []
                         if (config.sidecarName)
                             config.sidecarOptions.add("--network-alias ${config.sidecarName}")
                         config.sidecarOptions.add("--network ${networkName}")
                         sidecarImage.withRun(getDockerOptions(config.sidecarEnvVars, config.sidecarVolumeBind, config.sidecarOptions)) { container ->
-                            config.dockerOptions = config.dockerOptions?:[]
+                            config.dockerOptions = config.dockerOptions ?: []
                             if (config.dockerName)
                                 config.dockerOptions.add("--network-alias ${config.dockerName}")
                             config.dockerOptions.add("--network ${networkName}")
-                            if(config.sidecarReadyCommand) {
-                                waitForSidecarReadyOnDocker(container.id, config.sidecarReadyCommand)
+                            if (config.sidecarReadyCommand) {
+                                SidecarUtils.waitForSidecarReadyOnDocker(container.id, config.sidecarReadyCommand, script)
                             }
                             image.inside(getDockerOptions(config.dockerEnvVars, config.dockerVolumeBind, config.dockerOptions)) {
                                 echo "[INFO][${STEP_NAME}] Running with sidecar container."
                                 body()
                             }
                         }
-                    }finally{
+                    } finally {
                         sh "docker network remove ${networkName}"
                     }
                 }
@@ -259,41 +241,13 @@ void call(Map parameters = [:], body) {
     }
 }
 
-private waitForSidecarReadyOnDocker(String containerId, String command){
-    String dockerCommand = "docker exec ${containerId} ${command}"
-    waitForSidecarReady(dockerCommand)
-}
-
-private waitForSidecarReadyOnKubernetes(String containerName, String command){
-    container(name: containerName){
-        waitForSidecarReady(command)
-    }
-}
-
-private waitForSidecarReady(String command){
-    int sleepTimeInSeconds = 10
-    int timeoutInSeconds = 5 * 60
-    int maxRetries = timeoutInSeconds / sleepTimeInSeconds
-    int retries = 0
-    while(true){
-        echo "Waiting for sidecar container"
-        String status = sh script:command, returnStatus:true
-        if(status == "0") return
-        if(retries > maxRetries){
-            error("Timeout while waiting for sidecar container to be ready")
-        }
-
-        sleep sleepTimeInSeconds
-        retries++
-    }
-}
-
 /*
  * Returns a string with docker options containing
  * environment variables (if set).
  * Possible to extend with further options.
  * @param dockerEnvVars Map with environment variables
  */
+
 @NonCPS
 private getDockerOptions(Map dockerEnvVars, Map dockerVolumeBind, def dockerOptions) {
     def specialEnvironments = [
@@ -364,14 +318,15 @@ boolean isKubernetes() {
  * E.g. <code>description=Lorem ipsum</code> is
  * changed to <code>description=Lorem\ ipsum</code>.
  */
+
 @NonCPS
 def escapeBlanks(def s) {
 
-    def EQ='='
-    def parts=s.split(EQ)
+    def EQ = '='
+    def parts = s.split(EQ)
 
-    if(parts.length == 2) {
-        parts[1]=parts[1].replaceAll(' ', '\\\\ ')
+    if (parts.length == 2) {
+        parts[1] = parts[1].replaceAll(' ', '\\\\ ')
         s = parts.join(EQ)
     }
 

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -1,3 +1,5 @@
+import com.sap.piper.k8s.SidecarUtils
+
 import static com.sap.piper.Prerequisites.checkScript
 
 import com.sap.piper.ConfigurationHelper
@@ -77,6 +79,40 @@ import hudson.AbortException
      * Specifies a dedicated user home directory for the container which will be passed as value for environment variable `HOME`.
      */
     'dockerWorkspace',
+    /**
+     * as `dockerImage` for the sidecar container
+     */
+    'sidecarImage',
+    /**
+     * SideCar only:
+     * Name of the container in local network.
+     */
+    'sidecarName',
+    /**
+     * Set this to 'false' to bypass a docker image pull.
+     * Usefull during development process. Allows testing of images which are available in the local registry only.
+     */
+    'sidecarPullImage',
+    /**
+     * Command executed inside the container which returns exit code 0 when the container is ready to be used.
+     */
+    'sidecarReadyCommand',
+    /**
+     * as `dockerEnvVars` for the sidecar container
+     */
+    'sidecarEnvVars',
+    /**
+     * as `dockerWorkspace` for the sidecar container
+     */
+    'sidecarWorkspace',
+    /**
+     * as `dockerVolumeBind` for the sidecar container
+     */
+    'sidecarVolumeBind',
+    /**
+     * as `dockerOptions` for the sidecar container
+     */
+    'sidecarOptions',
     /** Defines the Kubernetes nodeSelector as per [https://github.com/jenkinsci/kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin).*/
     'nodeSelector',
     /**
@@ -148,9 +184,9 @@ void call(Map parameters = [:], body) {
         Map config = configHelper.use()
 
         new Utils().pushToSWA([
-            step: STEP_NAME,
+            step         : STEP_NAME,
             stepParamKey1: 'scriptMissing',
-            stepParam1: parameters?.script == null
+            stepParam1   : parameters?.script == null
         ], config)
 
         if (!parameters.containerMap) {
@@ -159,16 +195,16 @@ void call(Map parameters = [:], body) {
             config.containerMap = [(config.get('dockerImage')): config.containerName]
             config.containerCommands = config.containerCommand ? [(config.get('dockerImage')): config.containerCommand] : null
         }
-        executeOnPod(config, utils, body)
+        executeOnPod(config, utils, body, script)
     }
 }
 
 def getOptions(config) {
     def namespace = config.jenkinsKubernetes.namespace
     def options = [
-        name      : 'dynamic-agent-' + config.uniqueId,
-        label     : config.uniqueId,
-        yaml      : generatePodSpec(config)
+        name : 'dynamic-agent-' + config.uniqueId,
+        label: config.uniqueId,
+        yaml : generatePodSpec(config)
     ]
     if (namespace) {
         options.namespace = namespace
@@ -182,7 +218,7 @@ def getOptions(config) {
     return options
 }
 
-void executeOnPod(Map config, utils, Closure body) {
+void executeOnPod(Map config, utils, Closure body, Script script) {
     /*
      * There could be exceptions thrown by
         - The podTemplate
@@ -196,18 +232,21 @@ void executeOnPod(Map config, utils, Closure body) {
     try {
 
         def stashContent = config.stashContent
-        if (config.containerName && stashContent.isEmpty()){
+        if (config.containerName && stashContent.isEmpty()) {
             stashContent = [stashWorkspace(config, 'workspace')]
         }
         podTemplate(getOptions(config)) {
             node(config.uniqueId) {
+                if (config.sidecarReadyCommand) {
+                    SidecarUtils.waitForSidecarReadyOnKubernetes(config.sidecarName, config.sidecarReadyCommand, script)
+                }
                 if (config.containerName) {
                     Map containerParams = [name: config.containerName]
                     if (config.containerShell) {
                         containerParams.shell = config.containerShell
                     }
                     echo "ContainerConfig: ${containerParams}"
-                    container(containerParams){
+                    container(containerParams) {
                         try {
                             utils.unstashAll(stashContent)
                             body()
@@ -230,11 +269,11 @@ private String generatePodSpec(Map config) {
     def containers = getContainerList(config)
     def podSpec = [
         apiVersion: "v1",
-        kind: "Pod",
-        metadata: [
+        kind      : "Pod",
+        metadata  : [
             lables: config.uniqueId
         ],
-        spec: [
+        spec      : [
             containers: containers
         ]
     ]
@@ -247,17 +286,17 @@ private String generatePodSpec(Map config) {
 private String stashWorkspace(config, prefix, boolean chown = false, boolean stashBack = false) {
     def stashName = "${prefix}-${config.uniqueId}"
     try {
-        if (chown)  {
+        if (chown) {
             def securityContext = getSecurityContext(config)
             def runAsUser = securityContext?.runAsUser ?: 1000
             def fsGroup = securityContext?.fsGroup ?: 1000
-            sh """#!${config.containerShell?:'/bin/sh'}
+            sh """#!${config.containerShell ?: '/bin/sh'}
 chown -R ${runAsUser}:${fsGroup} ."""
         }
 
         def includes, excludes
 
-        if(stashBack) {
+        if (stashBack) {
             includes = config.stashIncludes.stashBack ?: config.stashIncludes.workspace
             excludes = config.stashExcludes.stashBack ?: config.stashExcludes.workspace
         } else {
@@ -272,7 +311,6 @@ chown -R ${runAsUser}:${fsGroup} ."""
         )
         //inactive due to negative side-effects, we may require a dedicated git stash to be used
         //useDefaultExcludes: false)
-
         return stashName
     } catch (AbortException | IOException e) {
         echo "${e.getMessage()}"
@@ -296,21 +334,20 @@ private List getContainerList(config) {
 
     //If no custom jnlp agent provided as default jnlp agent (jenkins/jnlp-slave) as defined in the plugin, see https://github.com/jenkinsci/kubernetes-plugin#pipeline-support
     def result = []
-
     //allow definition of jnlp image via environment variable JENKINS_JNLP_IMAGE in the Kubernetes landscape or via config as fallback
     if (env.JENKINS_JNLP_IMAGE || config.jenkinsKubernetes.jnlpAgent) {
         result.push([
-            name: 'jnlp',
+            name : 'jnlp',
             image: env.JENKINS_JNLP_IMAGE ?: config.jenkinsKubernetes.jnlpAgent
         ])
     }
     config.containerMap.each { imageName, containerName ->
         def containerPullImage = config.containerPullImageFlags?.get(imageName)
         def containerSpec = [
-            name: containerName.toLowerCase(),
-            image: imageName,
+            name           : containerName.toLowerCase(),
+            image          : imageName,
             imagePullPolicy: containerPullImage ? "Always" : "IfNotPresent",
-            env: getContainerEnvs(config, imageName)
+            env            : getContainerEnvs(config, imageName)
         ]
 
         def configuredCommand = config.containerCommands?.get(imageName)
@@ -321,30 +358,41 @@ private List getContainerList(config) {
                 '-f',
                 '/dev/null'
             ]
-        } else if(configuredCommand != "") {
+        } else if (configuredCommand != "") {
             // apparently "" is used as a flag for not settings container commands !?
             containerSpec['command'] =
-                    (configuredCommand in List) ? configuredCommand : [
-                        shell,
-                        '-c',
-                        configuredCommand
-                    ]
+                (configuredCommand in List) ? configuredCommand : [
+                    shell,
+                    '-c',
+                    configuredCommand
+                ]
         }
 
         if (config.containerPortMappings?.get(imageName)) {
             def ports = []
             def portCounter = 0
-            config.containerPortMappings.get(imageName).each {mapping ->
+            config.containerPortMappings.get(imageName).each { mapping ->
                 def name = "${containerName}${portCounter}".toString()
-                if(mapping.containerPort != mapping.hostPort) {
-                    echo ("[WARNING][${STEP_NAME}]: containerPort and hostPort are different for container '${containerName}'. "
+                if (mapping.containerPort != mapping.hostPort) {
+                    echo("[WARNING][${STEP_NAME}]: containerPort and hostPort are different for container '${containerName}'. "
                         + "The hostPort will be ignored.")
                 }
                 ports.add([name: name, containerPort: mapping.containerPort])
-                portCounter ++
+                portCounter++
             }
             containerSpec.ports = ports
         }
+        result.push(containerSpec)
+    }
+    if (config.sidecarImage) {
+        def containerSpec = [
+            name           : config.sidecarName.toLowerCase(),
+            image          : config.sidecarImage,
+            imagePullPolicy: config.sidecarPullImage ? "Always" : "IfNotPresent",
+            env            : getContainerEnvs(config, config.sidecarImage),
+            command        : []
+        ]
+
         result.push(containerSpec)
     }
     return result
@@ -356,13 +404,14 @@ private List getContainerList(config) {
  * (Kubernetes-Plugin only!)
  * @param config Map with configurations
  */
+
 private List getContainerEnvs(config, imageName) {
     def containerEnv = []
     def dockerEnvVars = config.containerEnvVars?.get(imageName) ?: config.dockerEnvVars ?: [:]
     def dockerWorkspace = config.containerWorkspaces?.get(imageName) != null ? config.containerWorkspaces?.get(imageName) : config.dockerWorkspace ?: ''
 
     def envVar = { e ->
-        [ name: e.key, value: e.value ]
+        [name: e.key, value: e.value]
     }
 
     if (dockerEnvVars) {


### PR DESCRIPTION
# Changes

In the Cloud SDK Pipeline we experience the 'bug' that when already having a pod ready for the stage to be executed, the configured sidecar container is not created.

To solve this issue I moved the sidecar logic which already exists in `dockerExecute` to `dockerExecuteOnKubernetes`. With this change it is possible to call `dockerExecute` in a K8s environment with a sidecar configured as well as directly calling `dockerExecuteOnKubernetes` with a sidecar configured.
I also moved the methods to check if a sidecar container is ready to use in a utils class since the methods are used in `dockerExecuteOnKubernetes` as well as in `dockerExecute`.

- [x] Tests
- [x] Documentation <- imho. not needed because change is refactoring
