### PR TITLE
Allow to configure m2path for artifactSetVersion with maven

### DIFF
--- a/src/com/sap/piper/versioning/MavenArtifactVersioning.groovy
+++ b/src/com/sap/piper/versioning/MavenArtifactVersioning.groovy
@@ -16,6 +16,6 @@ class MavenArtifactVersioning extends ArtifactVersioning {
 
     @Override
     def setVersion(version) {
-        script.mavenExecute script: script, goals: 'versions:set', defines: "-DnewVersion=${version} -DgenerateBackupPoms=false", pomPath: configuration.filePath
+        script.mavenExecute script: script, goals: 'versions:set', defines: "-DnewVersion=${version} -DgenerateBackupPoms=false", pomPath: configuration.filePath, m2Path: configuration.m2Path
     }
 }

--- a/vars/artifactSetVersion.groovy
+++ b/vars/artifactSetVersion.groovy
@@ -96,7 +96,11 @@ enum GitPushMode {NONE, HTTPS, SSH}
       * Push is only performed in case 'commitVersion' is set to 'true'.
       * @possibleValues 'SSH', 'HTTPS', 'NONE'
       */
-    'gitPushMode'
+    'gitPushMode',
+    /**
+     * Custom path for maven m2 directory. Only applicable if the configured buildTool is maven.
+    */
+    'm2Path'
 ]
 
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus(


### PR DESCRIPTION
# Changes

Allow to configure m2path for artifactSetVersion with maven which might be required to avoid downloading dependencies multiple times