### PR TITLE
Add tag release when building go binary

### DIFF
--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -64,7 +64,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     - name: build
-      run: CGO_ENABLED=0 go build -o piper -tags release && chmod +x piper
+      run: CGO_ENABLED=0 go build -o piper -tags release && chmod +x piper # with `-tags release` we ensure that shared test utilities won't end up in the binary
     - name: test
       env:
         PIPER_INTEGRATION_GITHUB_TOKEN: ${{secrets.PIPER_INTEGRATION_GITHUB_TOKEN}}

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -64,7 +64,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2
     - name: build
-      run: CGO_ENABLED=0 go build -o piper && chmod +x piper
+      run: CGO_ENABLED=0 go build -o piper -tags release && chmod +x piper
     - name: test
       env:
         PIPER_INTEGRATION_GITHUB_TOKEN: ${{secrets.PIPER_INTEGRATION_GITHUB_TOKEN}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN export GIT_COMMIT=$(git rev-parse HEAD) && \
             "-X github.com/SAP/jenkins-library/cmd.GitCommit=${GIT_COMMIT} \
             -X github.com/SAP/jenkins-library/pkg/log.LibraryRepository=${GIT_REPOSITORY} \
             -X github.com/SAP/jenkins-library/pkg/telemetry.LibraryRepository=${GIT_REPOSITORY}" \
+        -tags release \
         -o piper
 
 # FROM gcr.io/distroless/base:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN go test ./... -cover
 
 ## ONLY tests so far, building to be added later
 # execute build
+# with `-tags release` we ensure that shared test utilities won't end up in the binary
 RUN export GIT_COMMIT=$(git rev-parse HEAD) && \
     export GIT_REPOSITORY=$(git config --get remote.origin.url) && \
     CGO_ENABLED=0 go build \

--- a/pkg/mock/runner.go
+++ b/pkg/mock/runner.go
@@ -1,3 +1,5 @@
+// +build !release
+
 package mock
 
 import (


### PR DESCRIPTION
This change ensures that shared testing capabilities e.g. in `pkg/mock/runner` won't end up in the production code using go build tags (see [here](https://www.digitalocean.com/community/tutorials/customizing-go-binaries-with-build-tags) for more information.).

To verify that this PR works you can add  `// +build !release` to e.g. `cmd/interfaces.go` and then build the binary with `go build -tags release`. The result is that the code can't be compiled.