### PR TITLE
Fix: yaml util handling for boolean with value false

### DIFF
--- a/src/com/sap/piper/variablesubstitution/YamlUtils.groovy
+++ b/src/com/sap/piper/variablesubstitution/YamlUtils.groovy
@@ -96,7 +96,7 @@ class YamlUtils implements Serializable {
                 context.variablesReplaced = true // remember that variables were found in the YAML file that have been replaced.
             }
 
-            return complexResult ?: stringNode
+            return (complexResult != null) ? complexResult : stringNode
         }
         else if (manifestNode instanceof List) {
             List<Object> listNode = manifestNode as List<Object>

--- a/test/groovy/CfManifestSubstituteVariablesTest.groovy
+++ b/test/groovy/CfManifestSubstituteVariablesTest.groovy
@@ -445,8 +445,8 @@ public class CfManifestSubstituteVariablesTest extends BasePiperTest {
 
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("services").get(0) instanceof String)
 
-        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable").equals(true))
-        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable") instanceof Boolean)
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariableTrue").equals(true))
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariableTrue") instanceof Boolean)
 
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("floatVariable") == 0.25)
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("floatVariable") instanceof Double)

--- a/test/groovy/com/sap/piper/variablesubstitution/YamlUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/variablesubstitution/YamlUtilsTest.groovy
@@ -231,11 +231,11 @@ class YamlUtilsTest extends BasePiperTest {
 
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("services").get(0) instanceof String)
 
-        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable").equals(true))
-        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable") instanceof Boolean)
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariableTrue").equals(true))
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariableTrue") instanceof Boolean)
 
-        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable2").equals(false))
-        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable2") instanceof Boolean)
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariableFalse").equals(false))
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariableFalse") instanceof Boolean)
 
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("floatVariable") == 0.25)
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("floatVariable") instanceof Double)

--- a/test/groovy/com/sap/piper/variablesubstitution/YamlUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/variablesubstitution/YamlUtilsTest.groovy
@@ -234,6 +234,9 @@ class YamlUtilsTest extends BasePiperTest {
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable").equals(true))
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable") instanceof Boolean)
 
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable2").equals(false))
+        assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("booleanVariable2") instanceof Boolean)
+
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("floatVariable") == 0.25)
         assertTrue(manifestDataAfterReplacement.get("applications").get(0).get("env").get("floatVariable") instanceof Double)
 

--- a/test/resources/variableSubstitution/datatypes_manifest-variables.yml
+++ b/test/resources/variableSubstitution/datatypes_manifest-variables.yml
@@ -3,8 +3,8 @@ unique-prefix: uniquePrefix # A unique prefix. E.g. your D/I/C-User
 xsuaa-instance-name: uniquePrefix-catalog-service-odatav2-xsuaa
 hana-instance-name: uniquePrefix-catalog-service-odatav2-hana
 integer-variable: 1
-boolean-variable: Yes
-boolean-variable2: false
+boolean-variable-true: Yes
+boolean-variable-false: false
 float-variable: 0.25
 json-variable: >
   [

--- a/test/resources/variableSubstitution/datatypes_manifest-variables.yml
+++ b/test/resources/variableSubstitution/datatypes_manifest-variables.yml
@@ -4,6 +4,7 @@ xsuaa-instance-name: uniquePrefix-catalog-service-odatav2-xsuaa
 hana-instance-name: uniquePrefix-catalog-service-odatav2-hana
 integer-variable: 1
 boolean-variable: Yes
+boolean-variable2: false
 float-variable: 0.25
 json-variable: >
   [

--- a/test/resources/variableSubstitution/datatypes_manifest.yml
+++ b/test/resources/variableSubstitution/datatypes_manifest.yml
@@ -20,6 +20,7 @@ applications:
     xsuaa-instance-name: ((xsuaa-instance-name))
     db_service_instance_name: ((hana-instance-name))
     booleanVariable: ((boolean-variable))
+    booleanVariable2: ((boolean-variable2))
     floatVariable: ((float-variable))
     json-variable: ((json-variable))
     object-variable: ((object-variable))

--- a/test/resources/variableSubstitution/datatypes_manifest.yml
+++ b/test/resources/variableSubstitution/datatypes_manifest.yml
@@ -19,10 +19,10 @@ applications:
     spring.profiles.active: cloud # activate the spring profile named 'cloud'.
     xsuaa-instance-name: ((xsuaa-instance-name))
     db_service_instance_name: ((hana-instance-name))
-    booleanVariable: ((boolean-variable))
-    booleanVariable2: ((boolean-variable2))
+    booleanVariableTrue: ((boolean-variable-true))
+    booleanVariableFalse: ((boolean-variable-false))
     floatVariable: ((float-variable))
     json-variable: ((json-variable))
     object-variable: ((object-variable))
-    string-variable: ((boolean-variable))-((float-variable))-((integer-variable))-((json-variable))
-    single-var-with-string-constants: ((boolean-variable))-with-some-more-text
+    string-variable: ((boolean-variable-true))-((float-variable))-((integer-variable))-((json-variable))
+    single-var-with-string-constants: ((boolean-variable-true))-with-some-more-text


### PR DESCRIPTION
Fixes: yaml substitution does not work for booleans with value false. See #1579.


