### PR TITLE
fix(sonar): do not fail on missing task report file

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -107,7 +107,7 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 	taskReport, err := SonarUtils.ReadTaskReport(sonar.workingDir)
 	if err != nil {
 		log.Entry().WithError(err).Warning("Unable to read Sonar task report file.")
-	}else{
+	} else {
 		// write links JSON
 		links := []StepResults.Path{
 			StepResults.Path{

--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -106,17 +106,17 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 	// load task results
 	taskReport, err := SonarUtils.ReadTaskReport(sonar.workingDir)
 	if err != nil {
-		return err
+		log.Entry().WithError(err).Warning("Unable to read Sonar task report file.")
+	}else{
+		// write links JSON
+		links := []StepResults.Path{
+			StepResults.Path{
+				Target: taskReport.DashboardURL,
+				Name:   "Sonar Web UI",
+			},
+		}
+		StepResults.PersistReportsAndLinks("sonarExecuteScan", sonar.workingDir, nil, links)
 	}
-	// write links JSON
-	links := []StepResults.Path{
-		StepResults.Path{
-			Target: taskReport.DashboardURL,
-			Name:   "Sonar Web UI",
-		},
-	}
-	StepResults.PersistReportsAndLinks("sonarExecuteScan", sonar.workingDir, nil, links)
-
 	return nil
 }
 


### PR DESCRIPTION
~~In some cases~~ When `legacyPRHandling` is used `sonar-scanner-cli` does not to write a `.scannerwork/report-task.txt` file, which lead to a *file not found* issue.

**changes:**
- prevents the step from failing if `.scannerwork/report-task.txt` is missing / could not be read