### PR TITLE
Provide a timeout of 20m for the go Integration Tests

### DIFF
--- a/.github/workflows/integration-tests-pr.yaml
+++ b/.github/workflows/integration-tests-pr.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: test
         env:
           PIPER_INTEGRATION_GITHUB_TOKEN: ${{secrets.PIPER_INTEGRATION_GITHUB_TOKEN}}
-        run: go test -tags=integration ./integration/...
+        run: go test -tags=integration -timeout 20m ./integration/...
       - name: update status
         if: success()
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: test
         env:
           PIPER_INTEGRATION_GITHUB_TOKEN: ${{secrets.PIPER_INTEGRATION_GITHUB_TOKEN}}
-        run: go test -tags=integration ./integration/...
+        run: go test -tags=integration -timeout 20m ./integration/...
       - name: update status
         if: success()
         run: |

--- a/integration/run-tests.sh
+++ b/integration/run-tests.sh
@@ -2,5 +2,5 @@
 
 pushd ..
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags release -o piper
-go test -tags=integration ./integration/...
+go test -tags=integration -timeout 20m ./integration/...
 popd


### PR DESCRIPTION
#1472 Changes

Default is 10m, see https://golang.org/cmd/go/#hdr-Testing_flags
This fails often for me in practice, like so: https://github.com/SAP/jenkins-library/runs/716803728?check_suite_focus=true

- [ ] Tests
- [ ] Documentation
