### PR TITLE
artifactPrepareVersion: additional options

### DIFF
--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -179,6 +179,11 @@ func getGitCommitID(repository gitRepository) (plumbing.Hash, error) {
 func versioningTemplate(scheme string) (string, error) {
 	// generally: timestamp acts as build number providing a proper order
 	switch scheme {
+	case "docker":
+		// from Docker documentation:
+		// A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
+		// A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+		return "{{.Version}}{{if .Timestamp}}-{{.Timestamp}}{{if .CommitID}}-{{.CommitID}}{{end}}{{end}}", nil
 	case "maven":
 		// according to https://www.mojohaus.org/versions-maven-plugin/version-rules.html
 		return "{{.Version}}{{if .Timestamp}}-{{.Timestamp}}{{if .CommitID}}_{{.CommitID}}{{end}}{{end}}", nil

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -78,10 +78,7 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 		VersionField:        config.CustomVersionField,
 		VersionSection:      config.CustomVersionSection,
 		VersioningScheme:    config.CustomVersioningScheme,
-	}
-
-	if config.BuildTool == "docker" {
-		artifactOpts.VersionSource = config.DockerVersionSource
+		VersionSource:       config.DockerVersionSource,
 	}
 
 	var err error
@@ -121,7 +118,7 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 
 		now := time.Now()
 
-		newVersion, err = calculateNewVersion(versioningTempl, version, gitCommitID, config.IncludeCommitID, now)
+		newVersion, err = calculateNewVersion(versioningTempl, version, gitCommitID, config.IncludeCommitID, config.ShortCommitID, config.UnixTimestamp, now)
 		if err != nil {
 			return errors.Wrap(err, "failed to calculate new version")
 		}
@@ -195,10 +192,15 @@ func versioningTemplate(scheme string) (string, error) {
 	return "", fmt.Errorf("versioning scheme '%v' not supported", scheme)
 }
 
-func calculateNewVersion(versioningTemplate, currentVersion, commitID string, includeCommitID bool, t time.Time) (string, error) {
+func calculateNewVersion(versioningTemplate, currentVersion, commitID string, includeCommitID, shortCommitID, unixTimestamp bool, t time.Time) (string, error) {
 	tmpl, err := template.New("version").Parse(versioningTemplate)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create version template: %v", versioningTemplate)
+	}
+
+	timestamp := t.Format("20060102150405")
+	if unixTimestamp {
+		timestamp = fmt.Sprint(t.Unix())
 	}
 
 	buf := new(bytes.Buffer)
@@ -208,11 +210,14 @@ func calculateNewVersion(versioningTemplate, currentVersion, commitID string, in
 		CommitID  string
 	}{
 		Version:   currentVersion,
-		Timestamp: t.Format("20060102150405"),
+		Timestamp: timestamp,
 	}
 
 	if includeCommitID {
 		versionParts.CommitID = commitID
+		if shortCommitID {
+			versionParts.CommitID = commitID[0:7]
+		}
 	}
 
 	err = tmpl.Execute(buf, versionParts)

--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -28,7 +28,9 @@ type artifactPrepareVersionOptions struct {
 	M2Path                 string `json:"m2Path,omitempty"`
 	Password               string `json:"password,omitempty"`
 	ProjectSettingsFile    string `json:"projectSettingsFile,omitempty"`
+	ShortCommitID          bool   `json:"shortCommitId,omitempty"`
 	TagPrefix              string `json:"tagPrefix,omitempty"`
+	UnixTimestamp          bool   `json:"unixTimestamp,omitempty"`
 	Username               string `json:"username,omitempty"`
 	VersioningTemplate     string `json:"versioningTemplate,omitempty"`
 	VersioningType         string `json:"versioningType,omitempty"`
@@ -195,7 +197,9 @@ func addArtifactPrepareVersionFlags(cmd *cobra.Command, stepConfig *artifactPrep
 	cmd.Flags().StringVar(&stepConfig.M2Path, "m2Path", os.Getenv("PIPER_m2Path"), "Maven only - Path to the location of the local repository that should be used.")
 	cmd.Flags().StringVar(&stepConfig.Password, "password", os.Getenv("PIPER_password"), "Password/token for git authentication.")
 	cmd.Flags().StringVar(&stepConfig.ProjectSettingsFile, "projectSettingsFile", os.Getenv("PIPER_projectSettingsFile"), "Maven only - Path to the mvn settings file that should be used as project settings file.")
+	cmd.Flags().BoolVar(&stepConfig.ShortCommitID, "shortCommitId", false, "Defines if a short version of the commitId should be used. GitHub format is used (first 7 characters).")
 	cmd.Flags().StringVar(&stepConfig.TagPrefix, "tagPrefix", "build_", "Defines the prefix which is used for the git tag which is written during the versioning run (only `versioningType: cloud`).")
+	cmd.Flags().BoolVar(&stepConfig.UnixTimestamp, "unixTimestamp", false, "Defines if the Unix timestamp number should be used as build number instead of the standard date format.")
 	cmd.Flags().StringVar(&stepConfig.Username, "username", os.Getenv("PIPER_username"), "User name for git authentication")
 	cmd.Flags().StringVar(&stepConfig.VersioningTemplate, "versioningTemplate", os.Getenv("PIPER_versioningTemplate"), "DEPRECATED: Defines the template for the automatic version which will be created")
 	cmd.Flags().StringVar(&stepConfig.VersioningType, "versioningType", "cloud", "Defines the type of versioning (`cloud`: fully automatic, `cloud_noTag`: automatic but no tag created, `library`: manual)")
@@ -310,10 +314,26 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
+						Name:        "shortCommitId",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
 						Name:        "tagPrefix",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "unixTimestamp",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 					},

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -441,16 +441,20 @@ func TestCalculateNewVersion(t *testing.T) {
 	tt := []struct {
 		versioningTemplate string
 		includeCommitID    bool
+		shortCommitID      bool
+		unixTimestamp      bool
 		expected           string
 		expectedErr        string
 	}{
 		{versioningTemplate: "", expectedErr: "failed calculate version, new version is ''"},
 		{versioningTemplate: "{{.Version}}{{if .Timestamp}}-{{.Timestamp}}{{if .CommitID}}+{{.CommitID}}{{end}}{{end}}", expected: "1.2.3-20200101000000"},
 		{versioningTemplate: "{{.Version}}{{if .Timestamp}}-{{.Timestamp}}{{if .CommitID}}+{{.CommitID}}{{end}}{{end}}", includeCommitID: true, expected: "1.2.3-20200101000000+428ecf70bc22df0ba3dcf194b5ce53e769abab07"},
+		{versioningTemplate: "{{.Version}}{{if .Timestamp}}-{{.Timestamp}}{{if .CommitID}}+{{.CommitID}}{{end}}{{end}}", includeCommitID: true, shortCommitID: true, expected: "1.2.3-20200101000000+428ecf7"},
+		{versioningTemplate: "{{.Version}}{{if .Timestamp}}-{{.Timestamp}}{{if .CommitID}}+{{.CommitID}}{{end}}{{end}}", includeCommitID: true, unixTimestamp: true, expected: "1.2.3-1577836800+428ecf70bc22df0ba3dcf194b5ce53e769abab07"},
 	}
 
 	for _, test := range tt {
-		version, err := calculateNewVersion(test.versioningTemplate, currentVersion, commitID, test.includeCommitID, testTime)
+		version, err := calculateNewVersion(test.versioningTemplate, currentVersion, commitID, test.includeCommitID, test.shortCommitID, test.unixTimestamp, testTime)
 		assert.Equal(t, test.expected, version)
 		if len(test.expectedErr) == 0 {
 			assert.NoError(t, err)

--- a/pkg/versioning/docker.go
+++ b/pkg/versioning/docker.go
@@ -12,14 +12,15 @@ import (
 
 // Docker defines an artifact based on a Dockerfile
 type Docker struct {
-	artifact      Artifact
-	content       []byte
-	execRunner    mavenExecRunner
-	options       *Options
-	path          string
-	versionSource string
-	readFile      func(string) ([]byte, error)
-	writeFile     func(string, []byte, os.FileMode) error
+	artifact         Artifact
+	content          []byte
+	execRunner       mavenExecRunner
+	options          *Options
+	path             string
+	versionSource    string
+	versioningScheme string
+	readFile         func(string) ([]byte, error)
+	writeFile        func(string, []byte, os.FileMode) error
 }
 
 func (d *Docker) init() {
@@ -40,7 +41,10 @@ func (d *Docker) initDockerfile() {
 
 // VersioningScheme returns the relevant versioning scheme
 func (d *Docker) VersioningScheme() string {
-	return "maven"
+	if len(d.versioningScheme) == 0 {
+		return "docker"
+	}
+	return d.versioningScheme
 }
 
 // GetVersion returns the current version of the artifact

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -53,10 +53,11 @@ func GetArtifact(buildTool, buildDescriptorFilePath string, opts *Options, execR
 		}
 	case "docker":
 		artifact = &Docker{
-			execRunner:    execRunner,
-			options:       opts,
-			path:          buildDescriptorFilePath,
-			versionSource: opts.VersionSource,
+			execRunner:       execRunner,
+			options:          opts,
+			path:             buildDescriptorFilePath,
+			versionSource:    opts.VersionSource,
+			versioningScheme: opts.VersioningScheme,
 		}
 	case "dub":
 		if len(buildDescriptorFilePath) == 0 {

--- a/pkg/versioning/versioning_test.go
+++ b/pkg/versioning/versioning_test.go
@@ -30,7 +30,7 @@ func TestGetArtifact(t *testing.T) {
 		assert.Equal(t, "test.ini", theType.path)
 		assert.Equal(t, "theversion", theType.options.VersionField)
 		assert.Equal(t, "test", theType.options.VersionSection)
-		assert.Equal(t, "maven", docker.VersioningScheme())
+		assert.Equal(t, "docker", docker.VersioningScheme())
 	})
 
 	t.Run("dub", func(t *testing.T) {

--- a/resources/metadata/versioning.yaml
+++ b/resources/metadata/versioning.yaml
@@ -183,6 +183,13 @@ spec:
           - STEPS
           - STAGES
           - PARAMETERS
+      - name: shortCommitId
+        type: bool
+        description: Defines if a short version of the commitId should be used. GitHub format is used (first 7 characters).
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
       - name: tagPrefix
         type: string
         description: "Defines the prefix which is used for the git tag which is written during the versioning run (only `versioningType: cloud`)."
@@ -191,6 +198,13 @@ spec:
         - STAGES
         - STEPS
         default: build_
+      - name: unixTimestamp
+        type: bool
+        description: Defines if the Unix timestamp number should be used as build number instead of the standard date format.
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
       - name: username
         type: string
         description: User name for git authentication


### PR DESCRIPTION
# Changes
it is now possible to use
* a Unix timestamp number (instead of `YYYYMMDDHHMMss`)
* a short commit hash

for the automatically created version.

In addition a dedicated versioning scheme for Docker `docker` has been added instead of "misusing" `maven` 