### PR TITLE
Future proof the http-timeout test for go 1.14

### DIFF
--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -253,8 +253,9 @@ func TestTransportTimout(t *testing.T) {
 		// test
 		_, err := client.SendRequest(http.MethodGet, svr.URL, &buffer, nil, nil)
 		// assert
-		assert.Error(t, err, "expected request to fail")
-		assert.Contains(t, err.Error(), "timeout awaiting response headers")
+		if assert.Error(t, err, "expected request to fail") {
+			assert.Contains(t, err.Error(), "timeout awaiting response headers")
+		}
 	})
 	t.Run("timeout is not hit on transport level", func(t *testing.T) {
 		// init

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -253,10 +253,8 @@ func TestTransportTimout(t *testing.T) {
 		// test
 		_, err := client.SendRequest(http.MethodGet, svr.URL, &buffer, nil, nil)
 		// assert
-		assert.EqualError(t, err,
-			fmt.Sprintf("error opening %v: Get %v: net/http: timeout awaiting response headers",
-				svr.URL, svr.URL),
-			"expected request to fail")
+		assert.Error(t, err, "expected request to fail")
+		assert.Contains(t, err.Error(), "timeout awaiting response headers")
 	})
 	t.Run("timeout is not hit on transport level", func(t *testing.T) {
 		// init


### PR DESCRIPTION
Fix flaky test expectations of pkg/http timeout test.

The exact error message has changed in go 1.14.