### PR TITLE
whitesourceExecuteScan: Fix path for archiving UA logs

### DIFF
--- a/vars/whitesourceExecuteScan.groovy
+++ b/vars/whitesourceExecuteScan.groovy
@@ -409,7 +409,7 @@ private def triggerWhitesourceScanWithUserKey(script, config, utils, descriptorU
                     archiveArtifacts artifacts: "**/ws-l*", allowEmptyArchive: true
 
                     // archive UA log file
-                    archiveArtifacts artifacts: "/var/log/UA/*", allowEmptyArchive: true
+                    archiveArtifacts artifacts: "/var/log/UA/**/*.log", allowEmptyArchive: true
                 }
                 break
         }


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation
