### PR TITLE
switch downloader from POST to GET

### DIFF
--- a/pkg/http/downloader.go
+++ b/pkg/http/downloader.go
@@ -16,7 +16,7 @@ type Downloader interface {
 
 // DownloadFile downloads a file's content as GET request from the specified URL to the specified file
 func (c *Client) DownloadFile(url, filename string, header http.Header, cookies []*http.Cookie) error {
-	return c.DownloadRequest(http.MethodPost, url, filename, header, cookies)
+	return c.DownloadRequest(http.MethodGet, url, filename, header, cookies)
 }
 
 // DownloadRequest ...


### PR DESCRIPTION
Is there any reason for using a POST request for downloading some content. To my understanding POST is used for transmitting parameters where GET is used for simply retrieving something.