### PR TITLE
Fix wrong step name

### DIFF
--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -4,11 +4,15 @@ import com.sap.piper.JenkinsUtils
 import com.sap.piper.PiperGoUtils
 import com.sap.piper.Utils
 
+import groovy.transform.Field
+
 import static com.sap.piper.Prerequisites.checkScript
+
+@Field String STEP_NAME = getClass().getName()
 
 void call(Map parameters = [:], stepName, metadataFile, List credentialInfo, failOnMissingReports = false, failOnMissingLinks = false) {
 
-    handlePipelineStepErrors(stepName: stepName, stepParameters: parameters) {
+    handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters) {
 
         def stepParameters = [:].plus(parameters)
 


### PR DESCRIPTION
Otherwise we have two times a log message about
begin/end of the piper step calling piperExecuteBin and no
message about begin/end piperExecuteBin rather
than having that message only once and also having one
message about piperExecuteBin.

This makes troubleshooting harder causing more time/cycles
required for resolving an issue.
