### PR TITLE
Trim spaces from config value while reading CPE

### DIFF
--- a/pkg/piperenv/environment.go
+++ b/pkg/piperenv/environment.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/log"
 )
@@ -58,5 +59,5 @@ func readFromDisk(filename string) string {
 	if err != nil {
 		val = ""
 	}
-	return val
+	return strings.TrimSpace(val)
 }


### PR DESCRIPTION
I guess the white spaces are not significant.

We had e.g. a trailing `\n` in one of the CPE related files.