### PR TITLE
Hand over environment variables to shell execution

### DIFF
--- a/cmd/interfaces.go
+++ b/cmd/interfaces.go
@@ -6,6 +6,7 @@ import (
 
 type runner interface {
 	Dir(d string)
+	Env(e []string)
 	Stdout(out io.Writer)
 	Stderr(err io.Writer)
 }
@@ -13,11 +14,6 @@ type runner interface {
 type execRunner interface {
 	runner
 	RunExecutable(e string, p ...string) error
-}
-
-type envExecRunner interface {
-	execRunner
-	Env(e []string)
 }
 
 type shellRunner interface {

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -22,7 +22,7 @@ func kubernetesDeploy(config kubernetesDeployOptions, telemetryData *telemetry.C
 	runKubernetesDeploy(config, &c, log.Entry().Writer())
 }
 
-func runKubernetesDeploy(config kubernetesDeployOptions, command envExecRunner, stdout io.Writer) {
+func runKubernetesDeploy(config kubernetesDeployOptions, command execRunner, stdout io.Writer) {
 	if config.DeployTool == "helm" {
 		runHelmDeploy(config, command, stdout)
 	} else {
@@ -30,7 +30,7 @@ func runKubernetesDeploy(config kubernetesDeployOptions, command envExecRunner, 
 	}
 }
 
-func runHelmDeploy(config kubernetesDeployOptions, command envExecRunner, stdout io.Writer) {
+func runHelmDeploy(config kubernetesDeployOptions, command execRunner, stdout io.Writer) {
 	_, containerRegistry, err := splitRegistryURL(config.ContainerRegistryURL)
 	if err != nil {
 		log.Entry().WithError(err).Fatalf("Container registry url '%v' incorrect", config.ContainerRegistryURL)
@@ -130,7 +130,7 @@ func runHelmDeploy(config kubernetesDeployOptions, command envExecRunner, stdout
 
 }
 
-func runKubectlDeploy(config kubernetesDeployOptions, command envExecRunner) {
+func runKubectlDeploy(config kubernetesDeployOptions, command execRunner) {
 	_, containerRegistry, err := splitRegistryURL(config.ContainerRegistryURL)
 	if err != nil {
 		log.Entry().WithError(err).Fatalf("Container registry url '%v' incorrect", config.ContainerRegistryURL)

--- a/cmd/kubernetesDeploy_test.go
+++ b/cmd/kubernetesDeploy_test.go
@@ -104,7 +104,7 @@ spec:
 		var stdout bytes.Buffer
 		runKubernetesDeploy(opts, &e, &stdout)
 
-		assert.Equal(t, e.env[0], []string{"KUBECONFIG=This is my kubeconfig"})
+		assert.Equal(t, e.env, []string{"KUBECONFIG=This is my kubeconfig"})
 
 		assert.Equal(t, "kubectl", e.calls[0].exec, "Wrong secret lookup command")
 		assert.Equal(t, []string{

--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -18,7 +18,7 @@ import (
 
 type execMockRunner struct {
 	dir                 []string
-	env                 [][]string
+	env                 []string
 	calls               []execCall
 	stdout              io.Writer
 	stderr              io.Writer
@@ -33,7 +33,7 @@ type execCall struct {
 
 type shellMockRunner struct {
 	dir                 string
-	env                 [][]string
+	env                 []string
 	calls               []string
 	shell               []string
 	stdout              io.Writer
@@ -47,7 +47,7 @@ func (m *execMockRunner) Dir(d string) {
 }
 
 func (m *execMockRunner) Env(e []string) {
-	m.env = append(m.env, e)
+	m.env = append(m.env, e...)
 }
 
 func (m *execMockRunner) RunExecutable(e string, p ...string) error {
@@ -73,7 +73,7 @@ func (m *shellMockRunner) Dir(d string) {
 }
 
 func (m *shellMockRunner) Env(e []string) {
-	m.env = append(m.env, e)
+	m.env = append(m.env, e...)
 }
 
 func (m *shellMockRunner) RunShell(s string, c string) error {


### PR DESCRIPTION
There is a string slice for the command available. The entries
are Environment variables. Currently it is (only) possible to
use the environment from the caller. Now it is possible to set new
environment variables or to overwrite existing environment variables.

Can be used e.g. for re-defining HOME or for defining additional
tool specific environment variables.