### PR TITLE
Provide error message in log

### DIFF
--- a/cmd/gctsCreateRepository.go
+++ b/cmd/gctsCreateRepository.go
@@ -30,7 +30,7 @@ func gctsCreateRepository(config gctsCreateRepositoryOptions, telemetryData *tel
 	// error situations should stop execution through log.Entry().Fatal() call which leads to an os.Exit(1) in the end
 	err := createRepository(&config, telemetryData, &c, httpClient)
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: '%s'", err.Error())
 	}
 }
 

--- a/cmd/malwareExecuteScan.go
+++ b/cmd/malwareExecuteScan.go
@@ -46,7 +46,7 @@ func malwareExecuteScan(config malwareExecuteScanOptions, telemetryData *telemet
 	// error situations should stop execution through log.Entry().Fatal() call which leads to an os.Exit(1) in the end
 	err := runMalwareScan(&config, telemetryData, &c, httpClient)
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: '%s'", err.Error())
 	}
 }
 

--- a/cmd/mavenBuild.go
+++ b/cmd/mavenBuild.go
@@ -18,7 +18,7 @@ func mavenBuild(config mavenBuildOptions, telemetryData *telemetry.CustomData) {
 
 	err := runMavenBuild(&config, telemetryData, &c, &utils)
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: '%s'", err.Error())
 	}
 }
 

--- a/cmd/mavenExecute.go
+++ b/cmd/mavenExecute.go
@@ -15,7 +15,7 @@ func mavenExecute(config mavenExecuteOptions, _ *telemetry.CustomData) {
 	runner := command.Command{}
 	err := runMavenExecute(config, &runner)
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: '%s'", err.Error())
 	}
 }
 

--- a/cmd/mavenExecuteStaticCodeChecks.go
+++ b/cmd/mavenExecuteStaticCodeChecks.go
@@ -14,7 +14,7 @@ func mavenExecuteStaticCodeChecks(config mavenExecuteStaticCodeChecksOptions, te
 	c.Stderr(log.Writer())
 	err := runMavenStaticCodeChecks(&config, telemetryData, &c)
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: '%s'", err.Error())
 	}
 }
 

--- a/cmd/nexusUpload.go
+++ b/cmd/nexusUpload.go
@@ -128,7 +128,7 @@ func nexusUpload(options nexusUploadOptions, _ *telemetry.CustomData) {
 
 	err := runNexusUpload(utils, &uploader, &options)
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: '%s'", err.Error())
 	}
 }
 

--- a/cmd/npmExecuteScripts.go
+++ b/cmd/npmExecuteScripts.go
@@ -56,7 +56,7 @@ func npmExecuteScripts(config npmExecuteScriptsOptions, telemetryData *telemetry
 
 	err := runNpmExecuteScripts(&utils, &config)
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: '%s'", err.Error())
 	}
 }
 func runNpmExecuteScripts(utils npmExecuteScriptsUtilsInterface, options *npmExecuteScriptsOptions) error {

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -197,7 +197,7 @@ func {{.StepName}}(config {{ .StepName }}Options, telemetryData *telemetry.Custo
 	// error situations should stop execution through log.Entry().Fatal() call which leads to an os.Exit(1) in the end
 	err := run{{.StepName | title}}(&config, telemetryData, &c{{ range $notused, $oRes := .OutputResources}}, &{{ index $oRes "name" }}{{ end }})
 	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
+		log.Entry().WithError(err).Fatalf("step execution failed: %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
Currently we fail with a generic error message without more details about the
error which has been raised. The log message is created using 'WithError(err)'
but this does not result in any error details visible in the log message, neither with
verbose mode nor without.

Remarks / Questions

- already existing steps are apparently not updated. I guess we have to add this for existing steps manually (?)
- I would expect that `withError(err)` results in some error details in the log message. This is apparently not the case. What is the reason for the `withError`?
