### PR TITLE
fix(sonar): use SONAR_TOKEN in Sonar go

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -63,7 +63,7 @@ func runSonar(options sonarExecuteScanOptions, client piperhttp.Downloader, runn
 		sonar.addEnvironment("SONAR_HOST_URL=" + options.Host)
 	}
 	if len(options.Token) > 0 {
-		sonar.addEnvironment("SONAR_AUTH_TOKEN=" + options.Token)
+		sonar.addEnvironment("SONAR_TOKEN=" + options.Token)
 	}
 	if len(options.Organization) > 0 {
 		sonar.addOption("sonar.organization=" + options.Organization)

--- a/cmd/sonarExecuteScan_test.go
+++ b/cmd/sonarExecuteScan_test.go
@@ -96,7 +96,7 @@ func TestRunSonar(t *testing.T) {
 		assert.Contains(t, sonar.options, "-Dsonar.projectVersion=1.2.3")
 		assert.Contains(t, sonar.options, "-Dsonar.organization=SAP")
 		assert.Contains(t, sonar.environment, "SONAR_HOST_URL=https://sonar.sap.com")
-		assert.Contains(t, sonar.environment, "SONAR_AUTH_TOKEN=secret-ABC")
+		assert.Contains(t, sonar.environment, "SONAR_TOKEN=secret-ABC")
 		assert.Contains(t, sonar.environment, "SONAR_SCANNER_OPTS=-Djavax.net.ssl.trustStore="+path.Join(getWorkingDir(), ".certificates", "cacerts"))
 	})
 	t.Run("with custom options", func(t *testing.T) {


### PR DESCRIPTION
**changes:**
- use `SONAR_TOKEN` instead of `SONAR_AUTH_TOKEN` to provide API token

The Jenkins Sonar plugin provides `SONAR_AUTH_TOKEN` which is at least not considered by the Sonar CLI scanner.
The `SONAR_TOKEN` usage is also not explicitly documented though, only as part of [GitLab integration](https://docs.sonarqube.org/latest/analysis/gitlab-cicd/).