### PR TITLE
Fix bug and added documentation for cloudFoundryCreateService step

### DIFF
--- a/documentation/docs/steps/cloudFoundryCreateService.md
+++ b/documentation/docs/steps/cloudFoundryCreateService.md
@@ -1,0 +1,38 @@
+# ${docGenStepName}
+
+## ${docGenDescription}
+
+## ${docGenParameters}
+
+## ${docGenConfiguration}
+
+## ${docJenkinsPluginDependencies}
+
+## Example
+
+
+The following Example will create the services specified in a file `manifest-create-service.yml` in cloud foundry org `cfOrg` of Cloud Foundry installation accessed via `https://test.server.com` in space `cfSpace` by using the username & password stored in `cfCredentialsId`.
+
+```groovy
+cloudFoundryCreateService(
+            script: this,
+            cloudFoundry: [apiEndpoint: 'https://test.server.com',
+                credentialsId: 'cfCredentialsId', 
+                serviceManifest: 'manifest-create-service.yml', 
+                org: 'cfOrg', 
+                space: 'cfSpace'])
+```
+
+The following example additionally to above also makes use of a variable substitution file `mainfest-variable-substitution.yml`.
+
+```groovy
+cloudFoundryCreateService(
+            script: this,
+            cloudFoundry: [apiEndpoint: 'https://test.server.com',
+                credentialsId: 'cfCredentialsId', 
+                serviceManifest: 'manifest-create-service.yml', 
+                manifestVariablesFiles: ['mainfest-variable-substitution.yml'],                
+                org: 'cfOrg', 
+                space: 'cfSpace'])
+
+```

--- a/documentation/docs/steps/cloudFoundryCreateService.md
+++ b/documentation/docs/steps/cloudFoundryCreateService.md
@@ -10,16 +10,15 @@
 
 ## Example
 
-
 The following Example will create the services specified in a file `manifest-create-service.yml` in cloud foundry org `cfOrg` of Cloud Foundry installation accessed via `https://test.server.com` in space `cfSpace` by using the username & password stored in `cfCredentialsId`.
 
 ```groovy
 cloudFoundryCreateService(
             script: this,
             cloudFoundry: [apiEndpoint: 'https://test.server.com',
-                credentialsId: 'cfCredentialsId', 
-                serviceManifest: 'manifest-create-service.yml', 
-                org: 'cfOrg', 
+                credentialsId: 'cfCredentialsId',
+                serviceManifest: 'manifest-create-service.yml',
+                org: 'cfOrg',
                 space: 'cfSpace'])
 ```
 
@@ -29,10 +28,10 @@ The following example additionally to above also makes use of a variable substit
 cloudFoundryCreateService(
             script: this,
             cloudFoundry: [apiEndpoint: 'https://test.server.com',
-                credentialsId: 'cfCredentialsId', 
-                serviceManifest: 'manifest-create-service.yml', 
-                manifestVariablesFiles: ['mainfest-variable-substitution.yml'],                
-                org: 'cfOrg', 
+                credentialsId: 'cfCredentialsId',
+                serviceManifest: 'manifest-create-service.yml',
+                manifestVariablesFiles: ['mainfest-variable-substitution.yml'],
+                org: 'cfOrg',
                 space: 'cfSpace'])
 
 ```

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -187,6 +187,8 @@ steps:
       serviceManifest: 'service-manifest.yml'
     dockerImage: 'ppiper/cf-cli'
     dockerWorkspace: '/home/piper'
+    stashContent:
+      - 'deployDescriptor'
   detectExecuteScan:
     detect:
       projectVersion: '1'

--- a/test/groovy/CloudFoundryCreateServiceTest.groovy
+++ b/test/groovy/CloudFoundryCreateServiceTest.groovy
@@ -139,7 +139,7 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))        
         assertThat(shellRule.shell, hasItem(containsString("cf login -u 'test_cf' -p '********' -a https://api.cf.eu10.hana.ondemand.com -o 'testOrg' -s 'testSpace'")))
-        assertThat(shellRule.shell, hasItem(containsString(" cf create-service-push --no-push -f 'test.yml'")))
+        assertThat(shellRule.shell, hasItem(containsString(" cf create-service-push --no-push --service-manifest 'test.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))
     }
 
@@ -165,7 +165,7 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))        
         assertThat(shellRule.shell, hasItem(containsString("cf login -u 'test_cf' -p '********' -a https://api.cf.eu10.hana.ondemand.com -o 'testOrg' -s 'testSpace'")))
-        assertThat(shellRule.shell, hasItem(containsString("cf create-service-push --no-push -f 'test.yml' --var appName='testApplicationFromVarsList' --vars-file 'vars.yml'")))
+        assertThat(shellRule.shell, hasItem(containsString("cf create-service-push --no-push --service-manifest 'test.yml' --var appName='testApplicationFromVarsList' --vars-file 'vars.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))
     }
 
@@ -233,7 +233,7 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             cfManifestVariables: varsList
         ]) 
 
-        assertThat(shellRule.shell, hasItem(containsString("""cf create-service-push --no-push -f 'test.yml' --var appName='testApplicationFromVarsListWith'"'"''""")))
+        assertThat(shellRule.shell, hasItem(containsString("""cf create-service-push --no-push --service-manifest 'test.yml' --var appName='testApplicationFromVarsListWith'"'"''""")))
     }
 
     @Test
@@ -253,7 +253,7 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             cfManifestVariablesFiles: [varsFileName]
         ]) 
 
-        assertThat(shellRule.shell, hasItem(containsString("""cf create-service-push --no-push -f 'test.yml' --vars-file 'varsWith'"'"'.yml'""")))
+        assertThat(shellRule.shell, hasItem(containsString("""cf create-service-push --no-push --service-manifest 'test.yml' --vars-file 'varsWith'"'"'.yml'""")))
     }
 
     @Test
@@ -278,7 +278,7 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))        
         assertThat(shellRule.shell, hasItem(containsString("cf login -u 'test_cf' -p '********' -a https://api.cf.eu10.hana.ondemand.com -o 'testOrg' -s 'testSpace'")))
-        assertThat(shellRule.shell, hasItem(containsString(" cf create-service-push --no-push -f 'test.yml'")))
+        assertThat(shellRule.shell, hasItem(containsString(" cf create-service-push --no-push --service-manifest 'test.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))
     } 
 }

--- a/test/groovy/CloudFoundryCreateServiceTest.groovy
+++ b/test/groovy/CloudFoundryCreateServiceTest.groovy
@@ -156,11 +156,11 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',           
+            cfCredentialsId: 'test_cfCredentialsId',
             cfServiceManifest: 'test.yml',
             cfManifestVariablesFiles: [varsFileName],
             cfManifestVariables: varsList
-        ]) 
+        ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))        
@@ -180,9 +180,9 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
-            cfCredentialsId: 'escape_cfCredentialsId',           
+            cfCredentialsId: 'escape_cfCredentialsId',
             cfServiceManifest: 'test.yml'
-        ]) 
+        ])
 
         assertThat(shellRule.shell, hasItem(containsString("""cf login -u 'aUserWithA'"'"'' -p 'passHasA'"'"'' -a https://api.cf.eu10.hana.ondemand.com -o 'testOrg' -s 'testSpace'""")))
     }
@@ -196,9 +196,9 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: "testSpaceWith'",
-            cfCredentialsId: 'test_cfCredentialsId',           
+            cfCredentialsId: 'test_cfCredentialsId',
             cfServiceManifest: 'test.yml'
-        ]) 
+        ])
         assertThat(shellRule.shell, hasItem(containsString("""cf login -u 'test_cf' -p '********' -a https://api.cf.eu10.hana.ondemand.com -o 'testOrg' -s 'testSpaceWith'"'"''""")))
     }
 
@@ -211,9 +211,9 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             deployTool: 'cf_native',
             cfOrg: "testOrgWith'",
             cfSpace: "testSpace",
-            cfCredentialsId: 'test_cfCredentialsId',           
+            cfCredentialsId: 'test_cfCredentialsId',
             cfServiceManifest: 'test.yml'
-        ]) 
+        ])
         assertThat(shellRule.shell, hasItem(containsString("""cf login -u 'test_cf' -p '********' -a https://api.cf.eu10.hana.ondemand.com -o 'testOrgWith'"'"'' -s 'testSpace'""")))
     }
 
@@ -228,10 +228,10 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',           
+            cfCredentialsId: 'test_cfCredentialsId',
             cfServiceManifest: 'test.yml',
             cfManifestVariables: varsList
-        ]) 
+        ])
 
         assertThat(shellRule.shell, hasItem(containsString("""cf create-service-push --no-push --service-manifest 'test.yml' --var appName='testApplicationFromVarsListWith'"'"''""")))
     }
@@ -248,10 +248,10 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',           
+            cfCredentialsId: 'test_cfCredentialsId',
             cfServiceManifest: 'test.yml',
             cfManifestVariablesFiles: [varsFileName]
-        ]) 
+        ])
 
         assertThat(shellRule.shell, hasItem(containsString("""cf create-service-push --no-push --service-manifest 'test.yml' --vars-file 'varsWith'"'"'.yml'""")))
     }
@@ -271,12 +271,12 @@ class CloudFoundryCreateServiceTest extends BasePiperTest {
             deployTool: 'cf_native',
             cfOrg: 'testOrg',
             cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',           
+            cfCredentialsId: 'test_cfCredentialsId',
             cfServiceManifest: 'test.yml'
-        ]) 
+        ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
-        assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))        
+        assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerWorkspace', '/home/piper'))
         assertThat(shellRule.shell, hasItem(containsString("cf login -u 'test_cf' -p '********' -a https://api.cf.eu10.hana.ondemand.com -o 'testOrg' -s 'testSpace'")))
         assertThat(shellRule.shell, hasItem(containsString(" cf create-service-push --no-push --service-manifest 'test.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))

--- a/vars/cloudFoundryCreateService.groovy
+++ b/vars/cloudFoundryCreateService.groovy
@@ -125,8 +125,7 @@ private def executeCreateServicePush(script, Map config) {
 
         withCredentials([
             usernamePassword(credentialsId: config.cloudFoundry.credentialsId, passwordVariable: 'CF_PASSWORD', usernameVariable: 'CF_USERNAME')
-        ]) {
-            echo "cf create-service-push --no-push -f ${BashUtils.quoteAndEscape(config.cloudFoundry.serviceManifest)}${varPart}${varFilePart}"
+        ]) {          
             def returnCode = sh returnStatus: true, script: """#!/bin/bash
             set +x
             set -e

--- a/vars/cloudFoundryCreateService.groovy
+++ b/vars/cloudFoundryCreateService.groovy
@@ -79,8 +79,8 @@ import static com.sap.piper.Prerequisites.checkScript
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
 
 /**
- * Step that uses the CF Create-Service-Push plugin to create services in a Cloud Foundry space. The information about the services is provided in a yaml file as infrastructure as code. 
- * It is possible to use variable substitution inside of the yaml file like in a CF-push manifest yaml. 
+ * Step that uses the CF Create-Service-Push plugin to create services in a Cloud Foundry space. The information about the services is provided in a yaml file as infrastructure as code.
+ * It is possible to use variable substitution inside of the yaml file like in a CF-push manifest yaml.
  *
  * For more details how to specify the services in the yaml see the [github page of the plugin](https://github.com/dawu415/CF-CLI-Create-Service-Push-Plugin).
  *

--- a/vars/cloudFoundryCreateService.groovy
+++ b/vars/cloudFoundryCreateService.groovy
@@ -125,7 +125,7 @@ private def executeCreateServicePush(script, Map config) {
 
         withCredentials([
             usernamePassword(credentialsId: config.cloudFoundry.credentialsId, passwordVariable: 'CF_PASSWORD', usernameVariable: 'CF_USERNAME')
-        ]) {          
+        ]) {
             def returnCode = sh returnStatus: true, script: """#!/bin/bash
             set +x
             set -e


### PR DESCRIPTION
# Changes

Bug fix for plugin call, wrong parameter was used. Only default manifest-service.yml filename was working before.
- [x] Tests adapted!

Provide default value for stash-content to support execution in pipeline templates.
using "deployDescriptor" which contains all yml files. 

Added forgotten documentation md file for step.
- [x] documentation.