### PR TITLE
assign library field in logger with respect of containing repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ RUN go test ./... -cover
 # execute build
 # RUN go build -o piper
 RUN export GIT_COMMIT=$(git rev-parse HEAD) && \
-    go build -ldflags "-X github.com/SAP/jenkins-library/cmd.GitCommit=${GIT_COMMIT}" -o piper
+    export GIT_REPOSITORY=$(git config --get remote.origin.url) && \
+    go build \
+        -ldflags "-X github.com/SAP/jenkins-library/cmd.GitCommit=${GIT_COMMIT}" \
+        -ldflags "-X github.com/SAP/jenkins-library/pkg/log.LibraryRepository=${GIT_REPOSITORY}" \
+        -o piper
 
 # FROM gcr.io/distroless/base:latest
 # COPY --from=build-env /build/piper /piper

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,12 +4,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// LibraryRepository ...
+var LibraryRepository string
 var logger *logrus.Entry
 
 // Entry returns the logger entry or creates one if none is present.
 func Entry() *logrus.Entry {
 	if logger == nil {
-		logger = logrus.WithField("library", "sap/jenkins-library")
+		logger = logrus.WithField("library", LibraryRepository) //"sap/jenkins-library")
 	}
 	return logger
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,14 +4,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// LibraryRepository ...
+// LibraryRepository that is passed into with -ldflags
 var LibraryRepository string
 var logger *logrus.Entry
 
 // Entry returns the logger entry or creates one if none is present.
 func Entry() *logrus.Entry {
 	if logger == nil {
-		logger = logrus.WithField("library", LibraryRepository) //"sap/jenkins-library")
+		logger = logrus.WithField("library", LibraryRepository)
 	}
 	return logger
 }


### PR DESCRIPTION
**changes:**
- The *library* field in the `logrus.Entry` is assigned with the url of the current (built time) repository.
This way forks and dependent libraries provide the correct value in the logger.