### PR TITLE
Streamline implementation githubPublishRelease

### DIFF
--- a/resources/metadata/githubrelease.yaml
+++ b/resources/metadata/githubrelease.yaml
@@ -18,10 +18,6 @@ spec:
       - name: githubTokenCredentialsId
         description: Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.
         type: jenkins
-    resources:
-      - name: commonPipelineEnvironment
-        resourceSpec:
-          type: piperEnvironment
     params:
       - name: addClosedIssues
         description: 'If set to `true`, closed issues and merged pull-requests since the last release will added below the `releaseBodyHeader`'

--- a/test/groovy/GithubPublishReleaseTest.groovy
+++ b/test/groovy/GithubPublishReleaseTest.groovy
@@ -61,6 +61,6 @@ class GithubPublishReleaseTest extends BasePiperTest {
         // asserts
         assertThat(writeFileRule.files['metadata/githubrelease.yaml'], containsString('name: githubPublishRelease'))
         assertThat(withEnvArgs[0], allOf(startsWith('PIPER_parametersJSON'), containsString('"testParam":"This is test content"')))
-        assertThat(shellCallRule.shell[1], is('./piper githubPublishRelease --token thisIsATestToken'))
+        assertThat(shellCallRule.shell[1], is('./piper githubPublishRelease'))
     }
 }

--- a/vars/githubPublishRelease.groovy
+++ b/vars/githubPublishRelease.groovy
@@ -34,8 +34,8 @@ void call(Map parameters = [:]) {
             config = readJSON (text: sh(returnStdout: true, script: "./piper getConfig --contextConfig --stepMetadata '${METADATA_FILE}'"))
 
             // execute step
-            withCredentials([string(credentialsId: config.githubTokenCredentialsId, variable: 'TOKEN')]) {
-                sh "./piper githubPublishRelease  --token ${TOKEN}"
+            withCredentials([string(credentialsId: config.githubTokenCredentialsId, variable: 'PIPER_token')]) {
+                sh './piper githubPublishRelease'
             }
         }
     }


### PR DESCRIPTION
# Changes

The PR removes an unnecessary reference to a `resource`.
This is not required since the reference in the `parameters` section is sufficient.

In addition it is better to provide credentials via environment variable.

With the changes this step can now serve also as an example how to do things like:
* passing credentials
* using `commonPipelineEnvironment` as input resource

