### PR TITLE
Use piper exe in CWD for integration tests if available

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5,7 +5,10 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/SAP/jenkins-library/pkg/command"
@@ -27,7 +30,19 @@ func TestPiperHelp(t *testing.T) {
 
 func getPiperExecutable() string {
 	if p := os.Getenv("PIPER_INTEGRATION_EXECUTABLE"); len(p) > 0 {
+		fmt.Println("Piper executable for integration test: " + p)
 		return p
 	}
+
+	f := piperutils.Files{}
+	wd, _ := os.Getwd()
+	localPiper := path.Join(wd, "piper")
+	exists, _ := f.FileExists(localPiper)
+	if exists {
+		fmt.Println("Piper executable for integration test: " + localPiper)
+		return localPiper
+	}
+
+	fmt.Println("Piper executable for integration test: Using 'piper' from PATH")
 	return "piper"
 }


### PR DESCRIPTION
This change allows a development workflow where you don't need to set the `PIPER_INTEGRATION_EXECUTABLE` variable if your executable is available in the CWD. This should make it non-required to set the variable for most cases of local development.

# Changes

- [ ] Tests
- [ ] Documentation
