### PR TITLE
Implementation of Nexus upload as Go package

### DIFF
--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
@@ -44,7 +43,6 @@ type Uploader interface {
 	SetBaseURL(nexusURL, nexusVersion, repository, groupID string) error
 	SetArtifactsVersion(version string) error
 	AddArtifact(artifact ArtifactDescription) error
-	AddArtifactsFromJSON(json string) error
 	GetArtifacts() []ArtifactDescription
 	UploadArtifacts() error
 }
@@ -108,31 +106,6 @@ func validateArtifact(artifact ArtifactDescription) error {
 			artifact.File, artifact.ID, artifact.Type)
 	}
 	return nil
-}
-
-// AddArtifactsFromJSON parses the provided JSON string into an array of ArtifactDescriptions and adds each of
-// them via AddArtifact().
-func (nexusUpload *Upload) AddArtifactsFromJSON(json string) error {
-	artifacts, err := getArtifactsFromJSON(json)
-	if err != nil {
-		return err
-	}
-	if len(artifacts) == 0 {
-		return errors.New("no artifact descriptions found in JSON string")
-	}
-	for _, artifact := range artifacts {
-		err = nexusUpload.AddArtifact(artifact)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func getArtifactsFromJSON(artifactsAsJSON string) ([]ArtifactDescription, error) {
-	var artifacts []ArtifactDescription
-	err := json.Unmarshal([]byte(artifactsAsJSON), &artifacts)
-	return artifacts, err
 }
 
 func (nexusUpload *Upload) containsArtifact(artifact ArtifactDescription) bool {

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -182,7 +182,7 @@ func getBaseURL(nexusURL, nexusVersion, repository, groupID string) (string, err
 	case "nexus3":
 		baseURL += "/repository/"
 	default:
-		return "", fmt.Errorf("unsupported Nexus version '%s'", nexusVersion)
+		return "", fmt.Errorf("unsupported Nexus version '%s', must be 'nexus2' or 'nexus3'", nexusVersion)
 	}
 	groupPath := strings.ReplaceAll(groupID, ".", "/")
 	baseURL += repository + "/" + groupPath + "/"

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -18,8 +18,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// ArtifactDescription describes a single artifact that can be uploaded to a Nexus repository manager. The File string
-// must point to an existing file. The Classifier can be empty.
+// ArtifactDescription describes a single artifact that can be uploaded to a Nexus repository manager.
+// The File string must point to an existing file. The Classifier can be empty.
 type ArtifactDescription struct {
 	ID         string `json:"artifactId"`
 	Classifier string `json:"classifier"`
@@ -27,8 +27,8 @@ type ArtifactDescription struct {
 	File       string `json:"file"`
 }
 
-// Upload holds state for an upload session. Call SetBaseURL(), SetArtifactsVersion() and add at least one artifact via
-// AddArtifact(). Then call UploadArtifacts().
+// Upload holds state for an upload session. Call SetBaseURL(), SetArtifactsVersion() and add at least
+// one artifact via AddArtifact(). Then call UploadArtifacts().
 type Upload struct {
 	baseURL   string
 	version   string
@@ -77,8 +77,8 @@ func (nexusUpload *Upload) SetBaseURL(nexusURL, nexusVersion, repository, groupI
 	return nil
 }
 
-// SetArtifactsVersion sets the common version for all uploaded artifacts. The version is external to the artifact
-// descriptions so that it is consistent for all of them.
+// SetArtifactsVersion sets the common version for all uploaded artifacts. The version is external to
+// the artifact descriptions so that it is consistent for all of them.
 func (nexusUpload *Upload) SetArtifactsVersion(version string) error {
 	if version == "" {
 		return errors.New("version must not be empty")
@@ -104,7 +104,8 @@ func (nexusUpload *Upload) AddArtifact(artifact ArtifactDescription) error {
 
 func validateArtifact(artifact ArtifactDescription) error {
 	if artifact.File == "" || artifact.ID == "" || artifact.Type == "" {
-		return fmt.Errorf("Artifact.File (%v), ID (%v) or Type (%v) is empty", artifact.File, artifact.ID, artifact.Type)
+		return fmt.Errorf("Artifact.File (%v), ID (%v) or Type (%v) is empty",
+			artifact.File, artifact.ID, artifact.Type)
 	}
 	return nil
 }
@@ -194,7 +195,11 @@ func (nexusUpload *Upload) uploadArtifacts(client piperHttp.Sender) error {
 
 func (nexusUpload *Upload) createHTTPClient() *piperHttp.Client {
 	client := piperHttp.Client{}
-	clientOptions := piperHttp.ClientOptions{Username: nexusUpload.Username, Password: nexusUpload.Password, Logger: nexusUpload.Logger}
+	clientOptions := piperHttp.ClientOptions{
+		Username: nexusUpload.Username,
+		Password: nexusUpload.Password,
+		Logger:   nexusUpload.Logger,
+	}
 	client.SetOptions(clientOptions)
 	return &client
 }

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -49,7 +49,7 @@ type Uploader interface {
 
 func (nexusUpload *Upload) initLogger() {
 	if nexusUpload.Logger == nil {
-		nexusUpload.Logger = log.Entry().WithField("package", "SAP/jenkins-library/pkg/nexusUpload")
+		nexusUpload.Logger = log.Entry().WithField("package", "SAP/jenkins-library/pkg/nexus")
 	}
 }
 

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -93,6 +93,9 @@ func validateArtifact(artifact ArtifactDescription) error {
 		return fmt.Errorf("Artifact.File (%v), ID (%v) or Type (%v) is empty",
 			artifact.File, artifact.ID, artifact.Type)
 	}
+	if strings.Contains(artifact.ID, "/") {
+		return fmt.Errorf("Artifact.ID may not include slashes")
+	}
 	return nil
 }
 

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -38,7 +38,8 @@ type Upload struct {
 	Logger    *logrus.Entry
 }
 
-// Uploader provides an interface to the nexus upload for configuring the target Nexus Repository and adding artifacts.
+// Uploader provides an interface to the nexus upload for configuring the target Nexus Repository and
+// adding artifacts.
 type Uploader interface {
 	SetBaseURL(nexusURL, nexusVersion, repository, groupID string) error
 	SetArtifactsVersion(version string) error
@@ -86,7 +87,8 @@ func (nexusUpload *Upload) SetArtifactsVersion(version string) error {
 	return nil
 }
 
-// AddArtifact adds a single artifact to the Upload.
+// AddArtifact adds a single artifact to be uploaded later via UploadArtifacts(). If an identical artifact
+// description is already contained in the Upload, the function does nothing and returns no error.
 func (nexusUpload *Upload) AddArtifact(artifact ArtifactDescription) error {
 	err := validateArtifact(artifact)
 	if err != nil {
@@ -148,8 +150,7 @@ func (nexusUpload *Upload) GetArtifacts() []ArtifactDescription {
 	return artifacts
 }
 
-// UploadArtifacts performs the actual upload to Nexus. If any error occurs, the program will currently exit via
-// the logger.
+// UploadArtifacts performs the actual upload of all added artifacts to the Nexus server.
 func (nexusUpload *Upload) UploadArtifacts() error {
 	client := nexusUpload.createHTTPClient()
 	return nexusUpload.uploadArtifacts(client)

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -55,15 +55,6 @@ func (nexusUpload *Upload) initLogger() {
 
 // SetBaseURL constructs the base URL for all uploaded artifacts. No parameter can be empty.
 func (nexusUpload *Upload) SetBaseURL(nexusURL, nexusVersion, repository, groupID string) error {
-	if nexusURL == "" {
-		return errors.New("nexusURL must not be empty")
-	}
-	if repository == "" {
-		return errors.New("repository must not be empty")
-	}
-	if groupID == "" {
-		return errors.New("groupID must not be empty")
-	}
 	baseURL, err := getBaseURL(nexusURL, nexusVersion, repository, groupID)
 	if err != nil {
 		return err
@@ -175,6 +166,15 @@ func (nexusUpload *Upload) createHTTPClient() *piperHttp.Client {
 }
 
 func getBaseURL(nexusURL, nexusVersion, repository, groupID string) (string, error) {
+	if nexusURL == "" {
+		return "", errors.New("nexusURL must not be empty")
+	}
+	if repository == "" {
+		return "", errors.New("repository must not be empty")
+	}
+	if groupID == "" {
+		return "", errors.New("groupID must not be empty")
+	}
 	baseURL := nexusURL
 	switch nexusVersion {
 	case "nexus2":

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -135,7 +135,7 @@ func (nexusUpload *Upload) uploadArtifacts(client piperHttp.Sender) error {
 		return fmt.Errorf("the nexus.Upload needs to be configured by calling SetArtifactsVersion() first")
 	}
 	if len(nexusUpload.artifacts) == 0 {
-		return fmt.Errorf("no artifacts to upload, call AddArtifact() or AddArtifactsFromJSON() first")
+		return fmt.Errorf("no artifacts to upload, call AddArtifact() first")
 	}
 
 	nexusUpload.initLogger()

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -1,0 +1,292 @@
+package nexus
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	piperHttp "github.com/SAP/jenkins-library/pkg/http"
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/sirupsen/logrus"
+)
+
+// ArtifactDescription describes a single artifact that can be uploaded to a Nexus repository manager. The File string
+// must point to an existing file. The Classifier can be empty.
+type ArtifactDescription struct {
+	ID         string `json:"artifactId"`
+	Classifier string `json:"classifier"`
+	Type       string `json:"type"`
+	File       string `json:"file"`
+}
+
+// Upload holds state for an upload session. Call SetBaseURL(), SetArtifactsVersion() and add at least one artifact via
+// AddArtifact(). Then call UploadArtifacts().
+type Upload struct {
+	baseURL   string
+	version   string
+	Username  string
+	Password  string
+	artifacts []ArtifactDescription
+	Logger    *logrus.Entry
+}
+
+// Uploader provides an interface to the nexus upload for configuring the target Nexus Repository and adding artifacts.
+type Uploader interface {
+	SetBaseURL(nexusURL, nexusVersion, repository, groupID string) error
+	SetArtifactsVersion(version string) error
+	AddArtifact(artifact ArtifactDescription) error
+	AddArtifactsFromJSON(json string) error
+	GetArtifacts() []ArtifactDescription
+	UploadArtifacts() error
+}
+
+func (nexusUpload *Upload) initLogger() {
+	if nexusUpload.Logger == nil {
+		nexusUpload.Logger = log.Entry().WithField("package", "SAP/jenkins-library/pkg/nexusUpload")
+	}
+}
+
+// SetBaseURL constructs the base URL for all uploaded artifacts. No parameter can be empty.
+func (nexusUpload *Upload) SetBaseURL(nexusURL, nexusVersion, repository, groupID string) error {
+	if nexusURL == "" {
+		return errors.New("nexusURL must not be empty")
+	}
+	if nexusVersion != "nexus2" && nexusVersion != "nexus3" {
+		return errors.New("nexusVersion must be one of 'nexus2' or 'nexus3'")
+	}
+	if repository == "" {
+		return errors.New("repository must not be empty")
+	}
+	if groupID == "" {
+		return errors.New("groupID must not be empty")
+	}
+	baseURL, err := getBaseURL(nexusURL, nexusVersion, repository, groupID)
+	if err != nil {
+		return err
+	}
+	nexusUpload.baseURL = baseURL
+	return nil
+}
+
+// SetArtifactsVersion sets the common version for all uploaded artifacts. The version is external to the artifact
+// descriptions so that it is consistent for all of them.
+func (nexusUpload *Upload) SetArtifactsVersion(version string) error {
+	if version == "" {
+		return errors.New("version must not be empty")
+	}
+	nexusUpload.version = version
+	return nil
+}
+
+// AddArtifact adds a single artifact to the Upload.
+func (nexusUpload *Upload) AddArtifact(artifact ArtifactDescription) error {
+	err := validateArtifact(artifact)
+	if err != nil {
+		return err
+	}
+	if nexusUpload.containsArtifact(artifact) {
+		log.Entry().Infof("Nexus Upload already contains artifact %v\n", artifact)
+		return nil
+	}
+	nexusUpload.artifacts = append(nexusUpload.artifacts, artifact)
+	return nil
+}
+
+func validateArtifact(artifact ArtifactDescription) error {
+	if artifact.File == "" || artifact.ID == "" || artifact.Type == "" {
+		return fmt.Errorf("Artifact.File (%v), ID (%v) or Type (%v) is empty", artifact.File, artifact.ID, artifact.Type)
+	}
+	return nil
+}
+
+// AddArtifactsFromJSON parses the provided JSON string into an array of ArtifactDescriptions and adds each of
+// them via AddArtifact().
+func (nexusUpload *Upload) AddArtifactsFromJSON(json string) error {
+	artifacts, err := getArtifactsFromJSON(json)
+	if err != nil {
+		return err
+	}
+	if len(artifacts) == 0 {
+		return errors.New("no artifact descriptions found in JSON string")
+	}
+	for _, artifact := range artifacts {
+		err = nexusUpload.AddArtifact(artifact)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getArtifactsFromJSON(artifactsAsJSON string) ([]ArtifactDescription, error) {
+	var artifacts []ArtifactDescription
+	err := json.Unmarshal([]byte(artifactsAsJSON), &artifacts)
+	return artifacts, err
+}
+
+func (nexusUpload *Upload) containsArtifact(artifact ArtifactDescription) bool {
+	for _, n := range nexusUpload.artifacts {
+		if artifact == n {
+			return true
+		}
+	}
+	return false
+}
+
+// GetArtifacts returns a copy of the artifact descriptions array stored in the Upload.
+func (nexusUpload *Upload) GetArtifacts() []ArtifactDescription {
+	artifacts := make([]ArtifactDescription, len(nexusUpload.artifacts))
+	copy(artifacts, nexusUpload.artifacts)
+	return artifacts
+}
+
+// UploadArtifacts performs the actual upload to Nexus. If any error occurs, the program will currently exit via
+// the logger.
+func (nexusUpload *Upload) UploadArtifacts() error {
+	client := nexusUpload.createHTTPClient()
+	return nexusUpload.uploadArtifacts(client)
+}
+
+func (nexusUpload *Upload) uploadArtifacts(client piperHttp.Sender) error {
+	if nexusUpload.baseURL == "" {
+		return fmt.Errorf("the nexus.Upload needs to be configured by calling SetBaseURL() first")
+	}
+	if nexusUpload.version == "" {
+		return fmt.Errorf("the nexus.Upload needs to be configured by calling SetArtifactsVersion() first")
+	}
+	if len(nexusUpload.artifacts) == 0 {
+		return fmt.Errorf("no artifacts to upload, call AddArtifact() or AddArtifactsFromJSON() first")
+	}
+
+	nexusUpload.initLogger()
+
+	for _, artifact := range nexusUpload.artifacts {
+		url := getArtifactURL(nexusUpload.baseURL, nexusUpload.version, artifact)
+
+		var err error
+		err = uploadHash(client, artifact.File, url+".md5", md5.New(), 16)
+		if err != nil {
+			return err
+		}
+		err = uploadHash(client, artifact.File, url+".sha1", sha1.New(), 20)
+		if err != nil {
+			return err
+		}
+		err = uploadFile(client, artifact.File, url)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Reset all artifacts already uploaded, so the object could be re-used
+	nexusUpload.artifacts = nil
+	return nil
+}
+
+func (nexusUpload *Upload) createHTTPClient() *piperHttp.Client {
+	client := piperHttp.Client{}
+	clientOptions := piperHttp.ClientOptions{Username: nexusUpload.Username, Password: nexusUpload.Password, Logger: nexusUpload.Logger}
+	client.SetOptions(clientOptions)
+	return &client
+}
+
+func getBaseURL(nexusURL, nexusVersion, repository, groupID string) (string, error) {
+	baseURL := nexusURL
+	switch nexusVersion {
+	case "nexus2":
+		baseURL += "/content/repositories/"
+	case "nexus3":
+		baseURL += "/repository/"
+	default:
+		return "", fmt.Errorf("unsupported Nexus version '%s'", nexusVersion)
+	}
+	groupPath := strings.ReplaceAll(groupID, ".", "/")
+	baseURL += repository + "/" + groupPath + "/"
+	return baseURL, nil
+}
+
+func getArtifactURL(baseURL, version string, artifact ArtifactDescription) string {
+	url := baseURL
+
+	// Generate artifact name including optional classifier
+	artifactName := artifact.ID + "-" + version
+	if len(artifact.Classifier) > 0 {
+		artifactName += "-" + artifact.Classifier
+	}
+	artifactName += "." + artifact.Type
+
+	url += artifact.ID + "/" + version + "/" + artifactName
+
+	// Remove any double slashes, as Nexus does not like them, and prepend protocol
+	url = "http://" + strings.ReplaceAll(url, "//", "/")
+
+	return url
+}
+
+func uploadFile(client piperHttp.Sender, filePath, url string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open artifact file %s: %w", filePath, err)
+	}
+
+	defer file.Close()
+
+	err = uploadToNexus(client, file, url)
+	if err != nil {
+		return fmt.Errorf("failed to upload artifact file %s: %w", filePath, err)
+	}
+	return nil
+}
+
+func uploadHash(client piperHttp.Sender, filePath, url string, hash hash.Hash, length int) error {
+	hashReader, err := generateHashReader(filePath, hash, length)
+	if err != nil {
+		return fmt.Errorf("failed to generate hash %w", err)
+	}
+	err = uploadToNexus(client, hashReader, url)
+	if err != nil {
+		return fmt.Errorf("failed to upload hash %w", err)
+	}
+	return nil
+}
+
+func uploadToNexus(client piperHttp.Sender, stream io.Reader, url string) error {
+	response, err := client.SendRequest(http.MethodPut, url, stream, nil, nil)
+	if err == nil {
+		log.Entry().Info("Uploaded '"+url+"', response: ", response.StatusCode)
+	}
+	return err
+}
+
+func generateHashReader(filePath string, hash hash.Hash, length int) (io.Reader, error) {
+	// Open file
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer file.Close()
+
+	// Read file and feed the hash
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the requested number of bytes from the hash
+	hashInBytes := hash.Sum(nil)[:length]
+
+	// Convert the bytes to a string
+	hexString := hex.EncodeToString(hashInBytes)
+
+	// Finally create an io.Reader wrapping the string
+	return strings.NewReader(hexString), nil
+}

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -169,6 +169,10 @@ func getBaseURL(nexusURL, nexusVersion, repository, groupID string) (string, err
 	if nexusURL == "" {
 		return "", errors.New("nexusURL must not be empty")
 	}
+	nexusURL = strings.ToLower(nexusURL)
+	if strings.HasPrefix(nexusURL, "http://") || strings.HasPrefix(nexusURL, "https://") {
+		return "", errors.New("nexusURL must not start with 'http://' or 'https://'")
+	}
 	if repository == "" {
 		return "", errors.New("repository must not be empty")
 	}

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -58,9 +58,6 @@ func (nexusUpload *Upload) SetBaseURL(nexusURL, nexusVersion, repository, groupI
 	if nexusURL == "" {
 		return errors.New("nexusURL must not be empty")
 	}
-	if nexusVersion != "nexus2" && nexusVersion != "nexus3" {
-		return errors.New("nexusVersion must be one of 'nexus2' or 'nexus3'")
-	}
 	if repository == "" {
 		return errors.New("repository must not be empty")
 	}

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -13,7 +13,12 @@ import (
 func TestAddArtifactValid(t *testing.T) {
 	nexusUpload := Upload{}
 
-	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "artifact.id", Classifier: "", Type: "pom", File: "pom.xml"})
+	err := nexusUpload.AddArtifact(ArtifactDescription{
+		ID:         "artifact.id",
+		Classifier: "",
+		Type:       "pom",
+		File:       "pom.xml",
+	})
 
 	assert.NoError(t, err, "Expected to add valid artifact")
 	assert.True(t, len(nexusUpload.artifacts) == 1)
@@ -27,7 +32,12 @@ func TestAddArtifactValid(t *testing.T) {
 func TestAddArtifactMissingID(t *testing.T) {
 	nexusUpload := Upload{}
 
-	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "", Classifier: "", Type: "pom", File: "pom.xml"})
+	err := nexusUpload.AddArtifact(ArtifactDescription{
+		ID:         "",
+		Classifier: "",
+		Type:       "pom",
+		File:       "pom.xml",
+	})
 
 	assert.Error(t, err, "Expected to fail adding invalid artifact")
 	assert.True(t, len(nexusUpload.artifacts) == 0)
@@ -36,8 +46,18 @@ func TestAddArtifactMissingID(t *testing.T) {
 func TestAddDuplicateArtifact(t *testing.T) {
 	nexusUpload := Upload{}
 
-	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "blob", Classifier: "", Type: "pom", File: "pom.xml"})
-	err = nexusUpload.AddArtifact(ArtifactDescription{ID: "blob", Classifier: "", Type: "pom", File: "pom.xml"})
+	err := nexusUpload.AddArtifact(ArtifactDescription{
+		ID:         "blob",
+		Classifier: "",
+		Type:       "pom",
+		File:       "pom.xml",
+	})
+	err = nexusUpload.AddArtifact(ArtifactDescription{
+		ID:         "blob",
+		Classifier: "",
+		Type:       "pom",
+		File:       "pom.xml",
+	})
 	assert.NoError(t, err, "Expected to succeed adding duplicate artifact")
 	assert.True(t, len(nexusUpload.artifacts) == 1)
 }
@@ -118,18 +138,33 @@ func TestUpload_AddArtifactsFromJSON(t *testing.T) {
 	if err := nexusUpload.AddArtifactsFromJSON(json); err != nil {
 		t.Errorf("AddArtifactsFromJSON() error = %v", err)
 	}
-	assert.Equal(t, []ArtifactDescription{{ID: "myapp-pom", Classifier: "myapp-1.0", Type: "pom", File: "pom.xml"}}, nexusUpload.artifacts)
+	assert.Equal(t, []ArtifactDescription{{
+		ID:         "myapp-pom",
+		Classifier: "myapp-1.0",
+		Type:       "pom",
+		File:       "pom.xml",
+	}}, nexusUpload.artifacts)
 }
 
 func TestArtifactsNotDirectlyAccessible(t *testing.T) {
 	nexusUpload := Upload{}
 
-	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "artifact.id", Classifier: "", Type: "pom", File: "pom.xml"})
+	err := nexusUpload.AddArtifact(ArtifactDescription{
+		ID:         "artifact.id",
+		Classifier: "",
+		Type:       "pom",
+		File:       "pom.xml",
+	})
 	assert.NoError(t, err, "Expected to succeed adding valid artifact")
 
 	artifacts := nexusUpload.GetArtifacts()
 	// Overwrite array entry in the returned array...
-	artifacts[0] = ArtifactDescription{ID: "another.id", Classifier: "", Type: "pom", File: "pom.xml"}
+	artifacts[0] = ArtifactDescription{
+		ID:         "another.id",
+		Classifier: "",
+		Type:       "pom",
+		File:       "pom.xml",
+	}
 	// ... but expect the entry in nexusUpload object to be unchanged
 	assert.True(t, nexusUpload.artifacts[0].ID == "artifact.id")
 }
@@ -285,9 +320,12 @@ func TestUploadWorks(t *testing.T) {
 	assert.Equal(t, http.MethodPut, mockedHttp.requests[1].method)
 	assert.Equal(t, http.MethodPut, mockedHttp.requests[2].method)
 
-	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom.md5", mockedHttp.requests[0].url)
-	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom.sha1", mockedHttp.requests[1].url)
-	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom", mockedHttp.requests[2].url)
+	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom.md5",
+		mockedHttp.requests[0].url)
+	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom.sha1",
+		mockedHttp.requests[1].url)
+	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom",
+		mockedHttp.requests[2].url)
 }
 
 func TestUploadFailsAtMd5(t *testing.T) {

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUpload_AddArtifact(t *testing.T) {
+func TestAddArtifact(t *testing.T) {
 	t.Run("Test valid artifact", func(t *testing.T) {
 		nexusUpload := Upload{}
 
@@ -62,7 +62,7 @@ func TestUpload_AddArtifact(t *testing.T) {
 	})
 }
 
-func TestUpload_GetArtifacts(t *testing.T) {
+func TestGetArtifacts(t *testing.T) {
 	nexusUpload := Upload{}
 
 	err := nexusUpload.AddArtifact(ArtifactDescription{
@@ -85,7 +85,7 @@ func TestUpload_GetArtifacts(t *testing.T) {
 	assert.True(t, nexusUpload.artifacts[0].ID == "artifact.id")
 }
 
-func TestUpload_getBaseURL(t *testing.T) {
+func TestGetBaseURL(t *testing.T) {
 	t.Run("Test base URL for nexus2 is sensible", func(t *testing.T) {
 		baseURL, err := getBaseURL("localhost:8081/nexus", "nexus2", "maven-releases", "some.group.id")
 		assert.NoError(t, err, "Expected getBaseURL() to succeed")
@@ -103,7 +103,7 @@ func TestUpload_getBaseURL(t *testing.T) {
 	})
 }
 
-func TestUpload_SetBaseURL(t *testing.T) {
+func TestSetBaseURL(t *testing.T) {
 	t.Run("Test no host provided", func(t *testing.T) {
 		nexusUpload := Upload{}
 		err := nexusUpload.SetBaseURL("", "nexus3", "maven-releases", "some.group.id")

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -42,6 +42,45 @@ func TestAddArtifact(t *testing.T) {
 		assert.Error(t, err, "Expected to fail adding invalid artifact")
 		assert.True(t, len(nexusUpload.artifacts) == 0)
 	})
+	t.Run("Test invalid ID", func(t *testing.T) {
+		nexusUpload := Upload{}
+
+		err := nexusUpload.AddArtifact(ArtifactDescription{
+			ID:         "artifact/id",
+			Classifier: "",
+			Type:       "pom",
+			File:       "pom.xml",
+		})
+
+		assert.Error(t, err, "Expected to fail adding invalid artifact")
+		assert.True(t, len(nexusUpload.artifacts) == 0)
+	})
+	t.Run("Test missing type", func(t *testing.T) {
+		nexusUpload := Upload{}
+
+		err := nexusUpload.AddArtifact(ArtifactDescription{
+			ID:         "artifact",
+			Classifier: "",
+			Type:       "",
+			File:       "pom.xml",
+		})
+
+		assert.Error(t, err, "Expected to fail adding invalid artifact")
+		assert.True(t, len(nexusUpload.artifacts) == 0)
+	})
+	t.Run("Test missing file", func(t *testing.T) {
+		nexusUpload := Upload{}
+
+		err := nexusUpload.AddArtifact(ArtifactDescription{
+			ID:         "artifact",
+			Classifier: "",
+			Type:       "pom",
+			File:       "",
+		})
+
+		assert.Error(t, err, "Expected to fail adding invalid artifact")
+		assert.True(t, len(nexusUpload.artifacts) == 0)
+	})
 	t.Run("Test adding duplicate artifact is ignored", func(t *testing.T) {
 		nexusUpload := Upload{}
 

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -126,16 +126,17 @@ func TestSetBaseURL(t *testing.T) {
 	})
 }
 
-func TestSetInvalidArtifactsVersion(t *testing.T) {
-	nexusUpload := Upload{}
-	err := nexusUpload.SetArtifactsVersion("")
-	assert.Error(t, err, "Expected SetArtifactsVersion() to fail (empty version)")
-}
-
-func TestSetValidArtifactsVersion(t *testing.T) {
-	nexusUpload := Upload{}
-	err := nexusUpload.SetArtifactsVersion("1.0.0-SNAPSHOT")
-	assert.NoError(t, err, "Expected SetArtifactsVersion() to succeed")
+func TestSetArtifactsVersion(t *testing.T) {
+	t.Run("Test invalid artifact version", func(t *testing.T) {
+		nexusUpload := Upload{}
+		err := nexusUpload.SetArtifactsVersion("")
+		assert.Error(t, err, "Expected SetArtifactsVersion() to fail (empty version)")
+	})
+	t.Run("Test valid artifact version", func(t *testing.T) {
+		nexusUpload := Upload{}
+		err := nexusUpload.SetArtifactsVersion("1.0.0-SNAPSHOT")
+		assert.NoError(t, err, "Expected SetArtifactsVersion() to succeed")
+	})
 }
 
 type simpleHttpMock struct {

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -45,13 +45,13 @@ func TestAddArtifact(t *testing.T) {
 	t.Run("Test adding duplicate artifact is ignored", func(t *testing.T) {
 		nexusUpload := Upload{}
 
-		err := nexusUpload.AddArtifact(ArtifactDescription{
+		_ = nexusUpload.AddArtifact(ArtifactDescription{
 			ID:         "blob",
 			Classifier: "",
 			Type:       "pom",
 			File:       "pom.xml",
 		})
-		err = nexusUpload.AddArtifact(ArtifactDescription{
+		err := nexusUpload.AddArtifact(ArtifactDescription{
 			ID:         "blob",
 			Classifier: "",
 			Type:       "pom",
@@ -86,6 +86,7 @@ func TestGetArtifacts(t *testing.T) {
 }
 
 func TestGetBaseURL(t *testing.T) {
+	// Invalid parameters to getBaseURL() already tested via SetBaseURL() tests
 	t.Run("Test base URL for nexus2 is sensible", func(t *testing.T) {
 		baseURL, err := getBaseURL("localhost:8081/nexus", "nexus2", "maven-releases", "some.group.id")
 		assert.NoError(t, err, "Expected getBaseURL() to succeed")
@@ -95,11 +96,6 @@ func TestGetBaseURL(t *testing.T) {
 		baseURL, err := getBaseURL("localhost:8081", "nexus3", "maven-releases", "some.group.id")
 		assert.NoError(t, err, "Expected getBaseURL() to succeed")
 		assert.Equal(t, "localhost:8081/repository/maven-releases/some/group/id/", baseURL)
-	})
-	t.Run("Test unsupported nexus version", func(t *testing.T) {
-		baseURL, err := getBaseURL("localhost:8081", "nexus1", "maven-releases", "some.group.id")
-		assert.Error(t, err, "Expected getBaseURL() to fail")
-		assert.Equal(t, "", baseURL)
 	})
 }
 
@@ -123,6 +119,16 @@ func TestSetBaseURL(t *testing.T) {
 		nexusUpload := Upload{}
 		err := nexusUpload.SetBaseURL("localhost:8081", "nexus3", "maven-releases", "")
 		assert.Error(t, err, "Expected SetBaseURL() to fail (no groupID)")
+	})
+	t.Run("Test no nexus version provided", func(t *testing.T) {
+		nexusUpload := Upload{}
+		err := nexusUpload.SetBaseURL("localhost:8081", "nexus1", "maven-releases", "some.group.id")
+		assert.Error(t, err, "Expected SetBaseURL() to fail (unsupported nexus version)")
+	})
+	t.Run("Test unsupported nexus version provided", func(t *testing.T) {
+		nexusUpload := Upload{}
+		err := nexusUpload.SetBaseURL("localhost:8081", "nexus1", "maven-releases", "some.group.id")
+		assert.Error(t, err, "Expected SetBaseURL() to fail (unsupported nexus version)")
 	})
 }
 

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -1,0 +1,339 @@
+package nexus
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	piperhttp "github.com/SAP/jenkins-library/pkg/http"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddArtifactValid(t *testing.T) {
+	nexusUpload := Upload{}
+
+	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "artifact.id", Classifier: "", Type: "pom", File: "pom.xml"})
+
+	assert.NoError(t, err, "Expected to add valid artifact")
+	assert.True(t, len(nexusUpload.artifacts) == 1)
+
+	assert.True(t, nexusUpload.artifacts[0].ID == "artifact.id")
+	assert.True(t, nexusUpload.artifacts[0].Classifier == "")
+	assert.True(t, nexusUpload.artifacts[0].Type == "pom")
+	assert.True(t, nexusUpload.artifacts[0].File == "pom.xml")
+}
+
+func TestAddArtifactMissingID(t *testing.T) {
+	nexusUpload := Upload{}
+
+	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "", Classifier: "", Type: "pom", File: "pom.xml"})
+
+	assert.Error(t, err, "Expected to fail adding invalid artifact")
+	assert.True(t, len(nexusUpload.artifacts) == 0)
+}
+
+func TestAddDuplicateArtifact(t *testing.T) {
+	nexusUpload := Upload{}
+
+	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "blob", Classifier: "", Type: "pom", File: "pom.xml"})
+	err = nexusUpload.AddArtifact(ArtifactDescription{ID: "blob", Classifier: "", Type: "pom", File: "pom.xml"})
+	assert.NoError(t, err, "Expected to succeed adding duplicate artifact")
+	assert.True(t, len(nexusUpload.artifacts) == 1)
+}
+
+func TestAddArtifactsFromValidJSON(t *testing.T) {
+	nexusUpload := Upload{}
+
+	artifactJSON := `
+		[
+			{
+				"artifactId" : "my-app",
+				"classifier" : "",
+				"file"       : "app.jar",
+				"type"       : "jar"
+			},
+			{
+				"artifactId" : "my-app",
+				"file"       : "pom.xml",
+				"type"       : "pom"
+			}
+		]`
+
+	err := nexusUpload.AddArtifactsFromJSON(artifactJSON)
+	assert.NoError(t, err, "Expected to succeed adding 2 artifacts from valid JSON")
+	assert.Equal(t, 2, len(nexusUpload.artifacts))
+}
+
+func TestAddNoArtifactsFromPartiallyValidJSON(t *testing.T) {
+	nexusUpload := Upload{}
+
+	artifactJSON := `
+		[
+			{
+				"blah" : "blub",
+			},
+			{
+				"artifactId" : "my-app",
+				"file"       : "pom.xml",
+				"type"       : "pom"
+			}
+		]`
+
+	err := nexusUpload.AddArtifactsFromJSON(artifactJSON)
+	assert.Error(t, err, "Expected to fail adding artifacts from partially valid JSON")
+	assert.Equal(t, 0, len(nexusUpload.artifacts))
+}
+
+func TestAddArtifactsFromJSONWithWrongTypes(t *testing.T) {
+	nexusUpload := Upload{}
+
+	artifactJSON := `
+		[
+			{
+				"artifactId" : "my-app",
+				"file"       : 1,
+				"type"       : true
+			}
+		]`
+
+	err := nexusUpload.AddArtifactsFromJSON(artifactJSON)
+	assert.Error(t, err, "Expected to fail adding artifacts from JSON with wrong types")
+	assert.Equal(t, 0, len(nexusUpload.artifacts))
+}
+
+func TestAddNoArtifactsFromInvalidJSON(t *testing.T) {
+	nexusUpload := Upload{}
+
+	artifactJSON := "grmpf"
+
+	err := nexusUpload.AddArtifactsFromJSON(artifactJSON)
+	assert.Error(t, err, "Expected to fail adding artifacts from invalid JSON")
+	assert.Equal(t, 0, len(nexusUpload.artifacts))
+}
+
+func TestUpload_AddArtifactsFromJSON(t *testing.T) {
+	json := `[{"artifactId":"myapp-pom","classifier":"myapp-1.0","type":"pom","file":"pom.xml"}]`
+	nexusUpload := Upload{}
+	if err := nexusUpload.AddArtifactsFromJSON(json); err != nil {
+		t.Errorf("AddArtifactsFromJSON() error = %v", err)
+	}
+	assert.Equal(t, []ArtifactDescription{{ID: "myapp-pom", Classifier: "myapp-1.0", Type: "pom", File: "pom.xml"}}, nexusUpload.artifacts)
+}
+
+func TestArtifactsNotDirectlyAccessible(t *testing.T) {
+	nexusUpload := Upload{}
+
+	err := nexusUpload.AddArtifact(ArtifactDescription{ID: "artifact.id", Classifier: "", Type: "pom", File: "pom.xml"})
+	assert.NoError(t, err, "Expected to succeed adding valid artifact")
+
+	artifacts := nexusUpload.GetArtifacts()
+	// Overwrite array entry in the returned array...
+	artifacts[0] = ArtifactDescription{ID: "another.id", Classifier: "", Type: "pom", File: "pom.xml"}
+	// ... but expect the entry in nexusUpload object to be unchanged
+	assert.True(t, nexusUpload.artifacts[0].ID == "artifact.id")
+}
+
+func TestSensibleBaseURLNexus2(t *testing.T) {
+	baseURL, err := getBaseURL("localhost:8081/nexus", "nexus2", "maven-releases", "some.group.id")
+	assert.NoError(t, err, "Expected getBaseURL() to succeed")
+	assert.Equal(t, "localhost:8081/nexus/content/repositories/maven-releases/some/group/id/", baseURL)
+}
+
+func TestSensibleBaseURLNexus3(t *testing.T) {
+	baseURL, err := getBaseURL("localhost:8081", "nexus3", "maven-releases", "some.group.id")
+	assert.NoError(t, err, "Expected getBaseURL() to succeed")
+	assert.Equal(t, "localhost:8081/repository/maven-releases/some/group/id/", baseURL)
+}
+
+func TestBaseURLUnsupportedNexusVersion(t *testing.T) {
+	baseURL, err := getBaseURL("localhost:8081", "nexus1", "maven-releases", "some.group.id")
+	assert.Error(t, err, "Expected getBaseURL() to fail")
+	assert.Equal(t, "", baseURL)
+}
+
+func TestSetBaseURLParamChecking(t *testing.T) {
+	nexusUpload := Upload{}
+	err := nexusUpload.SetBaseURL("", "nexus3", "maven-releases", "some.group.id")
+	assert.Error(t, err, "Expected SetBaseURL() to fail (no host)")
+	err = nexusUpload.SetBaseURL("localhost:8081", "3", "maven-releases", "some.group.id")
+	assert.Error(t, err, "Expected SetBaseURL() to fail (invalid nexus version)")
+	err = nexusUpload.SetBaseURL("localhost:8081", "nexus3", "", "some.group.id")
+	assert.Error(t, err, "Expected SetBaseURL() to fail (no repository)")
+	err = nexusUpload.SetBaseURL("localhost:8081", "nexus3", "maven-releases", "")
+	assert.Error(t, err, "Expected SetBaseURL() to fail (no groupID)")
+}
+
+func TestSetInvalidArtifactsVersion(t *testing.T) {
+	nexusUpload := Upload{}
+	err := nexusUpload.SetArtifactsVersion("")
+	assert.Error(t, err, "Expected SetArtifactsVersion() to fail (empty version)")
+}
+
+func TestSetValidArtifactsVersion(t *testing.T) {
+	nexusUpload := Upload{}
+	err := nexusUpload.SetArtifactsVersion("1.0.0-SNAPSHOT")
+	assert.NoError(t, err, "Expected SetArtifactsVersion() to succeed")
+}
+
+type simpleHttpMock struct {
+	responseStatus string
+	responseError  error
+}
+
+func (m *simpleHttpMock) SendRequest(method, url string, body io.Reader, header http.Header, cookies []*http.Cookie) (*http.Response, error) {
+	return &http.Response{Status: m.responseStatus}, m.responseError
+}
+
+func (m *simpleHttpMock) SetOptions(options piperhttp.ClientOptions) {
+}
+
+func TestUploadNoInit(t *testing.T) {
+	var mockedHttp = simpleHttpMock{
+		responseStatus: "200 OK",
+		responseError:  nil,
+	}
+
+	t.Run("Expect that upload fails without base-URL", func(t *testing.T) {
+		nexusUpload := Upload{}
+
+		err := nexusUpload.uploadArtifacts(&mockedHttp)
+		assert.EqualError(t, err, "the nexus.Upload needs to be configured by calling SetBaseURL() first")
+	})
+
+	t.Run("Expect that upload fails without version", func(t *testing.T) {
+		nexusUpload := Upload{}
+		_ = nexusUpload.SetBaseURL("localhost:8081", "nexus3", "maven-releases", "my.group.id")
+
+		err := nexusUpload.uploadArtifacts(&mockedHttp)
+		assert.EqualError(t, err, "the nexus.Upload needs to be configured by calling SetArtifactsVersion() first")
+	})
+
+	t.Run("Expect that upload fails without artifacts", func(t *testing.T) {
+		nexusUpload := Upload{}
+		_ = nexusUpload.SetBaseURL("localhost:8081", "nexus3", "maven-releases", "my.group.id")
+		_ = nexusUpload.SetArtifactsVersion("1.0")
+
+		err := nexusUpload.uploadArtifacts(&mockedHttp)
+		assert.EqualError(t, err, "no artifacts to upload, call AddArtifact() or AddArtifactsFromJSON() first")
+	})
+}
+
+type request struct {
+	method string
+	url    string
+}
+
+type requestReply struct {
+	response string
+	err      error
+}
+
+type httpMock struct {
+	username       string
+	password       string
+	requestIndex   int
+	requestReplies []requestReply
+	requests       []request
+}
+
+func (m *httpMock) SendRequest(method, url string, body io.Reader, header http.Header, cookies []*http.Cookie) (*http.Response, error) {
+	// store the request
+	m.requests = append(m.requests, request{method: method, url: url})
+
+	// Return the configured response for this request's index
+	response := m.requestReplies[m.requestIndex].response
+	err := m.requestReplies[m.requestIndex].err
+
+	m.requestIndex++
+
+	return &http.Response{Status: response}, err
+}
+
+func (m *httpMock) SetOptions(options piperhttp.ClientOptions) {
+	m.username = options.Username
+	m.password = options.Password
+}
+
+func (m *httpMock) appendReply(reply requestReply) {
+	m.requestReplies = append(m.requestReplies, reply)
+}
+
+func createConfiguredNexusUpload() Upload {
+	nexusUpload := Upload{}
+	_ = nexusUpload.SetBaseURL("localhost:8081", "nexus3", "maven-releases", "my.group.id")
+	_ = nexusUpload.SetArtifactsVersion("1.0")
+	_ = nexusUpload.AddArtifact(ArtifactDescription{ID: "artifact.id", Classifier: "", Type: "pom", File: "../../pom.xml"})
+	return nexusUpload
+}
+
+func TestUploadWorks(t *testing.T) {
+	var mockedHttp = httpMock{}
+	// There will be three requests, md5, sha1 and the file itself
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+
+	nexusUpload := createConfiguredNexusUpload()
+
+	err := nexusUpload.uploadArtifacts(&mockedHttp)
+	assert.NoError(t, err, "Expected that uploading the artifact works")
+
+	assert.Equal(t, 3, mockedHttp.requestIndex, "Expected 3 HTTP requests")
+
+	assert.Equal(t, http.MethodPut, mockedHttp.requests[0].method)
+	assert.Equal(t, http.MethodPut, mockedHttp.requests[1].method)
+	assert.Equal(t, http.MethodPut, mockedHttp.requests[2].method)
+
+	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom.md5", mockedHttp.requests[0].url)
+	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom.sha1", mockedHttp.requests[1].url)
+	assert.Equal(t, "http://localhost:8081/repository/maven-releases/my/group/id/artifact.id/1.0/artifact.id-1.0.pom", mockedHttp.requests[2].url)
+}
+
+func TestUploadFailsAtMd5(t *testing.T) {
+	var mockedHttp = httpMock{}
+	// There will be three requests, md5, sha1 and the file itself
+	mockedHttp.appendReply(requestReply{response: "404 Error", err: fmt.Errorf("failed")})
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+
+	nexusUpload := createConfiguredNexusUpload()
+
+	err := nexusUpload.uploadArtifacts(&mockedHttp)
+	assert.Error(t, err, "Expected that uploading the artifact failed")
+
+	assert.Equal(t, 1, mockedHttp.requestIndex, "Expected only one HTTP requests")
+	assert.Equal(t, 1, len(nexusUpload.artifacts), "Expected the artifact to be still present in the nexusUpload")
+}
+
+func TestUploadFailsAtSha1(t *testing.T) {
+	var mockedHttp = httpMock{}
+	// There will be three requests, md5, sha1 and the file itself
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+	mockedHttp.appendReply(requestReply{response: "404 Error", err: fmt.Errorf("failed")})
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+
+	nexusUpload := createConfiguredNexusUpload()
+
+	err := nexusUpload.uploadArtifacts(&mockedHttp)
+	assert.Error(t, err, "Expected that uploading the artifact failed")
+
+	assert.Equal(t, 2, mockedHttp.requestIndex, "Expected only two HTTP requests")
+	assert.Equal(t, 1, len(nexusUpload.artifacts), "Expected the artifact to be still present in the nexusUpload")
+}
+
+func TestUploadFailsAtFile(t *testing.T) {
+	var mockedHttp = httpMock{}
+	// There will be three requests, md5, sha1 and the file itself
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+	mockedHttp.appendReply(requestReply{response: "200 OK", err: nil})
+	mockedHttp.appendReply(requestReply{response: "404 Error", err: fmt.Errorf("failed")})
+
+	nexusUpload := createConfiguredNexusUpload()
+
+	err := nexusUpload.uploadArtifacts(&mockedHttp)
+	assert.Error(t, err, "Expected that uploading the artifact failed")
+
+	assert.Equal(t, 3, mockedHttp.requestIndex, "Expected only three HTTP requests")
+	assert.Equal(t, 1, len(nexusUpload.artifacts), "Expected the artifact to be still present in the nexusUpload")
+}

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -105,6 +105,16 @@ func TestSetBaseURL(t *testing.T) {
 		err := nexusUpload.SetBaseURL("", "nexus3", "maven-releases", "some.group.id")
 		assert.Error(t, err, "Expected SetBaseURL() to fail (no host)")
 	})
+	t.Run("Test host wrongly includes protocol http://", func(t *testing.T) {
+		nexusUpload := Upload{}
+		err := nexusUpload.SetBaseURL("htTp://localhost:8081", "nexus3", "maven-releases", "some.group.id")
+		assert.Error(t, err, "Expected SetBaseURL() to fail (invalid host)")
+	})
+	t.Run("Test host wrongly includes protocol https://", func(t *testing.T) {
+		nexusUpload := Upload{}
+		err := nexusUpload.SetBaseURL("htTpS://localhost:8081", "nexus3", "maven-releases", "some.group.id")
+		assert.Error(t, err, "Expected SetBaseURL() to fail (invalid host)")
+	})
 	t.Run("Test invalid version provided", func(t *testing.T) {
 		nexusUpload := Upload{}
 		err := nexusUpload.SetBaseURL("localhost:8081", "3", "maven-releases", "some.group.id")

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -177,7 +177,7 @@ func TestUploadNoInit(t *testing.T) {
 		_ = nexusUpload.SetArtifactsVersion("1.0")
 
 		err := nexusUpload.uploadArtifacts(&mockedHttp)
-		assert.EqualError(t, err, "no artifacts to upload, call AddArtifact() or AddArtifactsFromJSON() first")
+		assert.EqualError(t, err, "no artifacts to upload, call AddArtifact() first")
 	})
 }
 
@@ -229,7 +229,7 @@ func createConfiguredNexusUpload() Upload {
 	return nexusUpload
 }
 
-func TestUpload_UploadArtifacts(t *testing.T) {
+func TestUploadArtifacts(t *testing.T) {
 	t.Run("Test upload works", func(t *testing.T) {
 		var mockedHttp = httpMock{}
 		// There will be three requests, md5, sha1 and the file itself


### PR DESCRIPTION
# Changes

The nexus package implements uploading artifacts to a Nexus repository manager version 2 or 3 via HTTP. It also generates the MD5 and SHA1 hash files for the uploaded artifacts in the Nexus repository.

Extracted from https://github.com/SAP/jenkins-library/pull/1201

- [x] Tests
- [x] Documentation
