### PR TITLE
Revert to mta builder image with Java 8

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -346,7 +346,7 @@ steps:
     classic:
       dockerImage: 'ppiper/mta-archive-builder'
     cloudMbt:
-      dockerImage: 'devxci/mbtci:1.0.10'
+      dockerImage: 'devxci/mbtci:1.0.8'
   neoDeploy:
     dockerImage: 'ppiper/neo-cli'
     deployMode: 'mta'


### PR DESCRIPTION
Mta builder updated to Java 11 in a "patch" update, cf https://github.com/SAP/cloud-mta-build-tool/commit/5e305d73d030a73b129971c89a8815a83b386ac7

We need Java 8 for the foreseeable future for building existing applications, thus reverting to a default image with Java 8.
