### PR TITLE
suppress error in log message on case there is no error available

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -29,18 +29,18 @@ func (formatter *PiperLogFormatter) Format(entry *logrus.Entry) (bytes []byte, e
 		stepName = "(noStepName)"
 	}
 
-	errorMessage := entry.Data[logrus.ErrorKey]
-	if errorMessage == nil {
-		errorMessage = "(noErrorMessage)"
+	errorMessageSnippet := ""
+	if entry.Data[logrus.ErrorKey] != nil {
+		errorMessageSnippet = fmt.Sprintf(" - %s", entry.Data[logrus.ErrorKey])
 	}
 
 	switch formatter.logFormat {
 	case logFormatDefault:
-		message = fmt.Sprintf("%-5s %-6s - %s - %s\n", entry.Level, stepName, entry.Message, errorMessage)
+		message = fmt.Sprintf("%-5s %-6s - %s%s\n", entry.Level, stepName, entry.Message, errorMessageSnippet)
 	case logFormatWithTimestamp:
-		message = fmt.Sprintf("%s %-5s %-6s - %s - %s\n", entry.Time.Format("15:04:05"), entry.Level, stepName, entry.Message, errorMessage)
+		message = fmt.Sprintf("%s %-5s %-6s %s%s\n", entry.Time.Format("15:04:05"), entry.Level, stepName, entry.Message, errorMessageSnippet)
 	case logFormatPlain:
-		message = fmt.Sprintf("%s - %s\n", entry.Message, errorMessage)
+		message = fmt.Sprintf("%s%s\n", entry.Message, errorMessageSnippet)
 	default:
 		formattedMessage, err := formatter.TextFormatter.Format(entry)
 		if err != nil {


### PR DESCRIPTION
This is a follow-up for #1535 which was merged maybe a little bit to fast after applying the latest review feedback.

@stippi2 outlined that it is a questionable approach to have always an error (or in case there is no error a remark `(noError)` in the log since that blurs the log with a log of irrelevant `(noError)` snippets.

Now an error is only put into the log in case there is an error (...`withError(./.)`) called on the log entry.

The whole thing started with #1527 which simply added the error message (in case where we have always an error message) to the log message. Maybe that approach was not that bad ...
