### PR TITLE
fix(sonar): remove .sonar-scanner and .certificates folder after scan

### DIFF
--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -56,24 +56,28 @@ void call(Map parameters = [:]) {
                 environment.add("PIPER_changeBranch=${env.CHANGE_BRANCH}")
                 environment.add("PIPER_changeTarget=${env.CHANGE_TARGET }")
             }
-            // load certificates into cacerts file
-            loadCertificates(customTlsCertificateLinks: stepConfig.customTlsCertificateLinks, verbose: stepConfig.verbose)
-            // execute step
-            dockerExecute(
-                script: script,
-                dockerImage: config.dockerImage,
-                dockerWorkspace: config.dockerWorkspace,
-                dockerOptions: config.dockerOptions
-            ) {
-                if(!fileExists('.git')) utils.unstash('git')
-                withSonarQubeEnv(stepConfig.instance) {
-                    withCredentials(credentials) {
-                        withEnv(environment){
-                            sh "./piper ${STEP_NAME}${customDefaultConfig}${customConfigArg}"
+            try {
+                // load certificates into cacerts file
+                loadCertificates(customTlsCertificateLinks: stepConfig.customTlsCertificateLinks, verbose: stepConfig.verbose)
+                // execute step
+                dockerExecute(
+                    script: script,
+                    dockerImage: config.dockerImage,
+                    dockerWorkspace: config.dockerWorkspace,
+                    dockerOptions: config.dockerOptions
+                ) {
+                    if(!fileExists('.git')) utils.unstash('git')
+                    withSonarQubeEnv(stepConfig.instance) {
+                        withCredentials(credentials) {
+                            withEnv(environment){
+                                sh "./piper ${STEP_NAME}${customDefaultConfig}${customConfigArg}"
+                            }
                         }
                     }
+                    jenkinsUtils.handleStepResults(STEP_NAME, false, false)
                 }
-                jenkinsUtils.handleStepResults(STEP_NAME, false, false)
+            } finally {
+                def ignore = sh script: 'rm -rf .sonar-scanner .certificates', returnStatus: true
             }
         }
     }


### PR DESCRIPTION
fixes #1449

**changes:**
- remove `.sonar-scanner` and `.certificates` folder after scan

[review without whitespace changes](https://github.com/SAP/jenkins-library/pull/1481/files?diff=split&w=1)