### PR TITLE
Copy file and create missing directories for the destination file

### DIFF
--- a/cmd/xsDeploy.go
+++ b/cmd/xsDeploy.go
@@ -120,7 +120,7 @@ func xsDeploy(config xsDeployOptions, telemetryData *telemetry.CustomData) {
 
 func runXsDeploy(XsDeployOptions xsDeployOptions, s shellRunner,
 	fExists func(string) (bool, error),
-	fCopy func(string, string) (int64, error),
+	fCopy func(string, string, bool) (int64, error),
 	fRemove func(string) error,
 	stdout io.Writer) error {
 
@@ -435,20 +435,20 @@ func executeCmd(templateID string, commandPattern string, properties interface{}
 	return nil
 }
 
-func copyFileFromHomeToPwd(xsSessionFile string, fCopy func(string, string) (int64, error)) error {
+func copyFileFromHomeToPwd(xsSessionFile string, fCopy func(string, string, bool) (int64, error)) error {
 	if fCopy == nil {
 		fCopy = piperutils.Copy
 	}
 	src, dest := fmt.Sprintf("%s/%s", os.Getenv("HOME"), xsSessionFile), fmt.Sprintf("%s", xsSessionFile)
 	log.Entry().Debugf("Copying xs session file from home directory ('%s') to workspace ('%s')", src, dest)
-	if _, err := fCopy(src, dest); err != nil {
+	if _, err := fCopy(src, dest, false); err != nil {
 		return errors.Wrapf(err, "Cannot copy xssession file from home directory ('%s') to workspace ('%s')", src, dest)
 	}
 	log.Entry().Debugf("xs session file copied from home directory ('%s') to workspace ('%s')", src, dest)
 	return nil
 }
 
-func copyFileFromPwdToHome(xsSessionFile string, fCopy func(string, string) (int64, error)) error {
+func copyFileFromPwdToHome(xsSessionFile string, fCopy func(string, string, bool) (int64, error)) error {
 
 	//
 	// We rely on running inside a docker container which is discarded after a single use.
@@ -462,7 +462,7 @@ func copyFileFromPwdToHome(xsSessionFile string, fCopy func(string, string) (int
 	}
 	src, dest := fmt.Sprintf("%s", xsSessionFile), fmt.Sprintf("%s/%s", os.Getenv("HOME"), xsSessionFile)
 	log.Entry().Debugf("Copying xs session file from workspace ('%s') to home directory ('%s')", src, dest)
-	if _, err := fCopy(src, dest); err != nil {
+	if _, err := fCopy(src, dest, false); err != nil {
 		return errors.Wrapf(err, "Cannot copy xssession file from workspace ('%s') to home directory ('%s')", src, dest)
 	}
 	log.Entry().Debugf("xs session file copied from workspace ('%s') to home directory ('%s')", src, dest)

--- a/cmd/xsDeploy_test.go
+++ b/cmd/xsDeploy_test.go
@@ -37,7 +37,7 @@ func TestDeploy(t *testing.T) {
 		return path == "dummy.mtar" || path == ".xs_session", nil
 	}
 
-	fCopy := func(src, dest string) (int64, error) {
+	fCopy := func(src, dest string, createMissingDirectories bool) (int64, error) {
 		copiedFiles = append(copiedFiles, fmt.Sprintf("%s->%s", src, dest))
 		return 0, nil
 	}

--- a/pkg/piperutils/fileUtils_test.go
+++ b/pkg/piperutils/fileUtils_test.go
@@ -1,6 +1,7 @@
 package piperutils
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
@@ -37,7 +38,41 @@ func TestCopy(t *testing.T) {
 	// clean up tmp dir
 	defer os.RemoveAll(dir)
 
-	result, err := Copy(file, filepath.Join(dir, "testFile2"))
+	result, err := Copy(file, filepath.Join(dir, "testFile2"), false)
 	assert.NoError(t, err, "Didn't expert error but got one")
 	assert.Equal(t, int64(3), result, "Expected true but got false")
+}
+
+func TestCopyIntoNestedFoldersWhichDoesNotExist(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dir2")
+	file := filepath.Join(dir, "testFile")
+	err = ioutil.WriteFile(file, []byte{byte(1), byte(2), byte(3)}, 0700)
+	if err != nil {
+		t.Fatal("Failed to create temporary workspace directory")
+	}
+	// clean up tmp dir
+	defer os.RemoveAll(dir)
+
+	result, err := Copy(file, filepath.Join(filepath.Join(filepath.Join(dir, "1"), "2"), "testFile2"), true)
+	assert.NoError(t, err, "Didn't expert error but got one")
+	assert.Equal(t, int64(3), result, "Expected true but got false")
+}
+
+func TestCopyIntoNestedFoldersWhichDoesNotExistDontCreateMissingFolders(t *testing.T) {
+	dir, err := ioutil.TempDir("", "dir2")
+	file := filepath.Join(dir, "testFile")
+	err = ioutil.WriteFile(file, []byte{byte(1), byte(2), byte(3)}, 0700)
+	if err != nil {
+		t.Fatal("Failed to create temporary workspace directory")
+	}
+	// clean up tmp dir
+	defer os.RemoveAll(dir)
+
+	dest := filepath.Join(filepath.Join(filepath.Join(dir, "1"), "2"), "testFile2")
+	_, err = Copy(file, dest, false)
+	if assert.Error(t, err) {
+		_, err := os.Stat(dest)
+		assert.True(t, os.IsNotExist(err))
+		assert.Equal(t, fmt.Sprintf("Parent folder for file '%s/1/2/3/testFile2' does not exist, createMissingDirectories was 'false'", dir), err.Error())
+	}
 }


### PR DESCRIPTION
@stippi2 : related to our discussion in pr #1176 

Now we can decide inside `FileUtils.Copy` if we want to create missing folders for the destination file.