### PR TITLE
Export general configuration

### DIFF
--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -54,8 +54,8 @@ func generateConfig() error {
 	}
 
 	var customConfig io.ReadCloser
-	if fileExists(generalConfig.customConfig) {
-		customConfig, err = configOptions.openFile(generalConfig.customConfig)
+	if fileExists(GeneralConfig.customConfig) {
+		customConfig, err = configOptions.openFile(GeneralConfig.customConfig)
 		if err != nil {
 			return errors.Wrap(err, "config: open failed")
 		}
@@ -66,7 +66,7 @@ func generateConfig() error {
 		return errors.Wrap(err, "defaults: retrieving step defaults failed")
 	}
 
-	for _, f := range generalConfig.defaultConfig {
+	for _, f := range GeneralConfig.defaultConfig {
 		fc, err := configOptions.openFile(f)
 		if err != nil {
 			return errors.Wrapf(err, "config: getting defaults failed: '%v'", f)
@@ -81,7 +81,7 @@ func generateConfig() error {
 		params = metadata.Spec.Inputs.Parameters
 	}
 
-	stepConfig, err = myConfig.GetStepConfig(flags, generalConfig.parametersJSON, customConfig, defaultConfig, paramFilter, params, generalConfig.stageName, configOptions.stepName)
+	stepConfig, err = myConfig.GetStepConfig(flags, GeneralConfig.parametersJSON, customConfig, defaultConfig, paramFilter, params, GeneralConfig.stageName, configOptions.stepName)
 	if err != nil {
 		return errors.Wrap(err, "getting step config failed")
 	}

--- a/cmd/githubPublishRelease_generated.go
+++ b/cmd/githubPublishRelease_generated.go
@@ -47,7 +47,7 @@ The result looks like
 ![Example release](../images/githubRelease.png)`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			log.SetStepName("githubPublishRelease")
-			log.SetVerbose(generalConfig.verbose)
+			log.SetVerbose(GeneralConfig.verbose)
 			return PrepareConfig(cmd, &metadata, "githubPublishRelease", &myGithubPublishReleaseOptions, openPiperFile)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/karmaExecuteTests_generated.go
+++ b/cmd/karmaExecuteTests_generated.go
@@ -34,7 +34,7 @@ In the Docker network, the containers can be referenced by the values provided i
     In a Kubernetes environment, the containers both need to be referenced with ` + "`" + `localhost` + "`" + `.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			log.SetStepName("karmaExecuteTests")
-			log.SetVerbose(generalConfig.verbose)
+			log.SetVerbose(GeneralConfig.verbose)
 			return PrepareConfig(cmd, &metadata, "karmaExecuteTests", &myKarmaExecuteTestsOptions, openPiperFile)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -33,7 +33,8 @@ It contains many steps which can be used within CI/CD systems as well as directl
 	//ToDo: respect stageName to also come from parametersJSON -> first env.STAGE_NAME, second: parametersJSON, third: flag
 }
 
-var generalConfig generalConfigOptions
+// GeneralConfig contains global configuration flags for piper binary
+var GeneralConfig generalConfigOptions
 
 // Execute is the starting point of the piper command line tool
 func Execute() {
@@ -52,12 +53,12 @@ func Execute() {
 
 func addRootFlags(rootCmd *cobra.Command) {
 
-	rootCmd.PersistentFlags().StringVar(&generalConfig.customConfig, "customConfig", ".pipeline/config.yml", "Path to the pipeline configuration file")
-	rootCmd.PersistentFlags().StringSliceVar(&generalConfig.defaultConfig, "defaultConfig", nil, "Default configurations, passed as path to yaml file")
-	rootCmd.PersistentFlags().StringVar(&generalConfig.parametersJSON, "parametersJSON", os.Getenv("PIPER_parametersJSON"), "Parameters to be considered in JSON format")
-	rootCmd.PersistentFlags().StringVar(&generalConfig.stageName, "stageName", os.Getenv("STAGE_NAME"), "Name of the stage for which configuration should be included")
-	rootCmd.PersistentFlags().StringVar(&generalConfig.stepConfigJSON, "stepConfigJSON", os.Getenv("PIPER_stepConfigJSON"), "Step configuration in JSON format")
-	rootCmd.PersistentFlags().BoolVarP(&generalConfig.verbose, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().StringVar(&GeneralConfig.customConfig, "customConfig", ".pipeline/config.yml", "Path to the pipeline configuration file")
+	rootCmd.PersistentFlags().StringSliceVar(&GeneralConfig.defaultConfig, "defaultConfig", nil, "Default configurations, passed as path to yaml file")
+	rootCmd.PersistentFlags().StringVar(&GeneralConfig.parametersJSON, "parametersJSON", os.Getenv("PIPER_parametersJSON"), "Parameters to be considered in JSON format")
+	rootCmd.PersistentFlags().StringVar(&GeneralConfig.stageName, "stageName", os.Getenv("STAGE_NAME"), "Name of the stage for which configuration should be included")
+	rootCmd.PersistentFlags().StringVar(&GeneralConfig.stepConfigJSON, "stepConfigJSON", os.Getenv("PIPER_stepConfigJSON"), "Step configuration in JSON format")
+	rootCmd.PersistentFlags().BoolVarP(&GeneralConfig.verbose, "verbose", "v", false, "verbose output")
 
 }
 
@@ -71,23 +72,23 @@ func PrepareConfig(cmd *cobra.Command, metadata *config.StepData, stepName strin
 	var myConfig config.Config
 	var stepConfig config.StepConfig
 
-	if len(generalConfig.stepConfigJSON) != 0 {
+	if len(GeneralConfig.stepConfigJSON) != 0 {
 		// ignore config & defaults in favor of passed stepConfigJSON
-		stepConfig = config.GetStepConfigWithJSON(flagValues, generalConfig.stepConfigJSON, filters)
+		stepConfig = config.GetStepConfigWithJSON(flagValues, GeneralConfig.stepConfigJSON, filters)
 	} else {
 		// use config & defaults
 
 		//accept that config file and defaults cannot be loaded since both are not mandatory here
-		customConfig, _ := openFile(generalConfig.customConfig)
+		customConfig, _ := openFile(GeneralConfig.customConfig)
 		var defaultConfig []io.ReadCloser
-		for _, f := range generalConfig.defaultConfig {
+		for _, f := range GeneralConfig.defaultConfig {
 			//ToDo: support also https as source
 			fc, _ := openFile(f)
 			defaultConfig = append(defaultConfig, fc)
 		}
 
 		var err error
-		stepConfig, err = myConfig.GetStepConfig(flagValues, generalConfig.parametersJSON, customConfig, defaultConfig, filters, metadata.Spec.Inputs.Parameters, generalConfig.stageName, stepName)
+		stepConfig, err = myConfig.GetStepConfig(flagValues, GeneralConfig.parametersJSON, customConfig, defaultConfig, filters, metadata.Spec.Inputs.Parameters, GeneralConfig.stageName, stepName)
 		if err != nil {
 			return errors.Wrap(err, "retrieving step configuration failed")
 		}

--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -81,14 +81,14 @@ func TestAddRootFlags(t *testing.T) {
 }
 
 func TestPrepareConfig(t *testing.T) {
-	defaultsBak := generalConfig.defaultConfig
-	generalConfig.defaultConfig = []string{"testDefaults.yml"}
-	defer func() { generalConfig.defaultConfig = defaultsBak }()
+	defaultsBak := GeneralConfig.defaultConfig
+	GeneralConfig.defaultConfig = []string{"testDefaults.yml"}
+	defer func() { GeneralConfig.defaultConfig = defaultsBak }()
 
 	t.Run("using stepConfigJSON", func(t *testing.T) {
-		stepConfigJSONBak := generalConfig.stepConfigJSON
-		generalConfig.stepConfigJSON = `{"testParam": "testValueJSON"}`
-		defer func() { generalConfig.stepConfigJSON = stepConfigJSONBak }()
+		stepConfigJSONBak := GeneralConfig.stepConfigJSON
+		GeneralConfig.stepConfigJSON = `{"testParam": "testValueJSON"}`
+		defer func() { GeneralConfig.stepConfigJSON = stepConfigJSONBak }()
 		testOptions := stepOptions{}
 		var testCmd = &cobra.Command{Use: "test", Short: "This is just a test"}
 		testCmd.Flags().StringVar(&testOptions.TestParam, "testParam", "", "test usage")
@@ -136,7 +136,7 @@ func TestPrepareConfig(t *testing.T) {
 		})
 
 		t.Run("error case", func(t *testing.T) {
-			generalConfig.defaultConfig = []string{"testDefaultsInvalid.yml"}
+			GeneralConfig.defaultConfig = []string{"testDefaultsInvalid.yml"}
 			testOptions := stepOptions{}
 			var testCmd = &cobra.Command{Use: "test", Short: "This is just a test"}
 			metadata := config.StepData{}

--- a/cmd/version_generated.go
+++ b/cmd/version_generated.go
@@ -21,7 +21,7 @@ func VersionCommand() *cobra.Command {
 		Long:  `Writes the commit hash and the tag (if any) to stdout and exits with 0.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			log.SetStepName("version")
-			log.SetVerbose(generalConfig.verbose)
+			log.SetVerbose(GeneralConfig.verbose)
 			return PrepareConfig(cmd, &metadata, "version", &myVersionOptions, openPiperFile)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/google/go-github/v28 v28.1.1
 	github.com/google/go-cmp v0.3.1
+	github.com/google/go-github/v28 v28.1.1
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/pkg/generator/step-metadata.go
+++ b/pkg/generator/step-metadata.go
@@ -54,7 +54,7 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 		Long: {{ $tick := "` + "`" + `" }}{{ $tick }}{{.Long | longName }}{{ $tick }},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			log.SetStepName("{{ .StepName }}")
-			log.SetVerbose(generalConfig.verbose)
+			log.SetVerbose(GeneralConfig.verbose)
 			return PrepareConfig(cmd, &metadata, "{{ .StepName }}", &my{{ .StepName | title}}Options, openPiperFile)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/generator/testdata/TestProcessMetaFiles/step_code_generated.golden
+++ b/pkg/generator/testdata/TestProcessMetaFiles/step_code_generated.golden
@@ -26,7 +26,7 @@ func TestStepCommand() *cobra.Command {
 		Long: `Long Test description`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			log.SetStepName("testStep")
-			log.SetVerbose(generalConfig.verbose)
+			log.SetVerbose(GeneralConfig.verbose)
 			return PrepareConfig(cmd, &metadata, "testStep", &myTestStepOptions, openPiperFile)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Allow for package external access to general configuration.

Use-case: re-use individual steps
