### PR TITLE
Emergency fix: revert part of #1455

### DIFF
--- a/vars/artifactPrepareVersion.groovy
+++ b/vars/artifactPrepareVersion.groovy
@@ -14,7 +14,5 @@ void call(Map parameters = [:]) {
         [type: 'usernamePassword', id: 'gitHttpsCredentialsId', env: ['PIPER_username', 'PIPER_password']],
     ]
     parameters = DownloadCacheUtils.injectDownloadCacheInMavenParameters(script, parameters)
-    withEnv(["SSH_KNOWN_HOSTS=${env.JENKINS_HOME}/.ssh/known_hosts"]) {
-        piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
-    }
+    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes

setting SSH environment variable breaks step on JaaS.
In addition it made the step hardly dependent on Jenkins.

In case there is really something missing we need a proper solution here.
