### PR TITLE
TMS: test that response content not exposed in case of authentication error and status code 3xx

### DIFF
--- a/test/groovy/com/sap/piper/integration/TransportManagementServiceTest.groovy
+++ b/test/groovy/com/sap/piper/integration/TransportManagementServiceTest.groovy
@@ -94,6 +94,28 @@ class TransportManagementServiceTest extends BasePiperTest {
     }
 
     @Test
+    void retrieveOAuthToken__failure__status__less__than__400() {
+        def uaaUrl = 'http://dummy.sap.com/oauth'
+        def clientId = 'myId'
+        def clientSecret = 'mySecret'
+        def responseStatusCode = 301
+        def responseContent = 'This response content should not be printed to the logs as well as be thrown in exception message'
+
+        thrown.expect(AbortException)
+        thrown.expectMessage("[TransportManagementService] OAuth Token retrieval failed (HTTP status code '${responseStatusCode}').")
+        thrown.expectMessage(not(containsString(responseContent)))
+        loggingRule.expect("[TransportManagementService] OAuth Token retrieval started.")
+        loggingRule.notExpect(responseContent)
+
+        helper.registerAllowedMethod('httpRequest', [Map.class], {
+            return [content: responseContent, status: responseStatusCode]
+        })
+
+        def tms = new TransportManagementService(nullScript, [verbose: false])
+        tms.authentication(uaaUrl, clientId, clientSecret)
+    }
+
+    @Test
     void retrieveOAuthToken__failure__status__400__inVerboseMode() {
         def uaaUrl = 'http://dummy.sap.com/oauth'
         def clientId = 'myId'
@@ -105,6 +127,29 @@ class TransportManagementServiceTest extends BasePiperTest {
         thrown.expectMessage("[TransportManagementService] OAuth Token retrieval failed (HTTP status code '${responseStatusCode}'). Response content '${responseContent}'.")
         loggingRule.expect("[TransportManagementService] OAuth Token retrieval started.")
         loggingRule.expect("[TransportManagementService] UAA-URL: '${uaaUrl}', ClientId: '${clientId}'")
+
+        helper.registerAllowedMethod('httpRequest', [Map.class], {
+            return [content: responseContent, status: responseStatusCode]
+        })
+
+        def tms = new TransportManagementService(nullScript, [verbose: true])
+        tms.authentication(uaaUrl, clientId, clientSecret)
+    }
+
+    @Test
+    void retrieveOAuthToken__failure__status__less__than__400__inVerboseMode() {
+        def uaaUrl = 'http://dummy.sap.com/oauth'
+        def clientId = 'myId'
+        def clientSecret = 'mySecret'
+        def responseStatusCode = 301
+        def responseContent = 'This response content should not be printed to the logs as well as be thrown in exception message'
+
+        thrown.expect(AbortException)
+        thrown.expectMessage("[TransportManagementService] OAuth Token retrieval failed (HTTP status code '${responseStatusCode}').")
+        thrown.expectMessage(not(containsString(responseContent)))
+        loggingRule.expect("[TransportManagementService] OAuth Token retrieval started.")
+        loggingRule.expect("[TransportManagementService] UAA-URL: '${uaaUrl}', ClientId: '${clientId}'")
+        loggingRule.notExpect(responseContent)
 
         helper.registerAllowedMethod('httpRequest', [Map.class], {
             return [content: responseContent, status: responseStatusCode]

--- a/test/groovy/util/JenkinsLoggingRule.groovy
+++ b/test/groovy/util/JenkinsLoggingRule.groovy
@@ -8,6 +8,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.Matchers.not
 import static org.junit.Assert.assertThat
 
 import org.hamcrest.Matchers
@@ -17,6 +18,7 @@ class JenkinsLoggingRule implements TestRule {
     final BasePipelineTest testInstance
 
     def expected = []
+    def notExpected = []
 
     String log = ""
 
@@ -26,6 +28,11 @@ class JenkinsLoggingRule implements TestRule {
 
     public JenkinsLoggingRule expect(String substring) {
         expected.add(substring)
+        return this
+    }
+
+    public JenkinsLoggingRule notExpect(String substring) {
+        notExpected.add(substring)
         return this
     }
 
@@ -61,6 +68,10 @@ class JenkinsLoggingRule implements TestRule {
                     expected.each { substring -> assertThat("Substring '${substring}' not contained in log.",
                                                             log,
                                                             containsString(substring)) }
+
+                    notExpected.each { substring -> assertThat("Substring '${substring}' is present in log.",
+                                                            log,
+                                                            not(containsString(substring))) }
 
                     if(caught != null) {
                         // do not swallow, so that other rules located farer away


### PR DESCRIPTION
This PR provides a test for the situation, when an error happens during authentication step in tmsUpload and error status code is 3xx. To really be sure that authentication token is not exposed to the logs, we print error response content only for status codes 4xx, 5xx (such content might contain usefull tips with regards to the error that has happened). The newly introduced test ensures that error response content is not printed to the logs in the case of 3xx status code during authentication.