### PR TITLE
Ignore email addresses containing string "noreply"

### DIFF
--- a/test/groovy/MailSendNotificationTest.groovy
+++ b/test/groovy/MailSendNotificationTest.groovy
@@ -41,6 +41,7 @@ class MailSendNotificationTest extends BasePiperTest {
 user1@domain.com noreply+github@domain.com
 user3@domain.com noreply+github@domain.com
 user2@domain.com user1@domain.com
+user1@users.noreply.github.com
 user1@domain.com noreply+github@domain.com
 user3@domain.com noreply+github@domain.com
 user3@domain.com noreply+github@domain.com

--- a/test/groovy/MailSendNotificationTest.groovy
+++ b/test/groovy/MailSendNotificationTest.groovy
@@ -41,7 +41,7 @@ class MailSendNotificationTest extends BasePiperTest {
 user1@domain.com noreply+github@domain.com
 user3@domain.com noreply+github@domain.com
 user2@domain.com user1@domain.com
-user1@users.noreply.github.com
+user1@noreply.domain.com
 user1@domain.com noreply+github@domain.com
 user3@domain.com noreply+github@domain.com
 user3@domain.com noreply+github@domain.com

--- a/vars/mailSendNotification.groovy
+++ b/vars/mailSendNotification.groovy
@@ -240,7 +240,7 @@ def getDistinctRecipients(recipients){
             address = address.trim()
             if(address
                 && address.contains("@")
-                && !address.startsWith("noreply")
+                && !address.contains("noreply")
                 && !knownAddresses.contains(address)) {
                 knownAddresses.add(address)
             }


### PR DESCRIPTION
# Changes
Hi,

we’re using an auto merge bot (github app) to merge our pull requests automatically. Unfortunately, it looks like we cannot easily configure an email address for our bot and piper is not able to send emails in case the bot’s internal github email address is part of the committer list:

[mailSendNotification] last 18 commits revealed following responsibles user1@domain.com user2@domain.com 56094+cos-probot-auto-merge[bot]@users.noreply.github.domain.co
[Pipeline] emailext
Failed to create e-mail address for 56094+cos-probot-auto-merge[bot]@users.noreply.github.domain.com
An attempt to send an e-mail to empty list of recipients, ignored.

To circumvent the problem for us and potential other github app consumers I’m creating this PR which avoids that Piper sends mails to users if the email address contains the string “noreply”.
- [x] Tests
- [ ] Documentation
