### PR TITLE
archive CF CLI trace output instead of printing

### DIFF
--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -788,8 +788,8 @@ class CloudFoundryDeployTest extends BasePiperTest {
         helper.registerAllowedMethod("archiveArtifacts", [Map.class], {
             map ->
                 archiveCliTraceOutput = true
-                Assert.assertEquals('cf.log'.toString() , map.artifacts.toString())
-                Assert.assertEquals(true , map.allowEmptyArchive)
+                assertEquals('cf.log'.toString() , map.artifacts.toString())
+                assertEquals(true , map.allowEmptyArchive)
         })
 
 

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -434,18 +434,15 @@ private deploy(def cfApiStatement, def cfDeployStatement, def config, Closure po
 
         if(config.verbose || returnCode != 0) {
             if(fileExists(file: cfTraceFile)) {
-                echo  '### START OF CF CLI TRACE OUTPUT ###'
-                // Would be nice to inline the two next lines, but that is not understood by the test framework
-                def cfTrace =  readFile(file: cfTraceFile)
-                echo cfTrace
-                echo '### END OF CF CLI TRACE OUTPUT ###'
+                echo  '### ARCHIVE CLI TRACE OUTPUT FILE ###'
+                archiveArtifacts artifacts: cfTraceFile, allowEmptyArchive: true
             } else {
                 echo "No trace file found at '${cfTraceFile}'"
             }
         }
 
         if(returnCode != 0){
-            error "[${STEP_NAME}] ERROR: The execution of the deploy command failed, see the log for details."
+            error "[${STEP_NAME}] ERROR: The execution of the deploy command failed, see the trace output file for details."
         }
 
         if(postDeployAction) postDeployAction(config)


### PR DESCRIPTION
Archiving the CF CLI output instead of printing it into the jenkins logs. 
Makes the Jenkins console log more readable in error case.
- [x] Tests
- [ ] Documentation
