### PR TITLE
TMS: implement response processing based on its HTTP response code for authentication and uploadFileToNode

### DIFF
--- a/src/com/sap/piper/integration/TransportManagementService.groovy
+++ b/src/com/sap/piper/integration/TransportManagementService.groovy
@@ -51,9 +51,22 @@ class TransportManagementService implements Serializable {
         }
 
         def response = sendApiRequest(parameters)
+        def responseStatusCode = response.status
+        if (responseStatusCode != 200) {
+            def errorMessage = "OAuth Token retrieval failed."
+            if (config.verbose) {
+                echo("OAuth Token retrieval failed due to unexpected response status ${response.status}.")
+                if (responseStatusCode >= 400) {
+                    echo("Response content '${response.content}'.")
+                }
+            } else {
+                errorMessage += " Consider re-running in verbose mode in order to get more details."
+            }
+            throw new Exception(errorMessage)
+        }
+        
         echo("OAuth Token retrieved successfully.")
-
-        return jsonUtils.jsonStringToGroovyObject(response).access_token
+        return jsonUtils.jsonStringToGroovyObject(response.content).access_token
 
     }
 
@@ -116,9 +129,22 @@ class TransportManagementService implements Serializable {
         }
 
         def response = sendApiRequest(parameters)
+        def responseStatusCode = response.status
+        if (responseStatusCode != 200) {
+            def errorMessage = "Node upload failed."
+            if (config.verbose) {
+                echo("Node upload failed due to unexpected response status ${response.status}.")
+                if (responseStatusCode >= 400) {
+                    echo("Response content '${response.content}'.")
+                }
+            } else {
+                errorMessage += " Consider re-running in verbose mode in order to get more details."
+            }
+            throw new Exception(errorMessage)
+        }
+        
         echo("Node upload successful.")
-
-        return jsonUtils.jsonStringToGroovyObject(response)
+        return jsonUtils.jsonStringToGroovyObject(response.content)
 
     }
 
@@ -128,7 +154,7 @@ class TransportManagementService implements Serializable {
             quiet                 : !config.verbose,
             consoleLogResponseBody: false, // must be false, otherwise this reveals the api-token in the auth-request
             ignoreSslErrors       : true,
-            validResponseCodes    : "100:399"
+            validResponseCodes    : "100:599"
         ]
 
         def response = script.httpRequest(defaultParameters + parameters)
@@ -137,7 +163,7 @@ class TransportManagementService implements Serializable {
             echo("Received response '${response.content}' with status ${response.status}.")
         }
 
-        return response.content
+        return response
     }
 
     private echo(message) {

--- a/test/groovy/com/sap/piper/integration/TransportManagementServiceTest.groovy
+++ b/test/groovy/com/sap/piper/integration/TransportManagementServiceTest.groovy
@@ -34,7 +34,7 @@ class TransportManagementServiceTest extends BasePiperTest {
             return [content: '{ "access_token": "myOAuthToken" }', status: 200]
         })
 
-        def uaaUrl = 'http://dummy.com/oauth'
+        def uaaUrl = 'http://this.is.some.fake.url.bla.bla/oauth'
         def clientId = 'myId'
         def clientSecret = 'mySecret'
 
@@ -57,7 +57,7 @@ class TransportManagementServiceTest extends BasePiperTest {
             return [content: '{ "access_token": "myOAuthToken" }', status: 200]
         })
 
-        def uaaUrl = 'http://dummy.com/oauth'
+        def uaaUrl = 'http://this.is.some.fake.url.bla.bla/oauth'
         def clientId = 'myId'
         def clientSecret = 'mySecret'
 
@@ -73,64 +73,53 @@ class TransportManagementServiceTest extends BasePiperTest {
 
     @Test
     void retrieveOAuthToken__failure() {
+        def uaaUrl = 'http://this.is.some.fake.url.bla.bla/oauth'
+        def clientId = 'myId'
+        def clientSecret = 'mySecret'
+        def responseStatusCode = 400
+        def responseContent = 'Here an error message is expected'
+
+        thrown.expect(AbortException)
+        thrown.expectMessage("[TransportManagementService] OAuth Token retrieval failed (HTTP status code '${responseStatusCode}'). Consider re-running in verbose mode in order to get more details for HTTP status codes 4xx and 5xx.")
+        loggingRule.expect("[TransportManagementService] OAuth Token retrieval started.")
+
         Map requestParams
         helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
             requestParams = m
-            return [content: 'Here an error message is expected', status: 400]
+            return [content: responseContent, status: responseStatusCode]
         })
 
-        def uaaUrl = 'http://dummy.com/oauth'
-        def clientId = 'myId'
-        def clientSecret = 'mySecret'
-
         def tms = new TransportManagementService(nullScript, [:])
-        def errorCaught = false
-        try {
-            tms.authentication(uaaUrl, clientId, clientSecret)
-        } catch (e) {
-            errorCaught = true
-            assertThat(e.getMessage(), is("OAuth Token retrieval failed. Consider re-running in verbose mode in order to get more details."))
-        } finally {
-            assertThat(errorCaught, is(true))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] OAuth Token retrieval started."))
-            assertThat(requestParams, hasEntry('url', "${uaaUrl}/oauth/token/?grant_type=client_credentials&response_type=token"))
-            assertThat(requestParams, hasEntry('requestBody', "grant_type=password&username=${clientId}&password=${clientSecret}".toString()))
-            assertThat(requestParams.customHeaders[1].value, is("Basic ${"${clientId}:${clientSecret}".bytes.encodeBase64()}"))
-        }
+        tms.authentication(uaaUrl, clientId, clientSecret)
     }
 
     @Test
     void retrieveOAuthToken__failure__status__400__inVerboseMode() {
+        def uaaUrl = 'http://this.is.some.fake.url.bla.bla/oauth'
+        def clientId = 'myId'
+        def clientSecret = 'mySecret'
+        def responseStatusCode = 400
+        def responseContent = 'Here an error message is expected'
+
+        thrown.expect(AbortException)
+        thrown.expectMessage("[TransportManagementService] OAuth Token retrieval failed (HTTP status code '${responseStatusCode}'). Response content '${responseContent}'.")
+        loggingRule.expect("[TransportManagementService] OAuth Token retrieval started.")
+        loggingRule.expect("[TransportManagementService] UAA-URL: '${uaaUrl}', ClientId: '${clientId}'")
+
         Map requestParams
         helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
             requestParams = m
-            return [content: 'Here an error message is expected', status: 400]
+            return [content: responseContent, status: responseStatusCode]
         })
-        
-        def uaaUrl = 'http://dummy.com/oauth'
-        def clientId = 'myId'
-        def clientSecret = 'mySecret'
-        
+
         def tms = new TransportManagementService(nullScript, [verbose: true])
-        def errorCaught = false
-        try {
-            tms.authentication(uaaUrl, clientId, clientSecret)
-        } catch (e) {
-            errorCaught = true
-            assertThat(e.getMessage(), is("OAuth Token retrieval failed."))
-        } finally {
-            assertThat(errorCaught, is(true))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] OAuth Token retrieval started."))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] UAA-URL: '${uaaUrl}', ClientId: '${clientId}'"))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] OAuth Token retrieval failed due to unexpected response status 400."))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] Response content 'Here an error message is expected'."))
-        }
+        tms.authentication(uaaUrl, clientId, clientSecret)
     }
 
     @Test
     void uploadFile__successfully() {
 
-        def url = 'http://dummy.com/oauth'
+        def url = 'http://this.is.some.fake.url.bla.bla'
         def token = 'myToken'
         def file = 'myFile.mtar'
         def namedUser = 'myUser'
@@ -150,7 +139,7 @@ class TransportManagementServiceTest extends BasePiperTest {
     @Ignore
     void uploadFile__withHttpErrorResponse__throwsError() {
 
-        def url = 'http://dummy.com/oauth'
+        def url = 'http://this.is.some.fake.url.bla.bla'
         def token = 'myWrongToken'
         def file = 'myFile.mtar'
         def namedUser = 'myUser'
@@ -167,7 +156,7 @@ class TransportManagementServiceTest extends BasePiperTest {
     @Test
     void uploadFile__inVerboseMode__yieldsMoreEchos() {
 
-        def url = 'http://dummy.com/oauth'
+        def url = 'http://this.is.some.fake.url.bla.bla'
         def token = 'myToken'
         def file = 'myFile.mtar'
         def namedUser = 'myUser'
@@ -191,7 +180,7 @@ class TransportManagementServiceTest extends BasePiperTest {
             return [content: '{ "upload": "success" }', status: 200]
         })
 
-        def url = 'http://dummy.com/oauth'
+        def url = 'http://this.is.some.fake.url.bla.bla'
         def token = 'myToken'
         def nodeName = 'myNode'
         def fileId = 1234
@@ -219,7 +208,7 @@ class TransportManagementServiceTest extends BasePiperTest {
             return [content: '{ "upload": "success" }', status: 200]
         })
 
-        def url = 'http://dummy.com/oauth'
+        def url = 'http://this.is.some.fake.url.bla.bla'
         def token = 'myToken'
         def nodeName = 'myNode'
         def fileId = 1234
@@ -237,65 +226,52 @@ class TransportManagementServiceTest extends BasePiperTest {
 
     @Test
     void uploadFileToNode__failure() {
-        Map requestParams
-        helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
-            requestParams = m
-            return [content: '{ "errorType": "TsInternalServerErrorException", "message": "The application has encountered an unexpected error." }', status: 400]
-        })
-        
-        def url = 'http://dummy.com/oauth'
+        def url = 'http://this.is.some.fake.url.bla.bla'
         def token = 'myToken'
         def nodeName = 'myNode'
         def fileId = 1234
         def description = "My description."
         def namedUser = 'myUser'
-        
+        def responseStatusCode = 400
+        def responseContent = '{ "errorType": "TsInternalServerErrorException", "message": "The application has encountered an unexpected error." }'
+
+        thrown.expect(AbortException)
+        thrown.expectMessage("[TransportManagementService] Node upload failed (HTTP status code '${responseStatusCode}'). Consider re-running in verbose mode in order to get more details for HTTP status codes 4xx and 5xx.")
+        loggingRule.expect("[TransportManagementService] Node upload started.")
+
+        Map requestParams
+        helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
+            requestParams = m
+            return [content: responseContent, status: responseStatusCode]
+        })
+
         def tms = new TransportManagementService(nullScript, [:])
-        def bodyRegEx = /^\{\s+"nodeName":\s+"myNode",\s+"contentType":\s+"MTA",\s+"description":\s+"My\s+description.",\s+"storageType":\s+"FILE",\s+"namedUser":\s+"myUser",\s+"entries":\s+\[\s+\{\s+"uri":\s+1234\s+}\s+]\s+}$/
-        def errorCaught = false
-        try {
-            tms.uploadFileToNode(url, token, nodeName, fileId, description, namedUser)
-        } catch (e) {
-            errorCaught = true
-            assertThat(e.getMessage(), is("Node upload failed. Consider re-running in verbose mode in order to get more details."))
-        } finally {
-            assertThat(errorCaught, is(true))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] Node upload started."))
-            assertThat(requestParams, hasEntry('url', "${url}/v2/nodes/upload"))
-            assert requestParams.requestBody ==~ bodyRegEx
-            assertThat(requestParams.customHeaders[0].value, is("Bearer ${token}"))
-        }
+        tms.uploadFileToNode(url, token, nodeName, fileId, description, namedUser)
     }
 
     @Test
     void uploadFileToNode__failure__status__400__inVerboseMode() {
-        Map requestParams
-        helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
-            requestParams = m
-            return [content: '{ "errorType": "TsInternalServerErrorException", "message": "The application has encountered an unexpected error." }', status: 400]
-        })
-        
-        def url = 'http://dummy.com/oauth'
+        def url = 'http://this.is.some.fake.url.bla.bla'
         def token = 'myToken'
         def nodeName = 'myNode'
         def fileId = 1234
         def description = "My description."
         def namedUser = 'myUser'
-        
+        def responseStatusCode = 400
+        def responseContent = '{ "errorType": "TsInternalServerErrorException", "message": "The application has encountered an unexpected error." }'
+
+        thrown.expect(AbortException)
+        thrown.expectMessage("[TransportManagementService] Node upload failed (HTTP status code '${responseStatusCode}'). Response content '${responseContent}'.")
+        loggingRule.expect("[TransportManagementService] Node upload started.")
+        loggingRule.expect("[TransportManagementService] URL: '${url}', NodeName: '${nodeName}', FileId: '${fileId}'")
+
+        Map requestParams
+        helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
+            requestParams = m
+            return [content: responseContent, status: responseStatusCode]
+        })
+
         def tms = new TransportManagementService(nullScript, [verbose: true])
-        def bodyRegEx = /^\{\s+"nodeName":\s+"myNode",\s+"contentType":\s+"MTA",\s+"description":\s+"My\s+description.",\s+"storageType":\s+"FILE",\s+"namedUser":\s+"myUser",\s+"entries":\s+\[\s+\{\s+"uri":\s+1234\s+}\s+]\s+}$/
-        def errorCaught = false
-        try {
-            tms.uploadFileToNode(url, token, nodeName, fileId, description, namedUser)
-        } catch (e) {
-            errorCaught = true
-            assertThat(e.getMessage(), is("Node upload failed."))
-        } finally {
-            assertThat(errorCaught, is(true))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] Node upload started."))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] URL: '${url}', NodeName: '${nodeName}', FileId: '${fileId}'"))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] Node upload failed due to unexpected response status 400."))
-            assertThat(loggingRule.log, containsString("[TransportManagementService] Response content '{ \"errorType\": \"TsInternalServerErrorException\", \"message\": \"The application has encountered an unexpected error.\" }'."))
-        }
+        tms.uploadFileToNode(url, token, nodeName, fileId, description, namedUser)
     }
 }


### PR DESCRIPTION
This PR aims to provide handling of responses with unexpected statuses for authentication(...) and uploadFileToNode(...) methods in TransportManagementService.groovy. It is considered that response content for the statuses from range 4xx, 5xx might contain usefull tips regarding the error. Such content is printed out to the logs in the case of verbose output. In the case of verbose output, reason of the failure (unexpected response status) is also printed to the logs.