### PR TITLE
[refactoring] condence common coding for cf deploy

### DIFF
--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -471,7 +471,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
         // asserts
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 's4sdk/docker-cf-cli'))
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))
-        assertThat(shellRule.shell, hasItem(containsString('cf login -u test_cf -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
+        assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(shellRule.shell, hasItem(containsString('cf deploy target/test.mtar -f')))
         assertThat(shellRule.shell, hasItem(containsString('cf logout')))
     }
@@ -491,7 +491,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
             mtaPath: 'target/test.mtar'
         ])
 
-        assertThat(shellRule.shell, hasItem(stringContainsInOrder(["cf login -u test_cf", 'cf bg-deploy', '-f', '--no-confirm'])))
+        assertThat(shellRule.shell, hasItem(stringContainsInOrder(["cf login -u \"test_cf\"", 'cf bg-deploy', '-f', '--no-confirm'])))
     }
 
     @Test

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -404,7 +404,7 @@ def deployCfNative (config) {
     deploy(null, deployStatement, config,  { c -> stopOldAppIfRunning(c) })
 }
 
-private deploy(def cfApiStatement, def cfDeployStatement, def config, Closure logoutAction) {
+private deploy(def cfApiStatement, def cfDeployStatement, def config, Closure postDeployAction) {
 
     withCredentials([usernamePassword(
         credentialsId: config.cloudFoundry.credentialsId,
@@ -448,7 +448,7 @@ private deploy(def cfApiStatement, def cfDeployStatement, def config, Closure lo
             error "[${STEP_NAME}] ERROR: The execution of the deploy command failed, see the log for details."
         }
 
-        if(logoutAction) logoutAction(config)
+        if(postDeployAction) postDeployAction(config)
 
         sh "cf logout"
     }


### PR DESCRIPTION
Small change beyond refactoring: for mtaDeploy the user is now quoted.

As promissed in [PR 865](https://github.com/SAP/jenkins-library/pull/865#discussion_r324145341)  common coding between mtaDeploy and cfNativeDeploy is now condenced.
