### PR TITLE
Fix CLI exec call building for keytool

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -176,8 +176,8 @@ func loadCertificates(certificateString string, client piperhttp.Downloader, run
 		keytoolOptions := []string{
 			"-import",
 			"-noprompt",
-			"-storepass changeit",
-			"-keystore " + trustStoreFile,
+			"-storepass", "changeit",
+			"-keystore", trustStoreFile,
 		}
 		tmpFolder := getTempDir()
 		defer os.RemoveAll(tmpFolder) // clean up

--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -192,8 +192,8 @@ func loadCertificates(certificateString string, client piperhttp.Downloader, run
 			if err := client.DownloadFile(certificate, target, nil, nil); err != nil {
 				return errors.Wrapf(err, "Download of TLS certificate failed")
 			}
-			options := append(keytoolOptions, "-file \""+target+"\"")
-			options = append(options, "-alias \""+filename+"\"")
+			options := append(keytoolOptions, "-file", target)
+			options = append(options, "-alias", filename)
 			// add certificate to keystore
 			if err := runner.RunExecutable("keytool", options...); err != nil {
 				return errors.Wrap(err, "Adding certificate to keystore failed")


### PR DESCRIPTION
The command line argument building for calling keytool was wrong.
* Parameters which are separated by a space on the command line are passed as separate argv entries to the tool by the shell. Translating this to `execRunner.RunExecutable()` means they need to be separate entries in the options array.
* Surrounding paths by quotes in the shell has the effect that the path can have special characters. They can also have spaces, which means the shell generates one argv entry for the path. For building the options array for `execRunner.RunExecutable()`, this is wrong, since we are already one step farther, we build the argv-array directly. Adding quotes means it will end up in the executed tool *with* the quotes.