### PR TITLE
chore: cache .m2 directory during groovy tests

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,7 +9,7 @@ on:
     - master
 
 jobs:
-  github-pages:
+  Build:
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/verify-groovy.yml
+++ b/.github/workflows/verify-groovy.yml
@@ -12,11 +12,20 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+
+    - uses: actions/checkout@v2
+
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: checkout
-      uses: actions/checkout@v2
+
+    - name: Cache Maven Packages
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
     - name: unit-test
       run: mvn --batch-mode clean verify -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn


### PR DESCRIPTION
**changes:**
- use cache action to cache `~/.m2` directory during Groovy test execution