### PR TITLE
fix: improve stepResults handling

### DIFF
--- a/pkg/piperenv/environment.go
+++ b/pkg/piperenv/environment.go
@@ -40,13 +40,13 @@ func writeToDisk(filename string, data []byte) error {
 
 	if _, err := os.Stat(filepath.Dir(filename)); os.IsNotExist(err) {
 		log.Entry().Debugf("Creating directory: %v", filepath.Dir(filename))
-		os.MkdirAll(filepath.Dir(filename), 0700)
+		os.MkdirAll(filepath.Dir(filename), 0755)
 	}
 
 	//ToDo: make sure to not overwrite file but rather add another file? Create error if already existing?
 	if len(data) > 0 {
 		log.Entry().Debugf("Writing file to disk: %v", filename)
-		return ioutil.WriteFile(filename, data, 0700)
+		return ioutil.WriteFile(filename, data, 0755)
 	}
 	return nil
 }

--- a/pkg/piperutils/stepResults.go
+++ b/pkg/piperutils/stepResults.go
@@ -18,6 +18,13 @@ type Path struct {
 
 // PersistReportsAndLinks stores the report paths and links in JSON format in the workspace for processing outside
 func PersistReportsAndLinks(stepName, workspace string, reports, links []Path) {
+	if reports == nil {
+		reports = []Path{}
+	}
+	if links == nil {
+		links = []Path{}
+	}
+
 	hasMandatoryReport := false
 	for _, report := range reports {
 		if report.Mandatory {

--- a/pkg/piperutils/stepResults_test.go
+++ b/pkg/piperutils/stepResults_test.go
@@ -8,50 +8,82 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPersistReportAndLinks(t *testing.T) {
-	workspace, err := ioutil.TempDir("", "workspace5")
-	if err != nil {
-		t.Fatal("Failed to create temporary workspace directory")
-	}
-	// clean up tmp dir
-	defer os.RemoveAll(workspace)
 
-	reports := []Path{Path{Target: "testFile1.json", Mandatory: true}, Path{Target: "testFile2.json"}}
-	links := []Path{Path{Target: "https://1234568.com/test", Name: "Weblink"}}
-	PersistReportsAndLinks("checkmarxExecuteScan", workspace, reports, links)
+	t.Run("default", func(t *testing.T) {
+		workspace, err := ioutil.TempDir("", "workspace5")
+		require.NoError(t, err, "Failed to create temporary workspace directory")
+		// clean up tmp dir
+		defer os.RemoveAll(workspace)
 
-	reportsJSONPath := filepath.Join(workspace, "checkmarxExecuteScan_reports.json")
-	reportsFileExists, err := FileExists(reportsJSONPath)
-	assert.NoError(t, err, "No error expected but got one")
-	assert.Equal(t, true, reportsFileExists, "checkmarxExecuteScan_reports.json missing")
+		reports := []Path{Path{Target: "testFile1.json", Mandatory: true}, Path{Target: "testFile2.json"}}
+		links := []Path{Path{Target: "https://1234568.com/test", Name: "Weblink"}}
+		PersistReportsAndLinks("checkmarxExecuteScan", workspace, reports, links)
 
-	linksJSONPath := filepath.Join(workspace, "checkmarxExecuteScan_links.json")
-	linksFileExists, err := FileExists(linksJSONPath)
-	assert.NoError(t, err, "No error expected but got one")
-	assert.Equal(t, true, linksFileExists, "checkmarxExecuteScan_links.json missing")
+		reportsJSONPath := filepath.Join(workspace, "checkmarxExecuteScan_reports.json")
+		assert.FileExists(t, reportsJSONPath)
 
-	var reportsLoaded []Path
-	var linksLoaded []Path
-	reportsFileData, err := ioutil.ReadFile(reportsJSONPath)
-	reportsDataString := string(reportsFileData)
-	println(reportsDataString)
-	assert.NoError(t, err, "No error expected but got one")
-	linksFileData, err := ioutil.ReadFile(linksJSONPath)
-	linksDataString := string(linksFileData)
-	println(linksDataString)
-	assert.NoError(t, err, "No error expected but got one")
-	json.Unmarshal(reportsFileData, &reportsLoaded)
-	json.Unmarshal(linksFileData, &linksLoaded)
+		linksJSONPath := filepath.Join(workspace, "checkmarxExecuteScan_links.json")
+		assert.FileExists(t, linksJSONPath)
 
-	assert.Equal(t, 2, len(reportsLoaded), "wrong number of reports")
-	assert.Equal(t, 1, len(linksLoaded), "wrong number of links")
-	assert.Equal(t, true, reportsLoaded[0].Mandatory, "mandatory flag on report 1 has wrong value")
-	assert.Equal(t, "testFile1.json", reportsLoaded[0].Target, "target value on report 1 has wrong value")
-	assert.Equal(t, false, reportsLoaded[1].Mandatory, "mandatory flag on report 2 has wrong value")
-	assert.Equal(t, "testFile2.json", reportsLoaded[1].Target, "target value on report 1 has wrong value")
-	assert.Equal(t, false, linksLoaded[0].Mandatory, "mandatory flag on link 1 has wrong value")
-	assert.Equal(t, "https://1234568.com/test", linksLoaded[0].Target, "target value on link 1 has wrong value")
-	assert.Equal(t, "Weblink", linksLoaded[0].Name, "name value on link 1 has wrong value")
+		var reportsLoaded []Path
+		var linksLoaded []Path
+		reportsFileData, err := ioutil.ReadFile(reportsJSONPath)
+		reportsDataString := string(reportsFileData)
+		println(reportsDataString)
+		assert.NoError(t, err, "No error expected but got one")
+
+		linksFileData, err := ioutil.ReadFile(linksJSONPath)
+		linksDataString := string(linksFileData)
+		println(linksDataString)
+		assert.NoError(t, err, "No error expected but got one")
+		json.Unmarshal(reportsFileData, &reportsLoaded)
+		json.Unmarshal(linksFileData, &linksLoaded)
+
+		assert.Equal(t, 2, len(reportsLoaded), "wrong number of reports")
+		assert.Equal(t, 1, len(linksLoaded), "wrong number of links")
+		assert.Equal(t, true, reportsLoaded[0].Mandatory, "mandatory flag on report 1 has wrong value")
+		assert.Equal(t, "testFile1.json", reportsLoaded[0].Target, "target value on report 1 has wrong value")
+		assert.Equal(t, false, reportsLoaded[1].Mandatory, "mandatory flag on report 2 has wrong value")
+		assert.Equal(t, "testFile2.json", reportsLoaded[1].Target, "target value on report 1 has wrong value")
+		assert.Equal(t, false, linksLoaded[0].Mandatory, "mandatory flag on link 1 has wrong value")
+		assert.Equal(t, "https://1234568.com/test", linksLoaded[0].Target, "target value on link 1 has wrong value")
+		assert.Equal(t, "Weblink", linksLoaded[0].Name, "name value on link 1 has wrong value")
+	})
+
+	t.Run("empty list", func(t *testing.T) {
+		// init
+		workspace, err := ioutil.TempDir("", "sonar-")
+		require.NoError(t, err, "Failed to create temporary workspace directory")
+		// clean up tmp dir
+		defer os.RemoveAll(workspace)
+
+		reportsJSONPath := filepath.Join(workspace, "sonarExecuteScan_reports.json")
+		linksJSONPath := filepath.Join(workspace, "sonarExecuteScan_links.json")
+
+		// prepare uninitialised parameters
+		var reports, links []Path
+		require.Empty(t, reports)
+		require.Empty(t, links)
+
+		// test
+		PersistReportsAndLinks("sonarExecuteScan", workspace, reports, links)
+		// assert
+		assert.FileExists(t, reportsJSONPath)
+		assert.FileExists(t, linksJSONPath)
+
+		for _, reportFile := range []string{reportsJSONPath, linksJSONPath} {
+			assert.FileExists(t, reportFile)
+			reportsFileData, err := ioutil.ReadFile(reportFile)
+			reportsFileDataString := string(reportsFileData)
+			require.NoError(t, err, "No error expected but got one")
+			println(reportsFileData)
+			println(reportsFileDataString)
+			assert.NotEmpty(t, reportsFileData)
+			assert.Equal(t, "[]", reportsFileDataString)
+		}
+	})
 }

--- a/pkg/piperutils/stepResults_test.go
+++ b/pkg/piperutils/stepResults_test.go
@@ -75,7 +75,6 @@ func TestPersistReportAndLinks(t *testing.T) {
 			assert.FileExists(t, reportFile)
 			reportsFileData, err := ioutil.ReadFile(reportFile)
 			require.NoError(t, err, "No error expected but got one")
-			assert.NotEmpty(t, reportsFileData)
 			assert.Equal(t, "[]", string(reportsFileData))
 		}
 	})

--- a/pkg/piperutils/stepResults_test.go
+++ b/pkg/piperutils/stepResults_test.go
@@ -71,9 +71,6 @@ func TestPersistReportAndLinks(t *testing.T) {
 		// test
 		PersistReportsAndLinks("sonarExecuteScan", workspace, reports, links)
 		// assert
-		assert.FileExists(t, reportsJSONPath)
-		assert.FileExists(t, linksJSONPath)
-
 		for _, reportFile := range []string{reportsJSONPath, linksJSONPath} {
 			assert.FileExists(t, reportFile)
 			reportsFileData, err := ioutil.ReadFile(reportFile)

--- a/pkg/piperutils/stepResults_test.go
+++ b/pkg/piperutils/stepResults_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestPersistReportAndLinks(t *testing.T) {
-
 	t.Run("default", func(t *testing.T) {
 		workspace, err := ioutil.TempDir("", "workspace5")
 		require.NoError(t, err, "Failed to create temporary workspace directory")
@@ -78,12 +77,9 @@ func TestPersistReportAndLinks(t *testing.T) {
 		for _, reportFile := range []string{reportsJSONPath, linksJSONPath} {
 			assert.FileExists(t, reportFile)
 			reportsFileData, err := ioutil.ReadFile(reportFile)
-			reportsFileDataString := string(reportsFileData)
 			require.NoError(t, err, "No error expected but got one")
-			println(reportsFileData)
-			println(reportsFileDataString)
 			assert.NotEmpty(t, reportsFileData)
-			assert.Equal(t, "[]", reportsFileDataString)
+			assert.Equal(t, "[]", string(reportsFileData))
 		}
 	})
 }


### PR DESCRIPTION
**changes:**
- add general *read* permissions on created files
- handle empty (`nil`) result sets

related to #1390

[compare without whitespaces](https://github.com/SAP/jenkins-library/pull/1425/files?diff=split&w=1) 