### PR TITLE
go code gen: no fmt in template for outgoing resources

### DIFF
--- a/cmd/checkmarxExecuteScan_generated.go
+++ b/cmd/checkmarxExecuteScan_generated.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -144,7 +143,7 @@ func (i *checkmarxExecuteScanInflux) persist(path, resourceName string) {
 
 	errCount := 0
 	for _, metric := range measurementContent {
-		err := piperenv.SetResourceParameter(path, resourceName, filepath.Join(metric.measurement, fmt.Sprintf("%vs", metric.valType), metric.name), metric.value)
+		err := piperenv.SetResourceParameter(path, resourceName, filepath.Join(metric.measurement, metric.valType+"s", metric.name), metric.value)
 		if err != nil {
 			log.Entry().WithError(err).Error("Error persisting influx environment.")
 			errCount++

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -33,7 +33,6 @@ const stepGoTemplate = `package cmd
 
 import (
 	{{ if .OSImport }}"os"{{ end }}
-	{{ if .OutputResources }}"fmt"{{ end }}
 	{{ if .OutputResources }}"path/filepath"{{ end }}
 
 	{{ if .ExportPrefix}}{{ .ExportPrefix }} "github.com/SAP/jenkins-library/cmd"{{ end -}}

--- a/pkg/generator/helper/resources.go
+++ b/pkg/generator/helper/resources.go
@@ -153,7 +153,7 @@ func (i *{{ .StepName }}{{ .Name | title}}) persist(path, resourceName string) {
 
 	errCount := 0
 	for _, metric := range measurementContent {
-		err := piperenv.SetResourceParameter(path, resourceName, filepath.Join(metric.measurement, fmt.Sprintf("%vs", metric.valType), metric.name), metric.value)
+		err := piperenv.SetResourceParameter(path, resourceName, filepath.Join(metric.measurement, metric.valType + "s", metric.name), metric.value)
 		if err != nil {
 			log.Entry().WithError(err).Error("Error persisting influx environment.")
 			errCount++


### PR DESCRIPTION
The import for  `fmt` is not needed always.

IMO it is not that cool to remove the `fmt` import manually after generating the code. That change removes the usage of `fmt.Sprintf` and replaces it by some string concatentation (`"a" + "b"`).

The cooler way would be to specify the condition more precise when the `fmt` gets rendered. Just in case somebody knows some more details.
