### PR TITLE
Fix Pom and other components to work TravisCI update to Java11 

### DIFF
--- a/documentation/bin/createDocu.sh
+++ b/documentation/bin/createDocu.sh
@@ -20,10 +20,10 @@ done
 export GROOVY_VERSION=2.4.16
 mkdir -p tmp
 curl -sL https://bintray.com/artifact/download/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip -o tmp/groovy.zip
-unzip tmp/groovy.zip -d tmp
+unzip -qq tmp/groovy.zip -d tmp
 sed -i "1s/sh/bash/" tmp/groovy-${GROOVY_VERSION}/bin/*
 PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH
-#export PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH
+export PATH
 
 export CLASSPATH_FILE='target/cp.txt'
 mvn clean test dependency:build-classpath -Dmdep.outputFile=${CLASSPATH_FILE} > /dev/null 2>&1

--- a/documentation/bin/createDocu.sh
+++ b/documentation/bin/createDocu.sh
@@ -17,6 +17,7 @@ do
     [ -e "${f}" ] && rm -rf "${f}"
 done
 
+groovy -version
 export CLASSPATH_FILE='target/cp.txt'
 mvn clean test dependency:build-classpath -Dmdep.outputFile=${CLASSPATH_FILE} > /dev/null 2>&1
 
@@ -27,6 +28,7 @@ mvn clean test dependency:build-classpath -Dmdep.outputFile=${CLASSPATH_FILE} > 
 # are performed by other pipeline steps. E.g.: each step includes basically a call to
 # handlePipelineStepErrors. The Plugin calls issues by handlePipelineStepErrors are also
 # reported for the step calling that auxiliar step).
+echo "before first groovy call"
 groovy  "${d}resolveTransitiveCalls" -in target/trackedCalls.json --out "${CALLS}"
 
 [ -f "${CALLS}" ] || { echo "File \"${CALLS}\" does not exist." ; exit 1; }

--- a/documentation/bin/createDocu.sh
+++ b/documentation/bin/createDocu.sh
@@ -21,11 +21,9 @@ export GROOVY_VERSION=2.4.16
 mkdir -p tmp
 curl -sL https://bintray.com/artifact/download/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip -o tmp/groovy.zip
 unzip tmp/groovy.zip -d tmp
-sed -i "1s/sh/bash/" tmp/groovy-${GROOVY_VERSION}/bin/* 
-PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH 
-export PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH 
-echo $PATH
-groovy -version
+sed -i "1s/sh/bash/" tmp/groovy-${GROOVY_VERSION}/bin/*
+PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH
+#export PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH
 
 export CLASSPATH_FILE='target/cp.txt'
 mvn clean test dependency:build-classpath -Dmdep.outputFile=${CLASSPATH_FILE} > /dev/null 2>&1
@@ -55,3 +53,5 @@ docker run \
 [ -f "${PLUGIN_MAPPING}" ] || { echo "Result file containing step to plugin mapping not found (${PLUGIN_MAPPING})."; exit 1;  }
 
 groovy -cp "target/classes:$(cat $CLASSPATH_FILE)" "${d}createDocu" "${@}"
+
+rm -rf tmp

--- a/documentation/bin/createDocu.sh
+++ b/documentation/bin/createDocu.sh
@@ -17,7 +17,16 @@ do
     [ -e "${f}" ] && rm -rf "${f}"
 done
 
+export GROOVY_VERSION=2.4.16
+mkdir -p tmp
+curl -sL https://bintray.com/artifact/download/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip -o tmp/groovy.zip
+unzip tmp/groovy.zip -d tmp
+sed -i "1s/sh/bash/" tmp/groovy-${GROOVY_VERSION}/bin/* 
+PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH 
+export PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH 
+echo $PATH
 groovy -version
+
 export CLASSPATH_FILE='target/cp.txt'
 mvn clean test dependency:build-classpath -Dmdep.outputFile=${CLASSPATH_FILE} > /dev/null 2>&1
 

--- a/documentation/bin/createDocu.sh
+++ b/documentation/bin/createDocu.sh
@@ -17,11 +17,11 @@ do
     [ -e "${f}" ] && rm -rf "${f}"
 done
 
+# local installation of groovy to run the 2 scripts below. If Travis CI installation is updated this can be removed
 export GROOVY_VERSION=2.4.16
 mkdir -p tmp
 curl -sL https://bintray.com/artifact/download/groovy/maven/apache-groovy-binary-${GROOVY_VERSION}.zip -o tmp/groovy.zip
 unzip -qq tmp/groovy.zip -d tmp
-sed -i "1s/sh/bash/" tmp/groovy-${GROOVY_VERSION}/bin/*
 PATH=$(pwd)/tmp/groovy-${GROOVY_VERSION}/bin:$PATH
 export PATH
 
@@ -35,7 +35,6 @@ mvn clean test dependency:build-classpath -Dmdep.outputFile=${CLASSPATH_FILE} > 
 # are performed by other pipeline steps. E.g.: each step includes basically a call to
 # handlePipelineStepErrors. The Plugin calls issues by handlePipelineStepErrors are also
 # reported for the step calling that auxiliar step).
-echo "before first groovy call"
 groovy  "${d}resolveTransitiveCalls" -in target/trackedCalls.json --out "${CALLS}"
 
 [ -f "${CALLS}" ] || { echo "File \"${CALLS}\" does not exist." ; exit 1; }

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
             <!-- any version of Groovy \>= 1.5.0 should work here -->
-            <version>2.4.12</version>
+            <version>2.4.17</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
         <dependency>
@@ -177,14 +177,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.22.2</version>
                 <configuration>
                     <testSourceDirectory>test/java</testSourceDirectory>
+                    <reuseForks>true</reuseForks>
+                    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.8.1</version>
                 <configuration>
                     <compilerId>groovy-eclipse-compiler</compilerId>
                 </configuration>
@@ -192,12 +194,12 @@
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-compiler</artifactId>
-                        <version>2.9.2-01</version>
+                        <version>3.4.0-01</version>
                     </dependency>
                     <dependency>
                         <groupId>org.codehaus.groovy</groupId>
                         <artifactId>groovy-eclipse-batch</artifactId>
-                        <version>2.4.3-01</version>
+                        <version>2.5.6-01</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/test/groovy/util/JenkinsWriteYamlRule.groovy
+++ b/test/groovy/util/JenkinsWriteYamlRule.groovy
@@ -11,9 +11,9 @@ import org.junit.runners.model.Statement
 class JenkinsWriteYamlRule implements TestRule {
 
     final BasePipelineTest testInstance
-    static final String DATA = "DATA" // key in files map to retrieve Yaml object graph data..
-    static final String CHARSET = "CHARSET" // key in files map to retrieve the charset of the serialized Yaml.
-    static final String SERIALIZED_YAML = "SERIALIZED_YAML" // key in files map to retrieve serialized Yaml.
+    public static final String DATA = "DATA" // key in files map to retrieve Yaml object graph data..
+    public static final String CHARSET = "CHARSET" // key in files map to retrieve the charset of the serialized Yaml.
+    public static final String SERIALIZED_YAML = "SERIALIZED_YAML" // key in files map to retrieve serialized Yaml.
 
     Map<String, Map<String, Object>> files = new HashMap<>()
 

--- a/vars/cfManifestSubstituteVariables.groovy
+++ b/vars/cfManifestSubstituteVariables.groovy
@@ -161,7 +161,7 @@ private Object substitute(String manifestFilePath, List<String> manifestVariable
     def manifestData = loadManifestData(manifestFilePath, debugHelper)
 
     // replace variables from list first.
-    List<Map<String>> reversedManifestVariablesList = manifestVariablesList.reverse() // to make sure last one wins.
+    List<Map<String, Object>> reversedManifestVariablesList = manifestVariablesList.reverse() // to make sure last one wins.
 
     def result = manifestData
     for (Map<String, Object> manifestVariableData : reversedManifestVariablesList) {


### PR DESCRIPTION
# Changes

This PR updates the pom.xml to work with Java 11.
It also updates the createDocu.sh script to update the groovy version for the test to 2.4.16 and fixes compile issues in 2 files with java 11 restrictions. 

First Tests were done with `docker run -it -v $(pwd):/code -v /home/vagrant/.m2:/var/maven/.m2 -e MAVEN_CONFIG=/var/maven/.m2 -u 1000 maven:slim /bin/bash` and `mvn clean verify -Duser.home=/var/maven`

Later tests were done with custom build docker maven image with groovy and docker inside. 

- [ ] Tests
- [ ] Documentation
