### PR TITLE
Store build tool in commonPipelineEnvironment

### DIFF
--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -64,6 +64,7 @@ void call(Map parameters = [:]) {
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName?:env.STAGE_NAME, STEP_CONFIG_KEYS)
             .mixin(parameters, PARAMETER_KEYS)
             .addIfEmpty('dockerImageTag', script.commonPipelineEnvironment.getArtifactVersion())
+            .addIfEmpty('buildTool', script.commonPipelineEnvironment.getBuildTool())
             .use()
 
         // telemetry reporting

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -10,6 +10,9 @@ class commonPipelineEnvironment implements Serializable {
     def artifactVersion
     def originalArtifactVersion
 
+    //stores the build tools if it inferred automatically, e.g. in the SAP Cloud SDK pipeline
+    String buildTool
+
     //Stores the current buildResult
     String buildResult = 'SUCCESS'
 
@@ -53,6 +56,8 @@ class commonPipelineEnvironment implements Serializable {
         appContainerProperties = [:]
         artifactVersion = null
         originalArtifactVersion = null
+
+        buildTool = null
 
         configuration = [:]
         containerProperties = [:]


### PR DESCRIPTION
# Changes
This is required by Cloud SDK Pipeline. Instead of configuring it the pipeline will infer the build tool and store it in the commonPipelineEnvironment.

- [ ] Tests
- [ ] Documentation
