### PR TITLE
Make cobertura defaults compatible with UI5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>fr.opensagres.js</groupId>
+            <artifactId>minimatch.java</artifactId>
+            <version>1.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -526,7 +526,7 @@ steps:
       archive: false
       active: false
     cobertura:
-      pattern: '**/target/coverage/cobertura-coverage.xml'
+      pattern: '**/target/coverage/**/cobertura-coverage.xml'
       onlyStableBuilds: true
       allowEmptyResults: true
       archive: false

--- a/test/groovy/TestsPublishResultsTest.groovy
+++ b/test/groovy/TestsPublishResultsTest.groovy
@@ -102,6 +102,9 @@ class TestsPublishResultsTest extends BasePiperTest {
         String sampleCoberturaPathForJava = 'my/workspace/my/project/target/coverage/cobertura-coverage.xml'
         assertTrue('Cobertura default pattern does not match files at target/coverage/cobertura-coverage.xml for Java projects',
             Minimatch.minimatch(sampleCoberturaPathForJava, publisherStepOptions.cobertura.coberturaReportFile))
+        String sampleCoberturaPathForKarma = 'my/workspace/my/project/target/coverage/Chrome 78.0.3904 (Mac OS X 10.14.6)/cobertura-coverage.xml'
+        assertTrue('Cobertura default pattern does not match files at target/coverage/<browser>/cobertura-coverage.xml for UI5 projects',
+            Minimatch.minimatch(sampleCoberturaPathForKarma, publisherStepOptions.cobertura.coberturaReportFile))
     }
 
     @Test

--- a/test/groovy/TestsPublishResultsTest.groovy
+++ b/test/groovy/TestsPublishResultsTest.groovy
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
 
 import util.Rules
+import minimatch.Minimatch
 
 class TestsPublishResultsTest extends BasePiperTest {
     Map publisherStepOptions
@@ -90,14 +91,17 @@ class TestsPublishResultsTest extends BasePiperTest {
         stepRule.step.testsPublishResults(script: nullScript, jacoco: true, cobertura: true)
 
         assertTrue('JaCoCo options are empty', publisherStepOptions.jacoco != null)
-        assertTrue('Cobertura options are empty', publisherStepOptions.cobertura != null)
         assertEquals('JaCoCo default pattern not set correct',
             '**/target/*.exec', publisherStepOptions.jacoco.execPattern)
-        assertEquals('Cobertura default pattern not set correct',
-            '**/target/coverage/cobertura-coverage.xml', publisherStepOptions.cobertura.coberturaReportFile)
         // ensure nothing else is published
         assertTrue('JUnit options are not empty', publisherStepOptions.junit == null)
         assertTrue('JMeter options are not empty', publisherStepOptions.jmeter == null)
+
+        assertTrue('Cobertura options are empty', publisherStepOptions.cobertura != null)
+        assertTrue('Cobertura default pattern is empty', publisherStepOptions.cobertura.coberturaReportFile != null)
+        String sampleCoberturaPathForJava = 'my/workspace/my/project/target/coverage/cobertura-coverage.xml'
+        assertTrue('Cobertura default pattern does not match files at target/coverage/cobertura-coverage.xml for Java projects',
+            Minimatch.minimatch(sampleCoberturaPathForJava, publisherStepOptions.cobertura.coberturaReportFile))
     }
 
     @Test
@@ -145,7 +149,7 @@ class TestsPublishResultsTest extends BasePiperTest {
                 }]
             }]
         }
-        
+
         stepRule.step.testsPublishResults(script: nullScript)
         assertJobStatusSuccess()
     }


### PR DESCRIPTION
# Changes

- update default file name pattern for cobertura coverage files in xml format. the new pattern should work for both Java (e.g. `target/cobertura/cobertura-coverage.xml`) as well as for UI5 (e.g. `target/cobertura/Chrome 76/cobertura-coverage.xml`)
- update the test case for the default settings of `testsPublishResults`: match the file pattern against sample file paths rather than just comparing the pattern itself

- [x] Tests
- [x] Documentation (auto-generated)
