### PR TITLE
Needed CLI separator for Fortify tools depends on platform

### DIFF
--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -573,8 +573,8 @@ func triggerFortifyScan(config fortifyExecuteScanOptions, command execRunner, bu
 	if config.BuildTool == "pip" {
 		if config.AutodetectClasspath {
 			separator := getSeparator()
-			template := fmt.Sprintf("import sys;p=sys.path;p.remove('');print('%v'.join(p))", separator)
-			classpath = autoresolvePipClasspath(config.PythonVersion, []string{"-c", template}, classpathFileName, command)
+			script := fmt.Sprintf("import sys;p=sys.path;p.remove('');print('%v'.join(p))", separator)
+			classpath = autoresolvePipClasspath(config.PythonVersion, []string{"-c", script}, classpathFileName, command)
 		}
 		// install the dev dependencies
 		if len(config.PythonRequirementsFile) > 0 {

--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -789,13 +789,15 @@ func appendToOptions(config *fortifyExecuteScanOptions, options []string, t map[
 	return options
 }
 
-func getSuppliedOrDefaultListAsString(suppliedList, defaultList []string, separator string) string {
-	var effectiveList []string
+func getSuppliedOrDefaultList(suppliedList, defaultList []string) []string {
 	if len(suppliedList) > 0 {
-		effectiveList = suppliedList
-	} else {
-		effectiveList = defaultList
+		return suppliedList
 	}
+	return defaultList
+}
+
+func getSuppliedOrDefaultListAsString(suppliedList, defaultList []string, separator string) string {
+	effectiveList := getSuppliedOrDefaultList(suppliedList, defaultList)
 	return strings.Join(effectiveList, separator)
 }
 

--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -516,7 +517,9 @@ func triggerFortifyScan(config fortifyExecuteScanOptions, command execRunner, bu
 	}
 	if config.BuildTool == "pip" {
 		if config.AutodetectClasspath {
-			classpath = autoresolvePipClasspath(config.PythonVersion, []string{"-c", "import sys;p=sys.path;p.remove('');print(';'.join(p))"}, classpathFileName, command)
+			separator := getSeparator()
+			template := fmt.Sprintf("import sys;p=sys.path;p.remove('');print('%v'.join(p))", separator)
+			classpath = autoresolvePipClasspath(config.PythonVersion, []string{"-c", template}, classpathFileName, command)
 		}
 		// install the dev dependencies
 		if len(config.PythonRequirementsFile) > 0 {
@@ -530,7 +533,7 @@ func triggerFortifyScan(config fortifyExecuteScanOptions, command execRunner, bu
 
 		config.Translate, err = populatePipTranslate(&config, classpath)
 		if err != nil {
-			log.Entry().WithError(err).Warnf("failed to apply pythonAdditionalPath ('%s') or pythonIncludes ('%s') parameter", config.PythonAdditionalPath, config.PythonIncludes)
+			log.Entry().WithError(err).Warnf("failed to apply pythonAdditionalPath ('%s') or src ('%s') parameter", config.PythonAdditionalPath, config.Src)
 		}
 
 	}
@@ -548,9 +551,14 @@ func populatePipTranslate(config *fortifyExecuteScanOptions, classpath string) (
 	var translateList []map[string]interface{}
 	translateList = append(translateList, make(map[string]interface{}))
 
-	translateList[0]["pythonPath"] = classpath + ";" + config.PythonAdditionalPath
-	translateList[0]["pythonIncludes"] = config.PythonIncludes
-	translateList[0]["pythonExcludes"] = strings.ReplaceAll(config.PythonExcludes, "-exclude ", "")
+	separator := getSeparator()
+
+	translateList[0]["pythonPath"] = classpath + separator +
+		getSuppliedOrDefaultListAsString(config.PythonAdditionalPath, []string{}, separator)
+	translateList[0]["pythonIncludes"] = getSuppliedOrDefaultListAsString(
+		config.Src, []string{"./**/*"}, " ")
+	translateList[0]["pythonExcludes"] = getSuppliedOrDefaultListAsString(
+		config.Exclude, []string{"./**/tests/**/*", "./**/setup.py"}, separator)
 
 	translateJSON, err := json.Marshal(translateList)
 
@@ -566,12 +574,11 @@ func populateMavenTranslate(config *fortifyExecuteScanOptions, classpath string)
 	translateList = append(translateList, make(map[string]interface{}))
 	translateList[0]["classpath"] = classpath
 
-	if len(config.Src) > 0 {
-		translateList[0]["src"] = config.Src
-	}
-	if len(config.Exclude) > 0 {
-		translateList[0]["exclude"] = config.Exclude
-	}
+	// "src" will be tokenized at " " in the end. This is probably fragile as it does not allow paths with spaces.
+	setTranslateEntryIfNotEmpty(translateList[0], "src", " ", config.Src,
+		[]string{"**/*.xml", "**/*.html", "**/*.jsp", "**/*.js", "**/src/main/resources/**/*", "**/src/main/java/**/*"})
+
+	setTranslateEntryIfNotEmpty(translateList[0], "exclude", getSeparator(), config.Exclude, []string{})
 
 	translateJSON, err := json.Marshal(translateList)
 
@@ -720,7 +727,37 @@ func appendToOptions(config *fortifyExecuteScanOptions, options []string, t map[
 		if len(t["pythonExcludes"]) > 0 {
 			options = append(options, "-exclude", t["pythonExcludes"])
 		}
-		return append(options, t["pythonIncludes"])
+		return append(options, tokenize(t["pythonIncludes"])...)
 	}
 	return options
+}
+
+func getSuppliedOrDefaultListAsString(suppliedList, defaultList []string, separator string) string {
+	var effectiveList []string
+	if len(suppliedList) > 0 {
+		effectiveList = suppliedList
+	} else {
+		effectiveList = defaultList
+	}
+	return strings.Join(effectiveList, separator)
+}
+
+// setTranslateEntryIfNotEmpty builds a string from either the user-supplied list, or the default list,
+// by joining the entries with the given separator. If the resulting string is not empty, it will be
+// placed as an entry in the provided map under the given key.
+func setTranslateEntryIfNotEmpty(translate map[string]interface{}, key, separator string, suppliedList, defaultList []string) {
+	value := getSuppliedOrDefaultListAsString(suppliedList, defaultList, separator)
+	if value != "" {
+		translate[key] = value
+	}
+}
+
+// getSeparator returns the separator string depending on the host platform. This assumes that
+// Piper executes the Fortify command line tools within the same OS platform as it is running on itself.
+func getSeparator() string {
+	if runtime.GOOS == "windows" {
+		return ";"
+	} else {
+		return ":"
+	}
 }

--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -814,7 +814,6 @@ func setTranslateEntryIfNotEmpty(translate map[string]interface{}, key, separato
 func getSeparator() string {
 	if runtime.GOOS == "windows" {
 		return ";"
-	} else {
-		return ":"
 	}
+	return ":"
 }

--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -490,9 +490,6 @@ func autoresolveMavenClasspath(config fortifyExecuteScanOptions, file string, co
 		Defines:             []string{fmt.Sprintf("-Dmdep.outputFile=%v", file), "-DincludeScope=compile"},
 		ReturnStdout:        false,
 	}
-	if len(strings.TrimSpace(config.MvnCustomArgs)) > 0 {
-		executeOptions.Flags = tokenize(config.MvnCustomArgs)
-	}
 	_, err := maven.Execute(&executeOptions, command)
 	if err != nil {
 		log.Entry().WithError(err).Warn("failed to determine classpath using Maven")

--- a/cmd/fortifyExecuteScan_generated.go
+++ b/cmd/fortifyExecuteScan_generated.go
@@ -230,7 +230,7 @@ func addFortifyExecuteScanFlags(cmd *cobra.Command, stepConfig *fortifyExecuteSc
 	cmd.Flags().StringVar(&stepConfig.FilterSetTitle, "filterSetTitle", `SAP`, "Title of the filter set to use for analysing the results")
 	cmd.Flags().StringVar(&stepConfig.PullRequestName, "pullRequestName", os.Getenv("PIPER_pullRequestName"), "The name of the pull request branch which will trigger creation of a new version in Fortify SSC based on the master branch version")
 	cmd.Flags().StringVar(&stepConfig.PullRequestMessageRegex, "pullRequestMessageRegex", `.*Merge pull request #(\\d+) from.*`, "Regex used to identify the PR-XXX reference within the merge commit message")
-	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", os.Getenv("PIPER_buildTool"), "Scan type used for the step which can be `'maven'`, `'pip'`")
+	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", `maven`, "Scan type used for the step which can be `'maven'`, `'pip'`")
 	cmd.Flags().StringVar(&stepConfig.ProjectSettingsFile, "projectSettingsFile", os.Getenv("PIPER_projectSettingsFile"), "Path to the mvn settings file that should be used as project settings file.")
 	cmd.Flags().StringVar(&stepConfig.GlobalSettingsFile, "globalSettingsFile", os.Getenv("PIPER_globalSettingsFile"), "Path to the mvn settings file that should be used as global settings file.")
 	cmd.Flags().StringVar(&stepConfig.M2Path, "m2Path", os.Getenv("PIPER_m2Path"), "Path to the location of the local repository that should be used.")
@@ -603,7 +603,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 					{
 						Name:        "buildTool",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},

--- a/cmd/fortifyExecuteScan_generated.go
+++ b/cmd/fortifyExecuteScan_generated.go
@@ -16,55 +16,51 @@ import (
 )
 
 type fortifyExecuteScanOptions struct {
-	AuthToken                       string `json:"authToken,omitempty"`
-	GithubToken                     string `json:"githubToken,omitempty"`
-	AutoCreate                      bool   `json:"autoCreate,omitempty"`
-	MvnCustomArgs                   string `json:"mvnCustomArgs,omitempty"`
-	ModulePath                      string `json:"modulePath,omitempty"`
-	PythonRequirementsFile          string `json:"pythonRequirementsFile,omitempty"`
-	AutodetectClasspath             bool   `json:"autodetectClasspath,omitempty"`
-	MustAuditIssueGroups            string `json:"mustAuditIssueGroups,omitempty"`
-	SpotAuditIssueGroups            string `json:"spotAuditIssueGroups,omitempty"`
-	PythonRequirementsInstallSuffix string `json:"pythonRequirementsInstallSuffix,omitempty"`
-	PythonVersion                   string `json:"pythonVersion,omitempty"`
-	UploadResults                   bool   `json:"uploadResults,omitempty"`
-	BuildDescriptorFile             string `json:"buildDescriptorFile,omitempty"`
-	CommitID                        string `json:"commitId,omitempty"`
-	CommitMessage                   string `json:"commitMessage,omitempty"`
-	GithubAPIURL                    string `json:"githubApiUrl,omitempty"`
-	Owner                           string `json:"owner,omitempty"`
-	Repository                      string `json:"repository,omitempty"`
-	Memory                          string `json:"memory,omitempty"`
-	UpdateRulePack                  bool   `json:"updateRulePack,omitempty"`
-	PythonExcludes                  string `json:"pythonExcludes,omitempty"`
-	ReportDownloadEndpoint          string `json:"reportDownloadEndpoint,omitempty"`
-	PollingMinutes                  int    `json:"pollingMinutes,omitempty"`
-	QuickScan                       bool   `json:"quickScan,omitempty"`
-	Translate                       string `json:"translate,omitempty"`
-	Src                             string `json:"src,omitempty"`
-	Exclude                         string `json:"exclude,omitempty"`
-	APIEndpoint                     string `json:"apiEndpoint,omitempty"`
-	ReportType                      string `json:"reportType,omitempty"`
-	PythonAdditionalPath            string `json:"pythonAdditionalPath,omitempty"`
-	ArtifactURL                     string `json:"artifactUrl,omitempty"`
-	ConsiderSuspicious              bool   `json:"considerSuspicious,omitempty"`
-	FprUploadEndpoint               string `json:"fprUploadEndpoint,omitempty"`
-	ProjectName                     string `json:"projectName,omitempty"`
-	PythonIncludes                  string `json:"pythonIncludes,omitempty"`
-	Reporting                       bool   `json:"reporting,omitempty"`
-	ServerURL                       string `json:"serverUrl,omitempty"`
-	BuildDescriptorExcludeList      string `json:"buildDescriptorExcludeList,omitempty"`
-	PullRequestMessageRegexGroup    int    `json:"pullRequestMessageRegexGroup,omitempty"`
-	DeltaMinutes                    int    `json:"deltaMinutes,omitempty"`
-	SpotCheckMinimum                int    `json:"spotCheckMinimum,omitempty"`
-	FprDownloadEndpoint             string `json:"fprDownloadEndpoint,omitempty"`
-	DefaultVersioningModel          string `json:"defaultVersioningModel,omitempty"`
-	PythonInstallCommand            string `json:"pythonInstallCommand,omitempty"`
-	ReportTemplateID                int    `json:"reportTemplateId,omitempty"`
-	FilterSetTitle                  string `json:"filterSetTitle,omitempty"`
-	PullRequestName                 string `json:"pullRequestName,omitempty"`
-	PullRequestMessageRegex         string `json:"pullRequestMessageRegex,omitempty"`
-	BuildTool                       string `json:"buildTool,omitempty"`
+	AuthToken                       string   `json:"authToken,omitempty"`
+	GithubToken                     string   `json:"githubToken,omitempty"`
+	AutoCreate                      bool     `json:"autoCreate,omitempty"`
+	ModulePath                      string   `json:"modulePath,omitempty"`
+	PythonRequirementsFile          string   `json:"pythonRequirementsFile,omitempty"`
+	AutodetectClasspath             bool     `json:"autodetectClasspath,omitempty"`
+	MustAuditIssueGroups            string   `json:"mustAuditIssueGroups,omitempty"`
+	SpotAuditIssueGroups            string   `json:"spotAuditIssueGroups,omitempty"`
+	PythonRequirementsInstallSuffix string   `json:"pythonRequirementsInstallSuffix,omitempty"`
+	PythonVersion                   string   `json:"pythonVersion,omitempty"`
+	UploadResults                   bool     `json:"uploadResults,omitempty"`
+	BuildDescriptorFile             string   `json:"buildDescriptorFile,omitempty"`
+	CommitID                        string   `json:"commitId,omitempty"`
+	CommitMessage                   string   `json:"commitMessage,omitempty"`
+	GithubAPIURL                    string   `json:"githubApiUrl,omitempty"`
+	Owner                           string   `json:"owner,omitempty"`
+	Repository                      string   `json:"repository,omitempty"`
+	Memory                          string   `json:"memory,omitempty"`
+	UpdateRulePack                  bool     `json:"updateRulePack,omitempty"`
+	ReportDownloadEndpoint          string   `json:"reportDownloadEndpoint,omitempty"`
+	PollingMinutes                  int      `json:"pollingMinutes,omitempty"`
+	QuickScan                       bool     `json:"quickScan,omitempty"`
+	Translate                       string   `json:"translate,omitempty"`
+	Src                             []string `json:"src,omitempty"`
+	Exclude                         []string `json:"exclude,omitempty"`
+	APIEndpoint                     string   `json:"apiEndpoint,omitempty"`
+	ReportType                      string   `json:"reportType,omitempty"`
+	PythonAdditionalPath            []string `json:"pythonAdditionalPath,omitempty"`
+	ArtifactURL                     string   `json:"artifactUrl,omitempty"`
+	ConsiderSuspicious              bool     `json:"considerSuspicious,omitempty"`
+	FprUploadEndpoint               string   `json:"fprUploadEndpoint,omitempty"`
+	ProjectName                     string   `json:"projectName,omitempty"`
+	Reporting                       bool     `json:"reporting,omitempty"`
+	ServerURL                       string   `json:"serverUrl,omitempty"`
+	PullRequestMessageRegexGroup    int      `json:"pullRequestMessageRegexGroup,omitempty"`
+	DeltaMinutes                    int      `json:"deltaMinutes,omitempty"`
+	SpotCheckMinimum                int      `json:"spotCheckMinimum,omitempty"`
+	FprDownloadEndpoint             string   `json:"fprDownloadEndpoint,omitempty"`
+	DefaultVersioningModel          string   `json:"defaultVersioningModel,omitempty"`
+	PythonInstallCommand            string   `json:"pythonInstallCommand,omitempty"`
+	ReportTemplateID                int      `json:"reportTemplateId,omitempty"`
+	FilterSetTitle                  string   `json:"filterSetTitle,omitempty"`
+	PullRequestName                 string   `json:"pullRequestName,omitempty"`
+	PullRequestMessageRegex         string   `json:"pullRequestMessageRegex,omitempty"`
+	BuildTool                       string   `json:"buildTool,omitempty"`
 }
 
 type fortifyExecuteScanInflux struct {
@@ -190,7 +186,6 @@ func addFortifyExecuteScanFlags(cmd *cobra.Command, stepConfig *fortifyExecuteSc
 	cmd.Flags().StringVar(&stepConfig.AuthToken, "authToken", os.Getenv("PIPER_authToken"), "The FortifyToken to use for authentication")
 	cmd.Flags().StringVar(&stepConfig.GithubToken, "githubToken", os.Getenv("PIPER_githubToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line")
 	cmd.Flags().BoolVar(&stepConfig.AutoCreate, "autoCreate", false, "Whether Fortify project and project version shall be implicitly auto created in case they cannot be found in the backend")
-	cmd.Flags().StringVar(&stepConfig.MvnCustomArgs, "mvnCustomArgs", ``, "Allows providing additional Maven command line parameters")
 	cmd.Flags().StringVar(&stepConfig.ModulePath, "modulePath", `./`, "Allows providing the path for the module to scan")
 	cmd.Flags().StringVar(&stepConfig.PythonRequirementsFile, "pythonRequirementsFile", os.Getenv("PIPER_pythonRequirementsFile"), "The requirements file used in `buildTool: 'pip'` to populate the build environment with the necessary dependencies")
 	cmd.Flags().BoolVar(&stepConfig.AutodetectClasspath, "autodetectClasspath", true, "Whether the classpath is automatically determined via build tool i.e. maven or pip or not at all")
@@ -202,33 +197,30 @@ func addFortifyExecuteScanFlags(cmd *cobra.Command, stepConfig *fortifyExecuteSc
 	cmd.Flags().StringVar(&stepConfig.BuildDescriptorFile, "buildDescriptorFile", os.Getenv("PIPER_buildDescriptorFile"), "Path to the build descriptor file addressing the module/folder to be scanned. Defaults are for buildTool=`maven`: `./pom.xml`, buildTool=`pip`: `./setup.py`.")
 	cmd.Flags().StringVar(&stepConfig.CommitID, "commitId", os.Getenv("PIPER_commitId"), "Set the Git commit ID for identifying artifacts throughout the scan.")
 	cmd.Flags().StringVar(&stepConfig.CommitMessage, "commitMessage", os.Getenv("PIPER_commitMessage"), "Set the Git commit message for identifying pull request merges throughout the scan.")
-	cmd.Flags().StringVar(&stepConfig.GithubAPIURL, "githubApiUrl", `https://api.github.com`, "Set the GitHub API url.")
+	cmd.Flags().StringVar(&stepConfig.GithubAPIURL, "githubApiUrl", `https://api.github.com`, "Set the GitHub API URL.")
 	cmd.Flags().StringVar(&stepConfig.Owner, "owner", os.Getenv("PIPER_owner"), "Set the GitHub organization.")
 	cmd.Flags().StringVar(&stepConfig.Repository, "repository", os.Getenv("PIPER_repository"), "Set the GitHub repository.")
 	cmd.Flags().StringVar(&stepConfig.Memory, "memory", `-Xmx4G -Xms512M`, "The amount of memory granted to the translate/scan executions")
 	cmd.Flags().BoolVar(&stepConfig.UpdateRulePack, "updateRulePack", true, "Whether the rule pack shall be updated and pulled from Fortify SSC before scanning or not")
-	cmd.Flags().StringVar(&stepConfig.PythonExcludes, "pythonExcludes", `-exclude ./**/tests/**/*;./**/setup.py`, "The excludes pattern used in `buildTool: 'pip'` for excluding specific .py files i.e. tests")
 	cmd.Flags().StringVar(&stepConfig.ReportDownloadEndpoint, "reportDownloadEndpoint", `/transfer/reportDownload.html`, "Fortify SSC endpoint for Report downloads")
-	cmd.Flags().IntVar(&stepConfig.PollingMinutes, "pollingMinutes", 30, "The number of minutes for which an uploaded FPR artifact's status is being polled to finish queuing/processing, if exceeded polling will be stopped and an error will be thrown")
+	cmd.Flags().IntVar(&stepConfig.PollingMinutes, "pollingMinutes", 30, "The number of minutes for which an uploaded FPR artifact''s status is being polled to finish queuing/processing, if exceeded polling will be stopped and an error will be thrown")
 	cmd.Flags().BoolVar(&stepConfig.QuickScan, "quickScan", false, "Whether a quick scan should be performed, please consult the related Fortify documentation on JAM on the impact of this setting")
 	cmd.Flags().StringVar(&stepConfig.Translate, "translate", os.Getenv("PIPER_translate"), "Options for translate phase of Fortify. Most likely, you do not need to set this parameter. See src, exclude. If `'src'` and `'exclude'` are set they are automatically used. Technical details: It has to be a JSON string of list of maps with required key `'src'`, and optional keys `'exclude'`, `'libDirs'`, `'aspnetcore'`, and `'dotNetCoreVersion'`")
-	cmd.Flags().StringVar(&stepConfig.Src, "src", `**/*.xml **/*.html **/*.jsp **/*.js **/src/main/resources/**/* **/src/main/java/**/*`, "Source directories to scan. Multiple entries are separated by space and wildcards can be used, e.g., `'src/main/resources/**/* src/main/java/**/*'`. If `translate` is set, this will ignored.")
-	cmd.Flags().StringVar(&stepConfig.Exclude, "exclude", os.Getenv("PIPER_exclude"), "Exludes directories/files from scan. Multiple entries are separated by semicolon and wildcards can be used, e.g., `'fileA;fileB;**/Test.java;'`. If `translate` is set, this will ignored.")
+	cmd.Flags().StringSliceVar(&stepConfig.Src, "src", []string{}, "A list of source directories to scan. Wildcards can be used, e.g., `'src/main/java/**/*'`. If `'translate'` is set, this will ignored. The default value for `buildTool: 'maven'` is ['**/*.xml', '**/*.html', '**/*.jsp', '**/*.js', '**/src/main/resources/**/*', '**/src/main/java/**/*'], for `buildTool: 'pip'` it is ['./**/*'].")
+	cmd.Flags().StringSliceVar(&stepConfig.Exclude, "exclude", []string{}, "A list of directories/files to be excluded from the scan. Wildcards can be used, e.g., `'**/Test.java'`. If `translate` is set, this will ignored.")
 	cmd.Flags().StringVar(&stepConfig.APIEndpoint, "apiEndpoint", `/api/v1`, "Fortify SSC endpoint used for uploading the scan results and checking the audit state")
 	cmd.Flags().StringVar(&stepConfig.ReportType, "reportType", `PDF`, "The type of report to be generated")
-	cmd.Flags().StringVar(&stepConfig.PythonAdditionalPath, "pythonAdditionalPath", `./lib;.`, "The addional path which can be used in `buildTool: 'pip'` for customization purposes")
-	cmd.Flags().StringVar(&stepConfig.ArtifactURL, "artifactUrl", os.Getenv("PIPER_artifactUrl"), "Path/Url pointing to an additional artifact repository for resolution of additional artifacts during the build")
+	cmd.Flags().StringSliceVar(&stepConfig.PythonAdditionalPath, "pythonAdditionalPath", []string{`./lib`, `.`}, "A list of additional paths which can be used in `buildTool: 'pip'` for customization purposes")
+	cmd.Flags().StringVar(&stepConfig.ArtifactURL, "artifactUrl", os.Getenv("PIPER_artifactUrl"), "Path/URL pointing to an additional artifact repository for resolution of additional artifacts during the build")
 	cmd.Flags().BoolVar(&stepConfig.ConsiderSuspicious, "considerSuspicious", true, "Whether suspicious issues should trigger the check to fail or not")
 	cmd.Flags().StringVar(&stepConfig.FprUploadEndpoint, "fprUploadEndpoint", `/upload/resultFileUpload.html`, "Fortify SSC endpoint for FPR uploads")
 	cmd.Flags().StringVar(&stepConfig.ProjectName, "projectName", `{{list .GroupID .ArtifactID | join "-" | trimAll "-"}}`, "The project used for reporting results in SSC")
-	cmd.Flags().StringVar(&stepConfig.PythonIncludes, "pythonIncludes", `./**/*`, "The includes pattern used in `buildTool: 'pip'` for including .py files")
 	cmd.Flags().BoolVar(&stepConfig.Reporting, "reporting", false, "Influences whether a report is generated or not")
 	cmd.Flags().StringVar(&stepConfig.ServerURL, "serverUrl", os.Getenv("PIPER_serverUrl"), "Fortify SSC Url to be used for accessing the APIs")
-	cmd.Flags().StringVar(&stepConfig.BuildDescriptorExcludeList, "buildDescriptorExcludeList", `[]`, "Build descriptor files to exclude modules from being scanned")
-	cmd.Flags().IntVar(&stepConfig.PullRequestMessageRegexGroup, "pullRequestMessageRegexGroup", 1, "The group number for extracting the pull request id in `pullRequestMessageRegex`")
+	cmd.Flags().IntVar(&stepConfig.PullRequestMessageRegexGroup, "pullRequestMessageRegexGroup", 1, "The group number for extracting the pull request id in `'pullRequestMessageRegex'`")
 	cmd.Flags().IntVar(&stepConfig.DeltaMinutes, "deltaMinutes", 5, "The number of minutes for which an uploaded FPR artifact is considered to be recent and healthy, if exceeded an error will be thrown")
 	cmd.Flags().IntVar(&stepConfig.SpotCheckMinimum, "spotCheckMinimum", 1, "The minimum number of issues that must be audited per category in the `Spot Checks of each Category` folder to avoid an error being thrown")
-	cmd.Flags().StringVar(&stepConfig.FprDownloadEndpoint, "fprDownloadEndpoint", `/download/currentStateFprDownload.html`, "Fortify SSC endpoint  for FPR downloads")
+	cmd.Flags().StringVar(&stepConfig.FprDownloadEndpoint, "fprDownloadEndpoint", `/download/currentStateFprDownload.html`, "Fortify SSC endpoint for FPR downloads")
 	cmd.Flags().StringVar(&stepConfig.DefaultVersioningModel, "defaultVersioningModel", `major`, "The default project versioning model used in case `projectVersion` parameter is empty for creating the version based on the build descriptor version to report results in SSC, can be one of `'major'`, `'major-minor'`, `'semantic'`, `'full'`")
 	cmd.Flags().StringVar(&stepConfig.PythonInstallCommand, "pythonInstallCommand", `{{.Pip}} install --user .`, "Additional install command that can be run when `buildTool: 'pip'` is used which allows further customizing the execution environment of the scan")
 	cmd.Flags().IntVar(&stepConfig.ReportTemplateID, "reportTemplateId", 18, "Report template ID to be used for generating the Fortify report")
@@ -275,14 +267,6 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Aliases:     []config.Alias{},
 					},
 					{
-						Name:        "mvnCustomArgs",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-					},
-					{
 						Name:        "modulePath",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
@@ -317,7 +301,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 					{
 						Name:        "spotAuditIssueGroups",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGE", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -411,14 +395,6 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Aliases:     []config.Alias{},
 					},
 					{
-						Name:        "pythonExcludes",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-					},
-					{
 						Name:        "reportDownloadEndpoint",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
@@ -454,17 +430,17 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Name:        "src",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
+						Type:        "[]string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{},
+						Aliases:     []config.Alias{{Name: "pythonIncludes"}},
 					},
 					{
 						Name:        "exclude",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
+						Type:        "[]string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{},
+						Aliases:     []config.Alias{{Name: "pythonExcludes"}},
 					},
 					{
 						Name:        "apiEndpoint",
@@ -486,7 +462,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Name:        "pythonAdditionalPath",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
+						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 					},
@@ -523,14 +499,6 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Aliases:     []config.Alias{{Name: "fortifyProjectName"}},
 					},
 					{
-						Name:        "pythonIncludes",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-					},
-					{
 						Name:        "reporting",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
@@ -545,14 +513,6 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "fortifyServerUrl"}, {Name: "sscUrl"}},
-					},
-					{
-						Name:        "buildDescriptorExcludeList",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
 					},
 					{
 						Name:        "pullRequestMessageRegexGroup",

--- a/cmd/fortifyExecuteScan_generated.go
+++ b/cmd/fortifyExecuteScan_generated.go
@@ -307,7 +307,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 					{
 						Name:        "spotAuditIssueGroups",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGE", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -438,7 +438,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "pythonIncludes"}},
+						Aliases:     []config.Alias{},
 					},
 					{
 						Name:        "exclude",
@@ -446,7 +446,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "pythonExcludes"}},
+						Aliases:     []config.Alias{},
 					},
 					{
 						Name:        "apiEndpoint",

--- a/cmd/fortifyExecuteScan_test.go
+++ b/cmd/fortifyExecuteScan_test.go
@@ -375,7 +375,7 @@ func TestTriggerFortifyScan(t *testing.T) {
 			AutodetectClasspath: true,
 			BuildDescriptorFile: "./pom.xml",
 			Memory:              "-Xmx4G -Xms2G",
-			Src:                 []string{"**/*.xml", "**/*.html **/*.jsp", "**/*.js", "src/main/resources/**/*", "src/main/java/**/*"}}
+			Src:                 []string{"**/*.xml", "**/*.html", "**/*.jsp", "**/*.js", "src/main/resources/**/*", "src/main/java/**/*"}}
 		triggerFortifyScan(config, &runner, "test", "testLabel", "my.group-myartifact")
 
 		assert.Equal(t, 3, runner.numExecutions)
@@ -540,7 +540,7 @@ func TestDeterminePullRequestMergeGithub(t *testing.T) {
 func TestTranslateProject(t *testing.T) {
 	t.Run("python", func(t *testing.T) {
 		execRunner := execRunnerMock{}
-		config := fortifyExecuteScanOptions{BuildTool: "pip", Memory: "-Xmx4G", Translate: `[{"pythonPath":"./some/path","pythonIncludes":"./**/*","pythonExcludes":"./tests/**/*"}]`}
+		config := fortifyExecuteScanOptions{BuildTool: "pip", Memory: "-Xmx4G", Translate: `[{"pythonPath":"./some/path","src":"./**/*","exclude":"./tests/**/*"}]`}
 		translateProject(&config, &execRunner, "/commit/7267658798797", "")
 		assert.Equal(t, "sourceanalyzer", execRunner.executions[0].executable, "Expected different executable")
 		assert.Equal(t, []string{"-verbose", "-64", "-b", "/commit/7267658798797", "-Xmx4G", "-python-path", "./some/path", "-exclude", "./tests/**/*", "./**/*"}, execRunner.executions[0].parameters, "Expected different parameters")
@@ -551,7 +551,7 @@ func TestTranslateProject(t *testing.T) {
 		config := fortifyExecuteScanOptions{BuildTool: "windows", Memory: "-Xmx6G", Translate: `[{"aspnetcore":"true","dotNetCoreVersion":"3.5","exclude":"./tests/**/*","libDirs":"tmp/","src":"./**/*"}]`}
 		translateProject(&config, &execRunner, "/commit/7267658798797", "")
 		assert.Equal(t, "sourceanalyzer", execRunner.executions[0].executable, "Expected different executable")
-		assert.Equal(t, []string{"-verbose", "-64", "-b", "/commit/7267658798797", "-Xmx6G", "-aspnetcore", "-dotnet-core-version", "3.5", "-exclude", "./tests/**/*", "-libdirs", "tmp/", "./**/*"}, execRunner.executions[0].parameters, "Expected different parameters")
+		assert.Equal(t, []string{"-verbose", "-64", "-b", "/commit/7267658798797", "-Xmx6G", "-aspnetcore", "-dotnet-core-version", "3.5", "-libdirs", "tmp/", "-exclude", "./tests/**/*", "./**/*"}, execRunner.executions[0].parameters, "Expected different parameters")
 	})
 
 	t.Run("java", func(t *testing.T) {
@@ -630,7 +630,7 @@ func TestPopulateMavenTranslate(t *testing.T) {
 		config := fortifyExecuteScanOptions{Exclude: []string{"./**/*"}}
 		translate, err := populateMavenTranslate(&config, "")
 		assert.NoError(t, err)
-		assert.Equal(t, `[{"classpath":"","exclude":"./**/*","src":"**/*.xml **/*.html **/*.jsp **/*.js **/src/main/resources/**/* **/src/main/java/**/*"}]`, translate)
+		assert.Equal(t, `[{"classpath":"","exclude":"./**/*","src":"**/*.xml:**/*.html:**/*.jsp:**/*.js:**/src/main/resources/**/*:**/src/main/java/**/*"}]`, translate)
 	})
 
 	t.Run("with translate", func(t *testing.T) {
@@ -647,7 +647,7 @@ func TestPopulatePipTranslate(t *testing.T) {
 		config := fortifyExecuteScanOptions{PythonAdditionalPath: []string{"./lib", "."}}
 		translate, err := populatePipTranslate(&config, "")
 		separator := getSeparator()
-		expected := fmt.Sprintf(`[{"pythonExcludes":"./**/tests/**/*%v./**/setup.py","pythonIncludes":"./**/*","pythonPath":"%v./lib%v."}]`,
+		expected := fmt.Sprintf(`[{"exclude":"./**/tests/**/*%v./**/setup.py","pythonPath":"%v./lib%v.","src":"./**/*"}]`,
 			separator, separator, separator)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, translate)
@@ -658,7 +658,7 @@ func TestPopulatePipTranslate(t *testing.T) {
 		translate, err := populatePipTranslate(&config, "")
 		separator := getSeparator()
 		expected := fmt.Sprintf(
-			`[{"pythonExcludes":"./**/tests/**/*%v./**/setup.py","pythonIncludes":"./**/*.py","pythonPath":"%v"}]`,
+			`[{"exclude":"./**/tests/**/*%v./**/setup.py","pythonPath":"%v","src":"./**/*.py"}]`,
 			separator, separator)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, translate)
@@ -669,7 +669,7 @@ func TestPopulatePipTranslate(t *testing.T) {
 		translate, err := populatePipTranslate(&config, "")
 		separator := getSeparator()
 		expected := fmt.Sprintf(
-			`[{"pythonExcludes":"./**/tests/**/*","pythonIncludes":"./**/*","pythonPath":"%v"}]`,
+			`[{"exclude":"./**/tests/**/*","pythonPath":"%v","src":"./**/*"}]`,
 			separator)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, translate)

--- a/resources/metadata/fortify.yaml
+++ b/resources/metadata/fortify.yaml
@@ -441,6 +441,11 @@ spec:
       type: string
       description: "Scan type used for the step which can be `'maven'`, `'pip'`"
       scope:
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: maven
     # Global maven settings, should be added to all maven steps
     - name: projectSettingsFile
       type: string

--- a/resources/metadata/fortify.yaml
+++ b/resources/metadata/fortify.yaml
@@ -250,9 +250,6 @@ spec:
         - PARAMETERS
         - STAGES
         - STEPS
-      aliases:
-        - name: pythonIncludes
-          deprecated: true
     - name: exclude
       type: "[]string"
       description: "A list of directories/files to be excluded from the scan. Wildcards can be used, e.g.,
@@ -261,9 +258,6 @@ spec:
         - PARAMETERS
         - STAGES
         - STEPS
-      aliases:
-        - name: pythonExcludes
-          deprecated: true
     - name: apiEndpoint
       aliases:
       - name: fortifyApiEndpoint

--- a/resources/metadata/fortify.yaml
+++ b/resources/metadata/fortify.yaml
@@ -12,10 +12,10 @@ spec:
   inputs:
     secrets:
       - name: fortifyCredentialsId
-        description: Jenkins 'Secret text' credentials ID containing token to authenticate to Fortify SSC.
+        description: "Jenkins 'Secret text' credentials ID containing token to authenticate to Fortify SSC."
         type: jenkins
       - name: githubTokenCredentialsId
-        description: Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.
+        description: "Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub."
         type: jenkins
     resources:
       - name: commonPipelineEnvironment
@@ -32,439 +32,423 @@ spec:
     params:
     - name: authToken
       type: string
-      description: The FortifyToken to use for authentication
+      description: "The FortifyToken to use for authentication"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       mandatory: true
       secret: true
     - name: githubToken
-      description: GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
+      description: "GitHub personal access token as per
+        https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
       type: string
       secret: true
     - name: autoCreate
       type: bool
-      description: Whether Fortify project and project version shall be implicitly auto created in case they cannot be found in the backend
+      description: "Whether Fortify project and project version shall be implicitly auto created in case they
+        cannot be found in the backend"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-    - name: mvnCustomArgs
-      type: string
-      description: Allows providing additional Maven command line parameters
-      scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: ''
+        - PARAMETERS
+        - STAGES
+        - STEPS
     - name: modulePath
       type: string
-      description: Allows providing the path for the module to scan
+      description: "Allows providing the path for the module to scan"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: './'
     - name: pythonRequirementsFile
       type: string
-      description: 'The requirements file used in `buildTool: ''pip''` to populate
-        the build environment with the necessary dependencies'
+      description: "The requirements file used in `buildTool: 'pip'` to populate
+        the build environment with the necessary dependencies"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
     - name: autodetectClasspath
       type: bool
-      description: Whether the classpath is automatically determined via build tool i.e. maven or pip or not at all
+      description: "Whether the classpath is automatically determined via build tool i.e. maven or pip or not at all"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: true
     - name: mustAuditIssueGroups
       type: string
-      description: Comma separated list of issue groups that must be audited completely
+      description: "Comma separated list of issue groups that must be audited completely"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: 'Corporate Security Requirements, Audit All'
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "Corporate Security Requirements, Audit All"
     - name: spotAuditIssueGroups
       type: string
-      description: 'Comma separated list of issue groups that are spot checked and for which `spotCheckMinimum` audited issues are enforced'
+      description: "Comma separated list of issue groups that are spot checked and for which `spotCheckMinimum`
+        audited issues are enforced"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: 'Spot Checks of Each Category'
+        - PARAMETERS
+        - STAGE
+        - STEPS
+      default: "Spot Checks of Each Category"
     - name: pythonRequirementsInstallSuffix
       type: string
-      description: 'The suffix for the command used to install the requirements file in `buildTool: ''pip''` to populate
-        the build environment with the necessary dependencies'
+      description: "The suffix for the command used to install the requirements file in `buildTool: 'pip'` to populate
+        the build environment with the necessary dependencies"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
     - name: pythonVersion
       type: string
-      description: 'Python version to be used in `buildTool: ''pip''`'
+      description: "Python version to be used in `buildTool: 'pip'`"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: python3
     - name: uploadResults
       type: bool
-      description: Whether results shall be uploaded or not
+      description: "Whether results shall be uploaded or not"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: true
     - name: buildDescriptorFile
       type: string
-      description: 'Path to the build descriptor file addressing the module/folder
+      description: "Path to the build descriptor file addressing the module/folder
         to be scanned. Defaults are for buildTool=`maven`: `./pom.xml`, buildTool=`pip`:
-        `./setup.py`.'
+        `./setup.py`."
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
     - name: commitId
-      description: 'Set the Git commit ID for identifying artifacts throughout the scan.'
+      description: "Set the Git commit ID for identifying artifacts throughout the scan."
       resourceRef:
         - name: commonPipelineEnvironment
           param: git/commitId
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       type: string
     - name: commitMessage
-      description: 'Set the Git commit message for identifying pull request merges throughout the scan.'
+      description: "Set the Git commit message for identifying pull request merges throughout the scan."
       resourceRef:
         - name: commonPipelineEnvironment
           param: git/commitMessage
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       type: string
     - name: githubApiUrl
-      description: Set the GitHub API url.
+      description: "Set the GitHub API URL."
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
       type: string
-      default: https://api.github.com
+      default: "https://api.github.com"
     - name: owner
       aliases:
         - name: githubOrg
-      description: 'Set the GitHub organization.'
+      description: "Set the GitHub organization."
       resourceRef:
         - name: commonPipelineEnvironment
           param: github/owner
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       type: string
     - name: repository
       aliases:
         - name: githubRepo
-      description: 'Set the GitHub repository.'
+      description: "Set the GitHub repository."
       resourceRef:
         - name: commonPipelineEnvironment
           param: github/repository
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       type: string
     - name: memory
       type: string
-      description: The amount of memory granted to the translate/scan executions
+      description: "The amount of memory granted to the translate/scan executions"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: -Xmx4G -Xms512M
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "-Xmx4G -Xms512M"
     - name: updateRulePack
       type: bool
-      description: Whether the rule pack shall be updated and pulled from Fortify SSC before scanning or not
+      description: "Whether the rule pack shall be updated and pulled from Fortify SSC before scanning or not"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: true
-    - name: pythonExcludes
-      type: string
-      description: 'The excludes pattern used in `buildTool: ''pip''` for excluding
-        specific .py files i.e. tests'
-      scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: -exclude ./**/tests/**/*;./**/setup.py
-      deprecated: true
     - name: reportDownloadEndpoint
       aliases:
       - name: fortifyReportDownloadEndpoint
       type: string
-      description: Fortify SSC endpoint for Report downloads
+      description: "Fortify SSC endpoint for Report downloads"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: /transfer/reportDownload.html
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "/transfer/reportDownload.html"
     - name: pollingMinutes
       type: int
-      description: The number of minutes for which an uploaded FPR artifact's status is being polled to finish queuing/processing, if exceeded polling will be stopped and an error will be thrown
+      description: "The number of minutes for which an uploaded FPR artifact''s status is being polled to finish
+        queuing/processing, if exceeded polling will be stopped and an error will be thrown"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: 30
     - name: quickScan
       type: bool
-      description: Whether a quick scan should be performed, please consult the related Fortify documentation on JAM on the impact of this setting
+      description: "Whether a quick scan should be performed, please consult the related Fortify documentation on
+        JAM on the impact of this setting"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: false
     - name: translate
       type: string
-      description: "Options for translate phase of Fortify. Most likely, you do not need to set this parameter. See src, exclude. If `'src'` and `'exclude'` are set they are automatically used. Technical details: It has to be a JSON string of list of maps with required key `'src'`, and optional keys `'exclude'`, `'libDirs'`, `'aspnetcore'`, and `'dotNetCoreVersion'`"
+      description: "Options for translate phase of Fortify. Most likely, you do not need to set this parameter.
+        See src, exclude. If `'src'` and `'exclude'` are set they are automatically used. Technical details:
+        It has to be a JSON string of list of maps with required key `'src'`, and optional keys `'exclude'`,
+        `'libDirs'`, `'aspnetcore'`, and `'dotNetCoreVersion'`"
       scope:
         - PARAMETERS
         - STAGES
         - STEPS
     - name: src
-      type: string
-      description: Source directories to scan. Multiple entries are separated by space and wildcards can be used, e.g., `'src/main/resources/**/* src/main/java/**/*'`. If `translate` is set, this will ignored.
+      type: "[]string"
+      description: "A list of source directories to scan. Wildcards can be used, e.g., `'src/main/java/**/*'`.
+        If `'translate'` is set, this will ignored. The default value for `buildTool: 'maven'` is
+        ['**/*.xml', '**/*.html', '**/*.jsp', '**/*.js', '**/src/main/resources/**/*', '**/src/main/java/**/*'], for
+        `buildTool: 'pip'` it is ['./**/*']."
       scope:
         - PARAMETERS
         - STAGES
         - STEPS
-      default: "**/*.xml **/*.html **/*.jsp **/*.js **/src/main/resources/**/* **/src/main/java/**/*"
+      aliases:
+        - name: pythonIncludes
+          deprecated: true
     - name: exclude
-      type: string
-      description: Exludes directories/files from scan. Multiple entries are separated by colon (non windows systems) and wildcards can be used, e.g., `'fileA:fileB:**/Test.java'`. If `translate` is set, this will ignored.
+      type: "[]string"
+      description: "A list of directories/files to be excluded from the scan. Wildcards can be used, e.g.,
+        `'**/Test.java'`. If `translate` is set, this will ignored."
       scope:
         - PARAMETERS
         - STAGES
         - STEPS
+      aliases:
+        - name: pythonExcludes
+          deprecated: true
     - name: apiEndpoint
       aliases:
       - name: fortifyApiEndpoint
       type: string
-      description: Fortify SSC endpoint used for uploading the scan results and checking the audit state
+      description: "Fortify SSC endpoint used for uploading the scan results and checking the audit state"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: /api/v1
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "/api/v1"
     - name: reportType
       type: string
       description: The type of report to be generated
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: PDF
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "PDF"
     - name: pythonAdditionalPath
-      type: string
-      description: 'The addional path which can be used in `buildTool: ''pip''` for
-        customization purposes'
+      type: "[]string"
+      description: "A list of additional paths which can be used in `buildTool: 'pip'` for customization purposes"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: ./lib;.
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: ["./lib", "."]
       deprecated: true
     - name: artifactUrl
       type: string
-      description: 'Path/Url pointing to an additional artifact repository for resolution of additional artifacts during the build'
+      description: "Path/URL pointing to an additional artifact repository for resolution of additional
+        artifacts during the build"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
     - name: considerSuspicious
       type: bool
-      description: Whether suspicious issues should trigger the check to fail or not
+      description: "Whether suspicious issues should trigger the check to fail or not"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: true
     - name: fprUploadEndpoint
       aliases:
-      - name: fortifyFprUploadEndpoint
+        - name: fortifyFprUploadEndpoint
       type: string
-      description: Fortify SSC endpoint for FPR uploads
+      description: "Fortify SSC endpoint for FPR uploads"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: /upload/resultFileUpload.html
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "/upload/resultFileUpload.html"
     - name: projectName
       aliases:
-      - name: fortifyProjectName
+        - name: fortifyProjectName
       type: string
-      description: The project used for reporting results in SSC
+      description: "The project used for reporting results in SSC"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: '{{list .GroupID .ArtifactID | join "-" | trimAll "-"}}'
-    - name: pythonIncludes
-      type: string
-      description: 'The includes pattern used in `buildTool: ''pip''` for including
-        .py files'
-      scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: ./**/*
-      deprecated: true
     - name: reporting
       type: bool
       description: Influences whether a report is generated or not
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: false
     - name: serverUrl
       aliases:
-      - name: fortifyServerUrl
-      - name: sscUrl
-        deprecated: true
+        - name: fortifyServerUrl
+        - name: sscUrl
+          deprecated: true
       type: string
-      description: Fortify SSC Url to be used for accessing the APIs
+      description: "Fortify SSC Url to be used for accessing the APIs"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
-    - name: buildDescriptorExcludeList
-      type: string
-      description: Build descriptor files to exclude modules from being scanned
-      scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: []
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
     - name: pullRequestMessageRegexGroup
       type: int
-      description: The group number for extracting the pull request id in `pullRequestMessageRegex`
+      description: "The group number for extracting the pull request id in `'pullRequestMessageRegex'`"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: 1
     - name: deltaMinutes
       type: int
-      description: The number of minutes for which an uploaded FPR artifact is considered to be recent and healthy, if exceeded an error will be thrown
+      description: "The number of minutes for which an uploaded FPR artifact is considered to be recent and
+        healthy, if exceeded an error will be thrown"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: 5
     - name: spotCheckMinimum
       type: int
-      description: The minimum number of issues that must be audited per category in the `Spot Checks of each Category` folder to avoid an error being thrown
+      description: "The minimum number of issues that must be audited per category in the `Spot Checks of each
+        Category` folder to avoid an error being thrown"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: 1
     - name: fprDownloadEndpoint
       aliases:
-      - name: fortifyFprDownloadEndpoint
+        - name: fortifyFprDownloadEndpoint
       type: string
-      description: Fortify SSC endpoint  for FPR downloads
+      description: "Fortify SSC endpoint for FPR downloads"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: /download/currentStateFprDownload.html
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "/download/currentStateFprDownload.html"
     - name: defaultVersioningModel
       type: string
-      description: The default project versioning model used in case `projectVersion` parameter is empty for creating the version based on the build descriptor version to report results in SSC, can be one of `'major'`, `'major-minor'`, `'semantic'`, `'full'`
+      description: "The default project versioning model used in case `projectVersion` parameter is empty for
+        creating the version based on the build descriptor version to report results in SSC, can be one of `'major'`,
+        `'major-minor'`, `'semantic'`, `'full'`"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: 'major'
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "major"
     - name: pythonInstallCommand
       type: string
-      description: 'Additional install command that can be run when `buildTool: ''pip''`
-        is used which allows further customizing the execution environment of the
-        scan'
+      description: "Additional install command that can be run when `buildTool: 'pip'`
+        is used which allows further customizing the execution environment of the scan"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: "{{.Pip}} install --user ."
     - name: reportTemplateId
       type: int
-      description: Report template ID to be used for generating the Fortify report
+      description: "Report template ID to be used for generating the Fortify report"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: 18
     - name: filterSetTitle
       type: string
-      description: Title of the filter set to use for analysing the results
+      description: "Title of the filter set to use for analysing the results"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: "SAP"
     - name: pullRequestName
       type: string
-      description: The name of the pull request branch which will trigger creation of a new version in Fortify SSC based on the master branch version
+      description: "The name of the pull request branch which will trigger creation of a new version in Fortify
+        SSC based on the master branch version"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
     - name: pullRequestMessageRegex
       type: string
-      description: Regex used to identify the PR-XXX reference within the merge commit message
+      description: "Regex used to identify the PR-XXX reference within the merge commit message"
       scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
+        - PARAMETERS
+        - STAGES
+        - STEPS
       default: '.*Merge pull request #(\\d+) from.*'
     - name: buildTool
       type: string
-      description: Scan type used for the step which can be `'maven'`, `'pip'`
+      description: "Scan type used for the step which can be `'maven'`, `'pip'`"
       scope:
-      - GENERAL
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: maven
+        - GENERAL
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: "maven"
   containers:
-  - image: ppiper/fortify
-    workingDir: /home/piper
+  - image: "ppiper/fortify"
+    workingDir: "/home/piper"
   outputs:
     resources:
       - name: influx

--- a/resources/metadata/fortify.yaml
+++ b/resources/metadata/fortify.yaml
@@ -260,7 +260,7 @@ spec:
       default: "**/*.xml **/*.html **/*.jsp **/*.js **/src/main/resources/**/* **/src/main/java/**/*"
     - name: exclude
       type: string
-      description: Exludes directories/files from scan. Multiple entries are separated by semicolon and wildcards can be used, e.g., `'fileA;fileB;**/Test.java;'`. If `translate` is set, this will ignored.
+      description: Exludes directories/files from scan. Multiple entries are separated by colon (non windows systems) and wildcards can be used, e.g., `'fileA:fileB:**/Test.java'`. If `translate` is set, this will ignored.
       scope:
         - PARAMETERS
         - STAGES

--- a/resources/metadata/fortify.yaml
+++ b/resources/metadata/fortify.yaml
@@ -95,7 +95,7 @@ spec:
         audited issues are enforced"
       scope:
         - PARAMETERS
-        - STAGE
+        - STAGES
         - STEPS
       default: "Spot Checks of Each Category"
     - name: pythonRequirementsInstallSuffix


### PR DESCRIPTION
# Changes
Es described in the Fortify documentation:
https://www.microfocus.com/documentation/fortify-static-code-analyzer-and-tools/1910/SCA_Guide_19.1.0.pdf

`- exclude: Removes files from the list of files to translate. Separate multiple file
paths with semicolons(Windows) or a colons(non-Windowssystems).`

* Also includes a cleanup of the meta-data YAML with regards to indentation and string quoting. 
* Removal of the mvnCustomArgs param which duplicates m2Path and related options.
* Removal of buildDescriptorExcludeList which was not implemented anyway.
* The already "deprecated" Python includes and excludes arguments have been merged with the Maven versions.
* Parameters which represent lists are now also typed as "[]string".
* Includes a fix where the python includes were not tokenized, (probably because of defaulting to "**/*", but it wouldn't have worked for anything else).
* src and exclude parameters have built-in defaults which depend on the build-tool (maven versus pip), i.e. these defaults are no longer visible in the meta-data.

- [x] Tests
- [x] Documentation
