### PR TITLE
Fix test by resetting application context after each test

### DIFF
--- a/test/groovy/util/BasePiperTest.groovy
+++ b/test/groovy/util/BasePiperTest.groovy
@@ -7,12 +7,14 @@ import com.sap.piper.Utils
 import org.junit.Before
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestExecutionListeners
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 
 @RunWith(SpringJUnit4ClassRunner)
 @ContextConfiguration(classes = [BasePiperTestContext.class])
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @TestExecutionListeners(listeners = [LibraryLoadingTestExecutionListener.class], mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
 abstract class BasePiperTest extends BasePipelineTest {
 


### PR DESCRIPTION
# Changes

Before every test used the same application context, including the same nullScript. 

- [x] Tests
- [ ] Documentation
