### PR TITLE
Remove redundancy: no duplicate stepName

### DIFF
--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -62,7 +62,7 @@ func generateConfig() error {
 		}
 	}
 
-	defaultConfig, paramFilter, err := defaultsAndFilters(&metadata)
+	defaultConfig, paramFilter, err := defaultsAndFilters(&metadata, metadata.Metadata.Name)
 	if err != nil {
 		return errors.Wrap(err, "defaults: retrieving step defaults failed")
 	}
@@ -82,7 +82,7 @@ func generateConfig() error {
 		params = metadata.Spec.Inputs.Parameters
 	}
 
-	stepConfig, err = myConfig.GetStepConfig(flags, GeneralConfig.ParametersJSON, customConfig, defaultConfig, paramFilter, params, GeneralConfig.StageName, configOptions.stepName)
+	stepConfig, err = myConfig.GetStepConfig(flags, GeneralConfig.ParametersJSON, customConfig, defaultConfig, paramFilter, params, GeneralConfig.StageName, metadata.Metadata.Name)
 	if err != nil {
 		return errors.Wrap(err, "getting step config failed")
 	}
@@ -101,17 +101,15 @@ func addConfigFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&configOptions.parametersJSON, "parametersJSON", os.Getenv("PIPER_parametersJSON"), "Parameters to be considered in JSON format")
 	cmd.Flags().StringVar(&configOptions.stepMetadata, "stepMetadata", "", "Step metadata, passed as path to yaml")
-	cmd.Flags().StringVar(&configOptions.stepName, "stepName", "", "Name of the step for which configuration should be included")
 	cmd.Flags().BoolVar(&configOptions.contextConfig, "contextConfig", false, "Defines if step context configuration should be loaded instead of step config")
 
 	cmd.MarkFlagRequired("stepMetadata")
-	cmd.MarkFlagRequired("stepName")
 
 }
 
-func defaultsAndFilters(metadata *config.StepData) ([]io.ReadCloser, config.StepFilters, error) {
+func defaultsAndFilters(metadata *config.StepData, stepName string) ([]io.ReadCloser, config.StepFilters, error) {
 	if configOptions.contextConfig {
-		defaults, err := metadata.GetContextDefaults(configOptions.stepName)
+		defaults, err := metadata.GetContextDefaults(stepName)
 		if err != nil {
 			return nil, config.StepFilters{}, errors.Wrap(err, "metadata: getting context defaults failed")
 		}

--- a/cmd/getConfig_test.go
+++ b/cmd/getConfig_test.go
@@ -41,7 +41,7 @@ func TestConfigCommand(t *testing.T) {
 	})
 
 	t.Run("Required flags", func(t *testing.T) {
-		exp := []string{"stepMetadata", "stepName"}
+		exp := []string{"stepMetadata"}
 		assert.Equal(t, exp, gotReq, "required flags incorrect")
 	})
 

--- a/cmd/getConfig_test.go
+++ b/cmd/getConfig_test.go
@@ -73,7 +73,7 @@ func TestDefaultsAndFilters(t *testing.T) {
 	t.Run("Context config", func(t *testing.T) {
 		configOptions.contextConfig = true
 		defer func() { configOptions.contextConfig = false }()
-		defaults, filters, err := defaultsAndFilters(&metadata)
+		defaults, filters, err := defaultsAndFilters(&metadata, "stepName")
 
 		assert.Equal(t, 1, len(defaults), "getting defaults failed")
 		assert.Equal(t, 0, len(filters.All), "wrong number of filter values")
@@ -81,7 +81,7 @@ func TestDefaultsAndFilters(t *testing.T) {
 	})
 
 	t.Run("Step config", func(t *testing.T) {
-		defaults, filters, err := defaultsAndFilters(&metadata)
+		defaults, filters, err := defaultsAndFilters(&metadata, "stepName")
 		assert.Equal(t, 0, len(defaults), "getting defaults failed")
 		assert.Equal(t, 1, len(filters.All), "wrong number of filter values")
 		assert.NoError(t, err, "error occured but none expected")


### PR DESCRIPTION
Up to now: provided explicity via command line argument and also contained in the
step metadata (which are as a file also provided as command line argument).

Now it is retrieved from the metadata file.

closes #952
