### PR TITLE
Build piper binary in Consumer Tests

### DIFF
--- a/consumer-test/TestRunnerThread.groovy
+++ b/consumer-test/TestRunnerThread.groovy
@@ -64,6 +64,8 @@ class TestRunnerThread extends Thread {
             "-e CASC_JENKINS_CONFIG=/workspace/jenkins.yml " +
             "-e ${testCaseConfig.deployCredentialEnv.username} " +
             "-e ${testCaseConfig.deployCredentialEnv.password} " +
+            "-e LIBRARY_VERSION_UNDER_TEST=${libraryVersionUnderTest} " +
+            "-e REPOSITORY_UNDER_TEST=${repositoryUnderTest} " +
             "-e BRANCH_NAME=${testCaseConfig.referenceAppRepo.branch} ppiper/jenkinsfile-runner")
 
         println "*****[INFO] Test case '${uniqueName}' finished successfully.*****"

--- a/src/com/sap/piper/PiperGoUtils.groovy
+++ b/src/com/sap/piper/PiperGoUtils.groovy
@@ -1,7 +1,5 @@
 package com.sap.piper
 
-import jenkins.model.Jenkins
-
 class PiperGoUtils implements Serializable {
 
     private static Script steps

--- a/src/com/sap/piper/PiperGoUtils.groovy
+++ b/src/com/sap/piper/PiperGoUtils.groovy
@@ -1,5 +1,7 @@
 package com.sap.piper
 
+import jenkins.model.Jenkins
+
 class PiperGoUtils implements Serializable {
 
     private static Script steps
@@ -19,30 +21,46 @@ class PiperGoUtils implements Serializable {
 
         if (utils.unstash('piper-bin').size() > 0) return
 
-        def libraries = getLibrariesInfo()
-        String version
-        libraries.each {lib ->
-            if (lib.name == 'piper-lib-os') {
-                version = lib.version
+        if (steps.env.REPOSITORY_UNDER_TEST && steps.env.LIBRARY_VERSION_UNDER_TEST) {
+            println("Running in a consumer test, building unit-under-test binary for verification.")
+            steps.dockerExecute(script: steps, dockerImage: 'golang:1.13', dockerOptions: '-u 0', dockerEnvVars: [
+                REPOSITORY_UNDER_TEST: steps.env.REPOSITORY_UNDER_TEST,
+                LIBRARY_VERSION_UNDER_TEST: steps.env.LIBRARY_VERSION_UNDER_TEST
+            ]) {
+                steps.sh 'wget https://github.com/$REPOSITORY_UNDER_TEST/archive/$LIBRARY_VERSION_UNDER_TEST.tar.gz'
+                steps.sh 'tar xzf $LIBRARY_VERSION_UNDER_TEST.tar.gz'
+                steps.dir("jenkins-library-${steps.env.LIBRARY_VERSION_UNDER_TEST}") {
+                    steps.sh 'CGO_ENABLED=0 go build -tags release -o ../piper . && chmod +x ../piper && chown 1000:999 ../piper'
+                }
+                steps.sh 'rm -rf $LIBRARY_VERSION_UNDER_TEST.tar.gz jenkins-library-$LIBRARY_VERSION_UNDER_TEST'
             }
-        }
-
-        def fallbackUrl = 'https://github.com/SAP/jenkins-library/releases/latest/download/piper_master'
-        def piperBinUrl = (version == 'master') ? fallbackUrl : "https://github.com/SAP/jenkins-library/releases/download/${version}/piper"
-
-        boolean downloaded = downloadGoBinary(piperBinUrl)
-        if (!downloaded) {
-            //Inform that no Piper binary is available for used library branch
-            steps.echo ("Not able to download go binary of Piper for version ${version}")
-            //Fallback to master version & throw error in case this fails
-            steps.retry(5) {
-                if (!downloadGoBinary(fallbackUrl)) {
-                    steps.sleep(2)
-                    steps.error("Download of Piper go binary failed.")
+        } else {
+            def libraries = getLibrariesInfo()
+            String version
+            libraries.each {lib ->
+                if (lib.name == 'piper-lib-os') {
+                    version = lib.version
                 }
             }
 
+            def fallbackUrl = 'https://github.com/SAP/jenkins-library/releases/latest/download/piper_master'
+            def piperBinUrl = (version == 'master') ? fallbackUrl : "https://github.com/SAP/jenkins-library/releases/download/${version}/piper"
+
+            boolean downloaded = downloadGoBinary(piperBinUrl)
+            if (!downloaded) {
+                //Inform that no Piper binary is available for used library branch
+                steps.echo ("Not able to download go binary of Piper for version ${version}")
+                //Fallback to master version & throw error in case this fails
+                steps.retry(5) {
+                    if (!downloadGoBinary(fallbackUrl)) {
+                        steps.sleep(2)
+                        steps.error("Download of Piper go binary failed.")
+                    }
+                }
+
+            }
         }
+
         utils.stashWithMessage('piper-bin', 'failed to stash piper binary', 'piper')
     }
 

--- a/src/com/sap/piper/PiperGoUtils.groovy
+++ b/src/com/sap/piper/PiperGoUtils.groovy
@@ -20,7 +20,7 @@ class PiperGoUtils implements Serializable {
         if (utils.unstash('piper-bin').size() > 0) return
 
         if (steps.env.REPOSITORY_UNDER_TEST && steps.env.LIBRARY_VERSION_UNDER_TEST) {
-            println("Running in a consumer test, building unit-under-test binary for verification.")
+            steps.echo("Running in a consumer test, building unit-under-test binary for verification.")
             steps.dockerExecute(script: steps, dockerImage: 'golang:1.13', dockerOptions: '-u 0', dockerEnvVars: [
                 REPOSITORY_UNDER_TEST: steps.env.REPOSITORY_UNDER_TEST,
                 LIBRARY_VERSION_UNDER_TEST: steps.env.LIBRARY_VERSION_UNDER_TEST


### PR DESCRIPTION
# Changes

This change makes sure we're using the piper version under test for the consumer tests.

- [ ] Tests
- [ ] Documentation
