### PR TITLE
Store instance as property to script binding

### DIFF
--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -230,7 +230,7 @@ class Helper {
 
         new GroovyClassLoader(classLoader, compilerConfig, true)
             .parseClass(new File(projectRoot, 'src/com/sap/piper/ConfigurationHelper.groovy'))
-            .newInstance(script, [:]).loadStepDefaults()
+            .newInstance(script, script, [:]).loadStepDefaults()
     }
 
     static Map getYamlResource(String resource) {

--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -5,14 +5,14 @@ class ConfigurationHelper implements Serializable {
 
     def static SEPARATOR = '/'
 
-    static ConfigurationHelper newInstance(Script step, Map config = [:]) {
-        new ConfigurationHelper(step, config)
+    static ConfigurationHelper newInstance(Script step, Script script, Map config = [:]) {
+        new ConfigurationHelper(step, script, config)
     }
 
     ConfigurationHelper loadStepDefaults(Map compatibleParameters = [:]) {
         DefaultValueCache.prepare(step)
-        this.config = ConfigurationLoader.defaultGeneralConfiguration()
-        mixin(ConfigurationLoader.defaultGeneralConfiguration(), null, compatibleParameters)
+        this.config = ConfigurationLoader.defaultGeneralConfiguration(step)
+        mixin(ConfigurationLoader.defaultGeneralConfiguration(step), null, compatibleParameters)
         mixin(ConfigurationLoader.defaultStepConfiguration(null, name), null, compatibleParameters)
     }
 
@@ -22,9 +22,9 @@ class ConfigurationHelper implements Serializable {
     private Map validationResults = null
     private String dependingOn
 
-    private ConfigurationHelper(Script step, Map config){
+    private ConfigurationHelper(Script step, Script script, Map config){
         this.config = config ?: [:]
-        this.step = step
+        this.step = script
         this.name = step.STEP_NAME
         if(!this.name) throw new IllegalArgumentException('Step has no public name property!')
     }

--- a/src/com/sap/piper/ConfigurationLoader.groovy
+++ b/src/com/sap/piper/ConfigurationLoader.groovy
@@ -27,7 +27,7 @@ class ConfigurationLoader implements Serializable {
     }
 
     static Map defaultGeneralConfiguration(script){
-        return DefaultValueCache.getInstance()?.getDefaultValues()?.general ?: [:]
+            return DefaultValueCache.getInstance(script?.getBinding())?.getDefaultValues()?.general ?: [:]
     }
 
     static Map postActionConfiguration(script, String actionName){
@@ -44,7 +44,7 @@ class ConfigurationLoader implements Serializable {
                 }
 
             case ConfigurationType.DEFAULT_CONFIGURATION:
-                return DefaultValueCache.getInstance()?.getDefaultValues()?.get(type)?.get(entryName) ?: [:]
+                return DefaultValueCache.getInstance(script?.getBinding())?.getDefaultValues()?.get(type)?.get(entryName) ?: [:]
             default:
                 throw new IllegalArgumentException("Unknown configuration type: ${configType}")
         }

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -17,7 +17,7 @@ class DefaultValueCache implements Serializable {
         }
     }
 
-    static getInstance(Binding scriptBinding){
+    static DefaultValueCache getInstance(Binding scriptBinding){
         if (instance) {
             return instance
         }
@@ -53,7 +53,7 @@ class DefaultValueCache implements Serializable {
         return result
     }
 
-    static void prepare(Script workflowScript, Map parameters = [:]) {
+    static void prepare(Script workflow, Map parameters = [:]) {
         if(parameters == null) parameters = [:]
         if(!DefaultValueCache.hasInstance() || parameters.customDefaults) {
             def defaultValues = [:]
@@ -65,13 +65,13 @@ class DefaultValueCache implements Serializable {
             if(customDefaults in List)
                 configFileList += customDefaults
             for (def configFileName : configFileList){
-                if(configFileList.size() > 1) workflowScript.echo "Loading configuration file '${configFileName}'"
-                def configuration = workflowScript.readYaml text: workflowScript.libraryResource(configFileName)
+                if(configFileList.size() > 1) workflow.echo "Loading configuration file '${configFileName}'"
+                def configuration = workflow.readYaml text: workflow.libraryResource(configFileName)
                 defaultValues = MapUtils.merge(
                         MapUtils.pruneNulls(defaultValues),
                         MapUtils.pruneNulls(configuration))
             }
-            DefaultValueCache.createInstance(workflowScript.getBinding(), defaultValues, customDefaults)
+            DefaultValueCache.createInstance(workflow.getBinding(), defaultValues, customDefaults)
         }
     }
 

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -22,15 +22,15 @@ class DefaultValueCache implements Serializable {
             return instance
         }
         if(scriptBinding?.hasVariable("defaultValueCacheInstance")) {
-            Map defaultValues = scriptBinding?.getProperty("defaultValueCacheInstance")
-            return createInstance(scriptBinding, defaultValues)
+            instance = scriptBinding?.getProperty("defaultValueCacheInstance")
+            return instance
         }
     }
 
     static createInstance(Binding scriptBinding, Map defaultValues, List customDefaults = []){
         instance = new DefaultValueCache(defaultValues, customDefaults)
         if(!scriptBinding?.hasVariable("defaultValueCacheInstance")) {
-            scriptBinding?.setProperty("defaultValueCacheInstance", defaultValues)
+            scriptBinding?.setProperty("defaultValueCacheInstance", instance)
         }
         return instance
     }

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -17,17 +17,17 @@ class DefaultValueCache implements Serializable {
         }
     }
 
-    static getInstance(scriptBinding){
+    static getInstance(Binding scriptBinding){
         if (instance) {
             return instance
         }
         if(scriptBinding?.hasVariable("defaultValueCacheInstance")) {
             Map defaultValues = scriptBinding?.getProperty("defaultValueCacheInstance")
-            return createInstance(defaultValues, scriptBinding)
+            return createInstance(scriptBinding, defaultValues)
         }
     }
 
-    static createInstance(Map defaultValues, scriptBinding, List customDefaults = []){
+    static createInstance(Binding scriptBinding, Map defaultValues, List customDefaults = []){
         instance = new DefaultValueCache(defaultValues, customDefaults)
         if(!scriptBinding?.hasVariable("defaultValueCacheInstance")) {
             scriptBinding?.setProperty("defaultValueCacheInstance", defaultValues)
@@ -53,7 +53,7 @@ class DefaultValueCache implements Serializable {
         return result
     }
 
-    static void prepare(Script steps, Map parameters = [:]) {
+    static void prepare(Script workflowScript, Map parameters = [:]) {
         if(parameters == null) parameters = [:]
         if(!DefaultValueCache.hasInstance() || parameters.customDefaults) {
             def defaultValues = [:]
@@ -65,13 +65,13 @@ class DefaultValueCache implements Serializable {
             if(customDefaults in List)
                 configFileList += customDefaults
             for (def configFileName : configFileList){
-                if(configFileList.size() > 1) steps.echo "Loading configuration file '${configFileName}'"
-                def configuration = steps.readYaml text: steps.libraryResource(configFileName)
+                if(configFileList.size() > 1) workflowScript.echo "Loading configuration file '${configFileName}'"
+                def configuration = workflowScript.readYaml text: workflowScript.libraryResource(configFileName)
                 defaultValues = MapUtils.merge(
                         MapUtils.pruneNulls(defaultValues),
                         MapUtils.pruneNulls(configuration))
             }
-            DefaultValueCache.createInstance(defaultValues, steps.getBinding(), customDefaults)
+            DefaultValueCache.createInstance(workflowScript.getBinding(), defaultValues, customDefaults)
         }
     }
 

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -74,11 +74,4 @@ class DefaultValueCache implements Serializable {
             DefaultValueCache.createInstance(workflow.getBinding(), defaultValues, customDefaults)
         }
     }
-
-    @Override
-    public String toString() {
-        return "DefaultValueCache{" +
-            "defaultValues=" + defaultValues +
-            '}'
-    }
 }

--- a/src/com/sap/piper/StepAssertions.groovy
+++ b/src/com/sap/piper/StepAssertions.groovy
@@ -2,7 +2,7 @@ package com.sap.piper
 
 class StepAssertions {
     def static assertFileIsConfiguredAndExists(Script step, Map configuration, String configurationKey) {
-        ConfigurationHelper.newInstance(step, configuration).withMandatoryProperty(configurationKey)
+        ConfigurationHelper.newInstance(step, step, configuration).withMandatoryProperty(configurationKey)
         assertFileExists(step, configuration[configurationKey])
     }
 

--- a/test/groovy/ChecksPublishResultsTest.groovy
+++ b/test/groovy/ChecksPublishResultsTest.groovy
@@ -154,9 +154,7 @@ class ChecksPublishResultsTest extends BasePiperTest {
     @Test
     void testPublishWithChangedStepDefaultSettings() throws Exception {
         // pmd has been set to active: true in step configuration
-        stepRule.step.checksPublishResults(script: [commonPipelineEnvironment: [
-            configuration: [steps: [checksPublishResults: [pmd: [active: true]]]]
-        ]])
+        stepRule.step.checksPublishResults(script: nullScript, pmd: [active: true])
 
         assertTrue("AnalysisPublisher options not set", publisherStepOptions['AnalysisPublisher'] != null)
         assertTrue("PmdPublisher options not set", publisherStepOptions['PmdPublisher'] != null)

--- a/test/groovy/HandlePipelineStepErrorsTest.groovy
+++ b/test/groovy/HandlePipelineStepErrorsTest.groovy
@@ -34,7 +34,7 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
         def isExecuted
         stepRule.step.handlePipelineStepErrors([
             stepName: 'testStep',
-            stepParameters: ['something': 'anything']
+            stepParameters: ['script': nullScript]
         ]) {
             isExecuted = true
         }
@@ -69,7 +69,7 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
         try {
             stepRule.step.handlePipelineStepErrors([
                 stepName: 'testStep',
-                stepParameters: ['something': 'anything']
+                stepParameters: [script: nullScript]
             ]) {
                 throw new Exception('TestError')
             }
@@ -137,7 +137,7 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
         try {
             stepRule.step.handlePipelineStepErrors([
                 stepName: 'test',
-                stepParameters: [jenkinsUtilsStub: jenkinsUtils],
+                stepParameters: [script: nullScript, jenkinsUtilsStub: jenkinsUtils],
                 failOnError: false
             ]) {
                 throw new AbortException('TestError')

--- a/test/groovy/PipelineExecuteTest.groovy
+++ b/test/groovy/PipelineExecuteTest.groovy
@@ -43,7 +43,8 @@ class PipelineExecuteTest extends BasePiperTest {
     @Test
     void straightForwardTest() {
 
-        stepRule.step.pipelineExecute(repoUrl: "https://test.com/myRepo.git")
+        stepRule.step.pipelineExecute(script: nullScript,
+            repoUrl: "https://test.com/myRepo.git")
 
         assert load == "Jenkinsfile"
         assert checkoutParameters.branch == 'master'
@@ -55,7 +56,8 @@ class PipelineExecuteTest extends BasePiperTest {
     @Test
     void parameterizeTest() {
 
-        stepRule.step.pipelineExecute(repoUrl: "https://test.com/anotherRepo.git",
+        stepRule.step.pipelineExecute(script: nullScript,
+                             repoUrl: "https://test.com/anotherRepo.git",
                              branch: 'feature',
                              path: 'path/to/Jenkinsfile',
                              credentialsId: 'abcd1234')
@@ -73,6 +75,6 @@ class PipelineExecuteTest extends BasePiperTest {
         thrown.expect(Exception)
         thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR repoUrl")
 
-        stepRule.step.pipelineExecute()
+        stepRule.step.pipelineExecute(script: nullScript)
     }
 }

--- a/test/groovy/PrepareDefaultValuesTest.groovy
+++ b/test/groovy/PrepareDefaultValuesTest.groovy
@@ -13,6 +13,8 @@ import util.JenkinsStepRule
 
 import util.Rules
 
+import javax.naming.Binding
+
 public class PrepareDefaultValuesTest extends BasePiperTest {
 
     private JenkinsStepRule stepRule = new JenkinsStepRule(this)
@@ -52,7 +54,7 @@ public class PrepareDefaultValuesTest extends BasePiperTest {
     @Test
     public void testReInitializeOnCustomConfig() {
 
-        def instance = DefaultValueCache.createInstance([key:'value'])
+        def instance = DefaultValueCache.createInstance([key:'value'], nullScript.getBinding())
 
         // existing instance is dropped in case a custom config is provided.
         stepRule.step.prepareDefaultValues(script: nullScript, customDefaults: 'custom.yml')
@@ -70,7 +72,7 @@ public class PrepareDefaultValuesTest extends BasePiperTest {
     @Test
     public void testNoReInitializeWithoutCustomConfig() {
 
-        def instance = DefaultValueCache.createInstance([key:'value'])
+        def instance = DefaultValueCache.createInstance([key:'value'], nullScript.getBinding())
 
         stepRule.step.prepareDefaultValues(script: nullScript)
 

--- a/test/groovy/PrepareDefaultValuesTest.groovy
+++ b/test/groovy/PrepareDefaultValuesTest.groovy
@@ -54,7 +54,7 @@ public class PrepareDefaultValuesTest extends BasePiperTest {
     @Test
     public void testReInitializeOnCustomConfig() {
 
-        def instance = DefaultValueCache.createInstance([key:'value'], nullScript.getBinding())
+        def instance = DefaultValueCache.createInstance(nullScript.getBinding(), [key:'value'])
 
         // existing instance is dropped in case a custom config is provided.
         stepRule.step.prepareDefaultValues(script: nullScript, customDefaults: 'custom.yml')
@@ -72,7 +72,7 @@ public class PrepareDefaultValuesTest extends BasePiperTest {
     @Test
     public void testNoReInitializeWithoutCustomConfig() {
 
-        def instance = DefaultValueCache.createInstance([key:'value'], nullScript.getBinding())
+        def instance = DefaultValueCache.createInstance(nullScript.getBinding(), [key:'value'])
 
         stepRule.step.prepareDefaultValues(script: nullScript)
 

--- a/test/groovy/SlackSendNotificationTest.groovy
+++ b/test/groovy/SlackSendNotificationTest.groovy
@@ -30,7 +30,8 @@ class SlackSendNotificationTest extends BasePiperTest {
 
     @Test
     void testNotificationBuildSuccessDefaultChannel() throws Exception {
-        stepRule.step.slackSendNotification(script: [currentBuild: [result: 'SUCCESS']])
+        nullScript.currentBuild = [result: 'SUCCESS']
+        stepRule.step.slackSendNotification(script: nullScript)
         // asserts
         assertEquals('Message not set correctly', 'SUCCESS: Job p <http://build.url|#1>', slackCallMap.message.toString())
         assertNull('Channel not set correctly', slackCallMap.channel)
@@ -40,7 +41,8 @@ class SlackSendNotificationTest extends BasePiperTest {
 
     @Test
     void testNotificationBuildSuccessCustomChannel() throws Exception {
-        stepRule.step.slackSendNotification(script: [currentBuild: [result: 'SUCCCESS']], channel: 'Test')
+        nullScript.currentBuild = [result: 'SUCCCESS']
+        stepRule.step.slackSendNotification(script: nullScript, channel: 'Test')
         // asserts
         assertEquals('Channel not set correctly', 'Test', slackCallMap.channel)
         assertJobStatusSuccess()
@@ -48,7 +50,8 @@ class SlackSendNotificationTest extends BasePiperTest {
 
     @Test
     void testNotificationBuildFailed() throws Exception {
-        stepRule.step.slackSendNotification(script: [currentBuild: [result: 'FAILURE']])
+        nullScript.currentBuild = [result: 'FAILURE']
+        stepRule.step.slackSendNotification(script: nullScript)
         // asserts
         assertEquals('Message not set correctly', 'FAILURE: Job p <http://build.url|#1>', slackCallMap.message.toString())
         assertEquals('Color not set correctly', '#E60000', slackCallMap.color)
@@ -56,7 +59,8 @@ class SlackSendNotificationTest extends BasePiperTest {
 
     @Test
     void testNotificationBuildStatusNull() throws Exception {
-        stepRule.step.slackSendNotification(script: [currentBuild: [:]])
+        nullScript.currentBuild = [:]
+        stepRule.step.slackSendNotification(script: nullScript)
         // asserts
         assertTrue('Missing build status not detected', loggingRule.log.contains('currentBuild.result is not set. Skipping Slack notification'))
         assertJobStatusSuccess()
@@ -64,7 +68,8 @@ class SlackSendNotificationTest extends BasePiperTest {
 
     @Test
     void testNotificationCustomMessageAndColor() throws Exception {
-        stepRule.step.slackSendNotification(script: [currentBuild: [:]], message: 'Custom Message', color: '#AAAAAA')
+        nullScript.currentBuild = [:]
+        stepRule.step.slackSendNotification(script: nullScript, message: 'Custom Message', color: '#AAAAAA')
         // asserts
         assertEquals('Custom message not set correctly', 'Custom Message', slackCallMap.message.toString())
         assertEquals('Custom color not set correctly', '#AAAAAA', slackCallMap.color)
@@ -73,8 +78,9 @@ class SlackSendNotificationTest extends BasePiperTest {
 
     @Test
     void testNotificationWithCustomCredentials() throws Exception {
+        nullScript.currentBuild = [:]
         stepRule.step.slackSendNotification(
-            script: [currentBuild: [:]],
+            script: nullScript,
             message: 'I am no Message',
             baseUrl: 'https://my.base.url',
             credentialsId: 'MY_TOKEN_ID'

--- a/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationHelperTest.groovy
@@ -72,14 +72,14 @@ class ConfigurationHelperTest {
 
     @Test
     void testConfigurationLoaderWithDefaults() {
-        Map config = ConfigurationHelper.newInstance(mockScript, [property1: '27']).use()
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [property1: '27']).use()
         // asserts
         Assert.assertThat(config, hasEntry('property1', '27'))
     }
 
     @Test
     void testConfigurationLoaderWithCustomSettings() {
-        Map config = ConfigurationHelper.newInstance(mockScript, [property1: '27'])
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [property1: '27'])
             .mixin([property1: '41'])
             .use()
         // asserts
@@ -89,7 +89,7 @@ class ConfigurationHelperTest {
     @Test
     void testConfigurationLoaderWithFilteredCustomSettings() {
         Set filter = ['property2']
-        Map config = ConfigurationHelper.newInstance(mockScript, [property1: '27'])
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [property1: '27'])
             .mixin([property1: '41', property2: '28', property3: '29'], filter)
             .use()
         // asserts
@@ -101,7 +101,7 @@ class ConfigurationHelperTest {
     @Test
     void testConfigurationHelperLoadingStepDefaults() {
         Set filter = ['property2']
-        Map config = ConfigurationHelper.newInstance(mockScript, [property1: '27'])
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [property1: '27'])
             .loadStepDefaults()
             .mixinGeneralConfig([configuration:[general: ['general': 'test', 'oldGeneral': 'test2']]], null, [general2: 'oldGeneral'])
             .mixinStageConfig([configuration:[stages:[testStage:['stage': 'test', 'oldStage': 'test2']]]], 'testStage', null, [stage2: 'oldStage'])
@@ -122,7 +122,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testConfigurationHelperAddIfEmpty() {
-        Map config = ConfigurationHelper.newInstance(mockScript, [:])
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [:])
             .mixin([property1: '41', property2: '28', property3: '29', property4: ''])
             .addIfEmpty('property3', '30')
             .addIfEmpty('property4', '40')
@@ -137,7 +137,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testConfigurationHelperAddIfNull() {
-        Map config = ConfigurationHelper.newInstance(mockScript, [:])
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [:])
             .mixin([property1: '29', property2: '', property3: null])
             .addIfNull('property1', '30')
             .addIfNull('property2', '30')
@@ -153,7 +153,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testConfigurationHelperDependingOn() {
-        Map config = ConfigurationHelper.newInstance(mockScript, [:])
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [:])
             .mixin([deep: [deeper: 'test'], scanType: 'maven', maven: [path: 'test2']])
             .dependingOn('scanType').mixin('deep/path')
             .use()
@@ -167,7 +167,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testConfigurationHelperWithPropertyInValues() {
-        ConfigurationHelper.newInstance(mockScript, [:])
+        ConfigurationHelper.newInstance(mockScript, mockScript, [:])
             .mixin([test: 'allowed'])
             .withPropertyInValues('test', ['allowed', 'allowed2'] as Set)
             .use()
@@ -177,7 +177,7 @@ class ConfigurationHelperTest {
     void testConfigurationHelperWithPropertyInValuesException() {
         def errorCaught = false
         try {
-        ConfigurationHelper.newInstance(mockScript, [:])
+        ConfigurationHelper.newInstance(mockScript, mockScript, [:])
             .mixin([test: 'disallowed'])
             .withPropertyInValues('test', ['allowed', 'allowed2'] as Set)
             .use()
@@ -191,7 +191,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testConfigurationLoaderWithBooleanValue() {
-        Map config = ConfigurationHelper.newInstance(mockScript, [property1: '27'])
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [property1: '27'])
             .mixin([property1: false])
             .mixin([property2: false])
             .use()
@@ -202,7 +202,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testConfigurationLoaderWithMixinDependent() {
-        Map config = ConfigurationHelper.newInstance(mockScript, [
+        Map config = ConfigurationHelper.newInstance(mockScript, mockScript, [
                 type: 'maven',
                 maven: [dockerImage: 'mavenImage', dockerWorkspace: 'mavenWorkspace'],
                 npm: [dockerImage: 'npmImage', dockerWorkspace: 'npmWorkspace', executeDocker: true, executeDocker3: false],
@@ -232,7 +232,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testHandleCompatibility() {
-        def configuration = ConfigurationHelper.newInstance(mockScript)
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript)
             .mixin([old1: 'oldValue1', old2: 'oldValue2', test: 'testValue'], null, [newStructure: [new1: 'old1', new2: 'old2']])
             .use()
 
@@ -243,7 +243,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testHandleCompatibilityFlat() {
-        def configuration = ConfigurationHelper.newInstance(mockScript)
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript)
             .mixin([old1: 'oldValue1', old2: 'oldValue2', test: 'testValue'], null, [new1: 'old1', new2: 'old2'])
             .use()
 
@@ -254,7 +254,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testHandleCompatibilityDeep() {
-        def configuration = ConfigurationHelper.newInstance(mockScript)
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript)
             .mixin([old1: 'oldValue1', old2: 'oldValue2', test: 'testValue'], null, [deep:[deeper:[newStructure: [new1: 'old1', new2: 'old2']]]])
             .use()
 
@@ -265,7 +265,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testHandleCompatibilityNewAvailable() {
-        def configuration = ConfigurationHelper.newInstance(mockScript, [old1: 'oldValue1', newStructure: [new1: 'newValue1'], test: 'testValue'])
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript, [old1: 'oldValue1', newStructure: [new1: 'newValue1'], test: 'testValue'])
             .mixin([old1: 'oldValue1', newStructure: [new1: 'newValue1'], test: 'testValue'], null, [newStructure: [new1: 'old1', new2: 'old2']])
             .use()
 
@@ -275,7 +275,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testHandleCompatibilityOldNotSet() {
-        def configuration = ConfigurationHelper.newInstance(mockScript, [old1: null, test: 'testValue'])
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript, [old1: null, test: 'testValue'])
             .mixin([old1: null, test: 'testValue'], null, [newStructure: [new1: 'old1', new2: 'old2']])
             .use()
 
@@ -285,7 +285,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testHandleCompatibilityNoneAvailable() {
-        def configuration = ConfigurationHelper.newInstance(mockScript, [old1: null, test: 'testValue'])
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript, [old1: null, test: 'testValue'])
             .mixin([test: 'testValue'], null, [newStructure: [new1: 'old1', new2: 'old2']])
             .use()
 
@@ -295,7 +295,7 @@ class ConfigurationHelperTest {
 
     @Test
     void testHandleCompatibilityPremigratedValues() {
-        def configuration = ConfigurationHelper.newInstance(mockScript, [old1: null, test: 'testValue'])
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript, [old1: null, test: 'testValue'])
             .mixin([someValueToMigrate: 'testValue2'], null, [someValueToMigrateSecondTime: 'someValueToMigrate', newStructure: [new1: 'old1', new2: 'someValueToMigrateSecondTime']])
             .use()
 
@@ -310,7 +310,7 @@ class ConfigurationHelperTest {
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR myKey')
 
-        ConfigurationHelper.newInstance(mockScript).withMandatoryProperty('myKey')
+        ConfigurationHelper.newInstance(mockScript, mockScript).withMandatoryProperty('myKey')
     }
 
     @Test
@@ -319,22 +319,22 @@ class ConfigurationHelperTest {
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage('My error message')
 
-        ConfigurationHelper.newInstance(mockScript).withMandatoryProperty('myKey', 'My error message')
+        ConfigurationHelper.newInstance(mockScript, mockScript).withMandatoryProperty('myKey', 'My error message')
     }
 
     @Test
     public void testWithMandoryParameterDefaultCustomFailureMessageProvidedSucceeds() {
-        ConfigurationHelper.newInstance(mockScript, [myKey: 'myValue']).withMandatoryProperty('myKey', 'My error message')
+        ConfigurationHelper.newInstance(mockScript, mockScript, [myKey: 'myValue']).withMandatoryProperty('myKey', 'My error message')
     }
 
     @Test
     public void testWithMandoryParameterDefaultCustomFailureMessageNotProvidedSucceeds() {
-        ConfigurationHelper.newInstance(mockScript, [myKey: 'myValue']).withMandatoryProperty('myKey')
+        ConfigurationHelper.newInstance(mockScript, mockScript, [myKey: 'myValue']).withMandatoryProperty('myKey')
     }
 
     @Test
     public void testWithMandoryWithFalseCondition() {
-        ConfigurationHelper.newInstance(mockScript, [verify: false])
+        ConfigurationHelper.newInstance(mockScript, mockScript, [verify: false])
             .withMandatoryProperty('missingKey', null, { c -> return c.get('verify') })
     }
 
@@ -343,20 +343,20 @@ class ConfigurationHelperTest {
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR missingKey')
 
-        ConfigurationHelper.newInstance(mockScript, [verify: true])
+        ConfigurationHelper.newInstance(mockScript, mockScript, [verify: true])
             .withMandatoryProperty('missingKey', null, { c -> return c.get('verify') })
     }
 
     @Test
     public void testWithMandoryWithTrueConditionExistingValue() {
-        ConfigurationHelper.newInstance(mockScript, [existingKey: 'anyValue', verify: true])
+        ConfigurationHelper.newInstance(mockScript, mockScript, [existingKey: 'anyValue', verify: true])
             .withMandatoryProperty('existingKey', null, { c -> return c.get('verify') })
     }
 
     @Test
     public void testTelemetryConfigurationAvailable() {
         Set filter = ['test']
-        def configuration = ConfigurationHelper.newInstance(mockScript, [test: 'testValue'])
+        def configuration = ConfigurationHelper.newInstance(mockScript, mockScript, [test: 'testValue'])
             .mixin([collectTelemetryData: false], filter)
             .use()
 
@@ -378,7 +378,7 @@ class ConfigurationHelperTest {
         assert bGString instanceof GString
         assert cGString instanceof GString
 
-        def config = ConfigurationHelper.newInstance(mockScript, [a: aGString,
+        def config = ConfigurationHelper.newInstance(mockScript, mockScript, [a: aGString,
                                               nextLevel: [b: bGString]])
                      .mixin([c : cGString])
                      .use()
@@ -393,7 +393,7 @@ class ConfigurationHelperTest {
 
     @Test
     public void testWithMandatoryParameterCollectFailuresAllParamtersArePresentResultsInNoExceptionThrown() {
-        ConfigurationHelper.newInstance(mockScript, [myKey1: 'a', myKey2: 'b'])
+        ConfigurationHelper.newInstance(mockScript, mockScript, [myKey1: 'a', myKey2: 'b'])
                                    .collectValidationFailures()
                                    .withMandatoryProperty('myKey1')
                                    .withMandatoryProperty('myKey2')
@@ -402,7 +402,7 @@ class ConfigurationHelperTest {
 
     @Test
     public void testWithMandatoryParameterCollectFailuresMultipleMissingParametersDoNotResultInFailuresDuringWithMandatoryProperties() {
-        ConfigurationHelper.newInstance(mockScript, [:]).collectValidationFailures()
+        ConfigurationHelper.newInstance(mockScript, mockScript, [:]).collectValidationFailures()
                                     .withMandatoryProperty('myKey1')
                                     .withMandatoryProperty('myKey2')
     }
@@ -411,7 +411,7 @@ class ConfigurationHelperTest {
     public void testWithMandatoryParameterCollectFailuresMultipleMissingParametersResultsInFailureDuringUse() {
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR: myKey2, myKey3')
-        ConfigurationHelper.newInstance(mockScript, [myKey1:'a']).collectValidationFailures()
+        ConfigurationHelper.newInstance(mockScript, mockScript, [myKey1:'a']).collectValidationFailures()
                                    .withMandatoryProperty('myKey1')
                                    .withMandatoryProperty('myKey2')
                                    .withMandatoryProperty('myKey3')
@@ -422,7 +422,7 @@ class ConfigurationHelperTest {
     public void testWithMandatoryParameterCollectFailuresOneMissingParametersResultsInFailureDuringUse() {
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR myKey2')
-        ConfigurationHelper.newInstance(mockScript, [myKey1:'a']).collectValidationFailures()
+        ConfigurationHelper.newInstance(mockScript, mockScript, [myKey1:'a']).collectValidationFailures()
                                    .withMandatoryProperty('myKey1')
                                    .withMandatoryProperty('myKey2')
                                    .use()
@@ -433,7 +433,7 @@ class ConfigurationHelperTest {
         Map config = ['key1':'value1']
         Set possibleValues = ['value1', 'value2', 'value3']
 
-        ConfigurationHelper.newInstance(mockScript, config).collectValidationFailures()
+        ConfigurationHelper.newInstance(mockScript, mockScript, config).collectValidationFailures()
                                    .withPropertyInValues('key1', possibleValues)
                                    .use()
     }
@@ -444,7 +444,7 @@ class ConfigurationHelperTest {
         Map config = ['key1':"$value"]
         Set possibleValues = ['value1', 'value2', 'value3']
 
-        ConfigurationHelper.newInstance(mockScript, config).collectValidationFailures()
+        ConfigurationHelper.newInstance(mockScript, mockScript, config).collectValidationFailures()
                                    .withPropertyInValues('key1', possibleValues)
                                    .use()
     }
@@ -454,7 +454,7 @@ class ConfigurationHelperTest {
         Map config = ['key1':3]
         Set possibleValues = [1, 2, 3]
 
-        ConfigurationHelper.newInstance(mockScript, config).collectValidationFailures()
+        ConfigurationHelper.newInstance(mockScript, mockScript, config).collectValidationFailures()
                                    .withPropertyInValues('key1', possibleValues)
                                    .use()
     }

--- a/test/groovy/com/sap/piper/ConfigurationLoaderTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationLoaderTest.groovy
@@ -1,66 +1,83 @@
 package com.sap.piper
 
+import org.junit.After
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 
 class ConfigurationLoaderTest {
 
-    private static getScript() {
+    static def mockScript = new Script() {
+        def commonPipelineEnvironment
+
+        @Override
+        Object run() {
+            return null
+        }
+    }
+
+    @Before
+    void setUp() {
         Map configuration = [:]
         configuration.general = [productiveBranch: 'master']
         configuration.steps = [executeMaven: [dockerImage: 'maven:3.2-jdk-8-onbuild']]
         configuration.stages = [staticCodeChecks: [pmdExcludes: '**']]
         configuration.postActions = [sendEmail: [recipients: 'myEmail']]
 
+        mockScript.commonPipelineEnvironment = [configuration: configuration]
+
         Map defaultConfiguration = [:]
         defaultConfiguration.general = [productiveBranch: 'develop']
         defaultConfiguration.steps = [executeGradle: [dockerImage: 'gradle:4.0.1-jdk8']]
         defaultConfiguration.stages = [staticCodeChecks: [pmdExcludes: '*.java']]
 
-        def pipelineEnvironment = [configuration: configuration]
-        DefaultValueCache.createInstance(defaultConfiguration)
-        return [commonPipelineEnvironment: pipelineEnvironment]
+        DefaultValueCache.createInstance(defaultConfiguration, mockScript.getBinding())
+    }
+
+    @After
+    void tearDown() {
+        DefaultValueCache.reset()
     }
 
     @Test
     void testLoadStepConfiguration() {
-        Map config = ConfigurationLoader.stepConfiguration(getScript(), 'executeMaven')
+        Map config = ConfigurationLoader.stepConfiguration(mockScript, 'executeMaven')
         Assert.assertEquals('maven:3.2-jdk-8-onbuild', config.dockerImage)
     }
 
     @Test
     void testLoadStageConfiguration() {
-        Map config = ConfigurationLoader.stageConfiguration(getScript(), 'staticCodeChecks')
+        Map config = ConfigurationLoader.stageConfiguration(mockScript, 'staticCodeChecks')
         Assert.assertEquals('**', config.pmdExcludes)
     }
 
     @Test
     void testLoadGeneralConfiguration() {
-        Map config = ConfigurationLoader.generalConfiguration(getScript())
+        Map config = ConfigurationLoader.generalConfiguration(mockScript)
         Assert.assertEquals('master', config.productiveBranch)
     }
 
     @Test
     void testLoadDefaultStepConfiguration() {
-        Map config = ConfigurationLoader.defaultStepConfiguration(getScript(), 'executeGradle')
+        Map config = ConfigurationLoader.defaultStepConfiguration(mockScript, 'executeGradle')
         Assert.assertEquals('gradle:4.0.1-jdk8', config.dockerImage)
     }
 
     @Test
     void testLoadDefaultStageConfiguration() {
-        Map config = ConfigurationLoader.defaultStageConfiguration(getScript(), 'staticCodeChecks')
+        Map config = ConfigurationLoader.defaultStageConfiguration(mockScript, 'staticCodeChecks')
         Assert.assertEquals('*.java', config.pmdExcludes)
     }
 
     @Test
     void testLoadDefaultGeneralConfiguration() {
-        Map config = ConfigurationLoader.defaultGeneralConfiguration(getScript())
+        Map config = ConfigurationLoader.defaultGeneralConfiguration(mockScript)
         Assert.assertEquals('develop', config.productiveBranch)
     }
 
     @Test
-    void testLoadPostActionConfiguration(){
-        Map config = ConfigurationLoader.postActionConfiguration(getScript(), 'sendEmail')
+    void testLoadPostActionConfiguration() {
+        Map config = ConfigurationLoader.postActionConfiguration(mockScript, 'sendEmail')
         Assert.assertEquals('myEmail', config.recipients)
     }
 }

--- a/test/groovy/com/sap/piper/ConfigurationLoaderTest.groovy
+++ b/test/groovy/com/sap/piper/ConfigurationLoaderTest.groovy
@@ -31,7 +31,7 @@ class ConfigurationLoaderTest {
         defaultConfiguration.steps = [executeGradle: [dockerImage: 'gradle:4.0.1-jdk8']]
         defaultConfiguration.stages = [staticCodeChecks: [pmdExcludes: '*.java']]
 
-        DefaultValueCache.createInstance(defaultConfiguration, mockScript.getBinding())
+        DefaultValueCache.createInstance(mockScript.getBinding(), defaultConfiguration)
     }
 
     @After

--- a/vars/abapEnvironmentPullGitRepo.groovy
+++ b/vars/abapEnvironmentPullGitRepo.groovy
@@ -73,7 +73,7 @@ void call(Map parameters = [:]) {
     handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters, failOnError: true) {
 
         def script = checkScript(this, parameters) ?: this
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/abapEnvironmentPullGitRepo.groovy
+++ b/vars/abapEnvironmentPullGitRepo.groovy
@@ -73,7 +73,7 @@ void call(Map parameters = [:]) {
     handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters, failOnError: true) {
 
         def script = checkScript(this, parameters) ?: this
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -39,7 +39,6 @@ enum GitPushMode {NONE, HTTPS, SSH}
       * @possibleValues `true`, `false`
       */
     'verbose',
-    ,
     /**
      * Specifies the source to be used for the main version which is used for generating the automatic version.
      * * This can either be the version of the base image - as retrieved from the `FROM` statement within the Dockerfile, e.g. `FROM jenkins:2.46.2`
@@ -137,7 +136,7 @@ void call(Map parameters = [:], Closure body = null) {
         if (script == null)
             script = this
         // load default & individual configuration
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
@@ -202,7 +201,7 @@ void call(Map parameters = [:], Closure body = null) {
 
             if(gitPushMode == GitPushMode.SSH) {
 
-                config = ConfigurationHelper.newInstance(this, config)
+                config = ConfigurationHelper.newInstance(this, script, config)
                     .addIfEmpty('gitSshUrl', isAppContainer(config)
                                 ?script.commonPipelineEnvironment.getAppContainerProperty('gitSshUrl')
                                 :script.commonPipelineEnvironment.getGitSshUrl())
@@ -215,7 +214,7 @@ void call(Map parameters = [:], Closure body = null) {
 
             } else if(gitPushMode == GitPushMode.HTTPS) {
 
-                config = ConfigurationHelper.newInstance(this, config)
+                config = ConfigurationHelper.newInstance(this, script, config)
                     .addIfEmpty('gitSshUrl', isAppContainer(config)
                                 ?script.commonPipelineEnvironment.getAppContainerProperty('gitHttpsUrl')
                                 :script.commonPipelineEnvironment.getGitHttpsUrl())

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -136,7 +136,7 @@ void call(Map parameters = [:], Closure body = null) {
         if (script == null)
             script = this
         // load default & individual configuration
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
@@ -201,7 +201,7 @@ void call(Map parameters = [:], Closure body = null) {
 
             if(gitPushMode == GitPushMode.SSH) {
 
-                config = ConfigurationHelper.newInstance(this, script, config)
+                config = ConfigurationHelper.newInstance(script, this, config)
                     .addIfEmpty('gitSshUrl', isAppContainer(config)
                                 ?script.commonPipelineEnvironment.getAppContainerProperty('gitSshUrl')
                                 :script.commonPipelineEnvironment.getGitSshUrl())
@@ -214,7 +214,7 @@ void call(Map parameters = [:], Closure body = null) {
 
             } else if(gitPushMode == GitPushMode.HTTPS) {
 
-                config = ConfigurationHelper.newInstance(this, script, config)
+                config = ConfigurationHelper.newInstance(script, this, config)
                     .addIfEmpty('gitSshUrl', isAppContainer(config)
                                 ?script.commonPipelineEnvironment.getAppContainerProperty('gitHttpsUrl')
                                 :script.commonPipelineEnvironment.getGitHttpsUrl())

--- a/vars/batsExecuteTests.groovy
+++ b/vars/batsExecuteTests.groovy
@@ -62,7 +62,7 @@ void call(Map parameters = [:]) {
 
         def script = checkScript(this, parameters) ?: this
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/batsExecuteTests.groovy
+++ b/vars/batsExecuteTests.groovy
@@ -62,7 +62,7 @@ void call(Map parameters = [:]) {
 
         def script = checkScript(this, parameters) ?: this
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -54,7 +54,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         // handle deprecated parameters
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
@@ -83,7 +83,7 @@ void call(Map parameters = [:]) {
                     echo "[${STEP_NAME}] No Docker daemon available, thus switching to Kaniko build"
                 }
 
-                ConfigurationHelper.newInstance(this, config)
+                ConfigurationHelper.newInstance(this, script, config)
                     .withMandatoryProperty('dockerImageName')
                     .withMandatoryProperty('dockerImageTag')
 

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -54,7 +54,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         // handle deprecated parameters
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
@@ -83,7 +83,7 @@ void call(Map parameters = [:]) {
                     echo "[${STEP_NAME}] No Docker daemon available, thus switching to Kaniko build"
                 }
 
-                ConfigurationHelper.newInstance(this, script, config)
+                ConfigurationHelper.newInstance(script, this, config)
                     .withMandatoryProperty('dockerImageName')
                     .withMandatoryProperty('dockerImageTag')
 

--- a/vars/cfManifestSubstituteVariables.groovy
+++ b/vars/cfManifestSubstituteVariables.groovy
@@ -74,7 +74,7 @@ void call(Map arguments = [:]) {
         def script = checkScript(this, arguments)  ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
                                         .loadStepDefaults()
                                         .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
                                         .mixinStageConfig(script.commonPipelineEnvironment, arguments.stageName ?: env.STAGE_NAME, STEP_CONFIG_KEYS)

--- a/vars/cfManifestSubstituteVariables.groovy
+++ b/vars/cfManifestSubstituteVariables.groovy
@@ -74,7 +74,7 @@ void call(Map arguments = [:]) {
         def script = checkScript(this, arguments)  ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
                                         .loadStepDefaults()
                                         .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
                                         .mixinStageConfig(script.commonPipelineEnvironment, arguments.stageName ?: env.STAGE_NAME, STEP_CONFIG_KEYS)

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -89,7 +89,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters?.cmUtils ?: new ChangeManagement(script, gitUtils)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/checkChangeInDevelopment.groovy
+++ b/vars/checkChangeInDevelopment.groovy
@@ -89,7 +89,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters?.cmUtils ?: new ChangeManagement(script, gitUtils)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/checksPublishResults.groovy
+++ b/vars/checksPublishResults.groovy
@@ -72,7 +72,7 @@ void call(Map parameters = [:]) {
         prepare(parameters)
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/checksPublishResults.groovy
+++ b/vars/checksPublishResults.groovy
@@ -72,7 +72,7 @@ void call(Map parameters = [:]) {
         prepare(parameters)
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/cloudFoundryCreateService.groovy
+++ b/vars/cloudFoundryCreateService.groovy
@@ -93,7 +93,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/cloudFoundryCreateService.groovy
+++ b/vars/cloudFoundryCreateService.groovy
@@ -93,7 +93,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/cloudFoundryCreateServiceKey.groovy
+++ b/vars/cloudFoundryCreateServiceKey.groovy
@@ -65,7 +65,7 @@ void call(Map parameters = [:]) {
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
 
         def script = checkScript(this, parameters) ?: this
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/cloudFoundryCreateServiceKey.groovy
+++ b/vars/cloudFoundryCreateServiceKey.groovy
@@ -65,7 +65,7 @@ void call(Map parameters = [:]) {
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
 
         def script = checkScript(this, parameters) ?: this
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -176,7 +176,7 @@ void call(Map parameters = [:]) {
 
         final script = checkScript(this, parameters) ?: this
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
@@ -236,7 +236,7 @@ void call(Map parameters = [:]) {
 
 private void handleMTADeployment(Map config, script) {
     // set default mtar path
-    config = ConfigurationHelper.newInstance(this, config)
+    config = ConfigurationHelper.newInstance(this, script, config)
         .addIfEmpty('mtaPath', config.mtaPath ?: findMtar())
         .use()
 

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -176,7 +176,7 @@ void call(Map parameters = [:]) {
 
         final script = checkScript(this, parameters) ?: this
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
@@ -236,7 +236,7 @@ void call(Map parameters = [:]) {
 
 private void handleMTADeployment(Map config, script) {
     // set default mtar path
-    config = ConfigurationHelper.newInstance(this, script, config)
+    config = ConfigurationHelper.newInstance(script, this, config)
         .addIfEmpty('mtaPath', config.mtaPath ?: findMtar())
         .use()
 

--- a/vars/containerExecuteStructureTests.groovy
+++ b/vars/containerExecuteStructureTests.groovy
@@ -85,7 +85,7 @@ void call(Map parameters = [:]) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/containerExecuteStructureTests.groovy
+++ b/vars/containerExecuteStructureTests.groovy
@@ -85,7 +85,7 @@ void call(Map parameters = [:]) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/containerPushToRegistry.groovy
+++ b/vars/containerPushToRegistry.groovy
@@ -57,7 +57,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/containerPushToRegistry.groovy
+++ b/vars/containerPushToRegistry.groovy
@@ -57,7 +57,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/detectExecuteScan.groovy
+++ b/vars/detectExecuteScan.groovy
@@ -87,7 +87,7 @@ void call(Map parameters = [:]) {
         def script = checkScript(this, parameters) ?: this
         def utils = parameters.juStabUtils ?: new Utils()
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS,CONFIG_KEY_COMPATIBILITY)

--- a/vars/detectExecuteScan.groovy
+++ b/vars/detectExecuteScan.groovy
@@ -87,7 +87,7 @@ void call(Map parameters = [:]) {
         def script = checkScript(this, parameters) ?: this
         def utils = parameters.juStabUtils ?: new Utils()
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS,CONFIG_KEY_COMPATIBILITY)

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -121,7 +121,7 @@ void call(Map parameters = [:], body) {
 
         def utils = parameters?.juStabUtils ?: new Utils()
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -121,7 +121,7 @@ void call(Map parameters = [:], body) {
 
         def utils = parameters?.juStabUtils ?: new Utils()
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -174,7 +174,7 @@ void call(Map parameters = [:], body) {
 
         def utils = parameters?.juStabUtils ?: new Utils()
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -174,7 +174,7 @@ void call(Map parameters = [:], body) {
 
         def utils = parameters?.juStabUtils ?: new Utils()
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/dubExecute.groovy
+++ b/vars/dubExecute.groovy
@@ -41,7 +41,7 @@ void call(Map parameters = [:], body = null) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/dubExecute.groovy
+++ b/vars/dubExecute.groovy
@@ -41,7 +41,7 @@ void call(Map parameters = [:], body = null) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/gaugeExecuteTests.groovy
+++ b/vars/gaugeExecuteTests.groovy
@@ -95,7 +95,7 @@ void call(Map parameters = [:]) {
         InfluxData.addField('step_data', 'gauge', false)
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, STEP_CONFIG_KEYS)

--- a/vars/gaugeExecuteTests.groovy
+++ b/vars/gaugeExecuteTests.groovy
@@ -95,7 +95,7 @@ void call(Map parameters = [:]) {
         InfluxData.addField('step_data', 'gauge', false)
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, STEP_CONFIG_KEYS)

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -49,7 +49,7 @@ void call(Map parameters = [:]) {
         final utils = parameters.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -49,7 +49,7 @@ void call(Map parameters = [:]) {
         final utils = parameters.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -9,6 +9,8 @@ import hudson.AbortException
 
 import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 
+import static com.sap.piper.Prerequisites.checkScript
+
 @Field STEP_NAME = getClass().getName()
 
 @Field Set GENERAL_CONFIG_KEYS = []
@@ -49,9 +51,12 @@ import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
  */
 @GenerateDocumentation
 void call(Map parameters = [:], body) {
+
+    def script = checkScript(this, parameters.stepParameters) ?: this
+
     // load default & individual configuration
     def cpe = parameters.stepParameters?.script?.commonPipelineEnvironment ?: null
-    Map config = ConfigurationHelper.newInstance(this, parameters.stepParameters?.script)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(cpe, GENERAL_CONFIG_KEYS)
         .mixinStepConfig(cpe, STEP_CONFIG_KEYS)

--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -51,7 +51,7 @@ import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 void call(Map parameters = [:], body) {
     // load default & individual configuration
     def cpe = parameters.stepParameters?.script?.commonPipelineEnvironment ?: null
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, parameters.stepParameters?.script)
         .loadStepDefaults()
         .mixinGeneralConfig(cpe, GENERAL_CONFIG_KEYS)
         .mixinStepConfig(cpe, STEP_CONFIG_KEYS)

--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -56,7 +56,7 @@ void call(Map parameters = [:], body) {
 
     // load default & individual configuration
     def cpe = parameters.stepParameters?.script?.commonPipelineEnvironment ?: null
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(cpe, GENERAL_CONFIG_KEYS)
         .mixinStepConfig(cpe, STEP_CONFIG_KEYS)

--- a/vars/healthExecuteCheck.groovy
+++ b/vars/healthExecuteCheck.groovy
@@ -40,7 +40,7 @@ void call(Map parameters = [:]) {
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
         def script = checkScript(this, parameters) ?: this
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment,  GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/healthExecuteCheck.groovy
+++ b/vars/healthExecuteCheck.groovy
@@ -40,7 +40,7 @@ void call(Map parameters = [:]) {
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
         def script = checkScript(this, parameters) ?: this
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment,  GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/influxWriteData.groovy
+++ b/vars/influxWriteData.groovy
@@ -75,7 +75,7 @@ void call(Map parameters = [:]) {
             script = this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/influxWriteData.groovy
+++ b/vars/influxWriteData.groovy
@@ -75,7 +75,7 @@ void call(Map parameters = [:]) {
             script = this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/kanikoExecute.groovy
+++ b/vars/kanikoExecute.groovy
@@ -59,7 +59,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/kanikoExecute.groovy
+++ b/vars/kanikoExecute.groovy
@@ -59,7 +59,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/karmaExecuteTests.groovy
+++ b/vars/karmaExecuteTests.groovy
@@ -79,7 +79,7 @@ void call(Map parameters = [:]) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/karmaExecuteTests.groovy
+++ b/vars/karmaExecuteTests.groovy
@@ -79,7 +79,7 @@ void call(Map parameters = [:]) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/mailSendNotification.groovy
+++ b/vars/mailSendNotification.groovy
@@ -80,7 +80,7 @@ void call(Map parameters = [:]) {
         def script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/mailSendNotification.groovy
+++ b/vars/mailSendNotification.groovy
@@ -80,7 +80,7 @@ void call(Map parameters = [:]) {
         def script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/mavenExecute.groovy
+++ b/vars/mavenExecute.groovy
@@ -49,7 +49,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/mavenExecute.groovy
+++ b/vars/mavenExecute.groovy
@@ -49,7 +49,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -66,7 +66,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/mtaBuild.groovy
+++ b/vars/mtaBuild.groovy
@@ -66,7 +66,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/multicloudDeploy.groovy
+++ b/vars/multicloudDeploy.groovy
@@ -45,7 +45,7 @@ void call(parameters = [:]) {
         def utils = parameters.utils ?: new Utils()
         def jenkinsUtils = parameters.jenkinsUtils ?: new JenkinsUtils()
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixin(parameters, PARAMETER_KEYS)

--- a/vars/multicloudDeploy.groovy
+++ b/vars/multicloudDeploy.groovy
@@ -45,7 +45,7 @@ void call(parameters = [:]) {
         def utils = parameters.utils ?: new Utils()
         def jenkinsUtils = parameters.jenkinsUtils ?: new JenkinsUtils()
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixin(parameters, PARAMETER_KEYS)

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -122,7 +122,7 @@ void call(parameters = [:]) {
         def utils = parameters.utils ?: new Utils()
 
         // load default & individual configuration
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
@@ -223,7 +223,7 @@ private deploy(script, Map configuration, NeoCommandHelper neoCommandHelper, doc
         sh "mkdir -p ${logFolder}"
         withEnv(["neo_logging_location=${pwd()}/${logFolder}"]) {
             if (deployMode.isWarDeployment()) {
-                ConfigurationHelper.newInstance(this, configuration).withPropertyInValues('warAction', WarAction.stringValues())
+                ConfigurationHelper.newInstance(this, script, configuration).withPropertyInValues('warAction', WarAction.stringValues())
                 WarAction warAction = WarAction.fromString(configuration.warAction)
 
                 if (warAction == WarAction.ROLLING_UPDATE) {

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -122,7 +122,7 @@ void call(parameters = [:]) {
         def utils = parameters.utils ?: new Utils()
 
         // load default & individual configuration
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
@@ -223,7 +223,7 @@ private deploy(script, Map configuration, NeoCommandHelper neoCommandHelper, doc
         sh "mkdir -p ${logFolder}"
         withEnv(["neo_logging_location=${pwd()}/${logFolder}"]) {
             if (deployMode.isWarDeployment()) {
-                ConfigurationHelper.newInstance(this, script, configuration).withPropertyInValues('warAction', WarAction.stringValues())
+                ConfigurationHelper.newInstance(script, this, configuration).withPropertyInValues('warAction', WarAction.stringValues())
                 WarAction warAction = WarAction.fromString(configuration.warAction)
 
                 if (warAction == WarAction.ROLLING_UPDATE) {

--- a/vars/newmanExecute.groovy
+++ b/vars/newmanExecute.groovy
@@ -81,7 +81,7 @@ void call(Map parameters = [:]) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/newmanExecute.groovy
+++ b/vars/newmanExecute.groovy
@@ -81,7 +81,7 @@ void call(Map parameters = [:]) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/npmExecute.groovy
+++ b/vars/npmExecute.groovy
@@ -41,7 +41,7 @@ void call(Map parameters = [:], body = null) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/npmExecute.groovy
+++ b/vars/npmExecute.groovy
@@ -41,7 +41,7 @@ void call(Map parameters = [:], body = null) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/pipelineExecute.groovy
+++ b/vars/pipelineExecute.groovy
@@ -42,7 +42,7 @@ void call(Map parameters = [:]) {
 
         handlePipelineStepErrors (stepName: 'pipelineExecute', stepParameters: parameters, failOnError: true) {
 
-            ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+            ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, this)
                 .loadStepDefaults()
                 .mixin(parameters, PARAMETER_KEYS)
                 .withMandatoryProperty('repoUrl')

--- a/vars/pipelineExecute.groovy
+++ b/vars/pipelineExecute.groovy
@@ -1,3 +1,5 @@
+import static com.sap.piper.Prerequisites.checkScript
+
 import com.sap.piper.GenerateDocumentation
 import com.sap.piper.ConfigurationHelper
 
@@ -41,8 +43,9 @@ void call(Map parameters = [:]) {
         Map config
 
         handlePipelineStepErrors (stepName: 'pipelineExecute', stepParameters: parameters, failOnError: true) {
+            def script = checkScript(this, parameters) ?: this
 
-            ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, this)
+            ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
                 .loadStepDefaults()
                 .mixin(parameters, PARAMETER_KEYS)
                 .withMandatoryProperty('repoUrl')

--- a/vars/pipelineRestartSteps.groovy
+++ b/vars/pipelineRestartSteps.groovy
@@ -43,7 +43,7 @@ void call(Map parameters = [:], body) {
         def script = checkScript(this, parameters) ?: this
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/pipelineRestartSteps.groovy
+++ b/vars/pipelineRestartSteps.groovy
@@ -43,7 +43,7 @@ void call(Map parameters = [:], body) {
         def script = checkScript(this, parameters) ?: this
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/pipelineStashFilesAfterBuild.groovy
+++ b/vars/pipelineStashFilesAfterBuild.groovy
@@ -44,7 +44,7 @@ void call(Map parameters = [:]) {
         //additional includes via passing e.g. stashIncludes: [opa5: '**/*.include']
         //additional excludes via passing e.g. stashExcludes: [opa5: '**/*.exclude']
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/pipelineStashFilesAfterBuild.groovy
+++ b/vars/pipelineStashFilesAfterBuild.groovy
@@ -44,7 +44,7 @@ void call(Map parameters = [:]) {
         //additional includes via passing e.g. stashIncludes: [opa5: '**/*.include']
         //additional excludes via passing e.g. stashExcludes: [opa5: '**/*.exclude']
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/pipelineStashFilesBeforeBuild.groovy
+++ b/vars/pipelineStashFilesBeforeBuild.groovy
@@ -42,7 +42,7 @@ void call(Map parameters = [:]) {
         if (script == null)
             script = this
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/pipelineStashFilesBeforeBuild.groovy
+++ b/vars/pipelineStashFilesBeforeBuild.groovy
@@ -42,7 +42,7 @@ void call(Map parameters = [:]) {
         if (script == null)
             script = this
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/piperInitRunStageConfiguration.groovy
+++ b/vars/piperInitRunStageConfiguration.groovy
@@ -35,7 +35,7 @@ void call(Map parameters = [:]) {
     script.commonPipelineEnvironment.configuration.runStep = [:]
 
     // load default & individual configuration
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/piperInitRunStageConfiguration.groovy
+++ b/vars/piperInitRunStageConfiguration.groovy
@@ -35,7 +35,7 @@ void call(Map parameters = [:]) {
     script.commonPipelineEnvironment.configuration.runStep = [:]
 
     // load default & individual configuration
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageAcceptance.groovy
+++ b/vars/piperPipelineStageAcceptance.groovy
@@ -46,7 +46,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageAcceptance.groovy
+++ b/vars/piperPipelineStageAcceptance.groovy
@@ -46,7 +46,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageAdditionalUnitTests.groovy
+++ b/vars/piperPipelineStageAdditionalUnitTests.groovy
@@ -31,7 +31,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageAdditionalUnitTests.groovy
+++ b/vars/piperPipelineStageAdditionalUnitTests.groovy
@@ -31,7 +31,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageBuild.groovy
+++ b/vars/piperPipelineStageBuild.groovy
@@ -40,7 +40,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageBuild.groovy
+++ b/vars/piperPipelineStageBuild.groovy
@@ -40,7 +40,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageCompliance.groovy
+++ b/vars/piperPipelineStageCompliance.groovy
@@ -25,7 +25,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageCompliance.groovy
+++ b/vars/piperPipelineStageCompliance.groovy
@@ -25,7 +25,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageConfirm.groovy
+++ b/vars/piperPipelineStageConfirm.groovy
@@ -34,7 +34,7 @@ void call(Map parameters = [:]) {
     def script = checkScript(this, parameters) ?: this
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageConfirm.groovy
+++ b/vars/piperPipelineStageConfirm.groovy
@@ -34,7 +34,7 @@ void call(Map parameters = [:]) {
     def script = checkScript(this, parameters) ?: this
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -50,7 +50,7 @@ void call(Map parameters = [:]) {
 
         setupCommonPipelineEnvironment script: script, customDefaults: parameters.customDefaults
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -50,7 +50,7 @@ void call(Map parameters = [:]) {
 
         setupCommonPipelineEnvironment script: script, customDefaults: parameters.customDefaults
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -24,7 +24,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -24,7 +24,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePRVoting.groovy
+++ b/vars/piperPipelineStagePRVoting.groovy
@@ -73,7 +73,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePRVoting.groovy
+++ b/vars/piperPipelineStagePRVoting.groovy
@@ -73,7 +73,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePerformance.groovy
+++ b/vars/piperPipelineStagePerformance.groovy
@@ -25,7 +25,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePerformance.groovy
+++ b/vars/piperPipelineStagePerformance.groovy
@@ -25,7 +25,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePost.groovy
+++ b/vars/piperPipelineStagePost.groovy
@@ -29,7 +29,7 @@ void call(Map parameters = [:]) {
     def stageName = parameters.stageName?:env.STAGE_NAME
     // ease handling extension
     stageName = stageName.replace('Declarative: ', '')
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePost.groovy
+++ b/vars/piperPipelineStagePost.groovy
@@ -29,7 +29,7 @@ void call(Map parameters = [:]) {
     def stageName = parameters.stageName?:env.STAGE_NAME
     // ease handling extension
     stageName = stageName.replace('Declarative: ', '')
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePromote.groovy
+++ b/vars/piperPipelineStagePromote.groovy
@@ -27,7 +27,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStagePromote.groovy
+++ b/vars/piperPipelineStagePromote.groovy
@@ -27,7 +27,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageRelease.groovy
+++ b/vars/piperPipelineStageRelease.groovy
@@ -34,7 +34,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageRelease.groovy
+++ b/vars/piperPipelineStageRelease.groovy
@@ -34,7 +34,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageSecurity.groovy
+++ b/vars/piperPipelineStageSecurity.groovy
@@ -27,7 +27,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPipelineStageSecurity.groovy
+++ b/vars/piperPipelineStageSecurity.groovy
@@ -27,7 +27,7 @@ void call(Map parameters = [:]) {
 
     def stageName = parameters.stageName?:env.STAGE_NAME
 
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)

--- a/vars/piperPublishWarnings.groovy
+++ b/vars/piperPublishWarnings.groovy
@@ -58,7 +58,7 @@ void call(Map parameters = [:]) {
         }
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/piperPublishWarnings.groovy
+++ b/vars/piperPublishWarnings.groovy
@@ -58,7 +58,7 @@ void call(Map parameters = [:]) {
         }
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -16,7 +16,7 @@ void call(Map parameters = [:], body) {
     def stageName = parameters.stageName?:env.STAGE_NAME
 
     // load default & individual configuration
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixin(ConfigurationLoader.defaultStageConfiguration(this, stageName))
         .mixinGeneralConfig(script.commonPipelineEnvironment)

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -16,7 +16,7 @@ void call(Map parameters = [:], body) {
     def stageName = parameters.stageName?:env.STAGE_NAME
 
     // load default & individual configuration
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixin(ConfigurationLoader.defaultStageConfiguration(this, stageName))
         .mixinGeneralConfig(script.commonPipelineEnvironment)

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -16,5 +16,5 @@ import groovy.transform.Field
  */
 @GenerateDocumentation
 void call(Map parameters = [:]) {
-    DefaultValueCache.prepare(this, parameters)
+    DefaultValueCache.prepare(parameters.script ?: this, parameters)
 }

--- a/vars/seleniumExecuteTests.groovy
+++ b/vars/seleniumExecuteTests.groovy
@@ -82,7 +82,7 @@ void call(Map parameters = [:], Closure body) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/seleniumExecuteTests.groovy
+++ b/vars/seleniumExecuteTests.groovy
@@ -82,7 +82,7 @@ void call(Map parameters = [:], Closure body) {
         def utils = parameters?.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -31,9 +31,9 @@ import groovy.transform.Field
 @GenerateDocumentation
 void call(Map parameters = [:]) {
 
-    handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
+    def script = checkScript(this, parameters)
+    handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters, script: script) {
 
-        def script = checkScript(this, parameters)
 
         prepareDefaultValues script: script, customDefaults: parameters.customDefaults
 
@@ -41,7 +41,7 @@ void call(Map parameters = [:]) {
 
         loadConfigurationFromFile(script, configFile)
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .use()

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -41,7 +41,7 @@ void call(Map parameters = [:]) {
 
         loadConfigurationFromFile(script, configFile)
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .use()

--- a/vars/slackSendNotification.groovy
+++ b/vars/slackSendNotification.groovy
@@ -53,7 +53,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         def script = checkScript(this, parameters) ?: this
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/slackSendNotification.groovy
+++ b/vars/slackSendNotification.groovy
@@ -53,7 +53,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         def script = checkScript(this, parameters) ?: this
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/snykExecute.groovy
+++ b/vars/snykExecute.groovy
@@ -70,7 +70,7 @@ void call(Map parameters = [:]) {
 
         def script = checkScript(this, parameters) ?: this
 
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/snykExecute.groovy
+++ b/vars/snykExecute.groovy
@@ -70,7 +70,7 @@ void call(Map parameters = [:]) {
 
         def script = checkScript(this, parameters) ?: this
 
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -101,7 +101,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         def script = checkScript(this, parameters) ?: this
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -101,7 +101,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
         def script = checkScript(this, parameters) ?: this
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/spinnakerTriggerPipeline.groovy
+++ b/vars/spinnakerTriggerPipeline.groovy
@@ -86,7 +86,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults(CONFIG_KEY_COMPATIBILITY)
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/spinnakerTriggerPipeline.groovy
+++ b/vars/spinnakerTriggerPipeline.groovy
@@ -86,7 +86,7 @@ void call(Map parameters = [:]) {
         final script = checkScript(this, parameters) ?: this
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults(CONFIG_KEY_COMPATIBILITY)
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/testsPublishResults.groovy
+++ b/vars/testsPublishResults.groovy
@@ -55,7 +55,7 @@ void call(Map parameters = [:]) {
         prepare(parameters)
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this)
+        Map configuration = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/testsPublishResults.groovy
+++ b/vars/testsPublishResults.groovy
@@ -55,7 +55,7 @@ void call(Map parameters = [:]) {
         prepare(parameters)
 
         // load default & individual configuration
-        Map configuration = ConfigurationHelper.newInstance(this, script)
+        Map configuration = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/tmsUpload.groovy
+++ b/vars/tmsUpload.groovy
@@ -64,7 +64,7 @@ void call(Map parameters = [:]) {
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/tmsUpload.groovy
+++ b/vars/tmsUpload.groovy
@@ -64,7 +64,7 @@ void call(Map parameters = [:]) {
         def jenkinsUtils = parameters.jenkinsUtilsStub ?: new JenkinsUtils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -125,7 +125,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .collectValidationFailures()
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -125,7 +125,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .collectValidationFailures()
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -82,7 +82,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -82,7 +82,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -111,7 +111,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -111,7 +111,7 @@ void call(parameters = [:]) {
 
         ChangeManagement cm = parameters.cmUtils ?: new ChangeManagement(script)
 
-        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(this, script)
+        ConfigurationHelper configHelper = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/uiVeri5ExecuteTests.groovy
+++ b/vars/uiVeri5ExecuteTests.groovy
@@ -91,7 +91,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/uiVeri5ExecuteTests.groovy
+++ b/vars/uiVeri5ExecuteTests.groovy
@@ -91,7 +91,7 @@ void call(Map parameters = [:]) {
         def utils = parameters.juStabUtils ?: new Utils()
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults()
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)

--- a/vars/whitesourceExecuteScan.groovy
+++ b/vars/whitesourceExecuteScan.groovy
@@ -238,7 +238,7 @@ void call(Map parameters = [:]) {
         }
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this)
+        Map config = ConfigurationHelper.newInstance(this, script)
             .loadStepDefaults(CONFIG_KEY_COMPATIBILITY)
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/whitesourceExecuteScan.groovy
+++ b/vars/whitesourceExecuteScan.groovy
@@ -238,7 +238,7 @@ void call(Map parameters = [:]) {
         }
 
         // load default & individual configuration
-        Map config = ConfigurationHelper.newInstance(this, script)
+        Map config = ConfigurationHelper.newInstance(script, this)
             .loadStepDefaults(CONFIG_KEY_COMPATIBILITY)
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS, CONFIG_KEY_COMPATIBILITY)

--- a/vars/xsDeploy.groovy
+++ b/vars/xsDeploy.groovy
@@ -96,7 +96,7 @@ void call(Map parameters = [:]) {
             Map projectConfig = readJSON (text: sh(returnStdout: true, script: projectConfigScript))
             Map contextConfig = readJSON (text: sh(returnStdout: true, script: contextConfigScript))
 
-            Map options = getOptions(parameters, projectConfig, contextConfig, script.commonPipelineEnvironment)
+            Map options = getOptions(script, parameters, projectConfig, contextConfig, script.commonPipelineEnvironment)
 
             Action action = options.action
             DeployMode mode = options.mode
@@ -194,10 +194,10 @@ String joinAndQuote(List l, String prefix = '') {
    3.) project config (nested inside docker node)
    4.) context config (if applicable (docker))
 */
-Map getOptions(Map parameters, Map projectConfig, Map contextConfig, def cpe) {
+Map getOptions(Script script, Map parameters, Map projectConfig, Map contextConfig, def cpe) {
 
     Set configKeys = ['docker', 'mode', 'action', 'dockerImage', 'dockerPullImage']
-    Map config = ConfigurationHelper.newInstance(this)
+    Map config = ConfigurationHelper.newInstance(this, script)
         .loadStepDefaults()
         .mixinGeneralConfig(cpe, configKeys)
         .mixinStepConfig(cpe, configKeys)

--- a/vars/xsDeploy.groovy
+++ b/vars/xsDeploy.groovy
@@ -1,13 +1,7 @@
 import static com.sap.piper.Prerequisites.checkScript
 
 import com.sap.piper.ConfigurationHelper
-
-import com.sap.piper.DefaultValueCache
-import com.sap.piper.JenkinsUtils
 import com.sap.piper.PiperGoUtils
-
-
-import com.sap.piper.GenerateDocumentation
 import com.sap.piper.Utils
 
 import groovy.transform.Field
@@ -197,7 +191,7 @@ String joinAndQuote(List l, String prefix = '') {
 Map getOptions(Script script, Map parameters, Map projectConfig, Map contextConfig, def cpe) {
 
     Set configKeys = ['docker', 'mode', 'action', 'dockerImage', 'dockerPullImage']
-    Map config = ConfigurationHelper.newInstance(this, script)
+    Map config = ConfigurationHelper.newInstance(script, this)
         .loadStepDefaults()
         .mixinGeneralConfig(cpe, configKeys)
         .mixinStepConfig(cpe, configKeys)


### PR DESCRIPTION
For us not to lose the instance when the pipeline is stopped we store its
values away in the script. If there is no instance but the respective
property is set, we create an instance with the values that were stored
away previously.
This means we need to give the script binding to the DefaultValueCache
class to store the default values from the instance in its binding.

Trying to solve #1050 and #788. Pipeline of the @kaylinche found [here](https://github.com/SAP/jenkins-library/files/3386403/Jenkinsfile.txt) works now (just need to use new getInstance method: DefaultValueCache.getInstance(this.getBinding())).

# Changes

- [x] Tests
- [x] Documentation
