### PR TITLE
artifactPrepareVersion: new versioning option

### DIFF
--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -104,7 +104,7 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 
 	newVersion := version
 
-	if versioningType == "cloud" {
+	if versioningType == "cloud" || versioningType == "cloud_noTag" {
 		versioningTempl, err := versioningTemplate(artifact.VersioningScheme())
 		if err != nil {
 			return errors.Wrapf(err, "failed to get versioning template for scheme '%v'", artifact.VersioningScheme())
@@ -140,10 +140,12 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 
 		//ToDo: what about closure in current Groovy step. Discard the possibility or provide extension mechanism?
 
-		// commit changes and push to repository (including new version tag)
-		gitCommitID, err = pushChanges(config, newVersion, repository, worktree, now)
-		if err != nil {
-			return errors.Wrapf(err, "failed to push changes for version '%v'", newVersion)
+		if versioningType == "cloud" {
+			// commit changes and push to repository (including new version tag)
+			gitCommitID, err = pushChanges(config, newVersion, repository, worktree, now)
+			if err != nil {
+				return errors.Wrapf(err, "failed to push changes for version '%v'", newVersion)
+			}
 		}
 	}
 

--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -126,7 +126,7 @@ func addArtifactPrepareVersionFlags(cmd *cobra.Command, stepConfig *artifactPrep
 	cmd.Flags().StringVar(&stepConfig.TagPrefix, "tagPrefix", "build_", "Defines the prefix which is used for the git tag which is written during the versioning run.")
 	cmd.Flags().StringVar(&stepConfig.Username, "username", os.Getenv("PIPER_username"), "User name for git authentication")
 	cmd.Flags().StringVar(&stepConfig.VersioningTemplate, "versioningTemplate", os.Getenv("PIPER_versioningTemplate"), "DEPRECATED: Defines the template for the automatic version which will be created")
-	cmd.Flags().StringVar(&stepConfig.VersioningType, "versioningType", "cloud", "Defines the type of versioning (cloud: fully automatic, library: manual, libraryTag (not available yet): automatic based on latest tag)")
+	cmd.Flags().StringVar(&stepConfig.VersioningType, "versioningType", "cloud", "Defines the type of versioning (`cloud`: fully automatic, `cloud_noTag`: automatic but no tag created, `library`: manual)")
 
 	cmd.MarkFlagRequired("buildTool")
 }

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -208,6 +208,45 @@ func TestRunArtifactPrepareVersion(t *testing.T) {
 		assert.Equal(t, telemetry.CustomData{Custom1Label: "buildTool", Custom1: "maven"}, telemetryData)
 	})
 
+	t.Run("success case - cloud_noTag", func(t *testing.T) {
+
+		config := artifactPrepareVersionOptions{
+			BuildTool:       "maven",
+			IncludeCommitID: true,
+			Password:        "****",
+			TagPrefix:       "v",
+			Username:        "testUser",
+			VersioningType:  "cloud_noTag",
+		}
+		telemetryData := telemetry.CustomData{}
+
+		cpe := artifactPrepareVersionCommonPipelineEnvironment{}
+
+		versioningMock := artifactVersioningMock{
+			originalVersion:  "1.2.3",
+			versioningScheme: "maven",
+		}
+
+		worktree := gitWorktreeMock{
+			commitHash: plumbing.ComputeHash(plumbing.CommitObject, []byte{2, 3, 4}),
+		}
+
+		conf := gitConfig.RemoteConfig{Name: "origin", URLs: []string{"https://my.test.server"}}
+
+		repo := gitRepositoryMock{
+			revisionHash: plumbing.ComputeHash(plumbing.CommitObject, []byte{1, 2, 3}),
+			remote:       git.NewRemote(nil, &conf),
+		}
+
+		err := runArtifactPrepareVersion(&config, &telemetryData, &cpe, &versioningMock, nil, &repo, func(r gitRepository) (gitWorktree, error) { return &worktree, nil })
+
+		assert.NoError(t, err)
+
+		assert.False(t, repo.pushCalled)
+		assert.Contains(t, cpe.artifactVersion, "1.2.3")
+		assert.Equal(t, repo.revisionHash.String(), cpe.git.commitID)
+	})
+
 	t.Run("success case - compatibility", func(t *testing.T) {
 		config := artifactPrepareVersionOptions{
 			BuildTool:          "maven",

--- a/resources/metadata/versioning.yaml
+++ b/resources/metadata/versioning.yaml
@@ -130,7 +130,7 @@ spec:
         - STEPS
       - name: versioningType
         type: string
-        description: "Defines the type of versioning (cloud: fully automatic, library: manual, libraryTag (not available yet): automatic based on latest tag)"
+        description: "Defines the type of versioning (`cloud`: fully automatic, `cloud_noTag`: automatic but no tag created, `library`: manual)"
         scope:
         - PARAMETERS
         - STAGES


### PR DESCRIPTION
# Changes

add versioning option `cloud_noTag`.
This allows teams to use automatic versioning without creating a tag on the SCM which contains the change.

This option needs to be handled with care since teams can create a build artifact with no real representation in the SCM.

Thus the `cloud_noTag` option is weak when it comes to providing a traceable build result

superseeds #1366


- [X] Tests
- [X] Documentation
