### PR TITLE
Make m2 path configurable for static code checks

### DIFF
--- a/cmd/mavenExecuteStaticCodeChecks.go
+++ b/cmd/mavenExecuteStaticCodeChecks.go
@@ -50,6 +50,7 @@ func runMavenStaticCodeChecks(config *mavenExecuteStaticCodeChecksOptions, telem
 	finalMavenOptions := maven.ExecuteOptions{
 		Goals:   goals,
 		Defines: defines,
+		M2Path:  config.M2Path,
 	}
 	_, err := maven.Execute(&finalMavenOptions, command)
 	return err

--- a/cmd/mavenExecuteStaticCodeChecks_generated.go
+++ b/cmd/mavenExecuteStaticCodeChecks_generated.go
@@ -16,6 +16,7 @@ import (
 type mavenExecuteStaticCodeChecksOptions struct {
 	SpotBugs                  bool     `json:"spotBugs,omitempty"`
 	Pmd                       bool     `json:"pmd,omitempty"`
+	M2Path                    string   `json:"m2Path,omitempty"`
 	MavenModulesExcludes      []string `json:"mavenModulesExcludes,omitempty"`
 	SpotBugsExcludeFilterFile string   `json:"spotBugsExcludeFilterFile,omitempty"`
 	SpotBugsIncludeFilterFile string   `json:"spotBugsIncludeFilterFile,omitempty"`
@@ -65,6 +66,7 @@ For more information please visit https://pmd.github.io/`,
 func addMavenExecuteStaticCodeChecksFlags(cmd *cobra.Command, stepConfig *mavenExecuteStaticCodeChecksOptions) {
 	cmd.Flags().BoolVar(&stepConfig.SpotBugs, "spotBugs", true, "Parameter to turn off SpotBugs.")
 	cmd.Flags().BoolVar(&stepConfig.Pmd, "pmd", true, "Parameter to turn off PMD.")
+	cmd.Flags().StringVar(&stepConfig.M2Path, "m2Path", "~/.m2/", "Path to the local m2 directory.")
 	cmd.Flags().StringSliceVar(&stepConfig.MavenModulesExcludes, "mavenModulesExcludes", []string{}, "Maven modules which should be excluded by the static code checks. By default the modules 'unit-tests' and 'integration-tests' will be excluded.")
 	cmd.Flags().StringVar(&stepConfig.SpotBugsExcludeFilterFile, "spotBugsExcludeFilterFile", os.Getenv("PIPER_spotBugsExcludeFilterFile"), "Path to a filter file with bug definitions which should be excluded.")
 	cmd.Flags().StringVar(&stepConfig.SpotBugsIncludeFilterFile, "spotBugsIncludeFilterFile", os.Getenv("PIPER_spotBugsIncludeFilterFile"), "Path to a filter file with bug definitions which should be included.")
@@ -92,6 +94,14 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "m2Path",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 					},

--- a/resources/metadata/mavenStaticCodeChecks.yaml
+++ b/resources/metadata/mavenStaticCodeChecks.yaml
@@ -26,6 +26,15 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: m2Path
+        description: Path to the local m2 directory.
+        type: string
+        default: '~/.m2/'
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: mavenModulesExcludes
         description: Maven modules which should be excluded by the static code checks. By default the modules 'unit-tests' and 'integration-tests' will be excluded.
         type: '[]string'


### PR DESCRIPTION
# Changes

this is an easy fix to get the static code checks using the m2 dir if configured.
@daniel-kurzynski will fix this with the implementation of the maven build step and getting it configurable under 
```
general:
  maven:
    m2Path: 
```



- [ ] Tests
- [ ] Documentation
