### PR TITLE
Support for generating enums

### DIFF
--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -22,6 +22,8 @@ func AvailableFlagValues(cmd *cobra.Command, filters *StepFilters) map[string]in
 			flagValues[pflag.Name], _ = flags.GetStringSlice(pflag.Name)
 		case "bool":
 			flagValues[pflag.Name], _ = flags.GetBool(pflag.Name)
+		case "enum":
+			flagValues[pflag.Name] = pflag.Value.String()
 		default:
 			fmt.Printf("Meta data type not set or not known: '%v'\n", pflag.Value.Type())
 			os.Exit(1)

--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -47,6 +47,7 @@ type StepParameters struct {
 	Type            string      `json:"type"`
 	Mandatory       bool        `json:"mandatory,omitempty"`
 	Default         interface{} `json:"default,omitempty"`
+	Values          []string    `json: values,omitempty`
 	Aliases         []Alias     `json:"aliases,omitempty"`
 	Conditions      []Condition `json:"conditions,omitempty"`
 }


### PR DESCRIPTION
In several steps we have some properties which can have several predefined values. Without having an enum-like pattern we have to handle that as string. This means we can also provide unreasonable values. And it is hard to document.

With that it is possible to provide enums on the meta level. E.g.:

```
   description: blah blah
   longDescription: |
     blah blah blub.
spec:
  inputs:
    params:
      - name: Weekday
        type: enum
        description: The days of the week
        default: SUNDAY
        values:
        - SUNDAY
        - MONDAY
        - TUESDAY
        - WEDNESDAY
        - THURSDAY
        - FRIDAY
        - SATURDAY
        scope:
        - GENERAL
        - PARAMETERS
        - STAGES
        - STEPS
```

This is only the generator code for having enums. In case somebody would like to see this in action use: https://github.com/marcusholl/jenkins-library/tree/enumExample

Possible next step(s):
  - provide additional metadata (docu) for each enum value.
  - ...