### PR TITLE
Build go binary without debug symbols

### DIFF
--- a/.github/workflows/upload-go-master.yml
+++ b/.github/workflows/upload-go-master.yml
@@ -22,6 +22,7 @@ jobs:
                   -X github.com/SAP/jenkins-library/pkg/log.LibraryRepository=${GITHUB_REPOSITORY} \
                   -X github.com/SAP/jenkins-library/pkg/telemetry.LibraryRepository=https://github.com/${GITHUB_REPOSITORY}.git" \
             -o piper_master .
+          stat --printf="File size of piper_master in bytes: %s\n" piper_master
       - uses: SAP/project-piper-action@master
         with:
           piper-version: master

--- a/.github/workflows/upload-go-master.yml
+++ b/.github/workflows/upload-go-master.yml
@@ -16,7 +16,7 @@ jobs:
       - env:
           CGO_ENABLED: 0
         run: |
-          go build -ldflags "-X github.com/SAP/jenkins-library/cmd.GitCommit=${GITHUB_SHA} \
+          go build -ldflags "-w -s -X github.com/SAP/jenkins-library/cmd.GitCommit=${GITHUB_SHA} \
                   -X github.com/SAP/jenkins-library/pkg/log.LibraryRepository=${GITHUB_REPOSITORY} \
                   -X github.com/SAP/jenkins-library/pkg/telemetry.LibraryRepository=https://github.com/${GITHUB_REPOSITORY}.git" \
             -o piper_master .

--- a/.github/workflows/upload-go-master.yml
+++ b/.github/workflows/upload-go-master.yml
@@ -16,6 +16,8 @@ jobs:
       - env:
           CGO_ENABLED: 0
         run: |
+          # See https://golang.org/cmd/link/ for info on -w (omit the DWARF symbol table) and -s (omit the symbol table and debug information)
+          # We use those flags to get a smaller compiled binary for faster downloads.
           go build -ldflags "-w -s -X github.com/SAP/jenkins-library/cmd.GitCommit=${GITHUB_SHA} \
                   -X github.com/SAP/jenkins-library/pkg/log.LibraryRepository=${GITHUB_REPOSITORY} \
                   -X github.com/SAP/jenkins-library/pkg/telemetry.LibraryRepository=https://github.com/${GITHUB_REPOSITORY}.git" \


### PR DESCRIPTION
This produces a much smaller binary for faster downloads.

See https://golang.org/cmd/link/ for docs on -s and -w flag.

A quick test on my mac produced this differences in file size. I think it is sensible to build the release binary without debug info, but I'm not sure if I overlook some negative consequence of doing this.

```
-rwxr-xr-x   1 x x  41M 2020-05-31 12:36 piper-normal*
-rwxr-xr-x   1 x x  34M 2020-05-31 12:37 piper-prod*
```

# Changes

- [ ] Tests
- [ ] Documentation
