### PR TITLE
Use specific token for automated go dependency update PR

### DIFF
--- a/.github/workflows/update-go-dependencies.yaml
+++ b/.github/workflows/update-go-dependencies.yaml
@@ -29,4 +29,4 @@ jobs:
         uses: SAP/project-piper-action@master
         with:
           command: githubCreatePullRequest
-          flags: --body="Update Go dependencies" --head=gh-action-update-golang-dependencies --title="Update Go dependencies" --token ${{ secrets.GITHUB_TOKEN }}
+          flags: --body="Update Go dependencies" --head=gh-action-update-golang-dependencies --title="Update Go dependencies" --token ${{ secrets.GO_DEPENDENCY_UPDATE_TOKEN }}


### PR DESCRIPTION
# Changes

This should fix the issue that the created PRs don't trigger tests.
