### PR TITLE
Provide an expected response from a shell call via stdout in shell mock runner

### DIFF
--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -32,6 +32,7 @@ type shellMockRunner struct {
 	stdout         io.Writer
 	stderr         io.Writer
 	shouldFailWith error
+	stdoutResponse string
 }
 
 func (m *execMockRunner) Dir(d string) {
@@ -64,9 +65,18 @@ func (m *shellMockRunner) RunShell(s string, c string) error {
 	if m.shouldFailWith != nil {
 		return m.shouldFailWith
 	}
+
+	if len(m.stdoutResponse) > 0 {
+		m.stdout.Write([]byte(m.stdoutResponse))
+	}
+
 	m.shell = append(m.shell, s)
 	m.calls = append(m.calls, c)
 	return nil
+}
+
+func (m *shellMockRunner) RegisterStdout(expected string) {
+	m.stdoutResponse = expected
 }
 
 func (m *shellMockRunner) Stdout(out io.Writer) {


### PR DESCRIPTION
Needed in case the go layer traverses some output of underlying tools.

Further improvement possible, e.g. return something via `stdout` depending on a regex. Usefull in case there are several shell calls during one go step. This applies also for `shouldFailWith`. But I think it is better to do this is a dedicated pull request. For now it is sufficient like it is.
