### PR TITLE
Clarify precedence in MapUtils#merge()

### DIFF
--- a/src/com/sap/piper/MapUtils.groovy
+++ b/src/com/sap/piper/MapUtils.groovy
@@ -20,6 +20,12 @@ class MapUtils implements Serializable {
         return result
     }
 
+    /**
+     * Merge two maps with the second one has precedence
+     * @param base First map
+     * @param overlay Second map, takes precedence
+     * @return The merged map
+     */
     static Map merge(Map base, Map overlay) {
 
         Map result = [:]

--- a/test/groovy/com/sap/piper/MapUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/MapUtilsTest.groovy
@@ -16,7 +16,7 @@ class MapUtilsTest {
     }
 
     @Test
-    void testMergeMapStraigtForward(){
+    void testMergeMapStraightForward(){
 
         Map a = [a: '1',
                  c: [d: '1',
@@ -29,6 +29,20 @@ class MapUtilsTest {
         assert merged == [a: '1',
                           b: '2',
                           c: [d: 'x', e: '2']]
+    }
+
+    @Test
+    void testMergeMapWithConflict(){
+
+        Map a = [a: '1',
+                 b: [c: 1]],
+            b = [a: '2',
+                 b: [c: 2]]
+
+        Map merged = MapUtils.merge(a, b)
+
+        assert merged == [a: '2',
+                          b: [c: 2]]
     }
 
     @Test


### PR DESCRIPTION
# Changes

Adds a comment and a test to make the behaviour of `MapUtils#merge()` more obvious.

- [x] Tests
- [x] Documentation
