### PR TITLE
Utils.evaluateFromMavenPom(): Handle errors

### DIFF
--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -163,5 +163,13 @@ static String evaluateFromMavenPom(Script script, String pomFileName, String pom
         defines: "-Dexpression=$pomPathExpression -DforceStdout -q",
         returnStdout: true
     )
+    if (resolvedExpression.startsWith('null object or invalid expression')) {
+        // There is no error indication (exit code or otherwise) from the
+        // 'evaluate' Maven plugin, only this output to stdout. The calling
+        // code assumes an empty string is returned when the property could
+        // not be resolved.
+        throw new RuntimeException("Cannot evaluate property value from '${pomFileName}', " +
+            "missing property or invalid expression '${pomPathExpression}'.")
+    }
     return resolvedExpression
 }


### PR DESCRIPTION
# Changes

Manual testing of using the mvn evaluate plugin has revealed the following behavior for properties that do not exist:
```
▶ mvn --file pom.xml -Dexpression=project.url -DforceStdout -q org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate
https://sap.github.io/jenkins-library/%
```
If I remove the `url` property, mvn will still have a 0 exit code and a non-empty output to stdout:
```
▶ mvn --file pom.xml -Dexpression=project.url -DforceStdout -q org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate
null object or invalid expression%
```
This change makes sure that Utils.evaluateFromMavenPom() returns an empty string when there was an error in the expression or the property cannot be resolved, instead of returning the error message itself as if it were the result.

It would be great if there was a test which then fails in case the mvn evaluate plugin returns a different error message after a dependency update. This would be more like an integration test that calls the actual mvn command line tool and needs the plugin installed. If someone could assist me with that, or point to an existing example, it would be greatly appreciated. Otherwise the change is definitely an important improvement of the status quo.

- [ ] Tests
- [ ] Documentation
