### PR TITLE
TMS: explicitly check in tests that there is no token in the logs

### DIFF
--- a/test/groovy/com/sap/piper/integration/TransportManagementServiceTest.groovy
+++ b/test/groovy/com/sap/piper/integration/TransportManagementServiceTest.groovy
@@ -31,25 +31,23 @@ class TransportManagementServiceTest extends BasePiperTest {
 
     @Test
     void retrieveOAuthToken__successfully() {
-        def uaaUrl = 'http://dummy.com/oauth'
-        def clientId = 'myId'
-        def clientSecret = 'mySecret'
-        def expectedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.Gfx6VO9tcxwk6xqx9yYzSfebfeakZp5JYIgP_edcw_A'
-        def responseContent = '{ "access_token": "' + expectedToken + '" }'
-
         Map requestParams
         helper.registerAllowedMethod('httpRequest', [Map.class], { m ->
             requestParams = m
-            return [content: responseContent, status: 200]
+            return [content: '{ "access_token": "myOAuthToken" }', status: 200]
         })
+
+        def uaaUrl = 'http://dummy.com/oauth'
+        def clientId = 'myId'
+        def clientSecret = 'mySecret'
 
         def tms = new TransportManagementService(nullScript, [verbose: false])
         def token = tms.authentication(uaaUrl, clientId, clientSecret)
 
         assertThat(loggingRule.log, containsString("[TransportManagementService] OAuth Token retrieval started."))
         assertThat(loggingRule.log, containsString("[TransportManagementService] OAuth Token retrieved successfully."))
-        assertThat(loggingRule.log, not(containsString(expectedToken)))
-        assertThat(token, is(expectedToken))
+        assertThat(loggingRule.log, not(containsString("myOAuthToken")))
+        assertThat(token, is('myOAuthToken'))
         assertThat(requestParams, hasEntry('url', "${uaaUrl}/oauth/token/?grant_type=client_credentials&response_type=token"))
         assertThat(requestParams, hasEntry('requestBody', "grant_type=password&username=${clientId}&password=${clientSecret}".toString()))
         assertThat(requestParams.customHeaders[1].value, is("Basic ${"${clientId}:${clientSecret}".bytes.encodeBase64()}"))
@@ -57,15 +55,13 @@ class TransportManagementServiceTest extends BasePiperTest {
 
     @Test
     void retrieveOAuthToken__inVerboseMode__yieldsMoreEchos() {
+        helper.registerAllowedMethod('httpRequest', [Map.class], {
+            return [content: '{ "access_token": "myOAuthToken" }', status: 200]
+        })
+
         def uaaUrl = 'http://dummy.com/oauth'
         def clientId = 'myId'
         def clientSecret = 'mySecret'
-        def expectedToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.Gfx6VO9tcxwk6xqx9yYzSfebfeakZp5JYIgP_edcw_A'
-        def responseContent = '{ "access_token": "' + expectedToken + '" }'
-
-        helper.registerAllowedMethod('httpRequest', [Map.class], {
-            return [content: responseContent, status: 200]
-        })
 
         def tms = new TransportManagementService(nullScript, [verbose: true])
         def token = tms.authentication(uaaUrl, clientId, clientSecret)
@@ -73,8 +69,8 @@ class TransportManagementServiceTest extends BasePiperTest {
         assertThat(loggingRule.log, containsString("[TransportManagementService] OAuth Token retrieval started."))
         assertThat(loggingRule.log, containsString("[TransportManagementService] UAA-URL: '${uaaUrl}', ClientId: '${clientId}'"))
         assertThat(loggingRule.log, containsString("[TransportManagementService] OAuth Token retrieved successfully."))
-        assertThat(loggingRule.log, not(containsString(expectedToken)))
-        assertThat(token, is(expectedToken))
+        assertThat(loggingRule.log, not(containsString("myOAuthToken")))
+        assertThat(token, is('myOAuthToken'))
     }
 
     @Test


### PR DESCRIPTION
This PR provides an extension for TMS-related junit tests, where it is explicitly asserted that there is no token present in the logs. 