### PR TITLE
Separate creating the commit from creating the tag

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -83,6 +83,7 @@ steps:
     sbt:
       filePath: 'sbtDescriptor.json'
       versioningTemplate: '${version}-${timestamp}${commitId?"+"+commitId:""}'
+    tagVersion: true
   batsExecuteTests:
     dockerImage: 'node:8-stretch'
     dockerWorkspace: '/home/node'

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -28,8 +28,7 @@ enum GitPushMode {NONE, HTTPS, SSH}
      */
     'buildTool',
     /**
-     * Controls if the changed version is committed and pushed to the git repository.
-     * If this is enabled (which is the default), you need to provide `gitCredentialsId` and `gitSshUrl`.
+     * Controls if the changed version is committed.
      * @possibleValues `true`, `false`
      */
     'commitVersion',
@@ -84,6 +83,12 @@ enum GitPushMode {NONE, HTTPS, SSH}
      * Defines the prefix which is used for the git tag which is written during the versioning run.
      */
     'tagPrefix',
+    /**
+     * Controls if a tag is created for the version.
+     * If this is enabled (which is the default), you need to provide `gitCredentialsId` and - in case the push is performd ssh -  `gitSshUrl`.
+     * @possibleValues `true`, `false`
+     */
+    'tagVersion',
     /**
      * Defines the timestamp to be used in the automatic version string. You could overwrite the default behavior by explicitly setting this string.
      */
@@ -197,7 +202,16 @@ void call(Map parameters = [:], Closure body = null) {
                     git tag ${config.tagPrefix}${newVersion}"""
                 config.gitCommitId = gitUtils.getGitCommitIdOrNull()
             } catch (e) {
-                error "[${STEP_NAME}]git commit and tag failed: ${e}"
+                error "[${STEP_NAME}]git commit failed: ${e}"
+            }
+        }
+
+        if (config.tagVersion) {
+            try {
+                sh """#!/bin/bash
+                    git tag ${config.tagPrefix}${newVersion}"""
+            } catch (e) {
+                error "[${STEP_NAME}]git tag failed: ${e}"
             }
 
             if(gitPushMode == GitPushMode.SSH) {


### PR DESCRIPTION
With that it possible to have the version changes only local on the build server without having them
contained in the upstream repository and to have a tag for the version which is checked out at the
beginning of the build rather than a tag for the versioning commit which is created on the build
server after checkout.

Test will be adjusted after we have a general consens about that change here.