### PR TITLE
Fix nexus upload to pass correct environment variable

### DIFF
--- a/vars/nexusUpload.groovy
+++ b/vars/nexusUpload.groovy
@@ -12,6 +12,6 @@ void call(Map parameters = [:]) {
     final script = checkScript(this, parameters) ?: this
     parameters = DownloadCacheUtils.injectDownloadCacheInMavenParameters(script, parameters)
 
-    List credentials = [[type: 'usernamePassword', id: 'nexusCredentialsId', env: ['PIPER_username', 'PIPER_password']]]
+    List credentials = [[type: 'usernamePassword', id: 'nexusCredentialsId', env: ['PIPER_user', 'PIPER_password']]]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes
Fix name of environment variable as nexusUpload parameter is called user instead of username:
https://github.com/SAP/jenkins-library/blob/master/cmd/nexusUpload_generated.go#L103

- [ ] Tests
- [ ] Documentation
