### PR TITLE
Run integration tests on push to it/* branch

### DIFF
--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -56,7 +56,7 @@ jobs:
     - name: verify
       run: git diff --name-only --exit-code
   integration:
-    if: github.repository=='SAP/jenkins-library'
+    if: github.repository=='SAP/jenkins-library' || startsWith(github.ref, 'it/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v1

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -56,6 +56,7 @@ jobs:
     - name: verify
       run: git diff --name-only --exit-code
   integration:
+    if: github.repository=='SAP/jenkins-library'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v1


### PR DESCRIPTION
Because the secrets cannot be read if the PR is coming from a fork.

@CCFenner will this fix [this](https://github.com/SAP/jenkins-library/pull/1198#issuecomment-588389291)?
