### PR TITLE
Extend nexusUpload to also handle npm

### DIFF
--- a/cmd/nexusUpload.go
+++ b/cmd/nexusUpload.go
@@ -175,8 +175,7 @@ func uploadNpmArtifacts(utils nexusUploadUtils, uploader nexus.Uploader, options
 		log.Entry().Info("No credentials provided for npm upload, trying to upload anonymously.")
 	}
 	execRunner.SetEnv(environment)
-	fmt.Println(strings.Join(environment, ", "))
-	err := execRunner.RunExecutable("npm", "publish", "-ddd")
+	err := execRunner.RunExecutable("npm", "publish")
 	return err
 }
 

--- a/cmd/nexusUpload.go
+++ b/cmd/nexusUpload.go
@@ -167,10 +167,12 @@ func runNexusUpload(utils nexusUploadUtils, uploader nexus.Uploader, options *ne
 
 func uploadNpmArtifacts(utils nexusUploadUtils, uploader nexus.Uploader, options *nexusUploadOptions) error {
 	execRunner := utils.getExecRunner()
-	environment := []string{"npm_config_registry=http://" + uploader.GetNpmRepoURL(), "npm_config_email=project-piper@no-reply.com"} //fixme use npmRepository
+	environment := []string{"npm_config_registry=http://" + uploader.GetNpmRepoURL(), "npm_config_email=project-piper@no-reply.com"}
 	if options.User != "" && options.Password != "" {
 		auth := b64.StdEncoding.EncodeToString([]byte(options.User + ":" + options.Password))
 		environment = append(environment, "npm_config__auth="+auth)
+	} else {
+		log.Entry().Info("No credentials provided for npm upload, trying to upload anonymously.")
 	}
 	execRunner.SetEnv(environment)
 	fmt.Println(strings.Join(environment, ", "))

--- a/cmd/nexusUpload_generated.go
+++ b/cmd/nexusUpload_generated.go
@@ -16,7 +16,7 @@ import (
 type nexusUploadOptions struct {
 	Version            string `json:"version,omitempty"`
 	Url                string `json:"url,omitempty"`
-	Repository         string `json:"repository,omitempty"`
+	MavenRepository    string `json:"mavenRepository,omitempty"`
 	NpmRepository      string `json:"npmRepository,omitempty"`
 	GroupID            string `json:"groupId,omitempty"`
 	ArtifactID         string `json:"artifactId,omitempty"`
@@ -64,8 +64,8 @@ func NexusUploadCommand() *cobra.Command {
 func addNexusUploadFlags(cmd *cobra.Command, stepConfig *nexusUploadOptions) {
 	cmd.Flags().StringVar(&stepConfig.Version, "version", "nexus3", "The Nexus Repository Manager version. Currently supported are 'nexus2' and 'nexus3'.")
 	cmd.Flags().StringVar(&stepConfig.Url, "url", os.Getenv("PIPER_url"), "URL of the nexus. The scheme part of the URL will not be considered, because only http is supported.")
-	cmd.Flags().StringVar(&stepConfig.Repository, "repository", os.Getenv("PIPER_repository"), "Name of the nexus repository for Maven and MTA deployments.")
-	cmd.Flags().StringVar(&stepConfig.NpmRepository, "npmRepository", os.Getenv("PIPER_npmRepository"), "Name of the nexus repository for npm deployments.")
+	cmd.Flags().StringVar(&stepConfig.MavenRepository, "mavenRepository", os.Getenv("PIPER_mavenRepository"), "Name of the nexus repository for Maven and MTA deployments. If this is not provided, Maven and MTA deployment is implicitly disabled.")
+	cmd.Flags().StringVar(&stepConfig.NpmRepository, "npmRepository", os.Getenv("PIPER_npmRepository"), "Name of the nexus repository for npm deployments. If this is not provided, npm deployment is implicitly disabled.")
 	cmd.Flags().StringVar(&stepConfig.GroupID, "groupId", os.Getenv("PIPER_groupId"), "Group ID of the artifacts. Only used in MTA projects, ignored for Maven.")
 	cmd.Flags().StringVar(&stepConfig.ArtifactID, "artifactId", os.Getenv("PIPER_artifactId"), "The artifact ID used for both the .mtar and mta.yaml files deployed for MTA projects, ignored for Maven.")
 	cmd.Flags().StringVar(&stepConfig.GlobalSettingsFile, "globalSettingsFile", os.Getenv("PIPER_globalSettingsFile"), "Path to the mvn settings file that should be used as global settings file.")
@@ -74,7 +74,6 @@ func addNexusUploadFlags(cmd *cobra.Command, stepConfig *nexusUploadOptions) {
 	cmd.Flags().StringVar(&stepConfig.Password, "password", os.Getenv("PIPER_password"), "Password for accessing the Nexus endpoint.")
 
 	cmd.MarkFlagRequired("url")
-	cmd.MarkFlagRequired("repository")
 }
 
 // retrieve step metadata
@@ -104,12 +103,12 @@ func nexusUploadMetadata() config.StepData {
 						Aliases:     []config.Alias{{Name: "nexus/url"}},
 					},
 					{
-						Name:        "repository",
+						Name:        "mavenRepository",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
-						Mandatory:   true,
-						Aliases:     []config.Alias{{Name: "nexus/repository"}},
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "nexus/mavenRepository"}},
 					},
 					{
 						Name:        "npmRepository",
@@ -117,7 +116,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{},
+						Aliases:     []config.Alias{{Name: "nexus/mavenRepository"}},
 					},
 					{
 						Name:        "groupId",

--- a/cmd/nexusUpload_generated.go
+++ b/cmd/nexusUpload_generated.go
@@ -17,6 +17,7 @@ type nexusUploadOptions struct {
 	Version            string `json:"version,omitempty"`
 	Url                string `json:"url,omitempty"`
 	Repository         string `json:"repository,omitempty"`
+	NpmRepository      string `json:"npmRepository,omitempty"`
 	GroupID            string `json:"groupId,omitempty"`
 	ArtifactID         string `json:"artifactId,omitempty"`
 	GlobalSettingsFile string `json:"globalSettingsFile,omitempty"`
@@ -63,7 +64,8 @@ func NexusUploadCommand() *cobra.Command {
 func addNexusUploadFlags(cmd *cobra.Command, stepConfig *nexusUploadOptions) {
 	cmd.Flags().StringVar(&stepConfig.Version, "version", "nexus3", "The Nexus Repository Manager version. Currently supported are 'nexus2' and 'nexus3'.")
 	cmd.Flags().StringVar(&stepConfig.Url, "url", os.Getenv("PIPER_url"), "URL of the nexus. The scheme part of the URL will not be considered, because only http is supported.")
-	cmd.Flags().StringVar(&stepConfig.Repository, "repository", os.Getenv("PIPER_repository"), "Name of the nexus repository.")
+	cmd.Flags().StringVar(&stepConfig.Repository, "repository", os.Getenv("PIPER_repository"), "Name of the nexus repository for Maven and MTA deployments.")
+	cmd.Flags().StringVar(&stepConfig.NpmRepository, "npmRepository", os.Getenv("PIPER_npmRepository"), "Name of the nexus repository for npm deployments.")
 	cmd.Flags().StringVar(&stepConfig.GroupID, "groupId", os.Getenv("PIPER_groupId"), "Group ID of the artifacts. Only used in MTA projects, ignored for Maven.")
 	cmd.Flags().StringVar(&stepConfig.ArtifactID, "artifactId", os.Getenv("PIPER_artifactId"), "The artifact ID used for both the .mtar and mta.yaml files deployed for MTA projects, ignored for Maven.")
 	cmd.Flags().StringVar(&stepConfig.GlobalSettingsFile, "globalSettingsFile", os.Getenv("PIPER_globalSettingsFile"), "Path to the mvn settings file that should be used as global settings file.")
@@ -108,6 +110,14 @@ func nexusUploadMetadata() config.StepData {
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{{Name: "nexus/repository"}},
+					},
+					{
+						Name:        "npmRepository",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
 					},
 					{
 						Name:        "groupId",

--- a/cmd/nexusUpload_generated.go
+++ b/cmd/nexusUpload_generated.go
@@ -50,7 +50,9 @@ Publishing npm projects makes use of npm's "publish" command.
 It requires a "package.json" file in the project's root directory which has "version" set and is not delared as "private".
 To find out what will be published, run "npm publish --dry-run" in the project's root folder.
 It will use your gitignore file to exclude the mached files from publishing.
-Note: npm's gitignore parser might yield different results from your git client, to ignore a "foo" directory globally use the glob pattern "**/foo".`,
+Note: npm's gitignore parser might yield different results from your git client, to ignore a "foo" directory globally use the glob pattern "**/foo".
+
+If an image for mavenExecute is configured, and npm packages are to be published, the image must have npm installed.`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			startTime = time.Now()
 			log.SetStepName("nexusUpload")

--- a/cmd/nexusUpload_generated.go
+++ b/cmd/nexusUpload_generated.go
@@ -125,7 +125,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "nexus/mavenRepository"}},
+						Aliases:     []config.Alias{{Name: "nexus/mavenRepository"}, {Name: "nexus/repository"}},
 					},
 					{
 						Name:        "npmRepository",

--- a/cmd/nexusUpload_generated.go
+++ b/cmd/nexusUpload_generated.go
@@ -26,7 +26,7 @@ type nexusUploadOptions struct {
 	Password           string `json:"password,omitempty"`
 }
 
-// NexusUploadCommand Upload artifacts to Nexus
+// NexusUploadCommand Upload artifacts to Nexus Repository Manager
 func NexusUploadCommand() *cobra.Command {
 	metadata := nexusUploadMetadata()
 	var stepConfig nexusUploadOptions
@@ -34,8 +34,23 @@ func NexusUploadCommand() *cobra.Command {
 
 	var createNexusUploadCmd = &cobra.Command{
 		Use:   "nexusUpload",
-		Short: "Upload artifacts to Nexus",
-		Long:  `Upload build artifacts to a Nexus Repository Manager. Supports MTA and (multi-module) Maven projects.`,
+		Short: "Upload artifacts to Nexus Repository Manager",
+		Long: `Upload build artifacts to a Nexus Repository Manager.
+
+Supports MTA, npm and (multi-module) Maven projects.
+MTA files will be uploaded to a Maven repository.
+
+The uploaded file-type depends on your project structure and step configuration.
+To upload Maven projects, you need a pom.xml in the project root and set the mavenRepository option.
+To upload MTA projects, you need a mta.yaml in the project root and set the mavenRepository option.
+To upload npm projects, you need a package.json in the project root and set the npmRepository option.
+
+npm:
+Publishing npm projects makes use of npm's "publish" command.
+It requires a "package.json" file in the project's root directory which has "version" set and is not delared as "private".
+To find out what will be published, run "npm publish --dry-run" in the project's root folder.
+It will use your gitignore file to exclude the mached files from publishing.
+Note: npm's gitignore parser might yield different results from your git client, to ignore a "foo" directory globally use the glob pattern "**/foo".`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			startTime = time.Now()
 			log.SetStepName("nexusUpload")
@@ -116,7 +131,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "nexus/mavenRepository"}},
+						Aliases:     []config.Alias{{Name: "nexus/npmRepository"}},
 					},
 					{
 						Name:        "groupId",

--- a/cmd/nexusUpload_test.go
+++ b/cmd/nexusUpload_test.go
@@ -16,6 +16,7 @@ import (
 type mockUtilsBundle struct {
 	mta          bool
 	maven        bool
+	npm          bool
 	files        map[string][]byte
 	removedFiles map[string][]byte
 	properties   map[string]map[string]string
@@ -23,8 +24,8 @@ type mockUtilsBundle struct {
 	execRunner   mock.ExecMockRunner
 }
 
-func newMockUtilsBundle(usesMta, usesMaven bool) mockUtilsBundle {
-	utils := mockUtilsBundle{mta: usesMta, maven: usesMaven}
+func newMockUtilsBundle(usesMta, usesMaven, usesNpm bool) mockUtilsBundle {
+	utils := mockUtilsBundle{mta: usesMta, maven: usesMaven, npm: usesNpm}
 	utils.files = map[string][]byte{}
 	utils.removedFiles = map[string][]byte{}
 	utils.properties = map[string]map[string]string{}
@@ -38,6 +39,10 @@ func (m *mockUtilsBundle) usesMta() bool {
 
 func (m *mockUtilsBundle) usesMaven() bool {
 	return m.maven
+}
+
+func (m *mockUtilsBundle) usesNpm() bool {
+	return m.npm
 }
 
 func (m *mockUtilsBundle) fileExists(path string) (bool, error) {
@@ -154,11 +159,12 @@ func (m *mockUploader) Clear() {
 
 func createOptions() nexusUploadOptions {
 	return nexusUploadOptions{
-		Repository: "maven-releases",
-		GroupID:    "my.group.id",
-		ArtifactID: "artifact.id",
-		Version:    "nexus3",
-		Url:        "localhost:8081",
+		MavenRepository: "maven-releases",
+		NpmRepository:   "npm-repo",
+		GroupID:         "my.group.id",
+		ArtifactID:      "artifact.id",
+		Version:         "nexus3",
+		Url:             "localhost:8081",
 	}
 }
 
@@ -194,7 +200,7 @@ var testPomXml = []byte(`
 
 func TestUploadMTAProjects(t *testing.T) {
 	t.Run("Uploading MTA project without groupId parameter fails", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.files["mta.yaml"] = testMtaYml
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
 		uploader := mockUploader{}
@@ -207,7 +213,7 @@ func TestUploadMTAProjects(t *testing.T) {
 		assert.Equal(t, 0, len(uploader.uploadedArtifacts))
 	})
 	t.Run("Uploading MTA project without artifactId parameter works", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.files["mta.yaml"] = testMtaYml
 		utils.files["test.mtar"] = []byte("contentsOfMtar")
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
@@ -222,7 +228,7 @@ func TestUploadMTAProjects(t *testing.T) {
 		}
 	})
 	t.Run("Uploading MTA project fails due to missing yaml file", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
 		uploader := mockUploader{}
 		options := createOptions()
@@ -233,7 +239,7 @@ func TestUploadMTAProjects(t *testing.T) {
 		assert.Equal(t, 0, len(uploader.uploadedArtifacts))
 	})
 	t.Run("Uploading MTA project fails due to garbage YAML content", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.files["mta.yaml"] = []byte("garbage")
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
 		uploader := mockUploader{}
@@ -246,7 +252,7 @@ func TestUploadMTAProjects(t *testing.T) {
 		assert.Equal(t, 0, len(uploader.uploadedArtifacts))
 	})
 	t.Run("Uploading MTA project fails due invalid version in YAML content", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.files["mta.yaml"] = []byte(testMtaYmlNoVersion)
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
 		uploader := mockUploader{}
@@ -259,7 +265,7 @@ func TestUploadMTAProjects(t *testing.T) {
 		assert.Equal(t, 0, len(uploader.uploadedArtifacts))
 	})
 	t.Run("Test uploading mta.yaml project fails due to missing mtar file", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.files["mta.yaml"] = testMtaYml
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
 		uploader := mockUploader{}
@@ -280,7 +286,7 @@ func TestUploadMTAProjects(t *testing.T) {
 		assert.Equal(t, 0, len(uploader.uploadedArtifacts))
 	})
 	t.Run("Test uploading mta.yaml project works", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.files["mta.yaml"] = testMtaYml
 		utils.files["test.mtar"] = []byte("contentsOfMtar")
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
@@ -303,7 +309,7 @@ func TestUploadMTAProjects(t *testing.T) {
 		}
 	})
 	t.Run("Test uploading mta.yml project works", func(t *testing.T) {
-		utils := newMockUtilsBundle(true, false)
+		utils := newMockUtilsBundle(true, false, false)
 		utils.files["mta.yml"] = testMtaYml
 		utils.files["test.mtar"] = []byte("contentsOfMtar")
 		utils.cpe[".pipeline/commonPipelineEnvironment/mtarFilePath"] = "test.mtar"
@@ -329,7 +335,7 @@ func TestUploadMTAProjects(t *testing.T) {
 
 func TestUploadArtifacts(t *testing.T) {
 	t.Run("Uploading MTA project fails without info", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		uploader := mockUploader{}
 		options := createOptions()
 
@@ -337,7 +343,7 @@ func TestUploadArtifacts(t *testing.T) {
 		assert.EqualError(t, err, "no group ID was provided, or could be established from project files")
 	})
 	t.Run("Uploading MTA project fails without any artifacts", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		uploader := mockUploader{}
 		options := createOptions()
 
@@ -347,7 +353,7 @@ func TestUploadArtifacts(t *testing.T) {
 		assert.EqualError(t, err, "no artifacts to upload")
 	})
 	t.Run("Uploading MTA project fails for unknown reasons", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 
 		// Configure mocked execRunner to fail
 		utils.execRunner.ShouldFailOnCommand = map[string]error{}
@@ -369,11 +375,11 @@ func TestUploadArtifacts(t *testing.T) {
 		assert.EqualError(t, err, "uploading artifacts for ID 'some.id' failed: failed to run executable, command: '[mvn -Durl=http:// -DgroupId=my.group.id -Dversion=3.0 -DartifactId=some.id -Dfile=mta.yaml -Dpackaging=yaml -DgeneratePom=false -Dfiles=artifact.mtar -Dclassifiers= -Dtypes=yaml --batch-mode "+deployGoal+"]', error: failed")
 	})
 	t.Run("Uploading bundle generates correct maven parameters", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		uploader := mockUploader{}
 		options := createOptions()
 
-		_ = uploader.SetRepoURL("localhost:8081", "nexus3", "maven-releases")
+		_ = uploader.SetRepoURL("localhost:8081", "nexus3", "maven-releases", "npm-repo")
 		_ = uploader.SetInfo(options.GroupID, "my.artifact", "4.0")
 		_ = uploader.AddArtifact(nexus.ArtifactDescription{
 			File: "mta.yaml",
@@ -408,7 +414,7 @@ func TestUploadArtifacts(t *testing.T) {
 
 func TestUploadMavenProjects(t *testing.T) {
 	t.Run("Uploading Maven project fails due to missing pom.xml", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		uploader := mockUploader{}
 		options := createOptions()
 
@@ -417,7 +423,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		assert.Equal(t, 0, len(uploader.uploadedArtifacts))
 	})
 	t.Run("Test uploading Maven project with POM packaging works", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.groupId", "com.mycompany.app")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
@@ -439,7 +445,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		}
 	})
 	t.Run("Test uploading Maven project with JAR packaging fails without main target", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.groupId", "com.mycompany.app")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
@@ -455,7 +461,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		assert.Equal(t, 0, len(uploader.uploadedArtifacts))
 	})
 	t.Run("Test uploading Maven project with JAR packaging works", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.groupId", "com.mycompany.app")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
@@ -482,7 +488,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		}
 	})
 	t.Run("Test uploading Maven project with fall-back to JAR packaging works", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.groupId", "com.mycompany.app")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
@@ -508,7 +514,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		}
 	})
 	t.Run("Test uploading Maven project with fall-back to group id from parameters works", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
 		utils.setProperty("pom.xml", "project.packaging", "pom")
@@ -522,7 +528,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		assert.NoError(t, err, "expected Maven upload to work")
 
 		assert.Equal(t, "localhost:8081/repository/maven-releases/",
-			uploader.GetRepoURL())
+			uploader.GetMavenRepoURL())
 		assert.Equal(t, "1.0", uploader.GetArtifactsVersion())
 		assert.Equal(t, "my-app", uploader.GetArtifactsID())
 
@@ -533,7 +539,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		}
 	})
 	t.Run("Test uploading Maven project with fall-back for finalBuildName works", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.groupId", "awesome.group")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
@@ -547,7 +553,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		assert.NoError(t, err, "expected Maven upload to work")
 
 		assert.Equal(t, "localhost:8081/repository/maven-releases/",
-			uploader.GetRepoURL())
+			uploader.GetMavenRepoURL())
 		assert.Equal(t, "1.0", uploader.GetArtifactsVersion())
 		assert.Equal(t, "my-app", uploader.GetArtifactsID())
 
@@ -560,7 +566,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		}
 	})
 	t.Run("Test uploading Maven project with application module and finalName works", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.groupId", "com.mycompany.app")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
@@ -646,7 +652,7 @@ func TestUploadMavenProjects(t *testing.T) {
 		}
 	})
 	t.Run("Write credentials settings", func(t *testing.T) {
-		utils := newMockUtilsBundle(false, true)
+		utils := newMockUtilsBundle(false, true, false)
 		utils.setProperty("pom.xml", "project.version", "1.0")
 		utils.setProperty("pom.xml", "project.groupId", "com.mycompany.app")
 		utils.setProperty("pom.xml", "project.artifactId", "my-app")
@@ -686,17 +692,8 @@ func TestUploadMavenProjects(t *testing.T) {
 	})
 }
 
-func TestUploadUnknownProjectFails(t *testing.T) {
-	utils := newMockUtilsBundle(false, false)
-	uploader := mockUploader{}
-	options := createOptions()
-
-	err := runNexusUpload(&utils, &uploader, &options)
-	assert.EqualError(t, err, "unsupported project structure")
-}
-
 func TestSetupNexusCredentialsSettingsFile(t *testing.T) {
-	utils := newMockUtilsBundle(false, true)
+	utils := newMockUtilsBundle(false, true, false)
 	options := nexusUploadOptions{User: "admin", Password: "admin123"}
 	mavenOptions := maven.ExecuteOptions{}
 	settingsPath, err := setupNexusCredentialsSettingsFile(&utils, &options, &mavenOptions)

--- a/integration/integration_nexus_upload_test.go
+++ b/integration/integration_nexus_upload_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,9 +20,9 @@ import (
 func TestNexusUpload(t *testing.T) {
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:        "sonatype/nexus3:3.21.1",
+		Image:        "sonatype/nexus3:3.22.0",
 		ExposedPorts: []string{"8081/tcp"},
-		Env:          map[string]string{"NEXUS_SECURITY_RANDOMPASSWORD": "false"},
+		Env:          map[string]string{"NEXUS_SECURITY_RANDOMPASSWORD": "false", "NEXUS_SCRIPTS_ALLOWCREATION": "true"},
 		WaitingFor:   wait.ForLog("Started Sonatype Nexus").WithStartupTimeout(5 * time.Minute), // Nexus takes more than one minute to boot
 	}
 	nexusContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -48,7 +49,7 @@ func TestNexusUpload(t *testing.T) {
 		"--artifactId=mymta",
 		"--user=admin",
 		"--password=admin123",
-		"--repository=maven-releases",
+		"--mavenRepository=maven-releases",
 		"--url=" + nexusIpAndPort,
 	}
 
@@ -62,9 +63,32 @@ func TestNexusUpload(t *testing.T) {
 		"nexusUpload",
 		"--user=admin",
 		"--password=admin123",
-		"--repository=maven-releases",
+		"--mavenRepository=maven-releases",
 		"--url=" + nexusIpAndPort,
 	}
+
+	err = cmd.RunExecutable(getPiperExecutable(), piperOptions...)
+	assert.NoError(t, err, "Calling piper with arguments %v failed.", piperOptions)
+
+	cmd = command.Command{}
+	cmd.SetDir("testdata/TestNexusIntegration/npm")
+
+	piperOptions = []string{
+		"nexusUpload",
+		"--user=admin",
+		"--password=admin123",
+		"--npmRepository=npm-repo",
+		"--url=" + nexusIpAndPort,
+	}
+
+	// Create npm repo for this test because nexus does not create one by default
+	request, err := http.NewRequest("POST", url + "/service/rest/beta/repositories/npm/hosted", strings.NewReader(`{"name": "npm-repo", "online": true, "storage": {"blobStoreName": "default", "strictContentTypeValidation": true, "writePolicy": "ALLOW_ONCE"}}`))
+	assert.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	request.SetBasicAuth("admin", "admin123")
+	response, err := http.DefaultClient.Do(request)
+	assert.NoError(t, err)
+	assert.Equal(t, 201, response.StatusCode)
 
 	err = cmd.RunExecutable(getPiperExecutable(), piperOptions...)
 	assert.NoError(t, err, "Calling piper with arguments %v failed.", piperOptions)
@@ -92,6 +116,10 @@ func TestNexusUpload(t *testing.T) {
 	resp, err = http.Get(url + "/repository/maven-releases/mygroup/mymta/0.3.0/mymta-0.3.0.mtar")
 	assert.NoError(t, err, "Downloading artifact failed")
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "Get mymta-0.3.0.mtar: %s", resp.Status)
+
+	resp, err = http.Get(url + "/repository/npm-repo/npm-nexus-upload-test/-/npm-nexus-upload-test-1.0.0.tgz")
+	assert.NoError(t, err, "Downloading artifact failed")
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "Get npm-nexus-upload-test-1.0.0.tgz: %s", resp.Status)
 }
 
 func TestNexus2Upload(t *testing.T) {
@@ -123,7 +151,7 @@ func TestNexus2Upload(t *testing.T) {
 		"--artifactId=mymta",
 		"--user=admin",
 		"--password=admin123",
-		"--repository=releases",
+		"--mavenRepository=releases",
 		"--version=nexus2",
 		"--url=" + nexusIpAndPort + "/nexus/",
 	}
@@ -138,10 +166,35 @@ func TestNexus2Upload(t *testing.T) {
 		"nexusUpload",
 		"--user=admin",
 		"--password=admin123",
-		"--repository=releases",
+		"--mavenRepository=releases",
 		"--version=nexus2",
 		"--url=" + nexusIpAndPort + "/nexus/",
 	}
+
+	err = cmd.RunExecutable(getPiperExecutable(), piperOptions...)
+	assert.NoError(t, err, "Calling piper with arguments %v failed.", piperOptions)
+
+	cmd = command.Command{}
+	cmd.SetDir("testdata/TestNexusIntegration/npm")
+
+	piperOptions = []string{
+		"nexusUpload",
+		"--user=admin",
+		"--password=admin123",
+		"--npmRepository=npm-repo",
+		"--version=nexus2",
+		"--url=" + nexusIpAndPort + "/nexus/",
+	}
+
+	// Create npm repo for this test because nexus does not create one by default
+	payload := strings.NewReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<repository><data><name>npm-repo</name><repoPolicy>RELEASE</repoPolicy><repoType>hosted</repoType><id>npm-repo</id><exposed>true</exposed><provider>npm-hosted</provider><providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole><format>npm</format></data></repository>")
+	request, _ := http.NewRequest("POST", url + "service/local/repositories", payload)
+	request.Header.Add("Content-Type", "application/xml")
+	request.Header.Add("Authorization", "Basic YWRtaW46YWRtaW4xMjM=")
+	response, err := http.DefaultClient.Do(request)
+	assert.NoError(t, err)
+	fmt.Println(response)
+	assert.Equal(t, 201, response.StatusCode)
 
 	err = cmd.RunExecutable(getPiperExecutable(), piperOptions...)
 	assert.NoError(t, err, "Calling piper with arguments %v failed.", piperOptions)
@@ -165,4 +218,8 @@ func TestNexus2Upload(t *testing.T) {
 	resp, err = http.Get(url + "content/repositories/releases/mygroup/mymta/0.3.0/mymta-0.3.0.mtar")
 	assert.NoError(t, err, "Downloading artifact failed")
 	assert.Equal(t, http.StatusOK, resp.StatusCode, "Get mymta-0.3.0.mtar: %s", resp.Status)
+
+	resp, err = http.Get(url + "content/repositories/npm-repo/npm-nexus-upload-test/-/npm-nexus-upload-test-1.0.0.tgz")
+	assert.NoError(t, err, "Downloading artifact failed")
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "Get npm-nexus-upload-test-1.0.0.tgz: %s", resp.Status)
 }

--- a/integration/integration_nexus_upload_test.go
+++ b/integration/integration_nexus_upload_test.go
@@ -22,7 +22,7 @@ func TestNexusUpload(t *testing.T) {
 	req := testcontainers.ContainerRequest{
 		Image:        "sonatype/nexus3:3.22.0",
 		ExposedPorts: []string{"8081/tcp"},
-		Env:          map[string]string{"NEXUS_SECURITY_RANDOMPASSWORD": "false", "NEXUS_SCRIPTS_ALLOWCREATION": "true"},
+		Env:          map[string]string{"NEXUS_SECURITY_RANDOMPASSWORD": "false"},
 		WaitingFor:   wait.ForLog("Started Sonatype Nexus").WithStartupTimeout(5 * time.Minute), // Nexus takes more than one minute to boot
 	}
 	nexusContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
@@ -82,7 +82,7 @@ func TestNexusUpload(t *testing.T) {
 	}
 
 	// Create npm repo for this test because nexus does not create one by default
-	request, err := http.NewRequest("POST", url + "/service/rest/beta/repositories/npm/hosted", strings.NewReader(`{"name": "npm-repo", "online": true, "storage": {"blobStoreName": "default", "strictContentTypeValidation": true, "writePolicy": "ALLOW_ONCE"}}`))
+	request, err := http.NewRequest("POST", url+"/service/rest/beta/repositories/npm/hosted", strings.NewReader(`{"name": "npm-repo", "online": true, "storage": {"blobStoreName": "default", "strictContentTypeValidation": true, "writePolicy": "ALLOW_ONCE"}}`))
 	assert.NoError(t, err)
 	request.Header.Set("Content-Type", "application/json")
 	request.SetBasicAuth("admin", "admin123")
@@ -188,7 +188,7 @@ func TestNexus2Upload(t *testing.T) {
 
 	// Create npm repo for this test because nexus does not create one by default
 	payload := strings.NewReader("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<repository><data><name>npm-repo</name><repoPolicy>RELEASE</repoPolicy><repoType>hosted</repoType><id>npm-repo</id><exposed>true</exposed><provider>npm-hosted</provider><providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole><format>npm</format></data></repository>")
-	request, _ := http.NewRequest("POST", url + "service/local/repositories", payload)
+	request, _ := http.NewRequest("POST", url+"service/local/repositories", payload)
 	request.Header.Add("Content-Type", "application/xml")
 	request.Header.Add("Authorization", "Basic YWRtaW46YWRtaW4xMjM=")
 	response, err := http.DefaultClient.Do(request)

--- a/integration/testdata/TestNexusIntegration/npm/package.json
+++ b/integration/testdata/TestNexusIntegration/npm/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "npm-nexus-upload-test",
+  "version": "1.0.0"
+}

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -40,7 +40,7 @@ type Uploader interface {
 	Clear()
 }
 
-// SetRepoURL constructs the base URL to the Nexus repository. No parameter can be empty.
+// SetRepoURL constructs the base URL to the Nexus repository. mavenRepository or npmRepository may be empty.
 func (nexusUpload *Upload) SetRepoURL(nexusURL, nexusVersion, mavenRepository, npmRepository string) error {
 	mavenRepoURL, err := getBaseURL(nexusURL, nexusVersion, mavenRepository)
 	if err != nil {

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -90,7 +90,7 @@ func (nexusUpload *Upload) GetMavenRepoURL() string {
 	return nexusUpload.mavenRepoURL
 }
 
-// GetMavenRepoURL returns the base URL for the nexus-npm repository.
+// GetNpmRepoURL returns the base URL for the nexus-npm repository.
 func (nexusUpload *Upload) GetNpmRepoURL() string {
 	return nexusUpload.npmRepoURL
 }

--- a/pkg/nexus/nexus.go
+++ b/pkg/nexus/nexus.go
@@ -85,11 +85,12 @@ func getBaseURL(nexusURL, nexusVersion, repository string) (string, error) {
 	return baseURL, nil
 }
 
-// GetRepoURL returns the base URL for the nexus repository.
+// GetMavenRepoURL returns the base URL for the nexus-maven repository.
 func (nexusUpload *Upload) GetMavenRepoURL() string {
 	return nexusUpload.mavenRepoURL
 }
 
+// GetMavenRepoURL returns the base URL for the nexus-npm repository.
 func (nexusUpload *Upload) GetNpmRepoURL() string {
 	return nexusUpload.npmRepoURL
 }

--- a/pkg/nexus/nexus_test.go
+++ b/pkg/nexus/nexus_test.go
@@ -104,41 +104,36 @@ func TestGetBaseURL(t *testing.T) {
 func TestSetBaseURL(t *testing.T) {
 	t.Run("Test no host provided", func(t *testing.T) {
 		nexusUpload := Upload{}
-		err := nexusUpload.SetRepoURL("", "nexus3", "maven-releases")
+		err := nexusUpload.SetRepoURL("", "nexus3", "maven-releases", "npm-repo")
 		assert.Error(t, err, "Expected SetRepoURL() to fail (no host)")
 	})
 	t.Run("Test host wrongly includes protocol http://", func(t *testing.T) {
 		nexusUpload := Upload{}
-		err := nexusUpload.SetRepoURL("htTp://localhost:8081", "nexus3", "maven-releases")
+		err := nexusUpload.SetRepoURL("htTp://localhost:8081", "nexus3", "maven-releases", "npm-repo")
 		if assert.NoError(t, err, "Expected SetRepoURL() to work") {
-			assert.Equal(t, "localhost:8081/repository/maven-releases/", nexusUpload.repoURL)
+			assert.Equal(t, "localhost:8081/repository/maven-releases/", nexusUpload.mavenRepoURL)
 		}
 	})
 	t.Run("Test host wrongly includes protocol https://", func(t *testing.T) {
 		nexusUpload := Upload{}
-		err := nexusUpload.SetRepoURL("htTpS://localhost:8081", "nexus3", "maven-releases")
+		err := nexusUpload.SetRepoURL("htTpS://localhost:8081", "nexus3", "maven-releases", "npm-repo")
 		if assert.NoError(t, err, "Expected SetRepoURL() to work") {
-			assert.Equal(t, "localhost:8081/repository/maven-releases/", nexusUpload.repoURL)
+			assert.Equal(t, "localhost:8081/repository/maven-releases/", nexusUpload.mavenRepoURL)
 		}
 	})
 	t.Run("Test invalid version provided", func(t *testing.T) {
 		nexusUpload := Upload{}
-		err := nexusUpload.SetRepoURL("localhost:8081", "3", "maven-releases")
+		err := nexusUpload.SetRepoURL("localhost:8081", "3", "maven-releases", "npm-repo")
 		assert.Error(t, err, "Expected SetRepoURL() to fail (invalid nexus version)")
-	})
-	t.Run("Test no repository provided", func(t *testing.T) {
-		nexusUpload := Upload{}
-		err := nexusUpload.SetRepoURL("localhost:8081", "nexus3", "")
-		assert.Error(t, err, "Expected SetRepoURL() to fail (no repository)")
 	})
 	t.Run("Test no nexus version provided", func(t *testing.T) {
 		nexusUpload := Upload{}
-		err := nexusUpload.SetRepoURL("localhost:8081", "nexus1", "maven-releases")
+		err := nexusUpload.SetRepoURL("localhost:8081", "nexus1", "maven-releases", "npm-repo")
 		assert.Error(t, err, "Expected SetRepoURL() to fail (unsupported nexus version)")
 	})
 	t.Run("Test unsupported nexus version provided", func(t *testing.T) {
 		nexusUpload := Upload{}
-		err := nexusUpload.SetRepoURL("localhost:8081", "nexus1", "maven-releases")
+		err := nexusUpload.SetRepoURL("localhost:8081", "nexus1", "maven-releases", "npm-repo")
 		assert.Error(t, err, "Expected SetRepoURL() to fail (unsupported nexus version)")
 	})
 }

--- a/resources/metadata/nexusUpload.yaml
+++ b/resources/metadata/nexusUpload.yaml
@@ -21,6 +21,8 @@ metadata:
     To find out what will be published, run "npm publish --dry-run" in the project's root folder.
     It will use your gitignore file to exclude the mached files from publishing.
     Note: npm's gitignore parser might yield different results from your git client, to ignore a "foo" directory globally use the glob pattern "**/foo".
+
+    If an image for mavenExecute is configured, and npm packages are to be published, the image must have npm installed.
 spec:
   inputs:
     secrets:
@@ -117,9 +119,7 @@ spec:
         scope:
         - PARAMETERS
   containers:
-    - name: mvn
-      image: maven:3.6-jdk-8
-      imagePullPolicy: Never
-    - name: node
-      image: node:12-buster-slim
+    # To allow both maven and mta we require an image that contains both tools. If the user configures an image for mavenExecute that also needs to contain both.
+    - name: mvn-npm
+      image: devxci/mbtci:1.0.4
       imagePullPolicy: Never

--- a/resources/metadata/nexusUpload.yaml
+++ b/resources/metadata/nexusUpload.yaml
@@ -39,24 +39,24 @@ spec:
         mandatory: true
         aliases:
           - name: nexus/url
-      - name: repository
+      - name: mavenRepository
         type: string
-        description: Name of the nexus repository for Maven and MTA deployments.
+        description: Name of the nexus repository for Maven and MTA deployments. If this is not provided, Maven and MTA deployment is implicitly disabled.
         scope:
           - PARAMETERS
           - STAGES
           - STEPS
-        mandatory: true
         aliases:
-          - name: nexus/repository
+          - name: nexus/mavenRepository
       - name: npmRepository
         type: string
-        description: Name of the nexus repository for npm deployments.
+        description: Name of the nexus repository for npm deployments. If this is not provided, npm deployment is implicitly disabled.
         scope:
           - PARAMETERS
           - STAGES
           - STEPS
-        mandatory: false
+        aliases:
+          - name: nexus/mavenRepository
       - name: groupId
         type: string
         description: Group ID of the artifacts. Only used in MTA projects, ignored for Maven.

--- a/resources/metadata/nexusUpload.yaml
+++ b/resources/metadata/nexusUpload.yaml
@@ -41,14 +41,22 @@ spec:
           - name: nexus/url
       - name: repository
         type: string
-        description: Name of the nexus repository.
+        description: Name of the nexus repository for Maven and MTA deployments.
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         mandatory: true
         aliases:
           - name: nexus/repository
+      - name: npmRepository
+        type: string
+        description: Name of the nexus repository for npm deployments.
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        mandatory: false
       - name: groupId
         type: string
         description: Group ID of the artifacts. Only used in MTA projects, ignored for Maven.

--- a/resources/metadata/nexusUpload.yaml
+++ b/resources/metadata/nexusUpload.yaml
@@ -65,6 +65,8 @@ spec:
           - STEPS
         aliases:
           - name: nexus/mavenRepository
+          - name: nexus/repository
+            deprecated: true
       - name: npmRepository
         type: string
         description: Name of the nexus repository for npm deployments. If this is not provided, npm deployment is implicitly disabled.

--- a/resources/metadata/nexusUpload.yaml
+++ b/resources/metadata/nexusUpload.yaml
@@ -3,9 +3,24 @@ metadata:
   aliases:
     - name: mavenExecute
       deprecated: false
-  description: Upload artifacts to Nexus
+  description: Upload artifacts to Nexus Repository Manager
   longDescription: |
-    Upload build artifacts to a Nexus Repository Manager. Supports MTA and (multi-module) Maven projects.
+    Upload build artifacts to a Nexus Repository Manager.
+
+    Supports MTA, npm and (multi-module) Maven projects.
+    MTA files will be uploaded to a Maven repository.
+
+    The uploaded file-type depends on your project structure and step configuration.
+    To upload Maven projects, you need a pom.xml in the project root and set the mavenRepository option.
+    To upload MTA projects, you need a mta.yaml in the project root and set the mavenRepository option.
+    To upload npm projects, you need a package.json in the project root and set the npmRepository option.
+
+    npm:
+    Publishing npm projects makes use of npm's "publish" command.
+    It requires a "package.json" file in the project's root directory which has "version" set and is not delared as "private".
+    To find out what will be published, run "npm publish --dry-run" in the project's root folder.
+    It will use your gitignore file to exclude the mached files from publishing.
+    Note: npm's gitignore parser might yield different results from your git client, to ignore a "foo" directory globally use the glob pattern "**/foo".
 spec:
   inputs:
     secrets:
@@ -56,7 +71,7 @@ spec:
           - STAGES
           - STEPS
         aliases:
-          - name: nexus/mavenRepository
+          - name: nexus/npmRepository
       - name: groupId
         type: string
         description: Group ID of the artifacts. Only used in MTA projects, ignored for Maven.
@@ -104,4 +119,7 @@ spec:
   containers:
     - name: mvn
       image: maven:3.6-jdk-8
+      imagePullPolicy: Never
+    - name: node
+      image: node:12-buster-slim
       imagePullPolicy: Never


### PR DESCRIPTION
# Changes

Upload npm to nexus if a package.json exists in the project root.

Minor breaking change: The parameter "repository" was renamed to "mavenRepository" so it is consistent with the newly introduced "npmRepository".

- [x] Tests
- [x] Documentation
