### PR TITLE
fix: sonarExecuteScan: safeguard unstash of git metadata

### DIFF
--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -190,7 +190,7 @@ void call(Map parameters = [:]) {
             script: script,
             dockerImage: configuration.dockerImage
         ){
-            if(!script.fileExists('.git/index')) {
+            if(!script.fileExists('.git')) {
                 utils.unstash('git')
             }
             worker(configuration)

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -190,7 +190,9 @@ void call(Map parameters = [:]) {
             script: script,
             dockerImage: configuration.dockerImage
         ){
-            unstash 'git'
+            if(script.fileExists('.git/index')) {
+                utils.unstash('git')
+            }
             worker(configuration)
         }
     }

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -190,7 +190,7 @@ void call(Map parameters = [:]) {
             script: script,
             dockerImage: configuration.dockerImage
         ){
-            if(script.fileExists('.git/index')) {
+            if(!script.fileExists('.git/index')) {
                 utils.unstash('git')
             }
             worker(configuration)


### PR DESCRIPTION
**changes:**
- in case a `.git` file is already present, no unstash of `git` stash is done to avoid read/write issues
(`java.nio.file.AccessDeniedException: /data/jenkins/workspace/project/.git/objects/pack/pack-c9858d29b71082e85.idx`)
- in case the `git` unstash fails, the pipeline will not stop as SCM analysis is optional and only necessary for PR decoration