### PR TITLE
Add documentation for the lint stage of Cloud SDK Pipeline

### DIFF
--- a/documentation/docs/pipelines/cloud-sdk/build-tools.md
+++ b/documentation/docs/pipelines/cloud-sdk/build-tools.md
@@ -134,7 +134,7 @@ If, on the other hand, ESLint configuration files exist in the project, they wil
 The execution happens according to ESLint's default execution behavior, i.e., for each JS file the ESLint config in that directory or one of the parent directories will be used to lint the file.
 Note, in this case only those files will be linted, for which an ESLint config exists.
 More details on the execution behavior of ESLint and the usage of configuration files can be found in the [related documentation](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy).
-Note, if you want to disable the default linting behavior, it is possible to, e.g., define a script `"ci-lint" : "exit 0"` in your `package.json`.
+Note, if it is necessary to disable the default linting behavior, it is possible to, e.g., define a script `"ci-lint" : "exit 0"` in your `package.json`.
 
 We recommend the use of a custom defined `ci-lint` script in your `package.json` to address project specific linting requirements.
 

--- a/documentation/docs/pipelines/cloud-sdk/build-tools.md
+++ b/documentation/docs/pipelines/cloud-sdk/build-tools.md
@@ -119,6 +119,27 @@ The user is responsible to use a proper reporter for generating the results.
 We recommend the tools used in the `package.json` of this [example project](https://github.com/SAP/cloud-s4-sdk-examples/blob/scaffolding-js/package.json).
 If you have multiple npm packages with unit tests the names of the report files must have unique names.
 
+#### Lint
+
+For each `package.json` where the script `ci-lint` is defined the command `npm run ci-lint` will be executed in this stage.
+The required format of the linting results is the checkstyle format as an `xml` file.
+The linting results have to be stored in a file named `*cilint.xml`, which may reside in any directory of the project.
+The linting results will then be published in Jenkins.
+
+If no script `ci-lint` is defined, the pipeline will check SAPUI5 components, if present, for the SAPUI5 recommended best practices.
+If none of the scenarios described apply and Javascript or Typescript files are present in the project, the pipeline will automatically execute ESLint.
+
+If no ESLint configuration files are present in the project directory, a general purpose configuration is used to lint all Javascript and/or Typescript files of the project.
+If, on the other hand, ESLint configuration files exist in the project, they will be used to lint Javascript files in the project.
+The execution happens according to ESLint's default execution behavior, i.e., for each JS file the ESLint config in that directory or one of the parent directories will be used to lint the file.
+Note, in this case only those files will be linted, for which an ESLint config exists.
+More details on the execution behavior of ESLint and the usage of configuration files can be found in the [related documentation](https://eslint.org/docs/user-guide/configuring#configuration-cascading-and-hierarchy).
+Note, if you want to disable the default linting behavior, it is possible to, e.g., define a script `"ci-lint" : "exit 0"` in your `package.json`.
+
+We recommend the use of a custom defined `ci-lint` script in your `package.json` to address project specific linting requirements.
+
+Note, the parameters defined for the Lint stage in `.pipeline/config.yml` only apply in case SAPUI5 components are checked by the pipeline and are ignored otherwise.
+
 #### End-to-End Tests
 
 This stage is only executed if you configured it in the file `.pipeline/config.yml`.


### PR DESCRIPTION
This change adds documentation for the new behavior and capabilities of
the lint stage of the Cloud SDK Pipeline.

# Changes

- [ ] Tests
- [x] Documentation
