### PR TITLE
Improve message in error case in http client

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -199,7 +199,7 @@ func (c *Client) handleResponse(response *http.Response) (*http.Response, error)
 		c.logger.WithField("HTTP Error", "500 (Internal Server Error)").Error("Unknown error occured.")
 	}
 
-	return response, fmt.Errorf("Request to %v returned with HTTP Code %v", response.Request.URL, response.StatusCode)
+	return response, fmt.Errorf("Request to %v returned with response %v", response.Request.URL, response.Status)
 }
 
 func (c *Client) applyDefaults() {


### PR DESCRIPTION
This might provide useful context to the user.

For example when you try to upload a SNAPSHOT jar to a maven-release
repo in nexus, this will print an error like

`returned with response 400 Repository version policy: RELEASE does not allow version: 1.0-SNAPSHOT`

instead of

`returned with HTTP Code 400`