### PR TITLE
Step generator: correct error handling

### DIFF
--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -59,7 +59,7 @@ func (p *artifactPrepareVersionCommonPipelineEnvironment) persist(path, resource
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Piper environment")
 	}
 }
 

--- a/cmd/checkmarxExecuteScan_generated.go
+++ b/cmd/checkmarxExecuteScan_generated.go
@@ -154,7 +154,7 @@ func (i *checkmarxExecuteScanInflux) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Influx environment")
 	}
 }
 

--- a/cmd/mtaBuild_generated.go
+++ b/cmd/mtaBuild_generated.go
@@ -50,7 +50,7 @@ func (p *mtaBuildCommonPipelineEnvironment) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Piper environment")
 	}
 }
 

--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -75,7 +75,7 @@ func (i *protecodeExecuteScanInflux) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Influx environment")
 	}
 }
 

--- a/cmd/xsDeploy_generated.go
+++ b/cmd/xsDeploy_generated.go
@@ -53,7 +53,7 @@ func (p *xsDeployCommonPipelineEnvironment) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Piper environment")
 	}
 }
 

--- a/pkg/generator/helper/resources.go
+++ b/pkg/generator/helper/resources.go
@@ -60,7 +60,7 @@ func (p *{{ .StepName }}{{ .Name | title}}) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Piper environment")
 	}
 }`
 
@@ -160,7 +160,7 @@ func (i *{{ .StepName }}{{ .Name | title}}) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Influx environment")
 	}
 }`
 

--- a/pkg/generator/helper/resources_test.go
+++ b/pkg/generator/helper/resources_test.go
@@ -2,8 +2,9 @@ package helper
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStructString(t *testing.T) {
@@ -77,7 +78,7 @@ func (i *TestStepTestInflux) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Influx environment")
 	}
 }`,
 		},

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
@@ -51,7 +51,7 @@ func (p *testStepCommonPipelineEnvironment) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Piper environment")
 	}
 }
 
@@ -86,7 +86,7 @@ func (i *testStepInfluxTest) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Influx environment")
 	}
 }
 

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
@@ -50,7 +50,7 @@ func (p *testStepCommonPipelineEnvironment) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Piper environment")
 	}
 }
 
@@ -85,7 +85,7 @@ func (i *testStepInfluxTest) persist(path, resourceName string) {
 		}
 	}
 	if errCount > 0 {
-		os.Exit(1)
+		log.Entry().Fatal("failed to persist Influx environment")
 	}
 }
 


### PR DESCRIPTION
Do not exit with `os.Exit(1)` but use `log.Entry().Fatal()` instead

# Changes

- [x] Tests
- ~[ ] Documentation~ not applicable
