### PR TITLE
Support property 'failOnWarning'.

### DIFF
--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -284,6 +284,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
                  applicationName: '42',
                  applicationDescription: 'Lorem ipsum',
                  abapPackage: 'XYZ',
+                 failOnWarning: false, // we use the non-default here in order to check if that gets forwarded.
                  cmUtils: cm,)
 
         assert cmUtilsReceivedParams ==
@@ -305,7 +306,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
                 abapPackage:'XYZ',
                 codePage: 'UTF-9',
                 acceptUnixStyleLineEndings: true,
-                failUploadOnWarning: true,
+                failUploadOnWarning: false,
             ]
     }
 

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -74,7 +74,11 @@ import static com.sap.piper.cm.StepHelpers.getBackendTypeAndLogInfoIfCMIntegrati
          * A pattern used for identifying lines holding the transport request id.
          * @parentConfigKey changeManagement
          */
-        'changeManagement/transportRequestLabel'
+        'changeManagement/transportRequestLabel',
+        /**
+         * RFC uploads only: Fail upload in case of a warning.
+         */
+        'failOnWarning'
   ]
 
 @Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS.plus([


### PR DESCRIPTION
Property is already implemented, but was not added to the
list of supported parameters, hence that property got filtered out.
