### PR TITLE
fix(mta): add os.Environ() only once to command

### DIFF
--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -4,6 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
+	"strings"
+	"text/template"
+	"time"
+
 	"github.com/SAP/jenkins-library/pkg/command"
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
@@ -11,10 +17,6 @@ import (
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"gopkg.in/yaml.v2"
-	"os"
-	"strings"
-	"text/template"
-	"time"
 )
 
 const templateMtaYml = `_schema-version: "3.1"

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -192,12 +192,13 @@ func getMarJarName(config mtaBuildOptions) string {
 }
 
 func addNpmBinToPath(e execRunner) error {
-	path := "./node_modules/.bin"
+	dir, _ := os.Getwd()
+	newPath := path.Join(dir, "node_modules", ".bin")
 	oldPath := os.Getenv("PATH")
 	if len(oldPath) > 0 {
-		path = path + ":" + oldPath
+		newPath = newPath + ":" + oldPath
 	}
-	e.SetEnv(append(os.Environ(), "PATH="+path))
+	e.SetEnv([]string{"PATH=" + newPath})
 	return nil
 }
 


### PR DESCRIPTION
**changes:**
- don't add `os.Environ()` to command environment (as it is already added [here](https://github.com/SAP/jenkins-library/blob/master/pkg/command/command.go#L107-L109))

related to #1223