### PR TITLE
Dont dedup mvn flags

### DIFF
--- a/cmd/mavenExecute.go
+++ b/cmd/mavenExecute.go
@@ -24,9 +24,9 @@ func runMavenExecute(config mavenExecuteOptions, runner execRunner) error {
 		ProjectSettingsFile:         config.ProjectSettingsFile,
 		GlobalSettingsFile:          config.GlobalSettingsFile,
 		M2Path:                      config.M2Path,
-		Goals:                       splitTrimAndDeDupParams(config.Goals),
-		Defines:                     splitTrimAndDeDupParams(config.Defines),
-		Flags:                       splitTrimAndDeDupParams(config.Flags),
+		Goals:                       splitAndTrimParams(config.Goals),
+		Defines:                     splitAndTrimParams(config.Defines),
+		Flags:                       splitAndTrimParams(config.Flags),
 		LogSuccessfulMavenTransfers: config.LogSuccessfulMavenTransfers,
 		ReturnStdout:                config.ReturnStdout,
 	}
@@ -38,6 +38,8 @@ func runMavenExecute(config mavenExecuteOptions, runner execRunner) error {
 	return err
 }
 
-func splitTrimAndDeDupParams(params []string) []string {
-	return sliceUtils.SplitTrimAndDeDup(params, " ")
+// We *must not* deduplicate the parameters here as this will break commands such as `mvn -pl a -pl b`,
+// which would become `mvn -pl a b` which is invalid
+func splitAndTrimParams(params []string) []string {
+	return sliceUtils.SplitAndTrim(params, " ")
 }

--- a/pkg/piperutils/slices.go
+++ b/pkg/piperutils/slices.go
@@ -54,9 +54,9 @@ func Trim(in []string) (out []string) {
 	return
 }
 
-// SplitTrimAndDeDup iterates over the strings in the given slice and splits each on the provided separator.
-// Each resulting sub-string is then a separate entry in the returned array. Duplicate and empty entries are eliminated.
-func SplitTrimAndDeDup(in []string, separator string) (out []string) {
+// SplitAndTrim iterates over the strings in the given slice and splits each on the provided separator.
+// Each resulting sub-string is then a separate entry in the returned array.
+func SplitAndTrim(in []string, separator string) (out []string) {
 	if len(in) == 0 {
 		return in
 	}
@@ -64,7 +64,7 @@ func SplitTrimAndDeDup(in []string, separator string) (out []string) {
 		entryParts := strings.Split(entry, separator)
 		for _, part := range entryParts {
 			part = strings.TrimSpace(part)
-			if part != "" && !ContainsString(out, part) {
+			if part != "" {
 				out = append(out, part)
 			}
 		}

--- a/pkg/piperutils/slices_test.go
+++ b/pkg/piperutils/slices_test.go
@@ -69,33 +69,33 @@ func TestSplitTrimAndDeDup(t *testing.T) {
 		// init
 		s := []string{" a", "", "-a-b --c ", "d-e", "f", " f", ""}
 		// test
-		s = SplitTrimAndDeDup(s, "-")
+		s = SplitAndTrim(s, "-")
 		// assert
-		assert.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, s)
+		assert.Equal(t, []string{"a", "a", "b", "c", "d", "e", "f", "f"}, s)
 	})
 	t.Run("Separator is space", func(t *testing.T) {
 		// init
 		s := []string{" a", " a b  c ", "d e", "f", "f ", ""}
 		// test
-		s = SplitTrimAndDeDup(s, " ")
+		s = SplitAndTrim(s, " ")
 		// assert
-		assert.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, s)
+		assert.Equal(t, []string{"a", "a", "b", "c", "d", "e", "f", "f"}, s)
 	})
 	t.Run("Separator is multi-char", func(t *testing.T) {
 		// init
 		s := []string{" a", " a** b**c ", "**d **e", "f**", "f ", ""}
 		// test
-		s = SplitTrimAndDeDup(s, "**")
+		s = SplitAndTrim(s, "**")
 		// assert
-		assert.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, s)
+		assert.Equal(t, []string{"a", "a", "b", "c", "d", "e", "f", "f"}, s)
 	})
 	t.Run("Separator is empty string", func(t *testing.T) {
 		// init
 		s := []string{" a", " a bc ", "d e", "f", "f ", ""}
 		// test
-		s = SplitTrimAndDeDup(s, "")
+		s = SplitAndTrim(s, "")
 		// assert
 		// If "sep" is empty, underlying strings.Split() splits after each UTF-8 char sequence.
-		assert.Equal(t, []string{"a", "b", "c", "d", "e", "f"}, s)
+		assert.Equal(t, []string{"a", "a", "b", "c", "d", "e", "f", "f"}, s)
 	})
 }


### PR DESCRIPTION
# Changes

In the current implementation we end up with a command containing `-pl !integration-tests !unit-tests` which is not valid syntax for maven. We need the second `-pl` which is the reason that we must not de-duplicate.
