### PR TITLE
Have Env inside execRunner rather than having a dedicated envExecRunner

### DIFF
--- a/cmd/interfaces.go
+++ b/cmd/interfaces.go
@@ -7,13 +7,6 @@ import (
 type execRunner interface {
 	RunExecutable(e string, p ...string) error
 	Dir(d string)
-	Stdout(out io.Writer)
-	Stderr(err io.Writer)
-}
-
-type envExecRunner interface {
-	RunExecutable(e string, p ...string) error
-	Dir(d string)
 	Env(e []string)
 	Stdout(out io.Writer)
 	Stderr(err io.Writer)

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -22,7 +22,7 @@ func kubernetesDeploy(config kubernetesDeployOptions) error {
 	return nil
 }
 
-func runKubernetesDeploy(config kubernetesDeployOptions, command envExecRunner, stdout io.Writer) {
+func runKubernetesDeploy(config kubernetesDeployOptions, command execRunner, stdout io.Writer) {
 	if config.DeployTool == "helm" {
 		runHelmDeploy(config, command, stdout)
 	} else {
@@ -30,7 +30,7 @@ func runKubernetesDeploy(config kubernetesDeployOptions, command envExecRunner, 
 	}
 }
 
-func runHelmDeploy(config kubernetesDeployOptions, command envExecRunner, stdout io.Writer) {
+func runHelmDeploy(config kubernetesDeployOptions, command execRunner, stdout io.Writer) {
 	_, containerRegistry, err := splitRegistryURL(config.ContainerRegistryURL)
 	if err != nil {
 		log.Entry().WithError(err).Fatalf("Container registry url '%v' incorrect", config.ContainerRegistryURL)
@@ -130,7 +130,7 @@ func runHelmDeploy(config kubernetesDeployOptions, command envExecRunner, stdout
 
 }
 
-func runKubectlDeploy(config kubernetesDeployOptions, command envExecRunner) {
+func runKubectlDeploy(config kubernetesDeployOptions, command execRunner) {
 	_, containerRegistry, err := splitRegistryURL(config.ContainerRegistryURL)
 	if err != nil {
 		log.Entry().WithError(err).Fatalf("Container registry url '%v' incorrect", config.ContainerRegistryURL)


### PR DESCRIPTION
This PR competes with #1117.

With this approach `envExecRunner` is removed an the corresponding property is included in `execRunner`.

The other PR keeps the `envExecRunner` but removes some redundancies.

Which way is the prefered one?
