### PR TITLE
feat(hadolint): enable correct handling of multiple scan results

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -457,7 +457,7 @@ steps:
     noDefaultExludes: []
   pipelineStashFilesBeforeBuild:
     stashIncludes:
-      buildDescriptor: '**/pom.xml, **/.mvn/**, **/assembly.xml, **/.swagger-codegen-ignore, **/package.json, **/requirements.txt, **/setup.py, **/mta*.y*ml, **/.npmrc, Dockerfile, .hadolint.yaml, **/VERSION, **/version.txt, **/Gopkg.*, **/dub.json, **/dub.sdl, **/build.sbt, **/sbtDescriptor.json, **/project/*, **/ui5.yaml, **/ui5.yml'
+      buildDescriptor: '**/pom.xml, **/.mvn/**, **/assembly.xml, **/.swagger-codegen-ignore, **/package.json, **/requirements.txt, **/setup.py, **/mta*.y*ml, **/.npmrc, **/Dockerfile, .hadolint.yaml, **/VERSION, **/version.txt, **/Gopkg.*, **/dub.json, **/dub.sdl, **/build.sbt, **/sbtDescriptor.json, **/project/*, **/ui5.yaml, **/ui5.yml'
       deployDescriptor: '**/manifest*.y*ml, **/*.mtaext.y*ml, **/*.mtaext, **/xs-app.json, helm/**, *.y*ml'
       git: '.git/**'
       opensourceConfiguration: '**/srcclr.yml, **/vulas-custom.properties, **/.nsprc, **/.retireignore, **/.retireignore.json, **/.snyk, **/wss-unified-agent.config, **/vendor/**/*'

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -109,11 +109,9 @@ void call(Map parameters = [:]) {
             )
             
             def resultFileSize = 0
-            File file = new File(pwd(), configuration.reportFile)
-            echo "${file.getAbsolutePath()} exists: ${file.exists()}"
-            if (file.exists()) {
+            if (fileExists(configuration.reportFile)) {
                 echo "File exists"
-                resultFileSize = file.length()
+                resultFileSize = readFile(configuration.reportFile).length()
             }
             
             echo "Result file size is ${resultFileSize}"

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -107,12 +107,15 @@ void call(Map parameters = [:]) {
                 enabledForFailure: true,
                 blameDisabled: true
             )
-
+            
             def resultFileSize = 0
             File file = new File(configuration.reportFile)
             if (file.exists()) {
+                echo "File exists"
                 resultFileSize = file.length()
             }
+            
+            echo "Result file size is ${resultFileSize}"
 
             if (result != 0 && resultFileSize == 0) {
                 error "HaDoLint scan on file ${configuration.dockerFile} failed due to technical issues, please check the log."

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -109,7 +109,8 @@ void call(Map parameters = [:]) {
             )
             
             def resultFileSize = 0
-            File file = new File("${pwd()}/${configuration.reportFile}")
+            File file = new File(pwd(), configuration.reportFile)
+            echo "${file.getAbsolutePath()} exists: ${file.exists()}"
             if (file.exists()) {
                 echo "File exists"
                 resultFileSize = file.length()

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -99,7 +99,7 @@ void call(Map parameters = [:]) {
             archiveArtifacts configuration.reportFile
             recordIssues(
                 tools: [checkStyle(
-                    name: configuration.reportName, 
+                    name: configuration.reportName,
                     pattern: configuration.reportFile,
                     id: configuration.reportName
                 )],

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -94,7 +94,7 @@ void call(Map parameters = [:]) {
             stashContent: existingStashes
         ) {
             // HaDoLint status code is ignore, results will be handled by recordIssues / archiveArtifacts
-            def ignore = sh returnStatus: true, script: "hadolint ${configuration.dockerFile} ${options.join(' ')}"
+            def result = sh returnStatus: true, script: "hadolint ${configuration.dockerFile} ${options.join(' ')}"
 
             archiveArtifacts configuration.reportFile
             recordIssues(
@@ -107,6 +107,10 @@ void call(Map parameters = [:]) {
                 enabledForFailure: true,
                 blameDisabled: true
             )
+            
+            if (result != 0) {
+                error "HaDoLint failed to scan file ${configuration.dockerFile}, please check the log for details."   
+            }
         }
     }
 }

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -113,9 +113,9 @@ void call(Map parameters = [:]) {
             if (file.exists()) {
                 resultFileSize = file.length()
             }
-            
+
             if (result != 0 && resultFileSize == 0) {
-                error "HaDoLint scan on file ${configuration.dockerFile} failed due to technical issues, please check the log."   
+                error "HaDoLint scan on file ${configuration.dockerFile} failed due to technical issues, please check the log."
             }
         }
     }

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -98,7 +98,11 @@ void call(Map parameters = [:]) {
 
             archiveArtifacts configuration.reportFile
             recordIssues(
-                tools: [checkStyle(name: configuration.reportName, pattern: configuration.reportFile)],
+                tools: [checkStyle(
+                    name: configuration.reportName, 
+                    pattern: configuration.reportFile,
+                    id: "hadolint-"+reportName
+                )],
                 qualityGates: configuration.qualityGates,
                 enabledForFailure: true,
                 blameDisabled: true

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -35,7 +35,7 @@ import groovy.transform.Field
     /**
      * Name of the result file used locally within the step.
      */
-    'reportFile'
+    'reportFile',
     /**
      * Name of the checkstyle report being generated our of the results.
      */

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -101,7 +101,7 @@ void call(Map parameters = [:]) {
                 tools: [checkStyle(
                     name: configuration.reportName, 
                     pattern: configuration.reportFile,
-                    id: "hadolint-"+configuration.reportName
+                    id: configuration.reportName
                 )],
                 qualityGates: configuration.qualityGates,
                 enabledForFailure: true,

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -108,8 +108,14 @@ void call(Map parameters = [:]) {
                 blameDisabled: true
             )
 
-            if (result != 0) {
-                error "HaDoLint scan on file ${configuration.dockerFile} detected issues, please check the log and report for details."   
+            def resultFileSize = 0
+            File file = new File(configuration.reportFile)
+            if (file.exists()) {
+                resultFileSize = file.length()
+            }
+            
+            if (result != 0 && resultFileSize == 0) {
+                error "HaDoLint scan on file ${configuration.dockerFile} failed due to technical issues, please check the log."   
             }
         }
     }

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -107,7 +107,7 @@ void call(Map parameters = [:]) {
                 enabledForFailure: true,
                 blameDisabled: true
             )
-            
+
             if (result != 0) {
                 error "HaDoLint failed to scan file ${configuration.dockerFile}, please check the log for details."   
             }

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -109,7 +109,7 @@ void call(Map parameters = [:]) {
             )
             
             def resultFileSize = 0
-            File file = new File(configuration.reportFile)
+            File file = new File("./${configuration.reportFile}")
             if (file.exists()) {
                 echo "File exists"
                 resultFileSize = file.length()

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -101,7 +101,7 @@ void call(Map parameters = [:]) {
                 tools: [checkStyle(
                     name: configuration.reportName, 
                     pattern: configuration.reportFile,
-                    id: "hadolint-"+reportName
+                    id: "hadolint-"+configuration.reportName
                 )],
                 qualityGates: configuration.qualityGates,
                 enabledForFailure: true,

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -109,7 +109,7 @@ void call(Map parameters = [:]) {
             )
 
             if (result != 0) {
-                error "HaDoLint failed to scan file ${configuration.dockerFile}, please check the log for details."   
+                error "HaDoLint scan on file ${configuration.dockerFile} detected issues, please check the log and report for details."   
             }
         }
     }

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -107,12 +107,12 @@ void call(Map parameters = [:]) {
                 enabledForFailure: true,
                 blameDisabled: true
             )
-            
+
             def resultFileSize = 0
             if (fileExists(configuration.reportFile)) {
                 resultFileSize = readFile(configuration.reportFile).length()
             }
-            
+
             if (result != 0 && resultFileSize == 0) {
                 error "HaDoLint scan on file ${configuration.dockerFile} failed due to technical issues, please check the log."
             }

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -110,12 +110,9 @@ void call(Map parameters = [:]) {
             
             def resultFileSize = 0
             if (fileExists(configuration.reportFile)) {
-                echo "File exists"
                 resultFileSize = readFile(configuration.reportFile).length()
             }
             
-            echo "Result file size is ${resultFileSize}"
-
             if (result != 0 && resultFileSize == 0) {
                 error "HaDoLint scan on file ${configuration.dockerFile} failed due to technical issues, please check the log."
             }

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -36,6 +36,10 @@ import groovy.transform.Field
      * Name of the result file used locally within the step.
      */
     'reportFile'
+    /**
+     * Name of the checkstyle report being generated our of the results.
+     */
+    'reportName'
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
 /**

--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -109,7 +109,7 @@ void call(Map parameters = [:]) {
             )
             
             def resultFileSize = 0
-            File file = new File("./${configuration.reportFile}")
+            File file = new File("${pwd()}/${configuration.reportFile}")
             if (file.exists()) {
                 echo "File exists"
                 resultFileSize = file.length()


### PR DESCRIPTION
**changes:**
- stash **all** `Dockerfile`s
- Allow modification of parameter `reportName` on step and parameter level to avoid collisions on report generation in case the step is execute several times.

- ~[ ] Tests~
- ~[ ] Documentation~
