### PR TITLE
Removing JSON config for Service Key Creation as in-line parameter

### DIFF
--- a/cmd/cloudFoundryCreateServiceKey.go
+++ b/cmd/cloudFoundryCreateServiceKey.go
@@ -62,12 +62,11 @@ func runCloudFoundryCreateServiceKey(config *cloudFoundryCreateServiceKeyOptions
 	if config.CfServiceKeyConfig == "" {
 		cfCreateServiceKeyScript = []string{"create-service-key", config.CfServiceInstance, config.CfServiceKeyName}
 	} else {
-		cfCreateServiceKeyScript = []string{"create-service-key", config.CfServiceInstance, config.CfServiceKeyName, "-c '", config.CfServiceKeyConfig, "'"}
+		cfCreateServiceKeyScript = []string{"create-service-key", config.CfServiceInstance, config.CfServiceKeyName, "-c", config.CfServiceKeyConfig}
 		fmt.Println(cfCreateServiceKeyScript)
 	}
 
 	err := c.RunExecutable("cf", cfCreateServiceKeyScript...)
-
 	if err != nil {
 		return fmt.Errorf("Failed to Create Service Key: %w", err)
 	}

--- a/cmd/cloudFoundryCreateServiceKey.go
+++ b/cmd/cloudFoundryCreateServiceKey.go
@@ -63,7 +63,6 @@ func runCloudFoundryCreateServiceKey(config *cloudFoundryCreateServiceKeyOptions
 		cfCreateServiceKeyScript = []string{"create-service-key", config.CfServiceInstance, config.CfServiceKeyName}
 	} else {
 		cfCreateServiceKeyScript = []string{"create-service-key", config.CfServiceInstance, config.CfServiceKeyName, "-c", config.CfServiceKeyConfig}
-		fmt.Println(cfCreateServiceKeyScript)
 	}
 
 	err := c.RunExecutable("cf", cfCreateServiceKeyScript...)

--- a/cmd/cloudFoundryCreateServiceKey_generated.go
+++ b/cmd/cloudFoundryCreateServiceKey_generated.go
@@ -78,9 +78,9 @@ func addCloudFoundryCreateServiceKeyFlags(cmd *cobra.Command, stepConfig *cloudF
 	cmd.Flags().StringVar(&stepConfig.Password, "password", os.Getenv("PIPER_password"), "User Password for CF User")
 	cmd.Flags().StringVar(&stepConfig.CfOrg, "cfOrg", os.Getenv("PIPER_cfOrg"), "CF org")
 	cmd.Flags().StringVar(&stepConfig.CfSpace, "cfSpace", os.Getenv("PIPER_cfSpace"), "CF Space")
-	cmd.Flags().StringVar(&stepConfig.CfServiceInstance, "cfServiceInstance", os.Getenv("PIPER_cfServiceInstance"), "Parameter of ServiceInstance Name to delete CloudFoundry Service")
-	cmd.Flags().StringVar(&stepConfig.CfServiceKeyName, "cfServiceKeyName", os.Getenv("PIPER_cfServiceKeyName"), "Parameter of CloudFoundry Service Key to be created")
-	cmd.Flags().StringVar(&stepConfig.CfServiceKeyConfig, "cfServiceKeyConfig", os.Getenv("PIPER_cfServiceKeyConfig"), "Configuration for Service Key Creation")
+	cmd.Flags().StringVar(&stepConfig.CfServiceInstance, "cfServiceInstance", os.Getenv("PIPER_cfServiceInstance"), "Parameter for CloudFoundry Service Instance Name")
+	cmd.Flags().StringVar(&stepConfig.CfServiceKeyName, "cfServiceKeyName", os.Getenv("PIPER_cfServiceKeyName"), "Parameter for Service Key name for CloudFoundry Service Key to be created")
+	cmd.Flags().StringVar(&stepConfig.CfServiceKeyConfig, "cfServiceKeyConfig", os.Getenv("PIPER_cfServiceKeyConfig"), "Path to JSON config file path or JSON in-line string for Cloud Foundry Service Key creation")
 
 	cmd.MarkFlagRequired("cfApiEndpoint")
 	cmd.MarkFlagRequired("username")

--- a/cmd/cloudFoundryCreateServiceKey_test.go
+++ b/cmd/cloudFoundryCreateServiceKey_test.go
@@ -41,11 +41,45 @@ func TestCloudFoundryCreateServiceKey(t *testing.T) {
 			assert.Equal(t, []string{"create-service-key", "testInstance", "testKey"}, execRunner.Calls[1].Params)
 		}
 	})
+	t.Run("CF Create Service Key with service Key config: Success case", func(t *testing.T) {
+		config := cloudFoundryCreateServiceKeyOptions{
+			CfAPIEndpoint:      "https://api.endpoint.com",
+			CfOrg:              "testOrg",
+			CfSpace:            "testSpace",
+			Username:           "testUser",
+			Password:           "testPassword",
+			CfServiceInstance:  "testInstance",
+			CfServiceKeyName:   "testKey",
+			CfServiceKeyConfig: "testconfig.yml",
+		}
+		error := runCloudFoundryCreateServiceKey(&config, &telemetryData, &execRunner)
+		if error == nil {
+			assert.Equal(t, "cf", execRunner.Calls[2].Exec)
+			assert.Equal(t, []string{"create-service-key", "testInstance", "testKey", "-c", "testconfig.yml"}, execRunner.Calls[2].Params)
+		}
+	})
+	t.Run("CF Create Service Key with service Key config: Success case", func(t *testing.T) {
+		config := cloudFoundryCreateServiceKeyOptions{
+			CfAPIEndpoint:      "https://api.endpoint.com",
+			CfOrg:              "testOrg",
+			CfSpace:            "testSpace",
+			Username:           "testUser",
+			Password:           "testPassword",
+			CfServiceInstance:  "testInstance",
+			CfServiceKeyName:   "testKey",
+			CfServiceKeyConfig: "{\"scenario_id\":\"SAP_COM_0510\",\"type\":\"basic\"}",
+		}
+		error := runCloudFoundryCreateServiceKey(&config, &telemetryData, &execRunner)
+		if error == nil {
+			assert.Equal(t, "cf", execRunner.Calls[3].Exec)
+			assert.Equal(t, []string{"create-service-key", "testInstance", "testKey", "-c", "{\"scenario_id\":\"SAP_COM_0510\",\"type\":\"basic\"}"}, execRunner.Calls[3].Params)
+		}
+	})
 	t.Run("CF Logout: Success case", func(t *testing.T) {
 		error := cloudFoundryLogout(&execRunner)
 		if error == nil {
-			assert.Equal(t, "cf", execRunner.Calls[2].Exec)
-			assert.Equal(t, "logout", execRunner.Calls[2].Params[0])
+			assert.Equal(t, "cf", execRunner.Calls[4].Exec)
+			assert.Equal(t, "logout", execRunner.Calls[4].Params[0])
 		}
 	})
 }

--- a/documentation/docs/steps/cloudFoundryCreateServiceKey.md
+++ b/documentation/docs/steps/cloudFoundryCreateServiceKey.md
@@ -5,9 +5,9 @@
 ## Prerequisites
 
 * This step is for creating a Service Key for an existing Service in Cloud Foundry.
-* Cloud Foundry API endpoint, organization, space, user and service instance are available
+* Cloud Foundry API endpoint, Organization, Space, user and Service Instance are available
 * Credentials have been configured in Jenkins with a dedicated Id
-* Additionally you can set the optional serviceKeyConfig flag to configure the Service Key creation with your respective JSON configuration.
+* Additionally you can set the optional `serviceKeyConfig` flag to configure the Service Key creation with your respective JSON configuration. The JSON configuration can either be a JSON or the path a dedicated JSON configuration file containing the JSON configuration. If you chose a dedicated config file, it must be stored in a file that must be referenced in the `serviceKeyConfigFile` flag. You must store the file in the same folder as your `Jenkinsfile` that starts the Pipeline in order for the Pipeline to be able to find the file. Most favourable SCM is Git.
 
 ## ${docGenParameters}
 
@@ -15,20 +15,77 @@
 
 ## ${docJenkinsPluginDependencies}
 
-## Example
+## Examples
 
-The following example creates a service key named "myServiceKey" for the service instance "myServiceInstance" in the provided cloud foundry organization and space. For the service key creation, the serviceKeyConfig is used.
+The following examples will create a Service Key named "myServiceKey" for the Service Instance "myServiceInstance" in the provided Cloud Foundry Organization and Space. For the Service Key creation in these example, the serviceKeyConfig parameter is used. It will show the different ways of passing the JSON configuration, either via a string or the path to a file containing the JSON configuration.
+If you dont want to use a special configuration simply remove the parameter since it is optional.
+
+### Create Service Key with JSON config file in Jenkinsfile
+
+This example covers the parameters for a Jenkinsfile when using the cloudFoundryCreateServiceKey step. It uses a `serviceKeaConfig.json` file with valid JSON objects for creating a Cloud Foundry Service Key.
+
+```groovy
+cloudFoundryCreateServiceKey(
+  cfApiEndpoint: 'https://test.server.com',
+  cfCredentialsId: 'cfCredentialsId',
+  cfOrg: 'cfOrg',
+  cfSpace: 'cfSpace',
+  cfServiceInstance: 'myServiceInstance',
+  cfServiceKeyName: 'myServiceKey',
+  cfServiceKeyConfig: 'serviceKeyConfig.json',
+  script: this,
+)
+```
+
+The JSON config file, e.g. `serviceKeyConfig.json` can look like this:
+
+```json
+{
+  "example":"value",
+  "example":"value"
+}
+```
+
+### Create Service Key with JSON string in Jenkinsfile
+
+The following example covers the creation of a Cloud Foundry Service Key in a Jenkinsfile with using a JSON string as a config for the Service Key creation. If you use a Jenkinsfile for passing the parameter values you need to escape the double quotes in the JSON config string.
+
+```groovy
+cloudFoundryCreateServiceKey(
+  cfApiEndpoint: 'https://test.server.com',
+  cfCredentialsId: 'cfCredentialsId',
+  cfOrg: 'cfOrg',
+  cfSpace: 'cfSpace',
+  cfServiceInstance: 'myServiceInstance',
+  cfServiceKeyName: 'myServiceKey',
+  cfServiceKeyConfig: '{\"example\":\"value\",\"example\":\"value\"}',
+  script: this,
+)
+```
+
+### Create Service Key with JSON string as parameter in .pipeline/config.yml file
+
+If you chose to provide a `config.yml` file you can provide the parameters including the values in this file. You only need to set the script parameter when calling the step:
 
 ```groovy
 cloudFoundryCreateServiceKey(
   script: this,
-  cloudFoundry: [
-      apiEndpoint: 'https://test.server.com',
-      credentialsId: 'cfCredentialsId',
-      org: 'cfOrg',
-      space: 'cfSpace',
-      serviceInstance: 'myServiceInstance',
-      serviceKeyName: 'myServiceKey',
-      serviceKeyConfig: '{ \"key\" : \"value\" }'
-  ])
+)
 ```
+
+The `.pipeline/config.yml` has to contain the following parameters accordingly:
+
+```yaml
+steps:
+    cloudFoundryCreateServiceKey:
+        cfApiEndpoint: 'https://test.server.com'
+        cfOrg: 'testOrg'
+        cfSpace: 'testSpace'
+        cfServiceInstance: 'testInstance'
+        cfServiceKeyName: 'myServiceKey'
+        cfServiceKeyConfig: '{"example":"value","example":"value"}'
+        cfCredentialsId: 'cfCredentialsId'
+```
+
+When using a `.pipeline/config.yml` file you don't need to escape the double quotes in the JSON config string.
+You can also pass the path to a JSON config file in the `cfServiceKeyConfig` parameter. Example: `cfServiceKeyConfig: 'serviceKeyconfig.json'`

--- a/resources/metadata/cloudFoundryCreateServiceKey.yaml
+++ b/resources/metadata/cloudFoundryCreateServiceKey.yaml
@@ -62,7 +62,7 @@ spec:
           - name: cloudFoundry/space
       - name: cfServiceInstance
         type: string
-        description: Parameter of ServiceInstance Name to delete CloudFoundry Service
+        description: Parameter for CloudFoundry Service Instance Name
         scope:
         - PARAMETERS
         - STAGES
@@ -72,7 +72,7 @@ spec:
           - name: cloudFoundry/serviceInstance
       - name: cfServiceKeyName
         type: string
-        description: Parameter of CloudFoundry Service Key to be created
+        description: Parameter for Service Key name for CloudFoundry Service Key to be created
         scope:
         - PARAMETERS
         - STAGES
@@ -82,7 +82,7 @@ spec:
           - name: cloudFoundry/serviceKeyName
       - name: cfServiceKeyConfig
         type: string
-        description: Configuration for Service Key Creation
+        description: Path to JSON config file path or JSON in-line string for Cloud Foundry Service Key creation
         scope:
         - PARAMETERS
         - STAGES


### PR DESCRIPTION
# Changes
This change will no longer support in-line passing of JSON config as parameter for `cfCreateServiceKeyConfig`. Only passing the path to a JSON config file will be supported at the moment. This is mostly covered in tests and the documentation has been adapted accordingly. Passing the JSON config as in-line parameter will be supported in a later feature release with test coverage.

- [x] Tests
- [x] Documentation
