### PR TITLE
Add functionality to lock and evaluate current build result

### DIFF
--- a/vars/errorWhenCurrentBuildResultIsWorseOrEqualTo.groovy
+++ b/vars/errorWhenCurrentBuildResultIsWorseOrEqualTo.groovy
@@ -1,0 +1,18 @@
+def call(Map parameters = [:]) {
+    final ERROR_MESSAGE_PREFIX = "Build was ABORTED and marked as FAILURE. "
+
+    handleStepErrors(stepName: 'errorWhenCurrentBuildResultIsWorseOrEqualTo', stepParameters: parameters) {
+        def script = parameters.script
+        def errorStatus = parameters.errorStatus
+        def errorHandler = parameters.errorHandler
+        def errorHandlerParameter = parameters.errorHandlerParameter
+        def errorMessage = parameters.errorMessage ?: ''
+
+        if (script.currentBuild.result && script.currentBuild.resultIsWorseOrEqualTo(errorStatus)) {
+            if (errorHandler) {
+                errorHandler(errorHandlerParameter)
+            }
+            error(ERROR_MESSAGE_PREFIX + errorMessage)
+        }
+    }
+}

--- a/vars/errorWhenCurrentBuildResultIsWorseOrEqualTo.groovy
+++ b/vars/errorWhenCurrentBuildResultIsWorseOrEqualTo.groovy
@@ -1,7 +1,7 @@
 def call(Map parameters = [:]) {
     final ERROR_MESSAGE_PREFIX = "Build was ABORTED and marked as FAILURE. "
 
-    handleStepErrors(stepName: 'errorWhenCurrentBuildResultIsWorseOrEqualTo', stepParameters: parameters) {
+    handlePipelineStepErrors(stepName: 'errorWhenCurrentBuildResultIsWorseOrEqualTo', stepParameters: parameters) {
         def script = parameters.script
         def errorStatus = parameters.errorStatus
         def errorHandler = parameters.errorHandler

--- a/vars/executeWithLockedCurrentBuildResult.groovy
+++ b/vars/executeWithLockedCurrentBuildResult.groovy
@@ -1,0 +1,15 @@
+def call(Map parameters = [:], body) {
+    handleStepErrors(stepName: 'executeWithLockedCurrentBuildResult', stepParameters: parameters) {
+        def script = parameters.script
+        def errorStatus = parameters.errorStatus
+        def errorHandler = parameters.errorHandler
+        def errorHandlerParameter = parameters.errorHandlerParameter
+        def errorMessage = parameters.errorMessage
+
+        lock(script.commonPipelineEnvironment.configuration.currentBuildResultLock) {
+            errorWhenCurrentBuildResultIsWorseOrEqualTo(script: script, errorStatus: 'FAILURE', errorMessage: "Because:\n currentBuild.result is ${script.currentBuild.result} \n and failure reason is ${buildFailureReason.FAILURE_REASON}.")
+            body()
+            errorWhenCurrentBuildResultIsWorseOrEqualTo(script: script, errorStatus: errorStatus, errorHandler: errorHandler, errorHandlerParameter: errorHandlerParameter, errorMessage: errorMessage)
+        }
+    }
+}

--- a/vars/executeWithLockedCurrentBuildResult.groovy
+++ b/vars/executeWithLockedCurrentBuildResult.groovy
@@ -1,5 +1,5 @@
 def call(Map parameters = [:], body) {
-    handleStepErrors(stepName: 'executeWithLockedCurrentBuildResult', stepParameters: parameters) {
+    handlePipelineStepErrors(stepName: 'executeWithLockedCurrentBuildResult', stepParameters: parameters) {
         def script = parameters.script
         def errorStatus = parameters.errorStatus
         def errorHandler = parameters.errorHandler


### PR DESCRIPTION
Add functionality to lock current build result, execute a Closure inside and then fail/pass the build based on the result of the Closure.