### PR TITLE
Remove option to use JENKINS_JNLP_IMAGE to configure jnlp image

### DIFF
--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -471,6 +471,30 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
     }
 
     @Test
+    void testDockerExecuteOnKubernetesCustomJnlpViaConfig() {
+
+        nullScript.commonPipelineEnvironment.configuration = [
+            general: [jenkinsKubernetes: [jnlpAgent: 'config/jnlp:latest']]
+        ]
+        //binding.variables.env.JENKINS_JNLP_IMAGE = 'config/jnlp:latest'
+        stepRule.step.dockerExecuteOnKubernetes(
+            script: nullScript,
+            juStabUtils: utils,
+            dockerImage: 'maven:3.5-jdk-8-alpine',
+        ) { bodyExecuted = true }
+        assertTrue(bodyExecuted)
+
+        assertThat(containersList, allOf(
+            hasItem('jnlp'),
+            hasItem('container-exec')
+        ))
+        assertThat(imageList, allOf(
+            hasItem('config/jnlp:latest'),
+            hasItem('maven:3.5-jdk-8-alpine'),
+        ))
+    }
+
+    @Test
     void testDockerExecuteOnKubernetesExecutionFails() {
 
         thrown.expect(AbortException)
@@ -479,7 +503,7 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
         nullScript.commonPipelineEnvironment.configuration = [
             general: [jenkinsKubernetes: [jnlpAgent: 'config/jnlp:latest']]
         ]
-
+        //binding.variables.env.JENKINS_JNLP_IMAGE = 'config/jnlp:latest'
         stepRule.step.dockerExecuteOnKubernetes(
             script: nullScript,
             juStabUtils: utils,

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -471,30 +471,6 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
     }
 
     @Test
-    void testDockerExecuteOnKubernetesCustomJnlpViaConfig() {
-
-        nullScript.commonPipelineEnvironment.configuration = [
-            general: [jenkinsKubernetes: [jnlpAgent: 'config/jnlp:latest']]
-        ]
-        //binding.variables.env.JENKINS_JNLP_IMAGE = 'config/jnlp:latest'
-        stepRule.step.dockerExecuteOnKubernetes(
-            script: nullScript,
-            juStabUtils: utils,
-            dockerImage: 'maven:3.5-jdk-8-alpine',
-        ) { bodyExecuted = true }
-        assertTrue(bodyExecuted)
-
-        assertThat(containersList, allOf(
-            hasItem('jnlp'),
-            hasItem('container-exec')
-        ))
-        assertThat(imageList, allOf(
-            hasItem('config/jnlp:latest'),
-            hasItem('maven:3.5-jdk-8-alpine'),
-        ))
-    }
-
-    @Test
     void testDockerExecuteOnKubernetesExecutionFails() {
 
         thrown.expect(AbortException)
@@ -503,7 +479,7 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
         nullScript.commonPipelineEnvironment.configuration = [
             general: [jenkinsKubernetes: [jnlpAgent: 'config/jnlp:latest']]
         ]
-        //binding.variables.env.JENKINS_JNLP_IMAGE = 'config/jnlp:latest'
+
         stepRule.step.dockerExecuteOnKubernetes(
             script: nullScript,
             juStabUtils: utils,

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -447,36 +447,12 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
     }
 
     @Test
-    void testDockerExecuteOnKubernetesCustomJnlpViaEnv() {
-
-        nullScript.commonPipelineEnvironment.configuration = [
-            general: [jenkinsKubernetes: [jnlpAgent: 'config/jnlp:latest']]
-        ]
-        binding.variables.env.JENKINS_JNLP_IMAGE = 'env/jnlp:latest'
-        stepRule.step.dockerExecuteOnKubernetes(
-            script: nullScript,
-            juStabUtils: utils,
-            dockerImage: 'maven:3.5-jdk-8-alpine',
-        ) { bodyExecuted = true }
-        assertTrue(bodyExecuted)
-
-        assertThat(containersList, allOf(
-            hasItem('jnlp'),
-            hasItem('container-exec')
-        ))
-        assertThat(imageList, allOf(
-            hasItem('env/jnlp:latest'),
-            hasItem('maven:3.5-jdk-8-alpine'),
-        ))
-    }
-
-    @Test
     void testDockerExecuteOnKubernetesCustomJnlpViaConfig() {
 
         nullScript.commonPipelineEnvironment.configuration = [
             general: [jenkinsKubernetes: [jnlpAgent: 'config/jnlp:latest']]
         ]
-        //binding.variables.env.JENKINS_JNLP_IMAGE = 'config/jnlp:latest'
+
         stepRule.step.dockerExecuteOnKubernetes(
             script: nullScript,
             juStabUtils: utils,
@@ -503,7 +479,7 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
         nullScript.commonPipelineEnvironment.configuration = [
             general: [jenkinsKubernetes: [jnlpAgent: 'config/jnlp:latest']]
         ]
-        //binding.variables.env.JENKINS_JNLP_IMAGE = 'config/jnlp:latest'
+
         stepRule.step.dockerExecuteOnKubernetes(
             script: nullScript,
             juStabUtils: utils,

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -161,15 +161,6 @@ import hudson.AbortException
 /**
  * Executes a closure inside a container in a kubernetes pod.
  * Proxy environment variables defined on the Jenkins machine are also available in the container.
- *
- * By default jnlp agent defined for kubernetes-plugin will be used (see https://github.com/jenkinsci/kubernetes-plugin#pipeline-support).
- *
- * It is possible to define a custom jnlp agent image by
- *
- * 1. Defining the jnlp image via environment variable JENKINS_JNLP_IMAGE in the Kubernetes landscape
- * 2. Defining the image via config (`jenkinsKubernetes.jnlpAgent`)
- *
- * Option 1 will take precedence over option 2.
  */
 @GenerateDocumentation
 void call(Map parameters = [:], body) {
@@ -357,11 +348,10 @@ private List getContainerList(config) {
 
     //If no custom jnlp agent provided as default jnlp agent (jenkins/jnlp-slave) as defined in the plugin, see https://github.com/jenkinsci/kubernetes-plugin#pipeline-support
     def result = []
-    //allow definition of jnlp image via environment variable JENKINS_JNLP_IMAGE in the Kubernetes landscape or via config as fallback
-    if (env.JENKINS_JNLP_IMAGE || config.jenkinsKubernetes.jnlpAgent) {
+    if (config.jenkinsKubernetes.jnlpAgent) {
         result.push([
             name : 'jnlp',
-            image: env.JENKINS_JNLP_IMAGE ?: config.jenkinsKubernetes.jnlpAgent
+            image: config.jenkinsKubernetes.jnlpAgent
         ])
     }
     config.containerMap.each { imageName, containerName ->


### PR DESCRIPTION
# Changes

Having the option to configure the JNLP image with the highest precedence via environment variable has the issue that consumers or the pipelines cannot easily change the configuration value.
For the Cloud SDK pipeline that is e.g. an issue if curl is missing in the jnlp image configured by the environment.
Furthermore, the concrete use case why it was introduced does not exist anymore. 
Thus, we would like to remove this option.

- [x] Tests
- [x] Documentation
