### PR TITLE
Allow MEMBERs to trigger integration tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Consumer Tests
 
     runs-on: ubuntu-latest
-    if: github.event.comment.body == '/it' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER')
+    if: github.event.comment.body == '/it' && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')
 
     steps:
       - name: get pull request url


### PR DESCRIPTION
# Changes

It turned out that we are considered as Members (Author is a member of the organization that owns the repository.)

https://developer.github.com/v4/enum/commentauthorassociation/

With this PR everyone in the SAP organization would be allowed to trigger pull requests. 
Is that fine with everyone?

- [ ] Tests
- [ ] Documentation
