### PR TITLE
Add DebugReport facility

### DIFF
--- a/resources/debug_report.txt
+++ b/resources/debug_report.txt
@@ -8,8 +8,8 @@ The log was generated at: `$utcTimestamp UTC`
 
 <% print failedBuild ? "## Unsuccessful Build" : "" %>
 
-<% print failedBuild ? "#### Failed Stage" : "" %>
-<% print failedBuild.get("stage") ? "`${failedBuild.get("stage")}`" : "" %>
+<% print failedBuild ? "#### Failed Step" : "" %>
+<% print failedBuild.get("step") ? "`${failedBuild.get("step")}`" : "" %>
 
 <% print failedBuild.get("reason") ? "#### Error Message" : "" %>
 <% print failedBuild.get("reason") ? "```\n${failedBuild.get("reason")}\n```" : "" %>
@@ -17,6 +17,7 @@ The log was generated at: `$utcTimestamp UTC`
 <% print failedBuild.get("stack_trace") ? "```" : "" %>
 <% print failedBuild.get("stack_trace").collect({each -> "${each}"}).join("\n") %>
 <% print failedBuild.get("stack_trace") ? "```" : "" %>
+<% print failedBuild.get("fatal") ? "#### Failure was fatal." : "" %>
 
 ## Pipeline Environment
 

--- a/resources/debug_report.txt
+++ b/resources/debug_report.txt
@@ -1,0 +1,101 @@
+# SAP Cloud SDK `<% print shareConfidentialInformation ? "Confidential" : "Redacted" %>` Debug Log
+
+The debug log is generated with each build and should be included in every support request, don't worry in case you don't understand all of its contents.
+
+The log was generated at: `$utcTimestamp UTC`
+
+#### Please be sure that this file doesn't contain any information that you are not allowed to share.
+
+<% print failedBuild ? "## Unsuccessful Build" : "" %>
+
+<% print failedBuild ? "#### Failed Stage" : "" %>
+<% print failedBuild.get("stage") ? "`${failedBuild.get("stage")}`" : "" %>
+
+<% print failedBuild.get("reason") ? "#### Error Message" : "" %>
+<% print failedBuild.get("reason") ? "```\n${failedBuild.get("reason")}\n```" : "" %>
+<% print failedBuild.get("stack_trace") ? "#### Stacktrace" : "" %>
+<% print failedBuild.get("stack_trace") ? "```" : "" %>
+<% print failedBuild.get("stack_trace").collect({each -> "${each}"}).join("\n") %>
+<% print failedBuild.get("stack_trace") ? "```" : "" %>
+
+## Pipeline Environment
+
+#### Environment
+`${environment.get("environment")}`
+
+#### Environment Variables
+Environment Variable | Value
+---------------------|------
+<% print environment.get("build_details").collect({each -> "${each}"}).join("\n") %>
+
+#### Docker Image
+`${environment.get("docker_image")}`
+
+## Build Tools Environment
+
+#### Build Tool
+`${buildTool}`
+
+<% print modulesMap && shareConfidentialInformation ? "#### MTA Modules" : "" %>
+
+<% print modulesMap && shareConfidentialInformation ? "Type | Path" : "" %>
+<% print modulesMap && shareConfidentialInformation ? "-----|-----" : "" %>
+<% print modulesMap && shareConfidentialInformation ? modulesMap.collect({each -> "${each.key} | ${each.value}"}).join("\n") : "" %>
+
+<% print npmModules && shareConfidentialInformation ? "#### NPM Modules" : "" %>
+
+<% print npmModules && shareConfidentialInformation ? "Path | Scripts" : "" %>
+<% print npmModules && shareConfidentialInformation ? "-----|--------" : "" %>
+<% print npmModules && shareConfidentialInformation ? npmModules.collect({each -> "${each.basePath} | ${each.npmScripts}"}).join("\n") : "" %>
+
+
+## Plugins
+
+<% print plugins ? "" : "No plugins were used for this build." %>
+
+<details><summary>Full list of plugins</summary>
+<p>
+
+<% print plugins ? "Shortname | Version | Displayname" : "" %>
+<% print plugins ? "----------|---------|------------" : "" %>
+<% print plugins.collect({each -> "${each}"}).join("\n") %>
+
+</p>
+</details>
+
+<% print shareConfidentialInformation ? "## Git Repository" : "" %>
+
+<% print shareConfidentialInformation ? gitRepo ? "" : "Git isn't used for version control" : "" %>
+
+<% print gitRepo && shareConfidentialInformation ? "Repository | Branch" : "" %>
+<% print gitRepo && shareConfidentialInformation ? "-----------|-------" : "" %>
+<% print gitRepo && shareConfidentialInformation ? "${gitRepo.get("URI")} | ${gitRepo.get("branch")}" : "" %>
+
+## Local Extensions
+
+<% print localExtensions ? "" : "No local extensions were used" %>
+
+<% print localExtensions ? "Local Extension | relationToOriginalStage" : "" %>
+<% print localExtensions ? "----------------|-------" : "" %>
+<% print localExtensions.collect({each -> "${each.key} | ${each.value}"}).join("\n") %>
+
+## Global Extension Repository
+
+<% print shareConfidentialInformation ? globalExtensionRepository ? "${globalExtensionRepository}" : "No global extension repository was loaded." : "" %>
+<% print globalExtensions ? "The repository included the following extensions:" : "No extension of the global extension repository was used." %>
+
+<% print globalExtensions ? "Global Extension | relationToOriginalStage" : "" %>
+<% print globalExtensions ? "-----------------|-------" : "" %>
+<% print globalExtensions.collect({each -> "${each.key} | ${each.value}"}).join("\n") %>
+
+Configuration file for global extensions: <% print globalExtensionConfigurationFilePath ?: "Global extensions don't have a configuration file" %>
+
+Shared project configuration: <% print shareConfidentialInformation ? sharedConfigFilePath ?: "No shared configuration" : sharedConfigFilePath != null %>
+
+<% print shareConfidentialInformation ? "## Shared Libraries" : "" %>
+
+<% print shareConfidentialInformation ? additionalSharedLibraries ? "" : "No additional shared libraries where loaded." : "" %>
+
+<% print additionalSharedLibraries && shareConfidentialInformation ? "name | branch | loadedByExtension" : "" %>
+<% print additionalSharedLibraries && shareConfidentialInformation ? "-----|--------|-------" : "" %>
+<% print shareConfidentialInformation ? additionalSharedLibraries.collect({each -> "${each}"}).join("\n") : "" %>

--- a/src/com/sap/piper/DebugReport.groovy
+++ b/src/com/sap/piper/DebugReport.groovy
@@ -106,7 +106,7 @@ class DebugReport {
                 plugins.add("${it.getShortName()} | ${it.getVersion()} | ${it.getDisplayName()}")
             }
         } catch (Throwable t) {
-            // Ignore
+            script.echo "Failed to retrieve Jenkins plugins for debug report  (${t.getMessage()})"
         }
 
         Map binding = getProperties()

--- a/src/com/sap/piper/DebugReport.groovy
+++ b/src/com/sap/piper/DebugReport.groovy
@@ -79,18 +79,16 @@ class DebugReport {
      *
      * @param stepName      The name of the crashed step or stage
      * @param err           The Throwable that was thrown
-     * @param isResilientAndNotMandatory
-     *                      Whether the step configuration indicated that this as
-     *                      "resilient" step which is not included in the list of mandatory steps.
+     * @param failedOnError Whether the failure was deemed fatal at the time of calling this method.
      */
-    void storeStepFailure(String stepName, Throwable err, boolean isResilientAndNotMandatory) {
-        failedBuild.put('stage', stepName)
+    void storeStepFailure(String stepName, Throwable err, boolean failedOnError) {
+        failedBuild.put('step', stepName)
         failedBuild.put('reason', err)
         failedBuild.put('stack_trace', err.getStackTrace())
-        if (isResilientAndNotMandatory) {
-            failedBuild.put('isResilient', 'true')
+        if (failedOnError) {
+            failedBuild.put('fatal', 'true')
         } else {
-            failedBuild.remove('isResilient')
+            failedBuild.remove('fatal')
         }
     }
 

--- a/src/com/sap/piper/DebugReport.groovy
+++ b/src/com/sap/piper/DebugReport.groovy
@@ -1,0 +1,132 @@
+package com.sap.piper
+
+import com.cloudbees.groovy.cps.NonCPS
+import groovy.text.SimpleTemplateEngine
+
+@Singleton
+class DebugReport {
+    String fileName
+    String projectIdentifier = null
+    Map environment = ['environment': 'custom']
+    String buildTool = null
+    Map modulesMap = [:]
+    List npmModules = []
+    Set plugins = []
+    Map gitRepo = [:]
+    Map localExtensions = [:]
+    String globalExtensionRepository = null
+    Map globalExtensions = [:]
+    String globalExtensionConfigurationFilePath = null
+    String sharedConfigFilePath = null
+    Set additionalSharedLibraries = []
+    Map failedBuild = [:]
+    boolean shareConfidentialInformation
+
+    /**
+     * Initialize debug report information from the environment variables.
+     *
+     * @param env The Jenkins global 'env' variable.
+     */
+    void initFromEnvironment(def env) {
+        Set buildDetails = []
+        buildDetails.add('Jenkins Version | ' + env.JENKINS_VERSION)
+        buildDetails.add('JAVA Version | ' + env.JAVA_VERSION)
+        environment.put('build_details', buildDetails)
+
+        if (!Boolean.valueOf(env.ON_K8S) && EnvironmentUtils.cxServerDirectoryExists()) {
+            environment.put('environment', 'cx-server')
+
+            String serverConfigContents = getServerConfigContents(
+                '/var/cx-server/server.cfg',
+                '/workspace/var/cx-server/server.cfg')
+            String docker_image = EnvironmentUtils.getDockerFile(serverConfigContents)
+            environment.put('docker_image', docker_image)
+        }
+    }
+
+    private static String getServerConfigContents(String... possibleFileLocations) {
+        for (String location in possibleFileLocations) {
+            File file = new File(location)
+            if (file.exists())
+                return file.getText('UTF-8')
+        }
+        return ''
+    }
+
+    /**
+     * Pulls and stores repository information from the provided Map for later inclusion in the debug report.
+     *
+     * @param scmCheckoutResult A Map including information about the checked out project,
+     * i.e. as returned by the Jenkins checkout() function.
+     */
+    void setGitRepoInfo(Map scmCheckoutResult) {
+        if (!scmCheckoutResult.GIT_URL)
+            return
+
+        gitRepo.put('URI', scmCheckoutResult.GIT_URL)
+        if (scmCheckoutResult.GIT_LOCAL_BRANCH) {
+            gitRepo.put('branch', scmCheckoutResult.GIT_LOCAL_BRANCH)
+        } else {
+            gitRepo.put('branch', scmCheckoutResult.GIT_BRANCH)
+        }
+    }
+
+    /**
+     * Stores crash information for a failed step. Multiple calls to this method overwrite already
+     * stored information, only the information stored last will appear in the debug report. In the
+     * current use-case where this can be called multiple times, all 'unstable' steps are listed in
+     * the 'unstableSteps' entry of the commonPipelineEnvironment.
+     *
+     * @param stepName      The name of the crashed step or stage
+     * @param err           The Throwable that was thrown
+     * @param isResilientAndNotMandatory
+     *                      Whether the step configuration indicated that this as
+     *                      "resilient" step which is not included in the list of mandatory steps.
+     */
+    void storeStepFailure(String stepName, Throwable err, boolean isResilientAndNotMandatory) {
+        failedBuild.put('stage', stepName)
+        failedBuild.put('reason', err)
+        failedBuild.put('stack_trace', err.getStackTrace())
+        if (isResilientAndNotMandatory) {
+            failedBuild.put('isResilient', 'true')
+        } else {
+            failedBuild.remove('isResilient')
+        }
+    }
+
+    String generateReport(Script script) {
+        String template = script.libraryResource 'debug_report.txt'
+
+        if (!projectIdentifier) {
+            projectIdentifier = 'NOT_SET'
+        }
+
+        try {
+            Jenkins.instance.getPluginManager().getPlugins().each {
+                plugins.add("${it.getShortName()} | ${it.getVersion()} | ${it.getDisplayName()}")
+            }
+        } catch (Throwable t) {
+            // Ignore
+        }
+
+        Map binding = getProperties()
+        Date now = new Date()
+
+        binding.utcTimestamp = now.format('yyyy-MM-dd HH:mm', TimeZone.getTimeZone('UTC'))
+        String fileNameTimestamp = now.format('yyyy-MM-dd-HH-mm', TimeZone.getTimeZone('UTC'))
+
+        if (shareConfidentialInformation) {
+            fileName = "confidential_debug_log_${fileNameTimestamp}_${projectIdentifier}.txt"
+        } else {
+            fileName = "redacted_debug_log_${fileNameTimestamp}_${projectIdentifier}.txt"
+        }
+
+        return fillTemplate(template, binding)
+    }
+
+    @NonCPS
+    private String fillTemplate(String template, binding) {
+        def engine = new SimpleTemplateEngine()
+        return engine.createTemplate(template).make(binding)
+    }
+}

--- a/test/groovy/HandlePipelineStepErrorsTest.groovy
+++ b/test/groovy/HandlePipelineStepErrorsTest.groovy
@@ -1,3 +1,4 @@
+import com.sap.piper.DebugReport
 import hudson.AbortException
 
 import static org.hamcrest.Matchers.is
@@ -82,7 +83,7 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
             assertThat(loggingRule.log, containsString('to show step parameters, set verbose:true'))
         }
     }
-    
+
     @Test
     void testHandleErrorsIgnoreFailure() {
         def errorOccured = false
@@ -173,4 +174,24 @@ class HandlePipelineStepErrorsTest extends BasePiperTest {
         assertThat(nullScript.currentBuild.result, is('UNSTABLE'))
         assertThat(errorMsg, is('[handlePipelineStepErrors] Error in step test - Build result set to \'UNSTABLE\''))
     }
+
+    @Test
+    void testFeedDebugReport() {
+        Exception err = new Exception('TestError')
+        try {
+            stepRule.step.handlePipelineStepErrors([
+                stepName: 'testStep',
+                stepParameters: ['something': 'anything'],
+            ]) {
+                throw err
+            }
+        } catch (ignore) {
+        } finally {
+            // asserts
+            assertThat(DebugReport.instance.failedBuild.step, is('testStep'))
+            assertThat(DebugReport.instance.failedBuild.fatal, is('true'))
+            assertThat(DebugReport.instance.failedBuild.reason, is(err))
+        }
+    }
+
 }

--- a/test/groovy/PiperStageWrapperTest.groovy
+++ b/test/groovy/PiperStageWrapperTest.groovy
@@ -1,3 +1,5 @@
+import com.sap.piper.DebugReport
+
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -143,5 +145,6 @@ class PiperStageWrapperTest extends BasePiperTest {
         assertThat(loggingRule.log, containsString('Stage Name: test_old_extension'))
         assertThat(loggingRule.log, containsString('Config: ['))
         assertThat(loggingRule.log, containsString('testBranch'))
+        assertThat(DebugReport.instance.localExtensions.test_old_extension, is('Extends'))
     }
 }

--- a/test/groovy/com/sap/piper/DebugReportTest.groovy
+++ b/test/groovy/com/sap/piper/DebugReportTest.groovy
@@ -5,12 +5,14 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import util.BasePiperTest
+import util.JenkinsLoggingRule
 import util.Rules
 
 class DebugReportTest extends BasePiperTest {
 
     @Rule
     public RuleChain ruleChain = Rules.getCommonRules(this)
+        .around(new JenkinsLoggingRule(this))
 
     @Test
     void testInitFromEnvironment() {

--- a/test/groovy/com/sap/piper/DebugReportTest.groovy
+++ b/test/groovy/com/sap/piper/DebugReportTest.groovy
@@ -1,0 +1,91 @@
+package com.sap.piper
+
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import util.BasePiperTest
+import util.Rules
+
+class DebugReportTest extends BasePiperTest {
+
+    @Rule
+    public RuleChain ruleChain = Rules.getCommonRules(this)
+
+    @Test
+    void testInitFromEnvironment() {
+        Map env = createEnv()
+        DebugReport.instance.initFromEnvironment(env)
+
+        Assert.assertTrue(DebugReport.instance.environment.containsKey('build_details'))
+        Assert.assertEquals('custom', DebugReport.instance.environment.get('environment'))
+
+        Set<String> buildDetails = DebugReport.instance.environment.build_details as Set<String>
+        Assert.assertTrue(buildDetails.size() > 0)
+
+        boolean foundJenkinsVersion = false
+        boolean foundJavaVersion = false
+
+        for (String details in buildDetails) {
+            if (details.contains(env.get('JENKINS_VERSION') as String))
+                foundJenkinsVersion = true
+            if (details.contains(env.get('JAVA_VERSION') as String))
+                foundJavaVersion = true
+        }
+        Assert.assertTrue(foundJenkinsVersion)
+        Assert.assertTrue(foundJavaVersion)
+    }
+
+    @Test
+    void testLogOutput() {
+        DebugReport.instance.initFromEnvironment(createEnv())
+        DebugReport.instance.setGitRepoInfo('GIT_URL' : 'git://url', 'GIT_LOCAL_BRANCH' : 'some-branch')
+
+        String debugReport = DebugReport.instance.generateReport(mockScript())
+
+        Assert.assertTrue(debugReport.contains('## Pipeline Environment'))
+        Assert.assertTrue(debugReport.contains('## Local Extensions'))
+        Assert.assertTrue(debugReport.contains('#### Environment\n' +
+            '`custom`'))
+        Assert.assertFalse(debugReport.contains('Repository | Branch'))
+        Assert.assertFalse(debugReport.contains('some-branch'))
+    }
+
+    @Test
+    void testLogOutputConfidential() {
+        DebugReport.instance.initFromEnvironment(createEnv())
+        DebugReport.instance.setGitRepoInfo('GIT_URL' : 'git://url', 'GIT_LOCAL_BRANCH' : 'some-branch')
+        DebugReport.instance.shareConfidentialInformation = true
+
+        String debugReport = DebugReport.instance.generateReport(mockScript())
+
+        Assert.assertTrue(debugReport.contains('## Pipeline Environment'))
+        Assert.assertTrue(debugReport.contains('## Local Extensions'))
+        Assert.assertTrue(debugReport.contains('#### Environment\n' +
+            '`custom`'))
+        Assert.assertTrue(debugReport.contains('Repository | Branch'))
+        Assert.assertTrue(debugReport.contains('some-branch'))
+    }
+
+    private Script mockScript() {
+        helper.registerAllowedMethod("libraryResource", [String.class], { path ->
+
+            File resource = new File(new File('resources'), path)
+            if (resource.exists()) {
+                return resource.getText()
+            }
+
+            return ''
+        })
+
+        return nullScript
+    }
+
+    private static Map createEnv() {
+        Map env = [:]
+        env.put('JENKINS_VERSION', '42')
+        env.put('JAVA_VERSION', '8')
+        env.put('ON_K8S', 'true')
+        return env
+    }
+}

--- a/test/resources/stages/test_global_overwriting.groovy
+++ b/test/resources/stages/test_global_overwriting.groovy
@@ -1,0 +1,7 @@
+void call(Map params) {
+    echo "Stage Name: ${params.stageName}"
+    echo "Config: ${params.config}"
+    echo "Not calling ${params.stageName}"
+    echo "Branch: ${params.script.commonPipelineEnvironment.gitBranch}"
+}
+return this

--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -79,10 +79,10 @@ void call(Map parameters = [:], body) {
             message += formatErrorMessage(config, ex)
         writeErrorToInfluxData(config, ex)
 
-        boolean isMandatory = config.stepName in config.mandatorySteps
-        DebugReport.instance.storeStepFailure(config.stepName, ex, config.isResilient && !isMandatory)
+        boolean failOnError = config.failOnError || config.stepName in config.mandatorySteps
+        DebugReport.instance.storeStepFailure(config.stepName, ex, failOnError)
 
-        if (config.failOnError || isMandatory) {
+        if (failOnError) {
             throw ex
         }
 
@@ -107,13 +107,12 @@ void call(Map parameters = [:], body) {
         cpe?.setValue('unstableSteps', unstableSteps)
 
     } catch (Throwable error) {
-
-        boolean isMandatory = config.stepName in config.mandatorySteps
-        DebugReport.instance.storeStepFailure(config.stepName, error, config.isResilient && !isMandatory)
-
         if (config.echoDetails)
             message += formatErrorMessage(config, error)
         writeErrorToInfluxData(config, error)
+
+        DebugReport.instance.storeStepFailure(config.stepName, error, true)
+
         throw error
     } finally {
         if (config.echoDetails)

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -2,6 +2,7 @@ import com.cloudbees.groovy.cps.NonCPS
 import com.sap.piper.Utils
 import com.sap.piper.ConfigurationHelper
 import com.sap.piper.ConfigurationLoader
+import com.sap.piper.DebugReport
 import com.sap.piper.k8s.ContainerMap
 import groovy.transform.Field
 
@@ -30,6 +31,7 @@ void call(Map parameters = [:], body) {
     stageLocking(config) {
         def containerMap = ContainerMap.instance.getMap().get(stageName) ?: [:]
         if (Boolean.valueOf(env.ON_K8S) && containerMap.size() > 0) {
+            DebugReport.instance.environment.put("environment", "Kubernetes")
             withEnv(["POD_NAME=${stageName}"]) {
                 dockerExecuteOnKubernetes(script: script, containerMap: containerMap) {
                     executeStage(script, body, stageName, config, utils)
@@ -77,8 +79,14 @@ private void executeStage(script, originalStage, stageName, config, utils) {
         if (globalExtensions) {
             echo "[${STEP_NAME}] Found global interceptor '${globalInterceptorFile}' for ${stageName}."
             // If we call the global interceptor, we will pass on originalStage as parameter
+            DebugReport.instance.globalExtensions.put(stageName, "Overwrites")
+            Closure modifiedOriginalStage = {
+                DebugReport.instance.globalExtensions.put(stageName, "Extends")
+                originalStage()
+            }
+
             body = {
-                callInterceptor(script, globalInterceptorFile, originalStage, stageName, config)
+                callInterceptor(script, globalInterceptorFile, modifiedOriginalStage, stageName, config)
             }
         }
 
@@ -86,7 +94,19 @@ private void executeStage(script, originalStage, stageName, config, utils) {
         if (projectExtensions) {
             echo "[${STEP_NAME}] Running project interceptor '${projectInterceptorFile}' for ${stageName}."
             // If we call the project interceptor, we will pass on body as parameter which contains either originalStage or the repository interceptor
-            callInterceptor(script, projectInterceptorFile, body, stageName, config)
+            if (projectExtensions && globalExtensions) {
+                DebugReport.instance.globalExtensions.put(stageName, "Unknown (Overwritten by local extension)")
+            }
+            DebugReport.instance.localExtensions.put(stageName, "Overwrites")
+            Closure modifiedOriginalBody = {
+                DebugReport.instance.localExtensions.put(stageName, "Extends")
+                if (projectExtensions && globalExtensions) {
+                    DebugReport.instance.globalExtensions.put(stageName, "Overwrites")
+                }
+                body.call()
+            }
+
+            callInterceptor(script, projectInterceptorFile, modifiedOriginalBody, stageName, config)
 
         } else {
             //TODO: assign projectInterceptorScript to body as done for globalInterceptorScript, currently test framework does not seem to support this case. Further investigations needed.

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -109,7 +109,10 @@ private void executeStage(script, originalStage, stageName, config, utils) {
             callInterceptor(script, projectInterceptorFile, modifiedOriginalBody, stageName, config)
 
         } else {
-            //TODO: assign projectInterceptorScript to body as done for globalInterceptorScript, currently test framework does not seem to support this case. Further investigations needed.
+            // NOTE: It may appear more elegant to re-assign 'body' more than once and then call 'body()' after the
+            // if-block. This could lead to infinite loops however, as any change to the local variable 'body' will
+            // become visible in all of the closures at the time they run. I.e. 'body' inside any of the closures will
+            // reflect the last assignment and not its value at the time of constructing the closure!
             body()
         }
 


### PR DESCRIPTION
The DebugReport is a global instance where steps can store information relevant for internal diagnoses of failed pipelines. In the SDK Pipeline, this is used to generate a debug report within the postActionArchiveDebugLog step. The reason for adding this to Piper is to feed information about extended or overwritten stages in piperStageWrapper into the DebugReport, as was done before in the SDK Pipeline's equivalent runAsStage step.

- [x] Tests
- [x] Documentation
