### PR TITLE
mailSendNotification: Avoid full merge trace being added to culprits

### DIFF
--- a/test/groovy/MailSendNotificationTest.groovy
+++ b/test/groovy/MailSendNotificationTest.groovy
@@ -58,10 +58,10 @@ user3@domain.com noreply+github@domain.com'''
 
     @Test
     void testCulpritsFromGitCommit() throws Exception {
-        def gitCommand = "git log -2 --pretty=format:'%ae %ce'"
+        def gitCommand = "git log -2 --first-parent --pretty=format:'%ae %ce'"
         def expected = "user2@domain.com user3@domain.com"
 
-        shellRule.setReturnValue("git log -2 --pretty=format:'%ae %ce'", 'user2@domain.com user3@domain.com')
+        shellRule.setReturnValue("git log -2 --first-parent --pretty=format:'%ae %ce'", 'user2@domain.com user3@domain.com')
 
         def result = stepRule.step.getCulprits(
             [

--- a/vars/mailSendNotification.groovy
+++ b/vars/mailSendNotification.groovy
@@ -223,7 +223,7 @@ def getCulprits(config, branch, numberOfCommits) {
             }
         }
 
-        def recipients = sh(returnStdout: true, script: "git log -${numberOfCommits} --pretty=format:'%ae %ce'")
+        def recipients = sh(returnStdout: true, script: "git log -${numberOfCommits} --first-parent --pretty=format:'%ae %ce'")
         return getDistinctRecipients(recipients)
     } catch(err) {
         echo "[${STEP_NAME}] Culprit retrieval from git failed with '${err.getMessage()}'. Please make sure to configure gitSshKeyCredentialsId. So far, only fixed list of recipients is used."


### PR DESCRIPTION
# Changes
Added `--first-parent` option to the `git log` command to ensure that only the first parent of a merge commit is being considered for author and committer determination. This should help with getting our culprits fan-out under control. 

- [x] Tests
- [ ] ~Documentation~ not relevant
