### PR TITLE
Init CPE with empty 'general' config

### DIFF
--- a/documentation/docs/steps/setupCommonPipelineEnvironment.md
+++ b/documentation/docs/steps/setupCommonPipelineEnvironment.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-* A **configuration file** with properties. The property values are used as default values in many pipeline steps.
+none
 
 ## ${docGenParameters}
 
@@ -14,7 +14,7 @@
 
 ## Side effects
 
-none
+* If no configuration file is provided, a `commonPipelineEnvironment` is created with an empty general configuration.
 
 ## Exceptions
 

--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -65,5 +65,17 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
         assertEquals('develop', nullScript.commonPipelineEnvironment.configuration.general.productiveBranch)
         assertEquals('my-maven-docker', nullScript.commonPipelineEnvironment.configuration.steps.mavenExecute.dockerImage)
     }
+
+    @Test
+    void "Without config file still sets up cpe with an empty general configuration"() throws Exception {
+
+        helper.registerAllowedMethod("fileExists", [String], { String path ->
+            return false
+        })
+
+        stepRule.step.setupCommonPipelineEnvironment(script: nullScript)
+
+        assertNotNull(nullScript.commonPipelineEnvironment.configuration.general)
+    }
 }
 

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -25,8 +25,8 @@ import groovy.transform.Field
  * Initializes the [`commonPipelineEnvironment`](commonPipelineEnvironment.md), which is used throughout the complete pipeline.
  *
  * !!! tip
- *    This step needs to run at the beginning of a pipeline right after the SCM checkout.
- *    Then subsequent pipeline steps consume the information from `commonPipelineEnvironment`; it does not need to be passed to pipeline steps explicitly.
+ *     This step needs to run at the beginning of a pipeline right after the SCM checkout.
+ *     Then subsequent pipeline steps consume the information from `commonPipelineEnvironment`; it does not need to be passed to pipeline steps explicitly.
  */
 @GenerateDocumentation
 void call(Map parameters = [:]) {

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -68,5 +68,7 @@ private loadConfigurationFromFile(script, String configFile) {
         script.commonPipelineEnvironment.configuration = readYaml(file: defaultYmlConfigFile)
     } else if (fileExists(defaultYamlConfigFile)) {
         script.commonPipelineEnvironment.configuration = readYaml(file: defaultYamlConfigFile)
+    } else {
+        script.commonPipelineEnvironment.configuration = [general: [:]]
     }
 }


### PR DESCRIPTION
If no config file is present an empty general config is
created to allow the pipeline to write to it.

# Changes

- [x] Tests
- [x] Documentation
