### PR TITLE
Revert breaking change with #1455

### DIFF
--- a/resources/metadata/versioning.yaml
+++ b/resources/metadata/versioning.yaml
@@ -223,10 +223,6 @@ spec:
       aliases:
         - name: gitCredentialsId
           deprecated: true
-  containers:
-    - name: mvn
-      image: maven:3.6-jdk-8
-      imagePullPolicy: Never
   outputs:
     resources:
       - name: commonPipelineEnvironment


### PR DESCRIPTION
# Changes

container definition in #1455 broke existing behavior:
- maven execution by default without Docker to improve performance in a Kubernetes cluster
- `git repository required - none available` due to stashing in Kubernetes which does not include git context so far due to performance reasons

We need a proper solution in case we want to execute the maven versioning inside a Docker container:
- proper stashing in Kubernetes
- conditional Docker image (only for Maven case)
- maven execution in container only in case maven is not found locally since no build logic involved for versioning (only version retrieval and update)
