### PR TITLE
Golang step metadata: Config aliases for steps

### DIFF
--- a/cmd/abapEnvironmentPullGitRepo_generated.go
+++ b/cmd/abapEnvironmentPullGitRepo_generated.go
@@ -84,6 +84,10 @@ func addAbapEnvironmentPullGitRepoFlags(cmd *cobra.Command, stepConfig *abapEnvi
 // retrieve step metadata
 func abapEnvironmentPullGitRepoMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "abapEnvironmentPullGitRepo",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/checkmarxExecuteScan_generated.go
+++ b/cmd/checkmarxExecuteScan_generated.go
@@ -236,6 +236,10 @@ func addCheckmarxExecuteScanFlags(cmd *cobra.Command, stepConfig *checkmarxExecu
 // retrieve step metadata
 func checkmarxExecuteScanMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "checkmarxExecuteScan",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/cloudFoundryDeleteService_generated.go
+++ b/cmd/cloudFoundryDeleteService_generated.go
@@ -78,6 +78,10 @@ func addCloudFoundryDeleteServiceFlags(cmd *cobra.Command, stepConfig *cloudFoun
 // retrieve step metadata
 func cloudFoundryDeleteServiceMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "cloudFoundryDeleteService",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -77,6 +77,10 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 // retrieve step metadata
 func detectExecuteScanMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "detectExecuteScan",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -93,7 +93,7 @@ func generateConfig() error {
 		params = metadata.Spec.Inputs.Parameters
 	}
 
-	stepConfig, err = myConfig.GetStepConfig(flags, GeneralConfig.ParametersJSON, customConfig, defaultConfig, paramFilter, params, resourceParams, GeneralConfig.StageName, metadata.Metadata.Name)
+	stepConfig, err = myConfig.GetStepConfig(flags, GeneralConfig.ParametersJSON, customConfig, defaultConfig, paramFilter, params, resourceParams, GeneralConfig.StageName, metadata.Metadata.Name, metadata.Metadata.Aliases)
 	if err != nil {
 		return errors.Wrap(err, "getting step config failed")
 	}

--- a/cmd/githubCreatePullRequest_generated.go
+++ b/cmd/githubCreatePullRequest_generated.go
@@ -91,6 +91,10 @@ func addGithubCreatePullRequestFlags(cmd *cobra.Command, stepConfig *githubCreat
 // retrieve step metadata
 func githubCreatePullRequestMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "githubCreatePullRequest",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/githubPublishRelease_generated.go
+++ b/cmd/githubPublishRelease_generated.go
@@ -102,6 +102,10 @@ func addGithubPublishReleaseFlags(cmd *cobra.Command, stepConfig *githubPublishR
 // retrieve step metadata
 func githubPublishReleaseMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "githubPublishRelease",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/karmaExecuteTests_generated.go
+++ b/cmd/karmaExecuteTests_generated.go
@@ -76,6 +76,10 @@ func addKarmaExecuteTestsFlags(cmd *cobra.Command, stepConfig *karmaExecuteTests
 // retrieve step metadata
 func karmaExecuteTestsMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "karmaExecuteTests",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -118,6 +118,10 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 // retrieve step metadata
 func kubernetesDeployMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "kubernetesDeploy",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/mavenBuild_generated.go
+++ b/cmd/mavenBuild_generated.go
@@ -74,6 +74,10 @@ func addMavenBuildFlags(cmd *cobra.Command, stepConfig *mavenBuildOptions) {
 // retrieve step metadata
 func mavenBuildMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "mavenBuild",
+			Aliases: []config.Alias{{Name: "mavenExecute", Deprecated: false}},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/mavenExecuteStaticCodeChecks_generated.go
+++ b/cmd/mavenExecuteStaticCodeChecks_generated.go
@@ -84,6 +84,10 @@ func addMavenExecuteStaticCodeChecksFlags(cmd *cobra.Command, stepConfig *mavenE
 // retrieve step metadata
 func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "mavenExecuteStaticCodeChecks",
+			Aliases: []config.Alias{{Name: "mavenExecute", Deprecated: false}},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/mavenExecute_generated.go
+++ b/cmd/mavenExecute_generated.go
@@ -77,6 +77,10 @@ func addMavenExecuteFlags(cmd *cobra.Command, stepConfig *mavenExecuteOptions) {
 // retrieve step metadata
 func mavenExecuteMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "mavenExecute",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/mtaBuild_generated.go
+++ b/cmd/mtaBuild_generated.go
@@ -108,6 +108,10 @@ func addMtaBuildFlags(cmd *cobra.Command, stepConfig *mtaBuildOptions) {
 // retrieve step metadata
 func mtaBuildMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "mtaBuild",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -128,7 +128,7 @@ func PrepareConfig(cmd *cobra.Command, metadata *config.StepData, stepName strin
 			defaultConfig = append(defaultConfig, fc)
 		}
 
-		stepConfig, err = myConfig.GetStepConfig(flagValues, GeneralConfig.ParametersJSON, customConfig, defaultConfig, filters, metadata.Spec.Inputs.Parameters, resourceParams, GeneralConfig.StageName, stepName)
+		stepConfig, err = myConfig.GetStepConfig(flagValues, GeneralConfig.ParametersJSON, customConfig, defaultConfig, filters, metadata.Spec.Inputs.Parameters, resourceParams, GeneralConfig.StageName, stepName, metadata.Metadata.Aliases)
 		if err != nil {
 			return errors.Wrap(err, "retrieving step configuration failed")
 		}

--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -148,6 +148,10 @@ func addProtecodeExecuteScanFlags(cmd *cobra.Command, stepConfig *protecodeExecu
 // retrieve step metadata
 func protecodeExecuteScanMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "protecodeExecuteScan",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/cmd/version_generated.go
+++ b/cmd/version_generated.go
@@ -57,6 +57,10 @@ func addVersionFlags(cmd *cobra.Command, stepConfig *versionOptions) {
 // retrieve step metadata
 func versionMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "version",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{},

--- a/cmd/xsDeploy_generated.go
+++ b/cmd/xsDeploy_generated.go
@@ -122,6 +122,10 @@ func addXsDeployFlags(cmd *cobra.Command, stepConfig *xsDeployOptions) {
 // retrieve step metadata
 func xsDeployMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "xsDeploy",
+			Aliases: []config.Alias{},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -95,6 +95,9 @@ func (c *Config) copyStepAliasConfig(stepName string, stepAliases []Alias) {
 				log.Entry().WithField("package", "SAP/jenkins-library/pkg/config").Warningf("DEPRECATION NOTICE: old step configuration used for step '%v'. Please switch to '%v'!", stepAlias.Name, stepName)
 			}
 			for paramName, paramValue := range c.Steps[stepAlias.Name] {
+				if c.Steps[stepName] == nil {
+					c.Steps[stepName] = map[string]interface{}{}
+				}
 				if c.Steps[stepName][paramName] == nil {
 					c.Steps[stepName][paramName] = paramValue
 				}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,13 +3,16 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ghodss/yaml"
-	"github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/SAP/jenkins-library/pkg/log"
+
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 )
 
 // Config defines the structure of the config files
@@ -43,7 +46,11 @@ func (c *Config) ReadConfig(configuration io.ReadCloser) error {
 }
 
 // ApplyAliasConfig adds configuration values available on aliases to primary configuration parameters
-func (c *Config) ApplyAliasConfig(parameters []StepParameters, filters StepFilters, stageName, stepName string) {
+func (c *Config) ApplyAliasConfig(parameters []StepParameters, filters StepFilters, stageName, stepName string, stepAliases []Alias) {
+	// copy configuration from step alias to correct step
+	if len(stepAliases) > 0 {
+		c.copyStepAliasConfig(stepName, stepAliases)
+	}
 	for _, p := range parameters {
 		c.General = setParamValueFromAlias(c.General, filters.General, p)
 		if c.Stages[stageName] != nil {
@@ -81,8 +88,23 @@ func getDeepAliasValue(configMap map[string]interface{}, key string) interface{}
 	return configMap[key]
 }
 
+func (c *Config) copyStepAliasConfig(stepName string, stepAliases []Alias) {
+	for _, stepAlias := range stepAliases {
+		if c.Steps[stepAlias.Name] != nil {
+			if stepAlias.Deprecated {
+				log.Entry().WithField("package", "SAP/jenkins-library/pkg/config").Warningf("DEPRECATION NOTICE: old step configuration used for step '%v'. Please switch to '%v'!", stepAlias.Name, stepName)
+			}
+			for paramName, paramValue := range c.Steps[stepAlias.Name] {
+				if c.Steps[stepName][paramName] == nil {
+					c.Steps[stepName][paramName] = paramValue
+				}
+			}
+		}
+	}
+}
+
 // GetStepConfig provides merged step configuration using defaults, config, if available
-func (c *Config) GetStepConfig(flagValues map[string]interface{}, paramJSON string, configuration io.ReadCloser, defaults []io.ReadCloser, filters StepFilters, parameters []StepParameters, envParameters map[string]interface{}, stageName, stepName string) (StepConfig, error) {
+func (c *Config) GetStepConfig(flagValues map[string]interface{}, paramJSON string, configuration io.ReadCloser, defaults []io.ReadCloser, filters StepFilters, parameters []StepParameters, envParameters map[string]interface{}, stageName, stepName string, stepAliases []Alias) (StepConfig, error) {
 	var stepConfig StepConfig
 	var d PipelineDefaults
 
@@ -91,7 +113,8 @@ func (c *Config) GetStepConfig(flagValues map[string]interface{}, paramJSON stri
 			return StepConfig{}, errors.Wrap(err, "failed to parse custom pipeline configuration")
 		}
 	}
-	c.ApplyAliasConfig(parameters, filters, stageName, stepName)
+
+	c.ApplyAliasConfig(parameters, filters, stageName, stepName, stepAliases)
 
 	// consider custom defaults defined in config.yml
 	if c.CustomDefaults != nil && len(c.CustomDefaults) > 0 {
@@ -121,7 +144,7 @@ func (c *Config) GetStepConfig(flagValues map[string]interface{}, paramJSON stri
 
 	// read defaults & merge general -> steps (-> general -> steps ...)
 	for _, def := range d.Defaults {
-		def.ApplyAliasConfig(parameters, filters, stageName, stepName)
+		def.ApplyAliasConfig(parameters, filters, stageName, stepName, stepAliases)
 		stepConfig.mixIn(def.General, filters.General)
 		stepConfig.mixIn(def.Steps[stepName], filters.Steps)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -427,44 +427,70 @@ func TestGetDeepAliasValue(t *testing.T) {
 }
 
 func TestCopyStepAliasConfig(t *testing.T) {
-	c := Config{
-		Steps: map[string]map[string]interface{}{
-			"step1": map[string]interface{}{
-				"p1": "p1_step",
-				"p2": "p2_step",
+	t.Run("Step config available", func(t *testing.T) {
+		c := Config{
+			Steps: map[string]map[string]interface{}{
+				"step1": map[string]interface{}{
+					"p1": "p1_step",
+					"p2": "p2_step",
+				},
+				"stepAlias1": map[string]interface{}{
+					"p2": "p2_stepAlias",
+					"p3": "p3_stepAlias",
+				},
+				"stepAlias2": map[string]interface{}{
+					"p3": "p3_stepAlias2",
+					"p4": "p4_stepAlias2",
+				},
 			},
-			"stepAlias1": map[string]interface{}{
-				"p2": "p2_stepAlias",
-				"p3": "p3_stepAlias",
-			},
-			"stepAlias2": map[string]interface{}{
-				"p3": "p3_stepAlias2",
-				"p4": "p4_stepAlias2",
-			},
-		},
-	}
+		}
 
-	expected := Config{
-		Steps: map[string]map[string]interface{}{
-			"step1": map[string]interface{}{
-				"p1": "p1_step",
-				"p2": "p2_step",
-				"p3": "p3_stepAlias",
-				"p4": "p4_stepAlias2",
+		expected := Config{
+			Steps: map[string]map[string]interface{}{
+				"step1": map[string]interface{}{
+					"p1": "p1_step",
+					"p2": "p2_step",
+					"p3": "p3_stepAlias",
+					"p4": "p4_stepAlias2",
+				},
+				"stepAlias1": map[string]interface{}{
+					"p2": "p2_stepAlias",
+					"p3": "p3_stepAlias",
+				},
+				"stepAlias2": map[string]interface{}{
+					"p3": "p3_stepAlias2",
+					"p4": "p4_stepAlias2",
+				},
 			},
-			"stepAlias1": map[string]interface{}{
-				"p2": "p2_stepAlias",
-				"p3": "p3_stepAlias",
-			},
-			"stepAlias2": map[string]interface{}{
-				"p3": "p3_stepAlias2",
-				"p4": "p4_stepAlias2",
-			},
-		},
-	}
+		}
 
-	c.copyStepAliasConfig("step1", []Alias{{Name: "stepAlias1"}, {Name: "stepAlias2"}})
-	assert.Equal(t, expected, c)
+		c.copyStepAliasConfig("step1", []Alias{{Name: "stepAlias1"}, {Name: "stepAlias2"}})
+		assert.Equal(t, expected, c)
+	})
+
+	t.Run("Step config not available", func(t *testing.T) {
+		c := Config{
+			Steps: map[string]map[string]interface{}{
+				"stepAlias1": map[string]interface{}{
+					"p2": "p2_stepAlias",
+				},
+			},
+		}
+
+		expected := Config{
+			Steps: map[string]map[string]interface{}{
+				"step1": map[string]interface{}{
+					"p2": "p2_stepAlias",
+				},
+				"stepAlias1": map[string]interface{}{
+					"p2": "p2_stepAlias",
+				},
+			},
+		}
+
+		c.copyStepAliasConfig("step1", []Alias{{Name: "stepAlias1"}})
+		assert.Equal(t, expected, c)
+	})
 }
 
 func TestGetJSON(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -82,6 +82,8 @@ steps:
     px4: px4_step
     p5: p5_step
     dependentParameter: dependentValue
+  stepAlias:
+    p8: p8_stepAlias
 stages:
   stage1:
     p5: p5_stage
@@ -90,7 +92,7 @@ stages:
 `
 		filters := StepFilters{
 			General:    []string{"p0", "p1", "p2", "p3", "p4"},
-			Steps:      []string{"p0", "p1", "p2", "p3", "p4", "p5", "dependentParameter", "pd1", "dependentValue", "pd2"},
+			Steps:      []string{"p0", "p1", "p2", "p3", "p4", "p5", "p8", "dependentParameter", "pd1", "dependentValue", "pd2"},
 			Stages:     []string{"p0", "p1", "p2", "p3", "p4", "p5", "p6"},
 			Parameters: []string{"p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7"},
 			Env:        []string{"p0", "p1", "p2", "p3", "p4", "p5"},
@@ -167,7 +169,8 @@ steps:
 
 		piperenv.SetParameter(filepath.Join(dir, "commonPipelineEnvironment"), "test_pe1", "pe1_val")
 
-		stepConfig, err := c.GetStepConfig(flags, paramJSON, myConfig, defaults, filters, parameterMetadata, stepMeta.GetResourceParameters(dir, "commonPipelineEnvironment"), "stage1", "step1")
+		stepAliases := []Alias{{Name: "stepAlias"}}
+		stepConfig, err := c.GetStepConfig(flags, paramJSON, myConfig, defaults, filters, parameterMetadata, stepMeta.GetResourceParameters(dir, "commonPipelineEnvironment"), "stage1", "step1", stepAliases)
 
 		assert.Equal(t, nil, err, "error occured but none expected")
 
@@ -181,6 +184,7 @@ steps:
 				"p5":  "p5_stage",
 				"p6":  "p6_param",
 				"p7":  "p7_flag",
+				"p8":  "p8_stepAlias",
 				"pd1": "pd1_dependent_default",
 				"pd2": "pd2_metadata_default",
 				"pe1": "pe1_val",
@@ -213,7 +217,7 @@ steps:
 
 		c.openFile = customDefaultsOpenFileMock
 
-		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConfDefaults)), nil, StepFilters{General: []string{"p0"}}, nil, nil, "stage1", "step1")
+		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConfDefaults)), nil, StepFilters{General: []string{"p0"}}, nil, nil, "stage1", "step1", []Alias{})
 
 		assert.NoError(t, err, "Error occured but no error expected")
 		assert.Equal(t, "p0_custom_default", stepConfig.Config["p0"])
@@ -226,7 +230,7 @@ steps:
 		stepParams := []StepParameters{StepParameters{Name: "p0", Scope: []string{"GENERAL"}, Type: "string", Default: "p0_step_default", Aliases: []Alias{{Name: "p0_alias"}}}}
 		testConf := "general:\n p1: p1_conf"
 
-		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConf)), nil, StepFilters{General: []string{"p0", "p1"}}, stepParams, nil, "stage1", "step1")
+		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConf)), nil, StepFilters{General: []string{"p0", "p1"}}, stepParams, nil, "stage1", "step1", []Alias{})
 
 		assert.NoError(t, err, "Error occured but no error expected")
 		assert.Equal(t, "p0_step_default", stepConfig.Config["p0"])
@@ -236,7 +240,7 @@ steps:
 	t.Run("Failure case config", func(t *testing.T) {
 		var c Config
 		myConfig := ioutil.NopCloser(strings.NewReader("invalid config"))
-		_, err := c.GetStepConfig(nil, "", myConfig, nil, StepFilters{}, []StepParameters{}, nil, "stage1", "step1")
+		_, err := c.GetStepConfig(nil, "", myConfig, nil, StepFilters{}, []StepParameters{}, nil, "stage1", "step1", []Alias{})
 		assert.EqualError(t, err, "failed to parse custom pipeline configuration: error unmarshalling \"invalid config\": error unmarshaling JSON: json: cannot unmarshal string into Go value of type config.Config", "default error expected")
 	})
 
@@ -244,7 +248,7 @@ steps:
 		var c Config
 		myConfig := ioutil.NopCloser(strings.NewReader(""))
 		myDefaults := []io.ReadCloser{ioutil.NopCloser(strings.NewReader("invalid defaults"))}
-		_, err := c.GetStepConfig(nil, "", myConfig, myDefaults, StepFilters{}, []StepParameters{}, nil, "stage1", "step1")
+		_, err := c.GetStepConfig(nil, "", myConfig, myDefaults, StepFilters{}, []StepParameters{}, nil, "stage1", "step1", []Alias{})
 		assert.EqualError(t, err, "failed to parse pipeline default configuration: error unmarshalling \"invalid defaults\": error unmarshaling JSON: json: cannot unmarshal string into Go value of type config.Config", "default error expected")
 	})
 
@@ -324,12 +328,21 @@ func TestApplyAliasConfig(t *testing.T) {
 				{Name: "p7_alias"},
 			},
 		},
+		{
+			Name: "p8",
+			Aliases: []Alias{
+				{Name: "p8_alias"},
+			},
+		},
+		{
+			Name: "p9",
+		},
 	}
 
 	filters := StepFilters{
 		General: []string{"p1", "p2"},
 		Stages:  []string{"p4"},
-		Steps:   []string{"p6"},
+		Steps:   []string{"p6", "p8"},
 	}
 
 	c := Config{
@@ -354,10 +367,17 @@ func TestApplyAliasConfig(t *testing.T) {
 				"p6_alias":   "p6_step",
 				"p7":         "p7_step",
 			},
+			"stepAlias1": map[string]interface{}{
+				"p7":       "p7_stepAlias",
+				"p8_alias": "p8_stepAlias",
+				"p9":       "p9_stepAlias",
+			},
 		},
 	}
 
-	c.ApplyAliasConfig(p, filters, "stage1", "step1")
+	stepAliases := []Alias{{Name: "stepAlias1"}}
+
+	c.ApplyAliasConfig(p, filters, "stage1", "step1", stepAliases)
 
 	t.Run("Global", func(t *testing.T) {
 		assert.Nil(t, c.General["p0"])
@@ -370,10 +390,12 @@ func TestApplyAliasConfig(t *testing.T) {
 		assert.Equal(t, "p4_stage", c.Stages["stage1"]["p4"])
 	})
 
-	t.Run("Stage", func(t *testing.T) {
+	t.Run("Steps", func(t *testing.T) {
 		assert.Nil(t, c.General["p5"])
 		assert.Equal(t, "p6_step", c.Steps["step1"]["p6"])
 		assert.Equal(t, "p7_step", c.Steps["step1"]["p7"])
+		assert.Equal(t, "p8_stepAlias", c.Steps["step1"]["p8"])
+		assert.Equal(t, "p9_stepAlias", c.Steps["step1"]["p9"])
 	})
 
 }
@@ -402,6 +424,47 @@ func TestGetDeepAliasValue(t *testing.T) {
 	for k, v := range tt {
 		assert.Equal(t, v.expected, getDeepAliasValue(c, v.key), fmt.Sprintf("wrong return value for run %v", k+1))
 	}
+}
+
+func TestCopyStepAliasConfig(t *testing.T) {
+	c := Config{
+		Steps: map[string]map[string]interface{}{
+			"step1": map[string]interface{}{
+				"p1": "p1_step",
+				"p2": "p2_step",
+			},
+			"stepAlias1": map[string]interface{}{
+				"p2": "p2_stepAlias",
+				"p3": "p3_stepAlias",
+			},
+			"stepAlias2": map[string]interface{}{
+				"p3": "p3_stepAlias2",
+				"p4": "p4_stepAlias2",
+			},
+		},
+	}
+
+	expected := Config{
+		Steps: map[string]map[string]interface{}{
+			"step1": map[string]interface{}{
+				"p1": "p1_step",
+				"p2": "p2_step",
+				"p3": "p3_stepAlias",
+				"p4": "p4_stepAlias2",
+			},
+			"stepAlias1": map[string]interface{}{
+				"p2": "p2_stepAlias",
+				"p3": "p3_stepAlias",
+			},
+			"stepAlias2": map[string]interface{}{
+				"p3": "p3_stepAlias2",
+				"p4": "p4_stepAlias2",
+			},
+		},
+	}
+
+	c.copyStepAliasConfig("step1", []Alias{{Name: "stepAlias1"}, {Name: "stepAlias2"}})
+	assert.Equal(t, expected, c)
 }
 
 func TestGetJSON(t *testing.T) {

--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -21,9 +21,10 @@ type StepData struct {
 
 // StepMetadata defines the metadata for a step, like step descriptions, parameters, ...
 type StepMetadata struct {
-	Name            string `json:"name"`
-	Description     string `json:"description"`
-	LongDescription string `json:"longDescription,omitempty"`
+	Name            string  `json:"name"`
+	Aliases         []Alias `json:"aliases,omitempty"`
+	Description     string  `json:"description"`
+	LongDescription string  `json:"longDescription,omitempty"`
 }
 
 // StepSpec defines the spec details for a step, like step inputs, containers, sidecars, ...

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -20,7 +20,8 @@ type stepInfo struct {
 	ExportPrefix     string
 	FlagsFunc        string
 	Long             string
-	Metadata         []config.StepParameters
+	StepParameters   []config.StepParameters
+	StepAliases      []config.Alias
 	OSImport         bool
 	OutputResources  []map[string]string
 	Short            string
@@ -56,7 +57,7 @@ import (
 )
 
 type {{ .StepName }}Options struct {
-	{{- range $key, $value := .Metadata }}
+	{{- range $key, $value := .StepParameters }}
 	{{ $value.Name | golangName }} {{ $value.Type }} ` + "`json:\"{{$value.Name}},omitempty\"`" + `{{end}}
 }
 
@@ -104,20 +105,24 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 }
 
 func {{.FlagsFunc}}(cmd *cobra.Command, stepConfig *{{.StepName}}Options) {
-	{{- range $key, $value := .Metadata }}
+	{{- range $key, $value := .StepParameters }}
 	cmd.Flags().{{ $value.Type | flagType }}(&stepConfig.{{ $value.Name | golangName }}, "{{ $value.Name }}", {{ $value.Default }}, "{{ $value.Description }}"){{ end }}
 	{{- printf "\n" }}
-	{{- range $key, $value := .Metadata }}{{ if $value.Mandatory }}
+	{{- range $key, $value := .StepParameters }}{{ if $value.Mandatory }}
 	cmd.MarkFlagRequired("{{ $value.Name }}"){{ end }}{{ end }}
 }
 
 // retrieve step metadata
 func {{ .StepName }}Metadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "{{ .StepName }}",
+			Aliases: []config.Alias{{ "{" }}{{ range $notused, $alias := .StepAliases }}{{ "{" }}Name: "{{ $alias.Name }}", Deprecated: {{ $alias.Deprecated }}{{ "}" }},{{ end }}{{ "}" }},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{
-					{{- range $key, $value := .Metadata }}
+					{{- range $key, $value := .StepParameters }}
 					{
 						Name:      "{{ $value.Name }}",
 						ResourceRef: []config.ResourceReference{{ "{" }}{{ range $notused, $ref := $value.ResourceRef }}{{ "{" }}Name: "{{ $ref.Name }}", Param: "{{ $ref.Param }}"{{ "}" }},{{ end }}{{ "}" }},
@@ -298,7 +303,8 @@ func getStepInfo(stepData *config.StepData, osImport bool, exportPrefix string) 
 			CreateCmdVar:     fmt.Sprintf("create%vCmd", strings.Title(stepData.Metadata.Name)),
 			Short:            stepData.Metadata.Description,
 			Long:             stepData.Metadata.LongDescription,
-			Metadata:         stepData.Spec.Inputs.Parameters,
+			StepParameters:   stepData.Spec.Inputs.Parameters,
+			StepAliases:      stepData.Metadata.Aliases,
 			FlagsFunc:        fmt.Sprintf("add%vFlags", strings.Title(stepData.Metadata.Name)),
 			OSImport:         osImport,
 			OutputResources:  oRes,

--- a/pkg/generator/helper/helper_test.go
+++ b/pkg/generator/helper/helper_test.go
@@ -16,6 +16,9 @@ import (
 func configOpenFileMock(name string) (io.ReadCloser, error) {
 	meta1 := `metadata:
   name: testStep
+  aliases:
+    - name: testStepAlias
+      deprecated: true
   description: Test description
   longDescription: |
     Long Test description
@@ -219,7 +222,7 @@ func TestGetStepInfo(t *testing.T) {
 	assert.Equal(t, "createTestStepCmd", myStepInfo.CreateCmdVar, "CreateCmdVar incorrect")
 	assert.Equal(t, "Test description", myStepInfo.Short, "Short incorrect")
 	assert.Equal(t, "Long Test description", myStepInfo.Long, "Long incorrect")
-	assert.Equal(t, stepData.Spec.Inputs.Parameters, myStepInfo.Metadata, "Metadata incorrect")
+	assert.Equal(t, stepData.Spec.Inputs.Parameters, myStepInfo.StepParameters, "Metadata incorrect")
 	assert.Equal(t, "addTestStepFlags", myStepInfo.FlagsFunc, "FlagsFunc incorrect")
 	assert.Equal(t, "addTestStepFlags", myStepInfo.FlagsFunc, "FlagsFunc incorrect")
 

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
@@ -142,6 +142,10 @@ func addTestStepFlags(cmd *cobra.Command, stepConfig *testStepOptions) {
 // retrieve step metadata
 func testStepMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "testStep",
+			Aliases: []config.Alias{{Name: "testStepAlias", Deprecated: true},},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
@@ -141,6 +141,10 @@ func addTestStepFlags(cmd *cobra.Command, stepConfig *testStepOptions) {
 // retrieve step metadata
 func testStepMetadata() config.StepData {
 	var theMetaData = config.StepData{
+		Metadata: config.StepMetadata{
+			Name:    "testStep",
+			Aliases: []config.Alias{{Name: "testStepAlias", Deprecated: true},},
+		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Parameters: []config.StepParameters{

--- a/resources/metadata/mavenBuild.yaml
+++ b/resources/metadata/mavenBuild.yaml
@@ -1,5 +1,8 @@
 metadata:
   name: mavenBuild
+  aliases:
+    - name: mavenExecute
+      deprecated: false
   description: This step will install the maven project into the local maven repository.
   longDescription: |
     This step will install the maven project into the local maven repository.

--- a/resources/metadata/mavenStaticCodeChecks.yaml
+++ b/resources/metadata/mavenStaticCodeChecks.yaml
@@ -1,5 +1,8 @@
 metadata:
   name: mavenExecuteStaticCodeChecks
+  aliases:
+    - name: mavenExecute
+      deprecated: false  
   description: Execute static code checks for Maven based projects. The plugins SpotBugs and PMD are used.
   longDescription: |
     Executes Spotbugs Maven plugin as well as Pmd Maven plugin for static code checks.

--- a/resources/metadata/mavenStaticCodeChecks.yaml
+++ b/resources/metadata/mavenStaticCodeChecks.yaml
@@ -2,7 +2,7 @@ metadata:
   name: mavenExecuteStaticCodeChecks
   aliases:
     - name: mavenExecute
-      deprecated: false  
+      deprecated: false
   description: Execute static code checks for Maven based projects. The plugins SpotBugs and PMD are used.
   longDescription: |
     Executes Spotbugs Maven plugin as well as Pmd Maven plugin for static code checks.


### PR DESCRIPTION
# Changes
Introduction of configuration aliases for steps.

This will ease following scenarios for example:
* config migration due to step name changes
* re-use of more general config, e.g. `mavenExecute` in `mavenBuild`

Configuration in step metadata is done as follows:

```
metadata:
  name: mavenBuild
  aliases:
    - name: mavenExecute
      deprecated: false
    - name: deprecatedMavenExecute
      deprecated: true
```

This configuration will ensure that relevant step configuration parameters of `mavenExecute` will be used for `mavenBuild` unless they are already defined for `mavenBuild`.

It is possible to define multiple aliases, like `deprecatedMavenExecute` in this example.
They are considered in order. 
That means step configuration parameters of `deprecatedMavenExecute` are only considered in case the configuration is neither available on `mavenBuild` nor on `mavenExecute`.

- [x] Tests
- ~[ ] Documentation~ not applicable
