### PR TITLE
Fix: Execute ABAP run ATC check test in temp folder

### DIFF
--- a/cmd/abapEnvironmentRunATCCheck_test.go
+++ b/cmd/abapEnvironmentRunATCCheck_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -194,6 +196,18 @@ func TestGetResultATCRun(t *testing.T) {
 
 func TestParseATCResult(t *testing.T) {
 	t.Run("succes case: test parsing example XML result", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "test get result ATC run")
+		if err != nil {
+			t.Fatal("Failed to create temporary directory")
+		}
+		oldCWD, _ := os.Getwd()
+		_ = os.Chdir(dir)
+		// clean up tmp dir
+		defer func() {
+			_ = os.Chdir(oldCWD)
+			_ = os.RemoveAll(dir)
+		}()
+
 		bodyString := `<?xml version="1.0" encoding="UTF-8"?>
 		<checkstyle>
 			<file name="testFile">
@@ -209,7 +223,7 @@ func TestParseATCResult(t *testing.T) {
 		</checkstyle>`
 		body := []byte(bodyString)
 
-		err := parseATCResult(body)
+		err = parseATCResult(body)
 		assert.Equal(t, nil, err)
 	})
 	t.Run("failure case: parsing empty xml", func(t *testing.T) {


### PR DESCRIPTION
# Changes

Execute the test in a temp folder in order to keep project clean.
