### PR TITLE
improve error message when parsing config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,7 +41,7 @@ func (c *Config) ReadConfig(configuration io.ReadCloser) error {
 
 	err = yaml.Unmarshal(content, &c)
 	if err != nil {
-		return NewParseError(fmt.Sprintf("error unmarshalling %q: %v", content, err))
+		return NewParseError(fmt.Sprintf("format of configuration is invalid %q: %v", content, err))
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -247,7 +247,7 @@ steps:
 		var c Config
 		myConfig := ioutil.NopCloser(strings.NewReader("invalid config"))
 		_, err := c.GetStepConfig(nil, "", myConfig, nil, StepFilters{}, []StepParameters{}, nil, nil, "stage1", "step1", []Alias{})
-		assert.EqualError(t, err, "failed to parse custom pipeline configuration: error unmarshalling \"invalid config\": error unmarshaling JSON: json: cannot unmarshal string into Go value of type config.Config", "default error expected")
+		assert.EqualError(t, err, "failed to parse custom pipeline configuration: format of configuration is invalid \"invalid config\": error unmarshaling JSON: json: cannot unmarshal string into Go value of type config.Config", "default error expected")
 	})
 
 	t.Run("Failure case defaults", func(t *testing.T) {


### PR DESCRIPTION
Improves the error message when a config couldn't be parsed.