### PR TITLE
Executing extensions in handlePipelineStepErrors

### DIFF
--- a/test/resources/stages/test_crashing_extension.groovy
+++ b/test/resources/stages/test_crashing_extension.groovy
@@ -1,0 +1,8 @@
+void call(Map params) {
+    params.originalStage()
+    String somePath = 'path/to/file'
+    int index = somePath.indexOf('fi1e') // Index is not what you think it is...
+    String fileName = somePath.substring(index) // ...Crash!
+    echo "File name is ${fileName}"
+}
+return this

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -29,17 +29,19 @@ void call(Map parameters = [:], body) {
         .use()
 
     stageLocking(config) {
-        def containerMap = ContainerMap.instance.getMap().get(stageName) ?: [:]
-        if (Boolean.valueOf(env.ON_K8S) && containerMap.size() > 0) {
-            DebugReport.instance.environment.put("environment", "Kubernetes")
-            withEnv(["POD_NAME=${stageName}"]) {
-                dockerExecuteOnKubernetes(script: script, containerMap: containerMap) {
+        handlePipelineStepErrors(stepName: stageName, stepParameters: parameters) {
+            def containerMap = ContainerMap.instance.getMap().get(stageName) ?: [:]
+            if (Boolean.valueOf(env.ON_K8S) && containerMap.size() > 0) {
+                DebugReport.instance.environment.put("environment", "Kubernetes")
+                withEnv(["POD_NAME=${stageName}"]) {
+                    dockerExecuteOnKubernetes(script: script, containerMap: containerMap) {
+                        executeStage(script, body, stageName, config, utils)
+                    }
+                }
+            } else {
+                node(config.nodeLabel) {
                     executeStage(script, body, stageName, config, utils)
                 }
-            }
-        } else {
-            node(config.nodeLabel) {
-                executeStage(script, body, stageName, config, utils)
             }
         }
     }


### PR DESCRIPTION
The code of extensions was not executed within the try-catch-block of `handlePipelineStepErrors`. The main benefit of this change is better logging and re-using the 'unstable' feature also for extended/overwritten steps.

# Changes

- [x] Tests
- [ ] Documentation
