### PR TITLE
Configure default jenkins agent for kubernetes

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -6,6 +6,8 @@
 #Project Setup
 general:
   collectTelemetryData: true
+  jenkinsKubernetes:
+    jnlpAgent: 'ppiper/jenkins-agent-k8s:v8'
   changeManagement:
     type: 'NONE' # SOLMAN, CTS, NONE
     transportRequestLabel: 'TransportRequest\s?:'


### PR DESCRIPTION
# Changes

Especially for go steps we are using `curl` to download the go binary which is not included in the default jenkins agent docker image. See also https://github.com/SAP/jenkins-library/issues/1409

This PR configures our ppiper kubernetes agent docker image as default which contains curl.

Alternative approach: Use wget instead of curl everywhere.

- [ ] Tests
- [x] Documentation
