### PR TITLE
Provide rule for mocking library resource calls

### DIFF
--- a/test/groovy/util/JenkinsLibraryResourceRule.groovy
+++ b/test/groovy/util/JenkinsLibraryResourceRule.groovy
@@ -1,0 +1,38 @@
+package util
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+import com.lesfurets.jenkins.unit.BasePipelineTest
+
+class JenkinsLibraryResourceRule implements TestRule {
+
+    final BasePipelineTest testInstance
+
+    JenkinsLibraryResourceRule(BasePipelineTest testInstance) {
+        this.testInstance = testInstance
+    }
+
+    @Override
+    Statement apply(Statement base, Description description) {
+        return statement(base)
+    }
+
+    private Statement statement(final Statement base) {
+        return new Statement() {
+            @Override
+            void evaluate() throws Throwable {
+                testInstance.helper.registerAllowedMethod("libraryResource", [String], { r ->
+                    File resource = new File(new File('resources'), r)
+                    if(! resource.exists()) {
+                        throw new RuntimeException("Resource '${resource}' not found.")
+                    }
+                    return resource.text
+                })
+
+                base.evaluate()
+            }
+        }
+    }
+}


### PR DESCRIPTION
We will need that rule in the future when migrating steps to go.
For resolving the configuration we need the step metadata which can be loaded via libraryResource.

Just the minimal implementation here, in case we need that we can add registering file, maybe also registering a default resource ...

We are performing a file access to the resources folder. In most cases it is better IMO to mock real file accesses, but here that seems to be justified IMO since we can serve the real resources from our own lib.