### PR TITLE
fix: read config.yaml in getConfig command

### DIFF
--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -54,10 +54,12 @@ func generateConfig() error {
 
 	resourceParams := metadata.GetResourceParameters(GeneralConfig.EnvRootPath, "commonPipelineEnvironment")
 
-	customConfig, err := configOptions.openFile(GeneralConfig.CustomConfig)
+	projectConfigFile := getProjectConfigFile(GeneralConfig.CustomConfig)
+
+	customConfig, err := configOptions.openFile(projectConfigFile)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return errors.Wrapf(err, "config: open configuration file '%v' failed", GeneralConfig.CustomConfig)
+			return errors.Wrapf(err, "config: open configuration file '%v' failed", projectConfigFile)
 		}
 		customConfig = nil
 	}


### PR DESCRIPTION
respect `.pipeline/config.yml` and `.pipeline/config.yaml` as in [`prepareConfig`](https://github.com/SAP/jenkins-library/blob/master/cmd/piper.go#L115) 