### PR TITLE
Persist default values on file system

### DIFF
--- a/documentation/bin/createDocu.groovy
+++ b/documentation/bin/createDocu.groovy
@@ -666,7 +666,17 @@ Map stages = Helper.resolveDocuRelevantStages(gse, stepsDir)
 boolean exceptionCaught = false
 
 def stepDescriptors = [:]
+
+MetaMethod oldPersistDefaults = DefaultValueCache.metaClass.
+    getStaticMetaMethod("persistDefaults", [Script, Map, List])
+DefaultValueCache.metaClass.static.persistDefaults = { Script s, Map dv, List cd ->
+    return null
+}
+
 DefaultValueCache.prepare(Helper.getDummyScript('noop'), [customDefaults: customDefaults])
+
+DefaultValueCache.metaClass.static.persistDefaults = oldPersistDefaults
+
 for (step in steps) {
     try {
         stepDescriptors."${step}" = handleStep(step, gse)

--- a/src/com/sap/piper/ConfigurationHelper.groovy
+++ b/src/com/sap/piper/ConfigurationHelper.groovy
@@ -11,9 +11,9 @@ class ConfigurationHelper implements Serializable {
 
     ConfigurationHelper loadStepDefaults(Map compatibleParameters = [:]) {
         DefaultValueCache.prepare(step)
-        this.config = ConfigurationLoader.defaultGeneralConfiguration()
+        this.config = ConfigurationLoader.defaultGeneralConfiguration(step)
         mixin(ConfigurationLoader.defaultGeneralConfiguration(), null, compatibleParameters)
-        mixin(ConfigurationLoader.defaultStepConfiguration(null, name), null, compatibleParameters)
+        mixin(ConfigurationLoader.defaultStepConfiguration(step, name), null, compatibleParameters)
     }
 
     private Map config

--- a/src/com/sap/piper/ConfigurationLoader.groovy
+++ b/src/com/sap/piper/ConfigurationLoader.groovy
@@ -27,7 +27,7 @@ class ConfigurationLoader implements Serializable {
     }
 
     static Map defaultGeneralConfiguration(script){
-        return DefaultValueCache.getInstance()?.getDefaultValues()?.general ?: [:]
+        return DefaultValueCache.getInstance(script)?.getDefaultValues()?.general ?: [:]
     }
 
     static Map postActionConfiguration(script, String actionName){
@@ -44,7 +44,7 @@ class ConfigurationLoader implements Serializable {
                 }
 
             case ConfigurationType.DEFAULT_CONFIGURATION:
-                return DefaultValueCache.getInstance()?.getDefaultValues()?.get(type)?.get(entryName) ?: [:]
+                return DefaultValueCache.getInstance(script)?.getDefaultValues()?.get(type)?.get(entryName) ?: [:]
             default:
                 throw new IllegalArgumentException("Unknown configuration type: ${configType}")
         }

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -33,6 +33,8 @@ class DefaultValueCache implements Serializable {
         return defaultValues
     }
 
+    // The reset method is only used for unit tests, in which case the persistence is mocked,
+    // that is why no files need to be deleted with this reset.
     static reset(){
         instance = null
     }

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -18,11 +18,10 @@ class DefaultValueCache implements Serializable {
     }
 
     static getInstance(script){
-        if (instance) {
-            return instance
-        } else {
-            return readDefaults(script)
+        if (!instance && script) {
+            createInstanceFromPersistence(script)
         }
+        return instance
     }
 
     static boolean hasInstance(){
@@ -69,16 +68,14 @@ class DefaultValueCache implements Serializable {
             }
             DefaultValueCache.createInstance(defaultValues, customDefaults)
 
-            persistDefaults(script, defaultValues, customDefaults)
+            if (script) {
+                persistDefaults(script, defaultValues, customDefaults)
+            }
 
         }
     }
 
-    static def persistDefaults(Script script, Map defaultValues, List customDefaults = []) {
-        if (!script) {
-            return null
-        }
-
+    static void persistDefaults(Script script, Map defaultValues, List customDefaults = []) {
         def defaultValuesAbsolutePath = "${script.WORKSPACE}/${defaultValuesRelativePath}"
         def customDefaultsAbsolutePath = "${script.WORKSPACE}/${customDefaultsRelativePath}"
 
@@ -92,11 +89,7 @@ class DefaultValueCache implements Serializable {
         }
     }
 
-    static def readDefaults(Script script) {
-        if (!script) {
-            return null
-        }
-
+    static void createInstanceFromPersistence(Script script) {
         def defaultValues = [:]
         def customDefaults = []
         def defaultValuesAbsolutePath = "${script.WORKSPACE}/${defaultValuesRelativePath}"
@@ -109,8 +102,6 @@ class DefaultValueCache implements Serializable {
         }
         if (defaultValues) {
             createInstance(defaultValues, customDefaults)
-            return instance
         }
-        return null
     }
 }

--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -25,6 +25,10 @@ class DefaultValueCache implements Serializable {
         }
     }
 
+    static boolean hasInstance(){
+        return instance!=null
+    }
+
     static createInstance(Map defaultValues, List customDefaults = []){
         instance = new DefaultValueCache(defaultValues, customDefaults)
     }
@@ -47,7 +51,7 @@ class DefaultValueCache implements Serializable {
 
     static void prepare(Script script, Map parameters = [:]) {
         if(parameters == null) parameters = [:]
-        if(!DefaultValueCache.getInstance() || parameters.customDefaults) {
+        if(!DefaultValueCache.hasInstance() || parameters.customDefaults) {
             def defaultValues = [:]
             def configFileList = ['default_pipeline_environment.yml']
             def customDefaults = parameters.customDefaults

--- a/test/groovy/PrepareDefaultValuesTest.groovy
+++ b/test/groovy/PrepareDefaultValuesTest.groovy
@@ -139,4 +139,29 @@ public class PrepareDefaultValuesTest extends BasePiperTest {
         assert loggingRule.log.contains("Loading configuration file 'default_pipeline_environment.yml'")
         assert loggingRule.log.contains("Loading configuration file 'custom.yml'")
     }
+
+    @Test
+    public void "Check that instance is re-created from files after reset"() {
+
+        DefaultValueCache.metaClass = null
+
+        stepRule.step.prepareDefaultValues(script: nullScript, customDefaults: 'custom.yml')
+
+        // reset destroys our instance, similar to a Jenkins restart
+        DefaultValueCache.reset()
+
+        nullScript.binding.setVariable("WORKSPACE", '/path/to/workspace')
+
+        def newInstance = DefaultValueCache.getInstance(nullScript)
+
+        def defaultValues = newInstance.getDefaultValues()
+        def customDefaults = newInstance.getCustomDefaults()
+
+        assert defaultValues.size() == 2
+        assert defaultValues.default == 'config'
+        assert defaultValues.custom == 'myConfig'
+
+        assert customDefaults.size() == 1
+        assert customDefaults[0] == 'custom.yml'
+    }
 }

--- a/test/groovy/util/JenkinsFileExistsRule.groovy
+++ b/test/groovy/util/JenkinsFileExistsRule.groovy
@@ -40,18 +40,29 @@ class JenkinsFileExistsRule implements TestRule {
             void evaluate() throws Throwable {
 
                 testInstance.helper.registerAllowedMethod('fileExists', [String.class], {s ->
-                    queriedFiles.add(s.toString())
-                    return s.toString() in existingFiles
+                    def fileName = s.toString()
+                    queriedFiles.add(fileName)
+                    return fileExists(fileName)
                 })
 
                 testInstance.helper.registerAllowedMethod('fileExists', [Map.class], {m ->
-                    queriedFiles.add(m.file.toString())
-                    return m.file.toString() in existingFiles}
-                )
+                    def fileName = m.file.toString()
+                    queriedFiles.add(fileName)
+                    return fileExists(fileName)
+                })
 
                 base.evaluate()
             }
         }
+    }
+
+    private boolean fileExists(String fileName) {
+        def fileExists = fileName in existingFiles
+        if (!fileExists && testInstance.binding.hasVariable('files')) {
+            Map files = testInstance.binding.getVariable('files')
+            fileExists = files.containsKey(fileName)
+        }
+        return fileExists
     }
 
 }

--- a/test/groovy/util/JenkinsReadJsonRule.groovy
+++ b/test/groovy/util/JenkinsReadJsonRule.groovy
@@ -31,8 +31,13 @@ class JenkinsReadJsonRule implements TestRule {
                         return js.parseText(m.text)
                     } else if(m.file) {
                         def js = new JsonSlurper()
-                        def reader = new BufferedReader(new FileReader( "${this.testRoot}${m.file}" ))
-                        return js.parse(reader)
+                        if (testInstance.binding.hasVariable('files')) {
+                            def files = testInstance.binding.getVariable('files')
+                            return js.parseText(files["${this.testRoot}${m.file}"])
+                        } else {
+                            def reader = new BufferedReader(new FileReader( "${this.testRoot}${m.file}" ))
+                            return js.parse(reader)
+                        }
                     } else {
                         throw new IllegalArgumentException("Key 'text' is missing in map ${m}.")
                     }

--- a/test/groovy/util/JenkinsResetDefaultCacheRule.groovy
+++ b/test/groovy/util/JenkinsResetDefaultCacheRule.groovy
@@ -27,7 +27,23 @@ class JenkinsResetDefaultCacheRule implements TestRule {
             @Override
             void evaluate() throws Throwable {
                 DefaultValueCache.reset()
+
+                MetaMethod oldReadDefaults = DefaultValueCache.metaClass.
+                    getStaticMetaMethod("readDefaults", Script)
+                MetaMethod oldPersistDefaults = DefaultValueCache.metaClass.
+                    getStaticMetaMethod("persistDefaults", [Script, Map, List])
+
+                DefaultValueCache.metaClass.static.readDefaults = { Script s ->
+                    return null
+                }
+                DefaultValueCache.metaClass.static.persistDefaults = { Script s, Map dv, List cd ->
+                    return null
+                }
+
                 base.evaluate()
+
+                DefaultValueCache.metaClass.static.readDefaults = oldReadDefaults
+                DefaultValueCache.metaClass.static.persistDefaults = oldPersistDefaults
             }
         }
     }

--- a/test/groovy/util/JenkinsResetDefaultCacheRule.groovy
+++ b/test/groovy/util/JenkinsResetDefaultCacheRule.groovy
@@ -28,12 +28,12 @@ class JenkinsResetDefaultCacheRule implements TestRule {
             void evaluate() throws Throwable {
                 DefaultValueCache.reset()
 
-                MetaMethod oldReadDefaults = DefaultValueCache.metaClass.
-                    getStaticMetaMethod("readDefaults", Script)
+                MetaMethod oldCreateInstanceFromPersistence = DefaultValueCache.metaClass.
+                    getStaticMetaMethod("createInstanceFromPersistence", Script)
                 MetaMethod oldPersistDefaults = DefaultValueCache.metaClass.
                     getStaticMetaMethod("persistDefaults", [Script, Map, List])
 
-                DefaultValueCache.metaClass.static.readDefaults = { Script s ->
+                DefaultValueCache.metaClass.static.createInstanceFromPersistence = { Script s ->
                     return null
                 }
                 DefaultValueCache.metaClass.static.persistDefaults = { Script s, Map dv, List cd ->
@@ -42,7 +42,7 @@ class JenkinsResetDefaultCacheRule implements TestRule {
 
                 base.evaluate()
 
-                DefaultValueCache.metaClass.static.readDefaults = oldReadDefaults
+                DefaultValueCache.metaClass.static.createInstanceFromPersistence = oldCreateInstanceFromPersistence
                 DefaultValueCache.metaClass.static.persistDefaults = oldPersistDefaults
             }
         }

--- a/test/groovy/util/JenkinsWriteJsonRule.groovy
+++ b/test/groovy/util/JenkinsWriteJsonRule.groovy
@@ -1,6 +1,7 @@
 package util
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
+import groovy.json.JsonOutput
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -25,7 +26,14 @@ class JenkinsWriteJsonRule implements TestRule {
             @Override
             void evaluate() throws Throwable {
 
-                testInstance.helper.registerAllowedMethod( 'writeJSON', [Map.class], {m -> files[m.file] = m.json.toString()})
+                testInstance.helper.registerAllowedMethod( 'writeJSON', [Map.class], { m ->
+                    def jsonText = m.json
+                    if (jsonText instanceof Map || jsonText instanceof List) {
+                        jsonText = JsonOutput.toJson(m.json)
+                    }
+                    files[m.file] = jsonText.toString()
+                    testInstance.binding.setVariable('files', files)
+                })
 
                 base.evaluate()
             }

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -16,5 +16,5 @@ import groovy.transform.Field
  */
 @GenerateDocumentation
 void call(Map parameters = [:]) {
-    DefaultValueCache.prepare(this, parameters)
+    DefaultValueCache.prepare(parameters.script ?: this, parameters)
 }

--- a/vars/prepareDefaultValues.groovy
+++ b/vars/prepareDefaultValues.groovy
@@ -16,5 +16,5 @@ import groovy.transform.Field
  */
 @GenerateDocumentation
 void call(Map parameters = [:]) {
-    DefaultValueCache.prepare(parameters.script ?: this, parameters)
+    DefaultValueCache.prepare(this, parameters)
 }


### PR DESCRIPTION
To read and write the default values the readJSON and writeJSON methods
are used, i.e. the map and list variables are persisted as JSON.
Static read and write methods only work if a script is present. If not a
restart will have the same behaviour as before.
prepareDefaultValues step should be called at the beginning of the
pipeline, which is automatically done when calling
setupCommonPipelineEnvironment step.

This PR is an alternative approach to PR #1082. It only fixes issue #788, not #1050. For the latter I suggest a separate PR where we persist the CPE.

# Changes

- [x] Tests
