### PR TITLE
Fail early if file which should be uploaded does not exist.

### DIFF
--- a/vars/tmsUpload.groovy
+++ b/vars/tmsUpload.groovy
@@ -94,6 +94,10 @@ void call(Map parameters = [:]) {
         def nodeName = config.nodeName
         def mtaPath = config.mtaPath
 
+        if(!fileExists(mtaPath)) {
+            error("Mta file '${mtaPath}' does not exist.")
+        }
+
         if (config.verbose) {
             echo "[TransportManagementService] CredentialsId: '${config.credentialsId}'"
             echo "[TransportManagementService] Node name: '${nodeName}'"


### PR DESCRIPTION
Right now we fail with some error message from curl.

The error messages is:

```
Warning: setting file /var/jenkins_home/workspace/TMS-Upload/doesNotExist  
Warning: failed!
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   162    0     0    0   162      0   1338 --:--:-- --:--:-- --:--:--  1338
curl: (26) read function returned funny value
```
which does not clearly point to the issue.