### PR TITLE
Fix: getting config should also work in case there is no project config

### DIFF
--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -53,9 +53,12 @@ func generateConfig() error {
 		return errors.Wrap(err, "metadata: read failed")
 	}
 
-	customConfig, err := configOptions.openFile(generalConfig.customConfig)
-	if err != nil {
-		return errors.Wrap(err, "config: open failed")
+	var customConfig io.ReadCloser
+	if fileExists(generalConfig.customConfig) {
+		customConfig, err = configOptions.openFile(generalConfig.customConfig)
+		if err != nil {
+			return errors.Wrap(err, "config: open failed")
+		}
 	}
 
 	defaultConfig, paramFilter, err := defaultsAndFilters(&metadata)
@@ -117,4 +120,12 @@ func defaultsAndFilters(metadata *config.StepData) ([]io.ReadCloser, config.Step
 	}
 	//ToDo: retrieve default values from metadata
 	return nil, metadata.GetParameterFilters(), nil
+}
+
+func fileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,12 +81,9 @@ func (c *Config) GetStepConfig(flagValues map[string]interface{}, paramJSON stri
 	var stepConfig StepConfig
 	var d PipelineDefaults
 
-	if err := c.ReadConfig(configuration); err != nil {
-		switch err.(type) {
-		case *ParseError:
+	if configuration != nil {
+		if err := c.ReadConfig(configuration); err != nil {
 			return StepConfig{}, errors.Wrap(err, "failed to parse custom pipeline configuration")
-		default:
-			//ignoring unavailability of config file since considered optional
 		}
 	}
 	c.ApplyAliasConfig(parameters, filters, stageName, stepName)


### PR DESCRIPTION
In case there was no project config file (`.pipeline/config.yml`)  we failed with a panic. In the current groovy code we are able to work also without project config. Should be the same for go also.

1.) this is handy for poc'ing
2.) It is a valid scenario to have no project config, eg. in case everything can be defined on landscape layer.