### PR TITLE
Drop cts use case from transport related steps

### DIFF
--- a/src/com/sap/piper/cm/BackendType.groovy
+++ b/src/com/sap/piper/cm/BackendType.groovy
@@ -1,5 +1,5 @@
 package com.sap.piper.cm
 
 public enum BackendType {
-    SOLMAN, CTS, RFC, NONE
+    SOLMAN, RFC, NONE
 }

--- a/src/com/sap/piper/cm/ChangeManagement.groovy
+++ b/src/com/sap/piper/cm/ChangeManagement.groovy
@@ -77,18 +77,6 @@ public class ChangeManagement implements Serializable {
         }
     }
 
-    String createTransportRequestCTS(Map docker, String transportType, String targetSystemId, String description, String endpoint, String credentialsId, String clientOpts = '') {
-        try {
-            def transportRequest = executeWithCredentials(BackendType.CTS, docker, endpoint, credentialsId, 'create-transport',
-                    ['-tt', transportType, '-ts', targetSystemId, '-d', "\"${description}\""],
-                    true,
-                    clientOpts)
-            return (transportRequest as String)?.trim()
-        }catch(AbortException e) {
-            throw new ChangeManagementException("Cannot create a transport request. $e.message.")
-        }
-    }
-
     String createTransportRequestSOLMAN(Map docker, String changeId, String developmentSystemId, String endpoint, String credentialsId, String clientOpts = '') {
 
         try {
@@ -166,35 +154,6 @@ public class ChangeManagement implements Serializable {
         if(rc != 0) {
             throw new ChangeManagementException(
                 "Cannot upload file into transport request. Return code from cm client: $rc.")
-        }
-    }
-
-    void uploadFileToTransportRequestCTS(
-        Map docker,
-        String transportRequestId,
-        String filePath,
-        String endpoint,
-        String credentialsId,
-        String cmclientOpts = '') {
-
-        def args = [
-                '-tID', transportRequestId,
-                "\"$filePath\""
-            ]
-
-        int rc = executeWithCredentials(
-            BackendType.CTS,
-            docker,
-            endpoint,
-            credentialsId,
-            'upload-file-to-transport',
-            args,
-            false,
-            cmclientOpts) as int
-
-        if(rc != 0) {
-            throw new ChangeManagementException(
-                "Cannot upload file into transport request. Return code from  cm client: $rc.")
         }
     }
 
@@ -293,10 +252,9 @@ public class ChangeManagement implements Serializable {
                     break
 
                 case BackendType.SOLMAN:
-                case BackendType.CTS:
 
                     if(! (args in Collection))
-                        throw new IllegalArgumentException("args expected as Collection for backend types ${[BackendType.SOLMAN, BackendType.CTS]}")
+                        throw new IllegalArgumentException("args expected as Collection for backend type ${BackendType.SOLMAN}")
 
                     shArgs.script = getCMCommandLine(type, endpoint, script.username, script.password,
                         command, args,
@@ -348,33 +306,6 @@ public class ChangeManagement implements Serializable {
             args,
             false,
             clientOpts) as int
-
-        if(rc != 0) {
-            throw new ChangeManagementException("Cannot release Transport Request '$transportRequestId'. Return code from cmclient: $rc.")
-        }
-    }
-
-    void releaseTransportRequestCTS(
-        Map docker,
-        String transportRequestId,
-        String endpoint,
-        String credentialsId,
-        String clientOpts = '') {
-
-        def cmd = 'export-transport'
-        def args = [
-            '-tID',
-            transportRequestId,
-        ]
-
-        int rc = executeWithCredentials(
-            BackendType.CTS,
-            docker,
-            endpoint,
-            credentialsId,
-            cmd,
-            args,
-            false) as int
 
         if(rc != 0) {
             throw new ChangeManagementException("Cannot release Transport Request '$transportRequestId'. Return code from cmclient: $rc.")

--- a/test/groovy/TransportRequestCreateTest.groovy
+++ b/test/groovy/TransportRequestCreateTest.groovy
@@ -159,59 +159,6 @@ public class TransportRequestCreateTest extends BasePiperTest {
     }
 
     @Test
-    public void createTransportRequestSuccessCTSTest() {
-
-        def result = [:]
-
-        ChangeManagement cm = new ChangeManagement(nullScript) {
-
-            String createTransportRequestCTS(
-                Map docker,
-                String transportType,
-                String targetSystemId,
-                String description,
-                String endpoint,
-                String credentialsId,
-                String clientOpts) {
-                result.docker = docker
-                result.transportType = transportType
-                result.targetSystemId = targetSystemId
-                result.description = description
-                result.endpoint = endpoint
-                result.credentialsId = credentialsId
-                result.clientOpts = clientOpts
-                return '001'
-            }
-        }
-
-        stepRule.step.call(script: nullScript,
-                        transportType: 'W',
-                        targetSystem: 'XYZ',
-                        description: 'desc',
-                        changeManagement: [type: 'CTS'],
-                        cmUtils: cm)
-
-        assert nullScript.commonPipelineEnvironment.getValue('transportRequestId') == '001'
-        assert result == [
-                         docker: [
-                             image: 'ppiper/cm-client',
-                             pullImage: true,
-                             envVars: [:],
-                             options: [],
-                         ],
-                         transportType: 'W',
-                         targetSystemId: 'XYZ',
-                         description: 'desc',
-                         endpoint: 'https://example.org/cm',
-                         credentialsId: 'CM',
-                         clientOpts: '-DmyProp=myVal'
-                         ]
-
-        assert loggingRule.log.contains("[INFO] Creating transport request.")
-        assert loggingRule.log.contains("[INFO] Transport Request '001' has been successfully created.")
-    }
-
-    @Test
     public void createTransportRequestSuccessRFCTest() {
 
         def result = [:]

--- a/test/groovy/TransportRequestReleaseTest.groovy
+++ b/test/groovy/TransportRequestReleaseTest.groovy
@@ -112,38 +112,6 @@ public class TransportRequestReleaseTest extends BasePiperTest {
     }
 
     @Test
-    public void releaseTransportRequestFailsCTSTest() {
-
-        thrown.expect(AbortException)
-        thrown.expectMessage("Something went wrong")
-
-        nullScript
-            .commonPipelineEnvironment
-                .configuration
-                    .general
-                        .changeManagement
-                            .type = 'CTS'
-
-        ChangeManagement cm = new ChangeManagement(nullScript) {
-
-            void releaseTransportRequestCTS(
-                                         Map docker,
-                                         String transportRequestId,
-                                         String endpoint,
-                                         String credentialsId,
-                                         String clientOpts) {
-
-                throw new ChangeManagementException('Something went wrong')
-            }
-        }
-
-        stepRule.step.transportRequestRelease(
-            script: nullScript,
-            transportRequestId: '001',
-            cmUtils: cm)
-    }
-
-    @Test
     public void releaseTransportRequestSuccessRFCTest() {
 
         def receivedParameters
@@ -214,59 +182,6 @@ public class TransportRequestReleaseTest extends BasePiperTest {
     }
 
     @Test
-    public void releaseTransportRequestSuccessCTSTest() {
-
-        def receivedParameters
-
-        nullScript
-            .commonPipelineEnvironment
-                .configuration
-                    .general
-                        .changeManagement =
-                            [
-                                credentialsId: 'CM',
-                                type: 'CTS',
-                                endpoint: 'https://example.org/cts'
-                            ]
-
-        ChangeManagement cm = new ChangeManagement(nullScript) {
-            void releaseTransportRequestCTS(
-                Map docker,
-                String transportRequestId,
-                String endpoint,
-                String credentialsId,
-                String clientOpts = '') {
-
-                receivedParameters = [
-                    docker: docker,
-                    transportRequestId: transportRequestId,
-                    endpoint: endpoint,
-                    credentialsId: credentialsId,
-                    clientOpts: clientOpts
-                ]
-            }
-        }
-
-        stepRule.step.transportRequestRelease(
-            script: nullScript,
-            transportRequestId: '002',
-            cmUtils: cm)
-
-        assert receivedParameters == [
-                    docker: [
-                        image:'ppiper/cm-client',
-                        options:[],
-                        envVars:[:],
-                        pullImage:true,
-                    ],
-                    transportRequestId: '002',
-                    endpoint: 'https://example.org/cts',
-                    credentialsId: 'CM',
-                    clientOpts: ''
-                ]
-    }
-
-    @Test
     public void releaseTransportRequestFailsRFCTest() {
 
         thrown.expect(AbortException)
@@ -330,24 +245,6 @@ public class TransportRequestReleaseTest extends BasePiperTest {
         stepRule.step.transportRequestRelease(
             script: nullScript,
             changeManagement: [type: 'SOLMAN']
-        )
-    }
-
-    @Test
-    public void releaseTransportRequestSanityChecksCTSTest() {
-
-        thrown.expect(IllegalArgumentException)
-        thrown.expectMessage(allOf(
-            containsString('ERROR - NO VALUE AVAILABLE FOR'),
-            containsString('changeManagement/endpoint')))
-
-        nullScript
-            .commonPipelineEnvironment
-                .configuration = null
-
-        stepRule.step.transportRequestRelease(
-            script: nullScript,
-            changeManagement: [type: 'CTS']
         )
     }
 

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -62,10 +62,6 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void changeDocumentIdNotProvidedSOLMANTest() {
 
-        // we expect the failure only for SOLMAN (which is the default).
-        // Use case for CTS without change document id is checked by the
-        // straight forward test case for CTS
-
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage("Change document id not provided (parameter: 'changeDocumentId' or via commit history).")
 
@@ -105,10 +101,6 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
     @Test
     public void applicationIdNotProvidedSOLMANTest() {
-
-        // we expect the failure only for SOLMAN (which is the default).
-        // Use case for CTS without applicationId is checked by the
-        // straight forward test case for CTS
 
         thrown.expect(IllegalArgumentException)
         thrown.expectMessage("ERROR - NO VALUE AVAILABLE FOR applicationId")
@@ -151,53 +143,6 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
                       applicationId: 'app',
                       filePath: '/path',
                       cmUtils: cm)
-    }
-
-    @Test
-    public void uploadFileToTransportRequestCTSSuccessTest() {
-
-        loggingRule.expect("[INFO] Uploading file '/path' to transport request '002'.")
-        loggingRule.expect("[INFO] File '/path' has been successfully uploaded to transport request '002'.")
-
-        ChangeManagement cm = new ChangeManagement(nullScript) {
-            void uploadFileToTransportRequestCTS(
-                                              Map docker,
-                                              String transportRequestId,
-                                              String filePath,
-                                              String endpoint,
-                                              String credentialsId,
-                                              String cmclientOpts) {
-
-                cmUtilReceivedParams.docker = docker
-                cmUtilReceivedParams.transportRequestId = transportRequestId
-                cmUtilReceivedParams.filePath = filePath
-                cmUtilReceivedParams.endpoint = endpoint
-                cmUtilReceivedParams.credentialsId = credentialsId
-                cmUtilReceivedParams.cmclientOpts = cmclientOpts
-            }
-        }
-
-        stepRule.step.transportRequestUploadFile(script: nullScript,
-                      changeManagement: [type: 'CTS'],
-                      transportRequestId: '002',
-                      filePath: '/path',
-                      cmUtils: cm)
-
-        assert cmUtilReceivedParams ==
-            [
-                docker: [
-                    image: 'ppiper/cm-client',
-                    options:[],
-                    envVars:[:],
-                    pullImage:true
-                ],
-                transportRequestId: '002',
-                filePath: '/path',
-                endpoint: 'https://example.org/cm',
-                credentialsId: 'CM',
-                cmclientOpts: ''
-            ]
-
     }
 
     @Test
@@ -541,7 +486,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void invalidBackendTypeTest() {
         thrown.expect(AbortException)
-        thrown.expectMessage('Invalid backend type: \'DUMMY\'. Valid values: [SOLMAN, CTS, RFC, NONE]. ' +
+        thrown.expectMessage('Invalid backend type: \'DUMMY\'. Valid values: [SOLMAN, RFC, NONE]. ' +
                              'Configuration: \'changeManagement/type\'.')
 
         stepRule.step.transportRequestUploadFile(script: nullScript,

--- a/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
+++ b/test/groovy/com/sap/piper/cm/ChangeManagementTest.groovy
@@ -240,31 +240,6 @@ public void testGetCommandLineWithCMClientOpts() {
     }
 
     @Test
-    public void testCreateTransportRequestCTSSucceeds() {
-
-        script.setReturnValue(JenkinsShellCallRule.Type.REGEX, 'cmclient.* -t CTS .*create-transport -tt W -ts XYZ -d "desc 123"$', '004')
-        def transportRequestId = new ChangeManagement(nullScript)
-            .createTransportRequestCTS(
-                [
-                    image: 'ppiper/cmclient',
-                    pullImage: true
-                ],
-                'W', // transport type
-                'XYZ', // target system
-                'desc 123', // description
-                'https://example.org/cm',
-                'me')
-
-        // the check for the transportRequestID is sufficient. This checks implicit the command line since that value is
-        // returned only in case the shell call matches.
-        assert transportRequestId == '004'
-
-        dockerExecuteRule.getDockerParams().dockerImage = 'ppiper/cmclient'
-        dockerExecuteRule.getDockerParams().dockerPullImage = true
-
-    }
-
-    @Test
     public void testUploadFileToTransportSucceedsSOLMAN() {
 
         // the regex provided below is an implicit check that the command line is fine.
@@ -288,29 +263,6 @@ public void testGetCommandLineWithCMClientOpts() {
         dockerExecuteRule.getDockerParams().dockerImage = 'ppiper/cmclient'
         dockerExecuteRule.getDockerParams().dockerPullImage = true
 
-    }
-
-    @Test
-    public void testUploadFileToTransportSucceedsCTS() {
-
-        // the regex provided below is an implicit check that the command line is fine.
-        script.setReturnValue(JenkinsShellCallRule.Type.REGEX, '-t CTS upload-file-to-transport -tID 002 "/path"', 0)
-
-        new ChangeManagement(nullScript).uploadFileToTransportRequestCTS(
-            [
-                image: 'ppiper/cmclient',
-                pullImage: true
-             ],
-            '002',
-            '/path',
-            'https://example.org/cm',
-            'me')
-
-        assert dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cmclient'
-        assert dockerExecuteRule.getDockerParams().dockerPullImage == true
-
-        // no assert for the shell command required here, since the regex registered
-        // above to the script rule is an implicit check for the command line.
     }
 
     @Test
@@ -424,29 +376,6 @@ public void testGetCommandLineWithCMClientOpts() {
 
         dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cm-client'
         dockerExecuteRule.getDockerParams().pullImage == true
-    }
-
-    @Test
-    public void testReleaseTransportRequestSucceedsCTS() {
-
-        // the regex provided below is an implicit check that the command line is fine.
-        script.setReturnValue(JenkinsShellCallRule.Type.REGEX, '-t CTS export-transport.*-tID 002', 0)
-
-        new ChangeManagement(nullScript).releaseTransportRequestCTS(
-            [
-                image: 'ppiper/cm-client',
-                pullImage: true,
-            ],
-            '002',
-            'https://example.org',
-            'me',
-            'openSesame')
-
-        // no assert required here, since the regex registered above to the script rule is an implicit check for
-        // the command line.
-
-        assert dockerExecuteRule.getDockerParams().dockerImage == 'ppiper/cm-client'
-        assert dockerExecuteRule.getDockerParams().dockerPullImage == true
     }
 
     @Test

--- a/vars/transportRequestCreate.groovy
+++ b/vars/transportRequestCreate.groovy
@@ -28,7 +28,7 @@ import hudson.AbortException
         /**
         * Defines where the transport request is created, e.g. SAP Solution Manager, ABAP System.
         * @parentConfigKey changeManagement
-        * @possibleValues `SOLMAN`, `CTS`, `RFC`
+        * @possibleValues `SOLMAN`, `RFC`
         */
         'type',
         /**
@@ -81,17 +81,9 @@ import hudson.AbortException
     */
     'developmentSystemId',
     /**
-    * The description of the transport request. Only for `CTS`.
+    * The description of the transport request.
     */
     'description',
-    /**
-    * The system receiving the transport request. Only for `CTS`.
-    */
-    'targetSystem',
-    /**
-    * Typically `W` (workbench) or `C` customizing. Only for `CTS`.
-    */
-    'transportType',
     /**
     * Provides additional details. Only for `RFC`.
     */
@@ -110,7 +102,7 @@ import hudson.AbortException
 * Creates
 *
 * * a Transport Request for a Change Document on the Solution Manager (type `SOLMAN`) or
-* * a Transport Request inside an ABAP system (type`CTS`)
+* * a Transport Request inside an ABAP system (type`RFC`)
 *
 * The id of the transport request is availabe via [commonPipelineEnvironment.getTransportRequestId()](commonPipelineEnvironment.md)
 */
@@ -146,9 +138,6 @@ void call(parameters = [:]) {
             .withMandatoryProperty('changeManagement/git/from')
             .withMandatoryProperty('changeManagement/git/to')
             .withMandatoryProperty('changeManagement/git/format')
-            .withMandatoryProperty('transportType', null, { backendType == BackendType.CTS})
-            .withMandatoryProperty('targetSystem', null, { backendType == BackendType.CTS})
-            .withMandatoryProperty('description', null, { backendType == BackendType.CTS})
             .withMandatoryProperty('changeManagement/rfc/developmentInstance', null, {backendType == BackendType.RFC})
             .withMandatoryProperty('changeManagement/rfc/developmentClient', null, {backendType == BackendType.RFC})
             .withMandatoryProperty('verbose', null, {backendType == BackendType.RFC})
@@ -187,16 +176,6 @@ void call(parameters = [:]) {
                         configuration.changeManagement.solman.docker,
                         configuration.changeDocumentId,
                         configuration.developmentSystemId,
-                        configuration.changeManagement.endpoint,
-                        configuration.changeManagement.credentialsId,
-                        configuration.changeManagement.clientOpts
-                    )
-                } else if(backendType == BackendType.CTS) {
-                    transportRequestId = cm.createTransportRequestCTS(
-                        configuration.changeManagement.cts.docker,
-                        configuration.transportType,
-                        configuration.targetSystem,
-                        configuration.description,
                         configuration.changeManagement.endpoint,
                         configuration.changeManagement.credentialsId,
                         configuration.changeManagement.clientOpts

--- a/vars/transportRequestRelease.groovy
+++ b/vars/transportRequestRelease.groovy
@@ -154,16 +154,6 @@ void call(parameters = [:]) {
                             configuration.changeManagement.clientOpts)
                         break
 
-                    case BackendType.CTS:
-
-                        cm.releaseTransportRequestCTS(
-                            configuration.changeManagement.cts.docker,
-                            configuration.transportRequestId,
-                            configuration.changeManagement.endpoint,
-                            configuration.changeManagement.credentialsId,
-                            configuration.changeManagement.clientOpts)
-                        break
-
                     case BackendType.RFC:
 
                         cm.releaseTransportRequestRFC(

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -27,7 +27,7 @@ import static com.sap.piper.cm.StepHelpers.getBackendTypeAndLogInfoIfCMIntegrati
         /**
         * Defines where the transport request is created, e.g. SAP Solution Manager, ABAP System.
         * @parentConfigKey changeManagement
-        * @possibleValues `SOLMAN`, `CTS`, `RFC`
+        * @possibleValues `SOLMAN`, `RFC`
         */
         'type',
         /**
@@ -83,7 +83,7 @@ import static com.sap.piper.cm.StepHelpers.getBackendTypeAndLogInfoIfCMIntegrati
         'applicationId', // SOLMAN
         'applicationDescription',
         /** The path of the file to upload.*/
-        'filePath', // SOLMAN, CTS
+        'filePath', // SOLMAN
         /** The URL where to find the UI5 package to upload to the transport request.  Only for `RFC`. */
         'applicationUrl', // RFC
         /** The ABAP package name of your application. */
@@ -134,7 +134,7 @@ void call(parameters = [:]) {
             .withMandatoryProperty('changeManagement/git/from')
             .withMandatoryProperty('changeManagement/git/to')
             .withMandatoryProperty('changeManagement/git/format')
-            .withMandatoryProperty('filePath', null, { backendType in [BackendType.SOLMAN, BackendType.CTS] })
+            .withMandatoryProperty('filePath', null, { backendType == BackendType.SOLMAN })
             .withMandatoryProperty('applicationUrl', null, { backendType == BackendType.RFC })
             .withMandatoryProperty('codePage', null, { backendType == BackendType.RFC })
             .withMandatoryProperty('acceptUnixStyleLineEndings', null, { backendType == BackendType.RFC })
@@ -200,15 +200,6 @@ void call(parameters = [:]) {
                             configuration.changeDocumentId,
                             configuration.transportRequestId,
                             configuration.applicationId,
-                            configuration.filePath,
-                            configuration.changeManagement.endpoint,
-                            configuration.changeManagement.credentialsId,
-                            configuration.changeManagement.clientOpts)
-                        break
-                    case BackendType.CTS:
-                        cm.uploadFileToTransportRequestCTS(
-                            configuration.changeManagement.cts?.docker ?: [:],
-                            configuration.transportRequestId,
                             configuration.filePath,
                             configuration.changeManagement.endpoint,
                             configuration.changeManagement.credentialsId,


### PR DESCRIPTION
It turned out that we can't support the CTS way when uploading files to a transport request. Hence removing that way. We have the remaining flavours SOLMAN and RFC.

This change is incompatible since it removes the CTS related way of creating a transport request, uploading files into a transport request and releasing a transport request. But since that way doesn't work anyway it is justified to be incompatible here.