### PR TITLE
Expose seleniumHubCredentialsId to higher-level Jenkins steps

### DIFF
--- a/vars/karmaExecuteTests.groovy
+++ b/vars/karmaExecuteTests.groovy
@@ -43,9 +43,7 @@ import groovy.transform.Field
     'modules',
     /** The command that is executed to start the tests. */
     'runCommand',
-    /**
-     * Defines the id of the user/password credentials to be used to connect to a Selenium Hub. The credentials are provided in the environment variables `PIPER_SELENIUM_HUB_USER` and `PIPER_SELENIUM_HUB_PASSWORD`.
-     */
+    /** @see seleniumExecuteTests */
     'seleniumHubCredentialsId',
     /** A map of environment variables to set in the sidecar container, similar to `dockerEnvVars`. */
     'sidecarEnvVars',

--- a/vars/karmaExecuteTests.groovy
+++ b/vars/karmaExecuteTests.groovy
@@ -43,6 +43,10 @@ import groovy.transform.Field
     'modules',
     /** The command that is executed to start the tests. */
     'runCommand',
+    /**
+     * Defines the id of the user/password credentials to be used to connect to a Selenium Hub. The credentials are provided in the environment variables `PIPER_SELENIUM_HUB_USER` and `PIPER_SELENIUM_HUB_PASSWORD`.
+     */
+    'seleniumHubCredentialsId',
     /** A map of environment variables to set in the sidecar container, similar to `dockerEnvVars`. */
     'sidecarEnvVars',
     /** The name of the docker image of the sidecar container. If empty, no sidecar container is started. */
@@ -99,6 +103,7 @@ void call(Map parameters = [:]) {
             dockerWorkspace: config.dockerWorkspace,
             dockerOptions: config.dockerOptions,
             failOnError: config.failOnError,
+            seleniumHubCredentialsId: config.seleniumHubCredentialsId,
             sidecarEnvVars: config.sidecarEnvVars,
             sidecarImage: config.sidecarImage,
             sidecarName: config.sidecarName,

--- a/vars/uiVeri5ExecuteTests.groovy
+++ b/vars/uiVeri5ExecuteTests.groovy
@@ -40,9 +40,7 @@ import static com.sap.piper.Prerequisites.checkScript
      * The host of the selenium hub, this is set automatically to `localhost` in a Kubernetes environment (determined by the `ON_K8S` environment variable) of to `selenium` in any other case. The value is only needed for the `runCommand`.
      */
     'seleniumHost',
-    /**
-     * Defines the id of the user/password credentials to be used to connect to a Selenium Hub. The credentials are provided in the environment variables `PIPER_SELENIUM_HUB_USER` and `PIPER_SELENIUM_HUB_PASSWORD`.
-     */
+    /** @see seleniumExecuteTests */
     'seleniumHubCredentialsId',
     /**
      * The port of the selenium hub. The value is only needed for the `runCommand`.

--- a/vars/uiVeri5ExecuteTests.groovy
+++ b/vars/uiVeri5ExecuteTests.groovy
@@ -41,6 +41,10 @@ import static com.sap.piper.Prerequisites.checkScript
      */
     'seleniumHost',
     /**
+     * Defines the id of the user/password credentials to be used to connect to a Selenium Hub. The credentials are provided in the environment variables `PIPER_SELENIUM_HUB_USER` and `PIPER_SELENIUM_HUB_PASSWORD`.
+     */
+    'seleniumHubCredentialsId',
+    /**
      * The port of the selenium hub. The value is only needed for the `runCommand`.
      */
     'seleniumPort',
@@ -118,6 +122,7 @@ void call(Map parameters = [:]) {
             dockerImage: config.dockerImage,
             dockerName: config.dockerName,
             dockerWorkspace: config.dockerWorkspace,
+            seleniumHubCredentialsId: config.seleniumHubCredentialsId,
             sidecarEnvVars: config.sidecarEnvVars,
             sidecarImage: config.sidecarImage,
             stashContent: config.stashContent


### PR DESCRIPTION
This PR follows up on #1171 and exposes the newly introduced parameter `seleniumHubCredentialsId` to higher-level functions such as `karmaExecuteTests` and `uiVeri5ExecuteTests`.

# Changes

- [ ] Tests
- [x] Documentation
