### PR TITLE
writeFile() cannot be passed a Map

### DIFF
--- a/test/groovy/util/JenkinsWriteFileRule.groovy
+++ b/test/groovy/util/JenkinsWriteFileRule.groovy
@@ -1,6 +1,9 @@
 package util
 
 import com.lesfurets.jenkins.unit.BasePipelineTest
+
+import static org.junit.Assert.assertNotNull
+import static org.junit.Assert.assertTrue
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -25,7 +28,17 @@ class JenkinsWriteFileRule implements TestRule {
             @Override
             void evaluate() throws Throwable {
 
-                testInstance.helper.registerAllowedMethod( 'writeFile', [Map.class], {m -> files[m.file] = m.text.toString()})
+                testInstance.helper.registerAllowedMethod( 'writeFile', [Map.class], { m ->
+                    assertNotNull(m.file)
+                    assertTrue(m.file instanceof CharSequence)
+                    assertNotNull(m.text)
+                    assertTrue(m.text instanceof CharSequence)
+                    if (m.encoding) {
+                        assertTrue(m.encoding instanceof CharSequence)
+                        // Would be nice to actually handle encoding
+                    }
+                    files[m.file] = m.text
+                })
 
                 base.evaluate()
             }

--- a/vars/debugReportArchive.groovy
+++ b/vars/debugReportArchive.groovy
@@ -63,7 +63,7 @@ void call(Map parameters = [:]) {
             echo result.contents
         }
 
-        script.writeFile file: result.fileName, text: result
+        script.writeFile file: result.fileName, text: result.contents
         script.archiveArtifacts artifacts: result.fileName
         echo "Successfully archived debug report as '${result.fileName}'"
     } catch (Exception e) {


### PR DESCRIPTION
I've changed the return type of DebugReport.generateReport() from
String to Map in order to get the generated file name as part of the
return value instead of getting it from a field of DebugReport. The
UnitTest checks whether writeFile() creates the debug_report file
successfully and whether it has the expected contents. The effect
of passing the Map instead of map.contents to writeFile() should
have been an unnecessary wrapping via Map.toString() as in the test,
but in the execution context of Jenkins, this throws an
IllegalArgumentException: Could not instantiate {... and then the
results of map.toString(). This could also be a problem with how
JenkinsWriteFileRule simulates the writeFile step.