### PR TITLE
fix(versioning): commit only modified files

### DIFF
--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -34,7 +34,6 @@ type gitRepository interface {
 }
 
 type gitWorktree interface {
-	Add(string) (plumbing.Hash, error)
 	Checkout(*git.CheckoutOptions) error
 	Commit(string, *git.CommitOptions) (plumbing.Hash, error)
 }

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -340,13 +340,8 @@ func pushChanges(config *artifactPrepareVersionOptions, newVersion string, repos
 }
 
 func addAndCommit(config *artifactPrepareVersionOptions, worktree gitWorktree, newVersion string, t time.Time) (plumbing.Hash, error) {
-	_, err := worktree.Add(".")
-	if err != nil {
-		return plumbing.Hash{}, errors.Wrap(err, "failed to execute 'git add .'")
-	}
-
 	//maybe more options are required: https://github.com/go-git/go-git/blob/master/_examples/commit/main.go
-	commit, err := worktree.Commit(fmt.Sprintf("update version %v", newVersion), &git.CommitOptions{Author: &object.Signature{Name: config.CommitUserName, When: t}})
+	commit, err := worktree.Commit(fmt.Sprintf("update version %v", newVersion), &git.CommitOptions{All: true, Author: &object.Signature{Name: config.CommitUserName, When: t}})
 	if err != nil {
 		return commit, errors.Wrap(err, "failed to commit new version")
 	}

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -131,8 +131,6 @@ func (r *gitRepositoryMock) Worktree() (*git.Worktree, error) {
 }
 
 type gitWorktreeMock struct {
-	addPath       string
-	addError      string
 	checkoutError string
 	checkoutOpts  *git.CheckoutOptions
 	commitHash    plumbing.Hash
@@ -141,13 +139,6 @@ type gitWorktreeMock struct {
 	commitError   string
 }
 
-func (w *gitWorktreeMock) Add(path string) (plumbing.Hash, error) {
-	if len(w.addError) > 0 {
-		return plumbing.Hash{}, fmt.Errorf(w.addError)
-	}
-	w.addPath = path
-	return plumbing.Hash{}, nil
-}
 func (w *gitWorktreeMock) Checkout(opts *git.CheckoutOptions) error {
 	if len(w.checkoutError) > 0 {
 		return fmt.Errorf(w.checkoutError)
@@ -407,7 +398,7 @@ func TestRunArtifactPrepareVersion(t *testing.T) {
 			versioningScheme: "maven",
 		}
 
-		worktree := gitWorktreeMock{addError: "add error"}
+		worktree := gitWorktreeMock{}
 		repo := gitRepositoryMock{}
 
 		err := runArtifactPrepareVersion(&config, &telemetry.CustomData{}, nil, &versioningMock, nil, &repo, func(r gitRepository) (gitWorktree, error) { return &worktree, nil })

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -488,7 +488,7 @@ func TestPushChanges(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "428ecf70bc22df0ba3dcf194b5ce53e769abab07", commitID)
 		assert.Equal(t, "update version 1.2.3", worktree.commitMsg)
-		assert.Equal(t, &git.CommitOptions{Author: &object.Signature{Name: "Project Piper", When: testTime}}, worktree.commitOpts)
+		assert.Equal(t, &git.CommitOptions{All: true, Author: &object.Signature{Name: "Project Piper", When: testTime}}, worktree.commitOpts)
 		assert.Equal(t, "1.2.3", repo.tag)
 		assert.Equal(t, "428ecf70bc22df0ba3dcf194b5ce53e769abab07", repo.tagHash.String())
 		assert.Equal(t, &git.PushOptions{RefSpecs: []gitConfig.RefSpec{"refs/tags/1.2.3:refs/tags/1.2.3"}, Auth: &http.BasicAuth{Username: config.Username, Password: config.Password}}, repo.pushOptions)
@@ -507,7 +507,7 @@ func TestPushChanges(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "428ecf70bc22df0ba3dcf194b5ce53e769abab07", commitID)
 		assert.Equal(t, "update version 1.2.3", worktree.commitMsg)
-		assert.Equal(t, &git.CommitOptions{Author: &object.Signature{Name: "Project Piper", When: testTime}}, worktree.commitOpts)
+		assert.Equal(t, &git.CommitOptions{All: true, Author: &object.Signature{Name: "Project Piper", When: testTime}}, worktree.commitOpts)
 		assert.Equal(t, "1.2.3", repo.tag)
 		assert.Equal(t, "428ecf70bc22df0ba3dcf194b5ce53e769abab07", repo.tagHash.String())
 		assert.Equal(t, &git.PushOptions{RefSpecs: []gitConfig.RefSpec{"refs/tags/1.2.3:refs/tags/1.2.3"}, Auth: &ssh.PublicKeysCallback{}}, repo.pushOptions)
@@ -529,16 +529,6 @@ func TestPushChanges(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "428ecf70bc22df0ba3dcf194b5ce53e769abab07", commitID)
 		assert.Equal(t, &git.PushOptions{RefSpecs: []gitConfig.RefSpec{"refs/tags/1.2.3:refs/tags/1.2.3"}, Auth: &ssh.PublicKeysCallback{}}, repo.pushOptions)
-	})
-
-	t.Run("error - git add", func(t *testing.T) {
-		config := artifactPrepareVersionOptions{}
-		repo := gitRepositoryMock{}
-		worktree := gitWorktreeMock{addError: "add error", commitHash: plumbing.ComputeHash(plumbing.CommitObject, []byte{1, 2, 3})}
-
-		commitID, err := pushChanges(&config, newVersion, &repo, &worktree, testTime)
-		assert.Equal(t, "0000000000000000000000000000000000000000", commitID)
-		assert.EqualError(t, err, "failed to execute 'git add .': add error")
 	})
 
 	t.Run("error - commit", func(t *testing.T) {


### PR DESCRIPTION
replaces #1544 
fixes #1537

> // All automatically stage files that have been modified and deleted, but
// new files you have not told Git about are not affected.
All bool