### PR TITLE
Automate go dependency updates

### DIFF
--- a/.github/workflows/update-go-dependencies.yaml
+++ b/.github/workflows/update-go-dependencies.yaml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+        with:
+          go-version: '1.13.x'
       - name: Perform update
         run: |
           git checkout -B gh-action-update-golang-dependencies

--- a/.github/workflows/update-go-dependencies.yaml
+++ b/.github/workflows/update-go-dependencies.yaml
@@ -1,10 +1,12 @@
 name: Update go dependencies and create PR
 
 on:
+  # Allow to trigger this manually just in case updates are required outside of the schedule. See https://goobar.io/2019/12/07/manually-trigger-a-github-actions-workflow/ for info on how that works.
   repository_dispatch:
     types: update-dependencies
+  # Schedule after our weekly release, so we can update the dependencies for the new development cycle on the master branch.
   schedule:
-    - cron:  '0 12 * * 1'
+    - cron:  '0 10 * * 1'
 
 jobs:
   build:

--- a/.github/workflows/update-go-dependencies.yaml
+++ b/.github/workflows/update-go-dependencies.yaml
@@ -1,0 +1,27 @@
+name: Update go dependencies and create PR
+
+on:
+  repository_dispatch:
+    types: update-dependencies
+  schedule:
+    - cron:  '0 12 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Perform update
+        run: |
+          git checkout -B gh-action-update-golang-dependencies
+          go get -u
+          go mod tidy
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -am "Automated go dependency update"
+          git push origin gh-action-update-golang-dependencies -f
+      - name: Create Pull Request
+        uses: SAP/project-piper-action@master
+        with:
+          command: githubCreatePullRequest
+          flags: --body="Update Go dependencies" --head=gh-action-update-golang-dependencies --title="Update Go dependencies" --token ${{ secrets.GITHUB_TOKEN }}

--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -11,3 +11,10 @@ steps:
     owner: 'SAP'
     repository: 'jenkins-library'
     releaseBodyHeader: ''
+  githubCreatePullRequest:
+    base: master
+    owner: 'SAP'
+    repository: 'jenkins-library'
+    labels:
+      - 'REVIEW'
+      - 'go-piper'


### PR DESCRIPTION
# Changes

New github action to trigger automatic go dependency updates on schedule.
Will create a new PR with updates on monday after the weekly release was triggered, so we can merge it to master and get a freshly updated master branch for the new development cycle.

- [ ] Tests
- [ ] Documentation
