### PR TITLE
Add CommitVersion flag for artifactPrepareVersion like it was in groovy

### DIFF
--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -140,10 +140,12 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 
 		//ToDo: what about closure in current Groovy step. Discard the possibility or provide extension mechanism?
 
-		// commit changes and push to repository (including new version tag)
-		gitCommitID, err = pushChanges(config, newVersion, repository, worktree, now)
-		if err != nil {
-			return errors.Wrapf(err, "failed to push changes for version '%v'", newVersion)
+		if config.CommitVersion {
+			// commit changes and push to repository (including new version tag)
+			gitCommitID, err = pushChanges(config, newVersion, repository, worktree, now)
+			if err != nil {
+				return errors.Wrapf(err, "failed to push changes for version '%v'", newVersion)
+			}
 		}
 	}
 

--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -24,6 +24,7 @@ type artifactPrepareVersionOptions struct {
 	GlobalSettingsFile  string `json:"globalSettingsFile,omitempty"`
 	IncludeCommitID     bool   `json:"includeCommitId,omitempty"`
 	M2Path              string `json:"m2Path,omitempty"`
+	CommitVersion       bool   `json:"commitVersion,omitempty"`
 	Password            string `json:"password,omitempty"`
 	ProjectSettingsFile string `json:"projectSettingsFile,omitempty"`
 	TagPrefix           string `json:"tagPrefix,omitempty"`
@@ -121,6 +122,7 @@ func addArtifactPrepareVersionFlags(cmd *cobra.Command, stepConfig *artifactPrep
 	cmd.Flags().StringVar(&stepConfig.GlobalSettingsFile, "globalSettingsFile", os.Getenv("PIPER_globalSettingsFile"), "Maven only - Path to the mvn settings file that should be used as global settings file.")
 	cmd.Flags().BoolVar(&stepConfig.IncludeCommitID, "includeCommitId", true, "Defines if the automatically generated version (versioningType 'cloud') should include the commit id hash .")
 	cmd.Flags().StringVar(&stepConfig.M2Path, "m2Path", os.Getenv("PIPER_m2Path"), "Maven only - Path to the location of the local repository that should be used.")
+	cmd.Flags().BoolVar(&stepConfig.CommitVersion, "commitVersion", false, "Controls if the changed version is committed and pushed to the git repository. If this is enabled (which is the default), you need to provide git coordinates for pushing.")
 	cmd.Flags().StringVar(&stepConfig.Password, "password", os.Getenv("PIPER_password"), "Password/token for git authentication")
 	cmd.Flags().StringVar(&stepConfig.ProjectSettingsFile, "projectSettingsFile", os.Getenv("PIPER_projectSettingsFile"), "Maven only - Path to the mvn settings file that should be used as project settings file.")
 	cmd.Flags().StringVar(&stepConfig.TagPrefix, "tagPrefix", "build_", "Defines the prefix which is used for the git tag which is written during the versioning run.")
@@ -204,6 +206,14 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
+					},
+					{
+						Name:        "commitVersion",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
 					},
 					{
 						Name:        "password",

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -169,6 +169,7 @@ func TestRunArtifactPrepareVersion(t *testing.T) {
 			TagPrefix:       "v",
 			Username:        "testUser",
 			VersioningType:  "cloud",
+			CommitVersion:   true,
 		}
 		telemetryData := telemetry.CustomData{}
 

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -355,6 +355,7 @@ func TestRunArtifactPrepareVersion(t *testing.T) {
 	t.Run("error - failed to push changes", func(t *testing.T) {
 		config := artifactPrepareVersionOptions{
 			VersioningType: "cloud",
+			CommitVersion:  true,
 		}
 
 		versioningMock := artifactVersioningMock{

--- a/resources/metadata/versioning.yaml
+++ b/resources/metadata/versioning.yaml
@@ -36,9 +36,9 @@ spec:
         type: string
         description: "For Docker only: Specifies the source to be used for for generating the automatic version. * This can either be the version of the base image - as retrieved from the `FROM` statement within the Dockerfile, e.g. `FROM jenkins:2.46.2` * Alternatively the name of an environment variable defined in the Docker image can be used which contains the version number, e.g. `ENV MY_VERSION 1.2.3`"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: filePath
         type: string
         description: "Defines a custom path to the descriptor file. Build tool specific defaults are used (e.g. maven: pom.xml, npm: package.json, mta: mta.yaml)"
@@ -88,6 +88,13 @@ spec:
           - STEPS
           - STAGES
           - PARAMETERS
+      - name: commitVersion
+        type: bool
+        description: "Controls if the changed version is committed and pushed to the git repository. If this is enabled (which is the default), you need to provide git coordinates for pushing."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: password
         type: string
         description: Password/token for git authentication


### PR DESCRIPTION
# Changes

This change allows to disable the commit/push when creating a new version which might be required when you can't push from your pipeline.


- [ ] Tests
- [ ] Documentation
