### PR TITLE
Increase default transport timeout to 3 mins

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -342,7 +342,7 @@ func (c *Client) handleResponse(response *http.Response) (*http.Response, error)
 
 func (c *Client) applyDefaults() {
 	if c.transportTimeout == 0 {
-		c.transportTimeout = 10 * time.Second
+		c.transportTimeout = 3 * time.Minute
 	}
 	if c.logger == nil {
 		c.logger = log.Entry().WithField("package", "SAP/jenkins-library/pkg/http")

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -38,7 +38,7 @@ type ClientOptions struct {
 	// for the request will be enforced. This should only be used if the
 	// length of the request bodies is known.
 	MaxRequestDuration time.Duration
-	// TransportTimeout defaults to 10 seconds, if not specified. It is
+	// TransportTimeout defaults to 3 minutes, if not specified. It is
 	// used for the transport layer and duration of handshakes and such.
 	TransportTimeout         time.Duration
 	Username                 string

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -96,7 +96,7 @@ func TestApplyDefaults(t *testing.T) {
 		client   Client
 		expected Client
 	}{
-		{client: Client{}, expected: Client{transportTimeout: 10 * time.Second, maxRequestDuration: 0, logger: log.Entry().WithField("package", "SAP/jenkins-library/pkg/http")}},
+		{client: Client{}, expected: Client{transportTimeout: 3 * time.Minute, maxRequestDuration: 0, logger: log.Entry().WithField("package", "SAP/jenkins-library/pkg/http")}},
 		{client: Client{transportTimeout: 10, maxRequestDuration: 5}, expected: Client{transportTimeout: 10, maxRequestDuration: 5, logger: log.Entry().WithField("package", "SAP/jenkins-library/pkg/http")}},
 	}
 


### PR DESCRIPTION
# Changes

Increase the default transport timeout to 3 minutes. The thinking is this: If a Pipeline will fail due to a network stall, it isn't so bad to have it stall for longer than necessary. On the other hand, to have a pipeline fail quickly because of a 10s network stall, while everything would have been fine just with a longer timeout, is very frustrating and may overall consume much more time than is saved by failing more quickly in the first situation.

- [x] Tests
- [x] Documentation
