### PR TITLE
Set revision in MavenArtifactVersioning

### DIFF
--- a/src/com/sap/piper/versioning/MavenArtifactVersioning.groovy
+++ b/src/com/sap/piper/versioning/MavenArtifactVersioning.groovy
@@ -17,5 +17,6 @@ class MavenArtifactVersioning extends ArtifactVersioning {
     @Override
     def setVersion(version) {
         script.mavenExecute script: script, goals: 'versions:set', defines: "-DnewVersion=${version} -DgenerateBackupPoms=false", pomPath: configuration.filePath
+        script.mavenExecute script: script, goals: 'versions:set-property', defines: "-Dproperty=revision -DnewVersion=$version", pomPath: configuration.filePath
     }
 }

--- a/test/groovy/com/sap/piper/versioning/MavenArtifactVersioningTest.groovy
+++ b/test/groovy/com/sap/piper/versioning/MavenArtifactVersioningTest.groovy
@@ -50,6 +50,7 @@ class MavenArtifactVersioningTest extends BasePiperTest{
         assertEquals(version, av.getVersion())
         av.setVersion('1.2.3-20180101')
         assertEquals('mvn --file \'pom.xml\' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101 -DgenerateBackupPoms=false', shellRule.shell[1])
+        assertEquals('mvn --file \'pom.xml\' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set-property -Dproperty=revision -DnewVersion=1.2.3-20180101', shellRule.shell[2])
     }
 
     @Test
@@ -58,5 +59,6 @@ class MavenArtifactVersioningTest extends BasePiperTest{
         assertEquals('1.2.3', av.getVersion())
         av.setVersion('1.2.3-20180101')
         assertEquals('mvn --file \'snapshot/pom.xml\' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set -DnewVersion=1.2.3-20180101 -DgenerateBackupPoms=false', shellRule.shell[1])
+        assertEquals('mvn --file \'snapshot/pom.xml\' --batch-mode -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn versions:set-property -Dproperty=revision -DnewVersion=1.2.3-20180101', shellRule.shell[2])
     }
 }

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -120,6 +120,7 @@ enum GitPushMode {NONE, HTTPS, SSH}
  * If this option is chosen, git credentials and the repository URL needs to be provided.
  * Since you might not want to configure the git credentials in Jenkins, committing and pushing can be disabled using the `commitVersion` parameter as described below.
  * If you require strict reproducibility of your builds, this should be used.
+ * In case you use maven ci-friendly versioning the property `revision` will be set to the value of the updated version.
  */
 @GenerateDocumentation
 void call(Map parameters = [:], Closure body = null) {


### PR DESCRIPTION
In case of maven ci-friendly versioning (https://maven.apache.org/maven-ci-friendly.html)
a revision property is used to define the version of the project.

When we set the version of the project we also have to update the revision
because there could be in-project dependencies (e.g. integration-tests)
which refer to the test artifacts version as ${revision}.

I tested the command locally with: 
```bash
mvn versions:set-property -Dproperty=someCrab -DnewVersion=123
```
Which does not result in an error if the property does not exist.
If the property is available it will be updated.

# Changes

- [x] Tests
- [x] Documentation
