### PR TITLE
Change go indent_size to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,4 +24,4 @@ indent_style = none
 indent_size = none
 [{go.mod,go.sum,*.go,*.golden}]
 indent_style = tab
-indent_size = 8
+indent_size = 4


### PR DESCRIPTION
I know this may lead to a discussion of taste and there may be a reason...

But an indent size of 4 seems for me suitable enough to have readable code - therefore my PR to change that in the editorconfig