### PR TITLE
Add Evaluate() method to maven package

### DIFF
--- a/pkg/maven/maven.go
+++ b/pkg/maven/maven.go
@@ -11,6 +11,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 )
 
+// ExecuteOptions are used by Execute() to construct the Maven command line.
 type ExecuteOptions struct {
 	PomPath                     string   `json:"pomPath,omitempty"`
 	ProjectSettingsFile         string   `json:"projectSettingsFile,omitempty"`
@@ -31,6 +32,8 @@ type mavenExecRunner interface {
 
 const mavenExecutable = "mvn"
 
+// Execute constructs a mvn command line from the given options, and uses the provided
+// mavenExecRunner to execute it.
 func Execute(options *ExecuteOptions, command mavenExecRunner) (string, error) {
 	stdOutBuf, stdOut := evaluateStdOut(options)
 	command.Stdout(stdOut)
@@ -52,6 +55,9 @@ func Execute(options *ExecuteOptions, command mavenExecRunner) (string, error) {
 	return string(stdOutBuf.Bytes()), nil
 }
 
+// Evaluate constructs ExecuteOptions for using the maven-help-plugin's 'evaluate' goal to
+// evaluate a given expression from a pom file. This allows to retrieve the value of - for
+// example - 'project.version' from a pom file exactly as Maven itself evaluates it.
 func Evaluate(pomFile, expression string, command mavenExecRunner) (string, error) {
 	expressionDefine := "-Dexpression=" + expression
 	options := ExecuteOptions{

--- a/pkg/maven/maven_test.go
+++ b/pkg/maven/maven_test.go
@@ -67,23 +67,21 @@ func TestExecute(t *testing.T) {
 
 func TestEvaluate(t *testing.T) {
 	t.Run("should evaluate expression", func(t *testing.T) {
-		expectedOutput := "com.awesome"
 		execMockRunner := mock.ExecMockRunner{}
 		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "com.awesome"}
 
 		result, err := Evaluate("pom.xml", "project.groupId", &execMockRunner)
 		if assert.NoError(t, err) {
-			assert.Equal(t, expectedOutput, result)
+			assert.Equal(t, "com.awesome", result)
 		}
 	})
 	t.Run("should not evaluate expression", func(t *testing.T) {
-		expectedOutput := ""
 		execMockRunner := mock.ExecMockRunner{}
 		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "null object or invalid expression"}
 
 		result, err := Evaluate("pom.xml", "project.groupId", &execMockRunner)
-		if assert.Error(t, err) {
-			assert.Equal(t, expectedOutput, result)
+		if assert.EqualError(t, err, "expression 'project.groupId' in file 'pom.xml' could not be resolved") {
+			assert.Equal(t, "", result)
 		}
 	})
 }

--- a/pkg/maven/maven_test.go
+++ b/pkg/maven/maven_test.go
@@ -65,6 +65,29 @@ func TestExecute(t *testing.T) {
 	})
 }
 
+func TestEvaluate(t *testing.T) {
+	t.Run("should evaluate expression", func(t *testing.T) {
+		expectedOutput := "com.awesome"
+		execMockRunner := mock.ExecMockRunner{}
+		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "com.awesome"}
+
+		result, err := Evaluate("pom.xml", "project.groupId", &execMockRunner)
+		if assert.NoError(t, err) {
+			assert.Equal(t, expectedOutput, result)
+		}
+	})
+	t.Run("should not evaluate expression", func(t *testing.T) {
+		expectedOutput := ""
+		execMockRunner := mock.ExecMockRunner{}
+		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "null object or invalid expression"}
+
+		result, err := Evaluate("pom.xml", "project.groupId", &execMockRunner)
+		if assert.Error(t, err) {
+			assert.Equal(t, expectedOutput, result)
+		}
+	})
+}
+
 type mockDownloader struct {
 	shouldFail bool
 }


### PR DESCRIPTION
# Changes

Replicates the functionality from the Groovy [`Utils.evaluateFromMavenPom()`](https://github.com/SAP/jenkins-library/blob/master/src/com/sap/piper/Utils.groovy#L157) class in Go.

- [x] Tests
- [x] Documentation
