### PR TITLE
fix(sonar): run sonar scan in NodeJS container

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -522,7 +522,7 @@ steps:
     toJson: false
     toHtml: false
   sonarExecuteScan:
-    dockerImage: 'maven:3.5-jdk-8'
+    dockerImage: 'node:8-stretch'
     instance: 'SonarCloud'
     options: []
     pullRequestProvider: 'GitHub'

--- a/test/groovy/SonarExecuteScanTest.groovy
+++ b/test/groovy/SonarExecuteScanTest.groovy
@@ -69,7 +69,7 @@ class SonarExecuteScanTest extends BasePiperTest {
         // asserts
         assertThat('Sonar instance is not set to the default value', sonarInstance, is('SonarCloud'))
         assertThat('Sonar project version is not set to the default value', jscr.shell, hasItem(containsString('sonar-scanner -Dsonar.projectVersion=1')))
-        assertThat('Docker image is not set to the default value', jedr.dockerParams.dockerImage, is('maven:3.5-jdk-8'))
+        assertThat('Docker image is not set to the default value', jedr.dockerParams.dockerImage, is('node:8-stretch'))
         assertJobStatusSuccess()
     }
 
@@ -247,7 +247,7 @@ class SonarExecuteScanTest extends BasePiperTest {
         // asserts
         assertThat(jscr.shell, allOf(
             hasItem(containsString('wget --directory-prefix .certificates/ --no-verbose http://url.to/my.cert')),
-            hasItem(containsString('keytool -import -noprompt -storepass changeit -keystore .sonar-scanner/jre/lib/security/cacerts -alias \'my.cert\' -file \'.certificates/my.cert\''))
+            hasItem(containsString('keytool -import -noprompt -storepass changeit -keystore .certificates/cacerts -alias \'my.cert\' -file \'.certificates/my.cert\''))
         ))
         assertJobStatusSuccess()
     }

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -119,7 +119,7 @@ void call(Map parameters = [:]) {
         if(configuration.options instanceof String)
             configuration.options = [].plus(configuration.options)
 
-        loadCertificates(config)
+        loadCertificates(configuration)
 
         def worker = { config ->
             try {

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -119,13 +119,17 @@ void call(Map parameters = [:]) {
         if(configuration.options instanceof String)
             configuration.options = [].plus(configuration.options)
 
+        loadCertificates(config)
+
         def worker = { config ->
             try {
                 withSonarQubeEnv(config.instance) {
 
                         loadSonarScanner(config)
 
-                        loadCertificates(config)
+                        if(fileExists('.certificates/cacerts')){
+                            sh 'mv .certificates/cacerts .sonar-scanner/jre/lib/security/cacerts'
+                        }
 
                         if(config.organization) config.options.add("sonar.organization=${config.organization}")
                         if(config.projectVersion) config.options.add("sonar.projectVersion=${config.projectVersion}")
@@ -222,7 +226,7 @@ private void loadCertificates(Map config) {
         '-import',
         '-noprompt',
         '-storepass changeit',
-        '-keystore .sonar-scanner/jre/lib/security/cacerts'
+        "-keystore ${certificateFolder}cacerts"
     ]
     if (config.customTlsCertificateLinks){
         if(config.verbose){


### PR DESCRIPTION
The SonarJS plugin [requires](https://docs.sonarqube.org/latest/analysis/languages/javascript/) NodeJS 8+ to be installed.

The PR changes the use image to `node:8-stretch` and handle TLS certificates differently to work around the absence of the Java `keytool` in the image.