### PR TITLE
sonar.pullrequest.branch to point to the name of the branch

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -505,7 +505,7 @@ steps:
     instance: 'SonarCloud'
     options: []
     pullRequestProvider: 'GitHub'
-    sonarScannerDownloadUrl: 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.3.0.1492-linux.zip'
+    sonarScannerDownloadUrl: 'https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.2.0.1873-linux.zip'
   testsPublishResults:
     failOnError: false
     junit:

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -133,7 +133,7 @@ void call(Map parameters = [:]) {
 
                     sh "PATH=\$PATH:${env.WORKSPACE}/.sonar-scanner/bin sonar-scanner ${config.options.join(' ')}"
                 }finally{
-                    sh 'rm -rf .sonar-scanner .certificates .scannerwork'
+                    sh 'rm -rf .certificates'
                 }
             }
         }

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -172,7 +172,7 @@ void call(Map parameters = [:]) {
                     // see https://sonarcloud.io/documentation/analysis/pull-request/
                     config.options.add("sonar.pullrequest.key=${env.CHANGE_ID}")
                     config.options.add("sonar.pullrequest.base=${env.CHANGE_TARGET}")
-                    config.options.add("sonar.pullrequest.branch=${env.BRANCH_NAME}")
+                    config.options.add("sonar.pullrequest.branch=${env.CHANGE_BRANCH}")
                     config.options.add("sonar.pullrequest.provider=${config.pullRequestProvider}")
                     switch(config.pullRequestProvider){
                         case 'GitHub':


### PR DESCRIPTION
According to the sonarqube documentation: https://docs.sonarqube.org/latest/analysis/pull-request/
sonar.pullrequest.branch is the name of the branch that contains the changes to be merged. Ex: sonar.pullrequest.branch=feature/my-new-feature.
So the change is needed to fix a wrong assignment to something like sonar.pullrequest.branch=PR-12

# Changes

- [ ] Tests
- [ ] Documentation
