### PR TITLE
Added EnvironmentUtils needed by DebugReport (#1126)

### DIFF
--- a/src/com/sap/piper/DebugReport.groovy
+++ b/src/com/sap/piper/DebugReport.groovy
@@ -39,8 +39,8 @@ class DebugReport {
             String serverConfigContents = getServerConfigContents(
                 '/var/cx-server/server.cfg',
                 '/workspace/var/cx-server/server.cfg')
-            String docker_image = EnvironmentUtils.getDockerFile(serverConfigContents)
-            environment.put('docker_image', docker_image)
+            String dockerImage = EnvironmentUtils.getDockerFile(serverConfigContents)
+            environment.put('docker_image', dockerImage)
         }
     }
 

--- a/src/com/sap/piper/EnvironmentUtils.groovy
+++ b/src/com/sap/piper/EnvironmentUtils.groovy
@@ -1,0 +1,22 @@
+package com.sap.piper
+
+import com.cloudbees.groovy.cps.NonCPS
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class EnvironmentUtils implements Serializable {
+    static boolean cxServerDirectoryExists() {
+        return Files.isDirectory(Paths.get('/var/cx-server/'));
+    }
+
+    @NonCPS
+    static String getDockerFile(String serverCfgAsString) {
+        String result = 'not_found'
+        serverCfgAsString.splitEachLine("=") { items ->
+            if (items[0].trim() == 'docker_image') {
+                result = items[1].trim().replaceAll('"', '')
+            }
+        }
+        return result
+    }
+}

--- a/test/groovy/com/sap/piper/EnvironmentUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/EnvironmentUtilsTest.groovy
@@ -1,0 +1,67 @@
+package com.sap.piper
+
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import util.BasePiperTest
+import util.JenkinsLoggingRule
+import util.Rules
+
+class EnvironmentUtilsTest {
+
+    @Test
+    void testCxServerDirectoryExists() {
+        Assert.assertFalse(EnvironmentUtils.cxServerDirectoryExists())
+    }
+
+    @Test
+    void testGetDockerFile() {
+        String cxServerCfgContents = '''
+#---------------------------------------------#
+#-- Build server configuration ---------------#
+#---------------------------------------------#
+
+#>> Address of the used docker registry. Override if you do not want to use Docker's default registry.
+docker_registry=some_registry
+
+#>> Name of the used docker image
+docker_image="some_path/some_file"
+
+#>> Enable TLS encryption
+tls_enabled=true
+'''
+        Assert.assertEquals( 'some_path/some_file',
+            EnvironmentUtils.getDockerFile(cxServerCfgContents))
+    }
+
+    @Test
+    void testGetDockerFileSpaces() {
+        String cxServerCfgContents = '''
+#>> Name of the used docker image
+ docker_image = "some_path/some_file:latest"
+'''
+        Assert.assertEquals( 'some_path/some_file:latest',
+            EnvironmentUtils.getDockerFile(cxServerCfgContents))
+    }
+
+    @Test
+    void testGetDockerFileTrailingSpaces() {
+        String cxServerCfgContents = '''
+#>> Name of the used docker image
+docker_image="some_path/some_file:latest"
+'''
+        Assert.assertEquals( 'some_path/some_file:latest',
+            EnvironmentUtils.getDockerFile(cxServerCfgContents))
+    }
+
+    @Test
+    void testGetDockerFileSpacesInPath() {
+        String cxServerCfgContents = '''
+#>> Name of the used docker image
+docker_image = "some path/some file:latest"
+'''
+        Assert.assertEquals( 'some path/some file:latest',
+            EnvironmentUtils.getDockerFile(cxServerCfgContents))
+    }
+}


### PR DESCRIPTION
This should have been added along with DebugReport. For context:
EnvironmentUtils used to be a class alongside DebugReport and thus
there was no 'import' directive. Working with Jenkins DSL stuff
has numbed my ability to pay attention to the IDE indicating errors.

# Changes

- [x] Tests
