### PR TITLE
Add DownloadCacheUtils for handling download cache docker container

### DIFF
--- a/resources/com.sap.piper/templates/mvn_download_cache_proxy_settings.xml
+++ b/resources/com.sap.piper/templates/mvn_download_cache_proxy_settings.xml
@@ -1,8 +1,8 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
     <mirrors>
         <mirror>
-            <id>s4sdk-mirror</id>
-            <name>s4sdk-mirror</name>
+            <id>download-cache</id>
+            <name>download-cache</name>
             <mirrorOf>central</mirrorOf>
             <url>http://__HOSTNAME__:8081/repository/mvn-proxy/</url>
         </mirror>

--- a/resources/com.sap.piper/templates/mvn_download_cache_proxy_settings.xml
+++ b/resources/com.sap.piper/templates/mvn_download_cache_proxy_settings.xml
@@ -1,0 +1,10 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>s4sdk-mirror</id>
+            <name>s4sdk-mirror</name>
+            <mirrorOf>central</mirrorOf>
+            <url>http://__HOSTNAME__:8081/repository/mvn-proxy/</url>
+        </mirror>
+    </mirrors>
+</settings>

--- a/src/com/sap/piper/DownloadCacheUtils.groovy
+++ b/src/com/sap/piper/DownloadCacheUtils.groovy
@@ -1,6 +1,13 @@
 package com.sap.piper
 
+
 class DownloadCacheUtils {
+
+    static boolean isEnabled(Script script) {
+        script.node('master') {
+            return (Boolean.valueOf(script.env.DL_CACHE_NETWORK) && Boolean.valueOf(script.env.DL_CACHE_HOSTNAME))
+        }
+    }
 
     static String getDockerOptions(Script script) {
         script.node('master') {

--- a/src/com/sap/piper/DownloadCacheUtils.groovy
+++ b/src/com/sap/piper/DownloadCacheUtils.groovy
@@ -1,0 +1,40 @@
+package com.sap.piper
+
+class DownloadCacheUtils {
+
+    static String getDockerOptions(Script script) {
+        script.node('master') {
+            String dockerNetwork = script.env.DL_CACHE_NETWORK
+            if (!dockerNetwork) {
+                return ''
+            }
+            return " --network=$dockerNetwork"
+        }
+    }
+
+    static String writeGlobalMavenSettingsForDownloadCache(Script script) {
+        String globalSettingsFilePath = '.pipeline/global_settings.xml'
+        if (script.fileExists(globalSettingsFilePath)) {
+            return globalSettingsFilePath
+        }
+
+        String hostname = ''
+        script.node('master') {
+            hostname = script.env.DL_CACHE_HOSTNAME // set by cx-server
+        }
+
+        if (!hostname) {
+            return ''
+        }
+
+        String mavenSettingsTemplate = script.libraryResource("mvn_download_cache_proxy_settings.xml")
+        String mavenSettings = mavenSettingsTemplate.replace('__HOSTNAME__', hostname)
+
+        if (!script.fileExists('.pipeline')) {
+            script.sh "mkdir .pipeline"
+        }
+
+        script.writeFile file: globalSettingsFilePath, text: mavenSettings
+        return globalSettingsFilePath
+    }
+}

--- a/src/com/sap/piper/DownloadCacheUtils.groovy
+++ b/src/com/sap/piper/DownloadCacheUtils.groovy
@@ -5,7 +5,9 @@ class DownloadCacheUtils {
 
     static boolean isEnabled(Script script) {
         script.node('master') {
-            return (Boolean.valueOf(script.env.DL_CACHE_NETWORK) && Boolean.valueOf(script.env.DL_CACHE_HOSTNAME))
+            String network = script.env.DL_CACHE_NETWORK
+            String host = script.env.DL_CACHE_HOSTNAME
+            return (network.asBoolean() && host.asBoolean())
         }
     }
 

--- a/src/com/sap/piper/DownloadCacheUtils.groovy
+++ b/src/com/sap/piper/DownloadCacheUtils.groovy
@@ -12,7 +12,7 @@ class DownloadCacheUtils {
         }
     }
 
-    static String writeGlobalMavenSettingsForDownloadCache(Script script) {
+    static String getGlobalMavenSettingsForDownloadCache(Script script) {
         String globalSettingsFilePath = '.pipeline/global_settings.xml'
         if (script.fileExists(globalSettingsFilePath)) {
             return globalSettingsFilePath

--- a/test/groovy/DownloadCacheUtilsTest.groovy
+++ b/test/groovy/DownloadCacheUtilsTest.groovy
@@ -5,21 +5,16 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import util.BasePiperTest
 import util.JenkinsFileExistsRule
-import util.JenkinsShellCallRule
 import util.Rules
 
-import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertFalse
-import static org.junit.Assert.assertTrue
+import static org.junit.Assert.*
 
 class DownloadCacheUtilsTest extends BasePiperTest {
-    private JenkinsShellCallRule shellRule = new JenkinsShellCallRule(this)
     private JenkinsFileExistsRule fileExistsRule = new JenkinsFileExistsRule(this, [])
 
     @Rule
     public RuleChain ruleChain = Rules
         .getCommonRules(this)
-        .around(shellRule)
         .around(fileExistsRule)
 
     @Before

--- a/test/groovy/DownloadCacheUtilsTest.groovy
+++ b/test/groovy/DownloadCacheUtilsTest.groovy
@@ -9,9 +9,10 @@ import util.JenkinsShellCallRule
 import util.Rules
 
 import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertTrue
 
-class DownloadCacheUtilsTest extends BasePiperTest{
+class DownloadCacheUtilsTest extends BasePiperTest {
     private JenkinsShellCallRule shellRule = new JenkinsShellCallRule(this)
     private JenkinsFileExistsRule fileExistsRule = new JenkinsFileExistsRule(this, [])
 
@@ -30,7 +31,7 @@ class DownloadCacheUtilsTest extends BasePiperTest{
             }
             return ''
         })
-        helper.registerAllowedMethod('node', [String.class, Closure.class]) {s, body ->
+        helper.registerAllowedMethod('node', [String.class, Closure.class]) { s, body ->
             body()
         }
     }
@@ -58,7 +59,7 @@ class DownloadCacheUtilsTest extends BasePiperTest{
         nullScript.env.DL_CACHE_HOSTNAME = 'cx-downloadcache'
         boolean writeFileExecuted = false
 
-        helper.registerAllowedMethod('writeFile', [Map.class]) {Map m ->
+        helper.registerAllowedMethod('writeFile', [Map.class]) { Map m ->
             writeFileExecuted = true
         }
         String expected = '.pipeline/global_settings.xml'
@@ -71,8 +72,15 @@ class DownloadCacheUtilsTest extends BasePiperTest{
     @Test
     void 'getGlobalMavenSettingsForDownloadCache should return filePath if file already exists'() {
         fileExistsRule.registerExistingFile('.pipeline/global_settings.xml')
+        boolean writeFileExecuted = false
+
+        helper.registerAllowedMethod('writeFile', [Map.class]) { Map m ->
+            writeFileExecuted = true
+        }
+
         String expected = '.pipeline/global_settings.xml'
         String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
+        assertFalse(writeFileExecuted)
         assertEquals(expected, actual)
     }
 

--- a/test/groovy/DownloadCacheUtilsTest.groovy
+++ b/test/groovy/DownloadCacheUtilsTest.groovy
@@ -40,6 +40,7 @@ class DownloadCacheUtilsTest extends BasePiperTest{
         nullScript.env.DL_CACHE_HOSTNAME = 'cx-downloadcache'
         nullScript.env.DL_CACHE_NETWORK = 'cx-network'
         boolean actual = DownloadCacheUtils.isEnabled(nullScript)
+
         assertTrue(actual)
     }
 
@@ -60,7 +61,6 @@ class DownloadCacheUtilsTest extends BasePiperTest{
         helper.registerAllowedMethod('writeFile', [Map.class]) {Map m ->
             writeFileExecuted = true
         }
-
         String expected = '.pipeline/global_settings.xml'
         String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
 
@@ -73,19 +73,14 @@ class DownloadCacheUtilsTest extends BasePiperTest{
         fileExistsRule.registerExistingFile('.pipeline/global_settings.xml')
         String expected = '.pipeline/global_settings.xml'
         String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
-
         assertEquals(expected, actual)
     }
 
     @Test
     void 'getGlobalMavenSettingsForDownloadCache should return empty string if dl cache not active'() {
         String expected = ''
-        helper.registerAllowedMethod('node', [String.class, Closure.class]) {s, body ->
-            body()
-        }
         String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
 
         assertEquals(expected, actual)
-
     }
 }

--- a/test/groovy/DownloadCacheUtilsTest.groovy
+++ b/test/groovy/DownloadCacheUtilsTest.groovy
@@ -35,16 +35,19 @@ class DownloadCacheUtilsTest extends BasePiperTest{
     @Test
     void writeGlobalMavenSettingsForDownloadCacheShouldWriteFile() {
         //binding.variables.env.DL_CACHE_HOSTNAME = 'cx-downloadcache'
-        binding.setVariable('env', [DL_CACHE_HOSTNAME: 'cx-downloadcache'])
+        Map bind = [DL_CACHE_HOSTNAME: 'cx-downloadcache']
+        binding.variables.env.DL_CACHE_HOSTNAME = 'asd'
+        binding.setProperty('DL_CACHE_HOSTNAME', 'asdasdasd')
+        binding.setVariable('env', bind)
         helper.registerAllowedMethod('node', [String.class, Closure.class]) {s, body ->
             body()
         }
         helper.registerAllowedMethod('env', []) { ->
-            return 'cx-downloadcache'
+            return [DL_CACHE_HOSTNAME: 'cx-downloadcache']
         }
 
         String expected = '.pipeline/global_settings.xml'
-        String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
+        String actual = DownloadCacheUtils.isEnabled(nullScript)//getGlobalMavenSettingsForDownloadCache(nullScript)
 
         assertEquals(expected, actual)
     }

--- a/test/groovy/DownloadCacheUtilsTest.groovy
+++ b/test/groovy/DownloadCacheUtilsTest.groovy
@@ -67,6 +67,7 @@ class DownloadCacheUtilsTest extends BasePiperTest {
     @Test
     void 'getGlobalMavenSettingsForDownloadCache should return filePath if file already exists'() {
         fileExistsRule.registerExistingFile('.pipeline/global_settings.xml')
+        nullScript.env.DL_CACHE_HOSTNAME = 'cx-downloadcache'
         boolean writeFileExecuted = false
 
         helper.registerAllowedMethod('writeFile', [Map.class]) { Map m ->

--- a/test/groovy/DownloadCacheUtilsTest.groovy
+++ b/test/groovy/DownloadCacheUtilsTest.groovy
@@ -4,14 +4,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import util.BasePiperTest
-import util.JenkinsEnvironmentRule
 import util.JenkinsFileExistsRule
 import util.JenkinsShellCallRule
 import util.Rules
 
 import static org.junit.Assert.assertEquals
-import static org.junit.Assert.assertThat
-import static org.junit.Assert.assertTrue
 
 class DownloadCacheUtilsTest extends BasePiperTest{
     private JenkinsShellCallRule shellRule = new JenkinsShellCallRule(this)
@@ -35,7 +32,6 @@ class DownloadCacheUtilsTest extends BasePiperTest{
 
     }
 
-
     @Test
     void writeGlobalMavenSettingsForDownloadCacheShouldWriteFile() {
         //binding.variables.env.DL_CACHE_HOSTNAME = 'cx-downloadcache'
@@ -43,9 +39,12 @@ class DownloadCacheUtilsTest extends BasePiperTest{
         helper.registerAllowedMethod('node', [String.class, Closure.class]) {s, body ->
             body()
         }
+        helper.registerAllowedMethod('env', []) { ->
+            return 'cx-downloadcache'
+        }
 
         String expected = '.pipeline/global_settings.xml'
-        String actual = DownloadCacheUtils.writeGlobalMavenSettingsForDownloadCache(nullScript)
+        String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
 
         assertEquals(expected, actual)
     }
@@ -53,10 +52,21 @@ class DownloadCacheUtilsTest extends BasePiperTest{
     @Test
     void writeGlobalMavenSettingsForDownloadCacheShouldNotWriteFile() {
         fileExistsRule.registerExistingFile('.pipeline/global_settings.xml')
+        String expected = '.pipeline/global_settings.xml'
+        String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
+
+        assertEquals(expected, actual)
     }
 
     @Test
     void writeGlobalMavenSettingsForDownloadCacheShouldReturnEmptyStringOnNoDlCache() {
+        String expected = ''
+        helper.registerAllowedMethod('node', [String.class, Closure.class]) {s, body ->
+            body()
+        }
+        String actual = DownloadCacheUtils.getGlobalMavenSettingsForDownloadCache(nullScript)
+
+        assertEquals(expected, actual)
 
     }
 }

--- a/test/groovy/DownloadCacheUtilsTest.groovy
+++ b/test/groovy/DownloadCacheUtilsTest.groovy
@@ -1,0 +1,62 @@
+import com.sap.piper.DownloadCacheUtils
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import util.BasePiperTest
+import util.JenkinsEnvironmentRule
+import util.JenkinsFileExistsRule
+import util.JenkinsShellCallRule
+import util.Rules
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
+
+class DownloadCacheUtilsTest extends BasePiperTest{
+    private JenkinsShellCallRule shellRule = new JenkinsShellCallRule(this)
+    private JenkinsFileExistsRule fileExistsRule = new JenkinsFileExistsRule(this, [])
+
+    @Rule
+    public RuleChain ruleChain = Rules
+        .getCommonRules(this)
+        .around(shellRule)
+        .around(fileExistsRule)
+
+    @Before
+    void init() {
+        helper.registerAllowedMethod("libraryResource", [String.class], { path ->
+            File resource = new File(new File('resources'), path)
+            if (resource.exists()) {
+                return resource.getText()
+            }
+            return ''
+        })
+
+    }
+
+
+    @Test
+    void writeGlobalMavenSettingsForDownloadCacheShouldWriteFile() {
+        //binding.variables.env.DL_CACHE_HOSTNAME = 'cx-downloadcache'
+        binding.setVariable('env', [DL_CACHE_HOSTNAME: 'cx-downloadcache'])
+        helper.registerAllowedMethod('node', [String.class, Closure.class]) {s, body ->
+            body()
+        }
+
+        String expected = '.pipeline/global_settings.xml'
+        String actual = DownloadCacheUtils.writeGlobalMavenSettingsForDownloadCache(nullScript)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    void writeGlobalMavenSettingsForDownloadCacheShouldNotWriteFile() {
+        fileExistsRule.registerExistingFile('.pipeline/global_settings.xml')
+    }
+
+    @Test
+    void writeGlobalMavenSettingsForDownloadCacheShouldReturnEmptyStringOnNoDlCache() {
+
+    }
+}


### PR DESCRIPTION
Especially for the use case with cx-server in a docker environment where a nexus container acts as a download cache dockerOptions and GlobalSettings are needed to configure mavenExecute to use the download cache.
This utility class implements the handling of dockerOptions and creates a maven global config on the fly.

The idea is to use this helper class every time we call a go step which executes maven.
