### PR TITLE
Strip "./" from paths to artifacts

### DIFF
--- a/src/com/sap/piper/JenkinsUtils.groovy
+++ b/src/com/sap/piper/JenkinsUtils.groovy
@@ -231,7 +231,13 @@ void handleStepResults(String stepName, boolean failOnMissingReports, boolean fa
     } else if (reportsFileExists) {
         def reports = readJSON(file: reportsFileName)
         for (report in reports) {
-            archiveArtifacts artifacts: report['target'], allowEmptyArchive: !report['mandatory']
+            String target = report['target'] as String
+            if (target != null && target.startsWith("./")) {
+                // archiveArtifacts does not match any files when they start with "./",
+                // even though that is a correct relative path.
+                target = target.substring(2)
+            }
+            archiveArtifacts artifacts: target, allowEmptyArchive: !report['mandatory']
         }
     }
 


### PR DESCRIPTION
# Changes

archiveArtifacts is documented to work from the current directory. But for some reason, it doesn't support glob patterns that start with `./`. It even logs an error message to the effect of "`./path/*.ext` does not match anything, did you mean `path/*.ext`?".

- [ ] Tests
- [ ] Documentation
