### PR TITLE
fix(telemetry): correct source URL for web reporting

### DIFF
--- a/.github/workflows/upload-go-master.yml
+++ b/.github/workflows/upload-go-master.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           go build -ldflags "-X github.com/SAP/jenkins-library/cmd.GitCommit=${GITHUB_SHA} \
                   -X github.com/SAP/jenkins-library/pkg/log.LibraryRepository=${GITHUB_REPOSITORY} \
-                  -X github.com/SAP/jenkins-library/pkg/telemetry.LibraryRepository=${GITHUB_REPOSITORY}" \
+                  -X github.com/SAP/jenkins-library/pkg/telemetry.LibraryRepository=https://github.com/${GITHUB_REPOSITORY}.git" \
             -o piper_master .
       - uses: SAP/project-piper-action@master
         with:


### PR DESCRIPTION
Telemetry reporting is failing (ignored) due to an incorrect source url.

**changes:**
- set the source url for telemetry reporting as `https://github.com/SAP/jenkins-library.git`