### PR TITLE
fix(sonar): keep .scannerwork directory to query quality gate status 

### DIFF
--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -141,7 +141,7 @@ void call(Map parameters = [:]) {
                     }
                 }
             } finally {
-                sh 'rm -rf .sonar-scanner .certificates .scannerwork'
+                sh 'rm -rf .sonar-scanner .certificates'
             }
         }
 


### PR DESCRIPTION
When executing `waitForQualityGate` in the pipeline, the `.scannerwork` directory is needed.

**changes:**
- preserves the `.scannerwork` directory