### PR TITLE
Refactor maven.Evaluate() to take options

### DIFF
--- a/cmd/nexusUpload.go
+++ b/cmd/nexusUpload.go
@@ -33,7 +33,7 @@ type nexusUploadUtils interface {
 	usesNpm() bool
 	getEnvParameter(path, name string) string
 	getExecRunner() execRunner
-	evaluate(options *maven.Options, expression string) (string, error)
+	evaluate(options *maven.EvaluateOptions, expression string) (string, error)
 	glob(pattern string) (matches []string, err error)
 }
 
@@ -114,7 +114,7 @@ func (u *utilsBundle) getExecRunner() execRunner {
 	return u.execRunner
 }
 
-func (u *utilsBundle) evaluate(options *maven.Options, expression string) (string, error) {
+func (u *utilsBundle) evaluate(options *maven.EvaluateOptions, expression string) (string, error) {
 	return maven.Evaluate(options, expression, u.getExecRunner())
 }
 
@@ -422,7 +422,7 @@ func uploadMavenArtifacts(utils nexusUploadUtils, uploader nexus.Uploader, optio
 	pomPath, targetFolder string) error {
 	pomFile := composeFilePath(pomPath, "pom", "xml")
 
-	evaluateOptions := &maven.Options{
+	evaluateOptions := &maven.EvaluateOptions{
 		PomPath:            pomFile,
 		GlobalSettingsFile: options.GlobalSettingsFile,
 		M2Path:             options.M2Path,

--- a/cmd/nexusUpload_test.go
+++ b/cmd/nexusUpload_test.go
@@ -102,17 +102,17 @@ func (m *mockUtilsBundle) setProperty(pomFile, expression, value string) {
 	pom[expression] = value
 }
 
-func (m *mockUtilsBundle) evaluate(pomFile, expression string) (string, error) {
-	pom := m.properties[pomFile]
+func (m *mockUtilsBundle) evaluate(options *maven.Options, expression string) (string, error) {
+	pom := m.properties[options.PomPath]
 	if pom == nil {
-		return "", fmt.Errorf("pom file '%s' not found", pomFile)
+		return "", fmt.Errorf("pom file '%s' not found", options.PomPath)
 	}
 	value := pom[expression]
 	if value == "<empty>" {
 		return "", nil
 	}
 	if value == "" {
-		return "", fmt.Errorf("property '%s' not found in '%s'", expression, pomFile)
+		return "", fmt.Errorf("property '%s' not found in '%s'", expression, options.PomPath)
 	}
 	return value, nil
 }

--- a/cmd/nexusUpload_test.go
+++ b/cmd/nexusUpload_test.go
@@ -102,7 +102,7 @@ func (m *mockUtilsBundle) setProperty(pomFile, expression, value string) {
 	pom[expression] = value
 }
 
-func (m *mockUtilsBundle) evaluate(options *maven.Options, expression string) (string, error) {
+func (m *mockUtilsBundle) evaluate(options *maven.EvaluateOptions, expression string) (string, error) {
 	pom := m.properties[options.PomPath]
 	if pom == nil {
 		return "", fmt.Errorf("pom file '%s' not found", options.PomPath)

--- a/pkg/maven/maven.go
+++ b/pkg/maven/maven.go
@@ -12,14 +12,6 @@ import (
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 )
 
-// Options stores basic options for a maven execution context.
-type Options struct {
-	PomPath             string `json:"pomPath,omitempty"`
-	ProjectSettingsFile string `json:"projectSettingsFile,omitempty"`
-	GlobalSettingsFile  string `json:"globalSettingsFile,omitempty"`
-	M2Path              string `json:"m2Path,omitempty"`
-}
-
 // ExecuteOptions are used by Execute() to construct the Maven command line.
 type ExecuteOptions struct {
 	PomPath                     string   `json:"pomPath,omitempty"`
@@ -31,6 +23,15 @@ type ExecuteOptions struct {
 	Flags                       []string `json:"flags,omitempty"`
 	LogSuccessfulMavenTransfers bool     `json:"logSuccessfulMavenTransfers,omitempty"`
 	ReturnStdout                bool     `json:"returnStdout,omitempty"`
+}
+
+// EvaluateOptions are used by Evaluate() to construct the Maven command line.
+// In contrast to ExecuteOptions, fewer settings are required for Evaluate and thus a separate type is needed.
+type EvaluateOptions struct {
+	PomPath             string `json:"pomPath,omitempty"`
+	ProjectSettingsFile string `json:"projectSettingsFile,omitempty"`
+	GlobalSettingsFile  string `json:"globalSettingsFile,omitempty"`
+	M2Path              string `json:"m2Path,omitempty"`
 }
 
 type mavenExecRunner interface {
@@ -85,7 +86,7 @@ func Execute(options *ExecuteOptions, command mavenExecRunner) (string, error) {
 // Evaluate constructs ExecuteOptions for using the maven-help-plugin's 'evaluate' goal to
 // evaluate a given expression from a pom file. This allows to retrieve the value of - for
 // example - 'project.version' from a pom file exactly as Maven itself evaluates it.
-func Evaluate(options *Options, expression string, command mavenExecRunner) (string, error) {
+func Evaluate(options *EvaluateOptions, expression string, command mavenExecRunner) (string, error) {
 	expressionDefine := "-Dexpression=" + expression
 	executeOptions := ExecuteOptions{
 		PomPath:             options.PomPath,

--- a/pkg/maven/maven_test.go
+++ b/pkg/maven/maven_test.go
@@ -97,7 +97,7 @@ func TestEvaluate(t *testing.T) {
 		execMockRunner := mock.ExecMockRunner{}
 		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "com.awesome"}
 
-		result, err := Evaluate(&Options{PomPath: "pom.xml"}, "project.groupId", &execMockRunner)
+		result, err := Evaluate(&EvaluateOptions{PomPath: "pom.xml"}, "project.groupId", &execMockRunner)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "com.awesome", result)
 		}
@@ -106,7 +106,7 @@ func TestEvaluate(t *testing.T) {
 		execMockRunner := mock.ExecMockRunner{}
 		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "null object or invalid expression"}
 
-		result, err := Evaluate(&Options{PomPath: "pom.xml"}, "project.groupId", &execMockRunner)
+		result, err := Evaluate(&EvaluateOptions{PomPath: "pom.xml"}, "project.groupId", &execMockRunner)
 		if assert.EqualError(t, err, "expression 'project.groupId' in file 'pom.xml' could not be resolved") {
 			assert.Equal(t, "", result)
 		}

--- a/pkg/maven/maven_test.go
+++ b/pkg/maven/maven_test.go
@@ -97,7 +97,7 @@ func TestEvaluate(t *testing.T) {
 		execMockRunner := mock.ExecMockRunner{}
 		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "com.awesome"}
 
-		result, err := Evaluate("pom.xml", "project.groupId", &execMockRunner)
+		result, err := Evaluate(&Options{PomPath: "pom.xml"}, "project.groupId", &execMockRunner)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "com.awesome", result)
 		}
@@ -106,7 +106,7 @@ func TestEvaluate(t *testing.T) {
 		execMockRunner := mock.ExecMockRunner{}
 		execMockRunner.StdoutReturn = map[string]string{"mvn --file pom.xml -Dexpression=project.groupId -DforceStdout -q -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn --batch-mode org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate": "null object or invalid expression"}
 
-		result, err := Evaluate("pom.xml", "project.groupId", &execMockRunner)
+		result, err := Evaluate(&Options{PomPath: "pom.xml"}, "project.groupId", &execMockRunner)
 		if assert.EqualError(t, err, "expression 'project.groupId' in file 'pom.xml' could not be resolved") {
 			assert.Equal(t, "", result)
 		}

--- a/pkg/versioning/maven.go
+++ b/pkg/versioning/maven.go
@@ -18,7 +18,7 @@ type mavenExecRunner interface {
 
 type mavenRunner interface {
 	Execute(*maven.ExecuteOptions, mavenExecRunner) (string, error)
-	Evaluate(string, string, mavenExecRunner) (string, error)
+	Evaluate(*maven.Options, string, mavenExecRunner) (string, error)
 }
 
 // MavenDescriptor holds the unique identifier combination for Maven built Java artifacts
@@ -31,17 +31,14 @@ type MavenDescriptor struct {
 
 // Maven defines a maven artifact used for versioning
 type Maven struct {
-	pomPath             string
-	runner              mavenRunner
-	execRunner          mavenExecRunner
-	projectSettingsFile string
-	globalSettingsFile  string
-	m2Path              string
+	options    maven.Options
+	runner     mavenRunner
+	execRunner mavenExecRunner
 }
 
 func (m *Maven) init() {
-	if len(m.pomPath) == 0 {
-		m.pomPath = "pom.xml"
+	if len(m.options.PomPath) == 0 {
+		m.options.PomPath = "pom.xml"
 	}
 
 	if m.execRunner == nil {
@@ -81,7 +78,7 @@ func (m *Maven) GetCoordinates() (Coordinates, error) {
 func (m *Maven) GetPackaging() (string, error) {
 	m.init()
 
-	packaging, err := m.runner.Evaluate(m.pomPath, "project.packaging", m.execRunner)
+	packaging, err := m.runner.Evaluate(&m.options, "project.packaging", m.execRunner)
 	if err != nil {
 		return "", errors.Wrap(err, "Maven - getting packaging failed")
 	}
@@ -92,7 +89,7 @@ func (m *Maven) GetPackaging() (string, error) {
 func (m *Maven) GetGroupID() (string, error) {
 	m.init()
 
-	groupID, err := m.runner.Evaluate(m.pomPath, "project.groupId", m.execRunner)
+	groupID, err := m.runner.Evaluate(&m.options, "project.groupId", m.execRunner)
 	if err != nil {
 		return "", errors.Wrap(err, "Maven - getting groupId failed")
 	}
@@ -103,7 +100,7 @@ func (m *Maven) GetGroupID() (string, error) {
 func (m *Maven) GetArtifactID() (string, error) {
 	m.init()
 
-	artifactID, err := m.runner.Evaluate(m.pomPath, "project.artifactId", m.execRunner)
+	artifactID, err := m.runner.Evaluate(&m.options, "project.artifactId", m.execRunner)
 	if err != nil {
 		return "", errors.Wrap(err, "Maven - getting artifactId failed")
 	}
@@ -114,7 +111,7 @@ func (m *Maven) GetArtifactID() (string, error) {
 func (m *Maven) GetVersion() (string, error) {
 	m.init()
 
-	version, err := m.runner.Evaluate(m.pomPath, "project.version", m.execRunner)
+	version, err := m.runner.Evaluate(&m.options, "project.version", m.execRunner)
 	if err != nil {
 		return "", errors.Wrap(err, "Maven - getting version failed")
 	}
@@ -126,15 +123,15 @@ func (m *Maven) GetVersion() (string, error) {
 func (m *Maven) SetVersion(version string) error {
 	m.init()
 
-	groupID, err := m.runner.Evaluate(m.pomPath, "project.groupId", m.execRunner)
+	groupID, err := m.runner.Evaluate(&m.options, "project.groupId", m.execRunner)
 	if err != nil {
 		return errors.Wrap(err, "Maven - getting groupId failed")
 	}
 	opts := maven.ExecuteOptions{
-		PomPath:             m.pomPath,
-		ProjectSettingsFile: m.projectSettingsFile,
-		GlobalSettingsFile:  m.globalSettingsFile,
-		M2Path:              m.m2Path,
+		PomPath:             m.options.PomPath,
+		ProjectSettingsFile: m.options.ProjectSettingsFile,
+		GlobalSettingsFile:  m.options.GlobalSettingsFile,
+		M2Path:              m.options.M2Path,
 		Goals:               []string{"org.codehaus.mojo:versions-maven-plugin:2.7:set"},
 		Defines: []string{
 			fmt.Sprintf("-DnewVersion=%v", version),

--- a/pkg/versioning/maven.go
+++ b/pkg/versioning/maven.go
@@ -18,7 +18,7 @@ type mavenExecRunner interface {
 
 type mavenRunner interface {
 	Execute(*maven.ExecuteOptions, mavenExecRunner) (string, error)
-	Evaluate(*maven.Options, string, mavenExecRunner) (string, error)
+	Evaluate(*maven.EvaluateOptions, string, mavenExecRunner) (string, error)
 }
 
 // MavenDescriptor holds the unique identifier combination for Maven built Java artifacts
@@ -31,7 +31,7 @@ type MavenDescriptor struct {
 
 // Maven defines a maven artifact used for versioning
 type Maven struct {
-	options    maven.Options
+	options    maven.EvaluateOptions
 	runner     mavenRunner
 	execRunner mavenExecRunner
 }

--- a/pkg/versioning/maven_test.go
+++ b/pkg/versioning/maven_test.go
@@ -12,13 +12,13 @@ type mavenMockRunner struct {
 	evaluateErrorString string
 	executeErrorString  string
 	stdout              string
-	opts                *maven.ExecuteOptions
+	opts                *maven.Options
+	execOpts            *maven.ExecuteOptions
 	expression          string
-	pomFile             string
 }
 
-func (m *mavenMockRunner) Evaluate(pomFile, expression string, runner mavenExecRunner) (string, error) {
-	m.pomFile = pomFile
+func (m *mavenMockRunner) Evaluate(opts *maven.Options, expression string, runner mavenExecRunner) (string, error) {
+	m.opts = opts
 	m.expression = expression
 	if len(m.evaluateErrorString) > 0 {
 		return "", fmt.Errorf(m.evaluateErrorString)
@@ -27,7 +27,7 @@ func (m *mavenMockRunner) Evaluate(pomFile, expression string, runner mavenExecR
 }
 
 func (m *mavenMockRunner) Execute(opts *maven.ExecuteOptions, runner mavenExecRunner) (string, error) {
-	m.opts = opts
+	m.execOpts = opts
 	if len(m.executeErrorString) > 0 {
 		return "", fmt.Errorf(m.executeErrorString)
 	}
@@ -44,13 +44,14 @@ func TestMavenGetVersion(t *testing.T) {
 		}
 		mvn := &Maven{
 			runner:  &runner,
-			pomPath: "path/to/pom.xml",
+			options: maven.Options{PomPath: "path/to/pom.xml", M2Path: "path/to/m2"},
 		}
 		version, err := mvn.GetVersion()
 		assert.NoError(t, err)
 		assert.Equal(t, "1.2.3", version)
 		assert.Equal(t, "project.version", runner.expression)
-		assert.Equal(t, "path/to/pom.xml", runner.pomFile)
+		assert.Equal(t, "path/to/pom.xml", runner.opts.PomPath)
+		assert.Equal(t, "path/to/m2", runner.opts.M2Path)
 	})
 
 	t.Run("error case", func(t *testing.T) {
@@ -74,11 +75,12 @@ func TestMavenSetVersion(t *testing.T) {
 			stdout: "testGroup",
 		}
 		mvn := &Maven{
-			runner:              &runner,
-			pomPath:             "path/to/pom.xml",
-			projectSettingsFile: "project-settings.xml",
-			globalSettingsFile:  "global-settings.xml",
-			m2Path:              "m2/path",
+			runner: &runner,
+			options: maven.Options{
+				PomPath:             "path/to/pom.xml",
+				ProjectSettingsFile: "project-settings.xml",
+				GlobalSettingsFile:  "global-settings.xml",
+				M2Path:              "m2/path"},
 		}
 		expectedOptions := maven.ExecuteOptions{
 			PomPath:             "path/to/pom.xml",
@@ -90,7 +92,7 @@ func TestMavenSetVersion(t *testing.T) {
 		}
 		err := mvn.SetVersion("1.2.4")
 		assert.NoError(t, err)
-		assert.Equal(t, &expectedOptions, runner.opts)
+		assert.Equal(t, &expectedOptions, runner.execOpts)
 	})
 
 	t.Run("evaluate error", func(t *testing.T) {
@@ -100,7 +102,7 @@ func TestMavenSetVersion(t *testing.T) {
 		}
 		mvn := &Maven{
 			runner:  &runner,
-			pomPath: "path/to/pom.xml",
+			options: maven.Options{PomPath: "path/to/pom.xml"},
 		}
 		err := mvn.SetVersion("1.2.4")
 		assert.EqualError(t, err, "Maven - getting groupId failed: maven eval failed")
@@ -113,7 +115,7 @@ func TestMavenSetVersion(t *testing.T) {
 		}
 		mvn := &Maven{
 			runner:  &runner,
-			pomPath: "path/to/pom.xml",
+			options: maven.Options{PomPath: "path/to/pom.xml"},
 		}
 		err := mvn.SetVersion("1.2.4")
 		assert.EqualError(t, err, "Maven - setting version 1.2.4 failed: maven exec failed")

--- a/pkg/versioning/maven_test.go
+++ b/pkg/versioning/maven_test.go
@@ -12,12 +12,12 @@ type mavenMockRunner struct {
 	evaluateErrorString string
 	executeErrorString  string
 	stdout              string
-	opts                *maven.Options
+	opts                *maven.EvaluateOptions
 	execOpts            *maven.ExecuteOptions
 	expression          string
 }
 
-func (m *mavenMockRunner) Evaluate(opts *maven.Options, expression string, runner mavenExecRunner) (string, error) {
+func (m *mavenMockRunner) Evaluate(opts *maven.EvaluateOptions, expression string, runner mavenExecRunner) (string, error) {
 	m.opts = opts
 	m.expression = expression
 	if len(m.evaluateErrorString) > 0 {
@@ -44,7 +44,7 @@ func TestMavenGetVersion(t *testing.T) {
 		}
 		mvn := &Maven{
 			runner:  &runner,
-			options: maven.Options{PomPath: "path/to/pom.xml", M2Path: "path/to/m2"},
+			options: maven.EvaluateOptions{PomPath: "path/to/pom.xml", M2Path: "path/to/m2"},
 		}
 		version, err := mvn.GetVersion()
 		assert.NoError(t, err)
@@ -76,7 +76,7 @@ func TestMavenSetVersion(t *testing.T) {
 		}
 		mvn := &Maven{
 			runner: &runner,
-			options: maven.Options{
+			options: maven.EvaluateOptions{
 				PomPath:             "path/to/pom.xml",
 				ProjectSettingsFile: "project-settings.xml",
 				GlobalSettingsFile:  "global-settings.xml",
@@ -102,7 +102,7 @@ func TestMavenSetVersion(t *testing.T) {
 		}
 		mvn := &Maven{
 			runner:  &runner,
-			options: maven.Options{PomPath: "path/to/pom.xml"},
+			options: maven.EvaluateOptions{PomPath: "path/to/pom.xml"},
 		}
 		err := mvn.SetVersion("1.2.4")
 		assert.EqualError(t, err, "Maven - getting groupId failed: maven eval failed")
@@ -115,7 +115,7 @@ func TestMavenSetVersion(t *testing.T) {
 		}
 		mvn := &Maven{
 			runner:  &runner,
-			options: maven.Options{PomPath: "path/to/pom.xml"},
+			options: maven.EvaluateOptions{PomPath: "path/to/pom.xml"},
 		}
 		err := mvn.SetVersion("1.2.4")
 		assert.EqualError(t, err, "Maven - setting version 1.2.4 failed: maven exec failed")

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -36,8 +36,8 @@ type mvnRunner struct{}
 func (m *mvnRunner) Execute(options *maven.ExecuteOptions, execRunner mavenExecRunner) (string, error) {
 	return maven.Execute(options, execRunner)
 }
-func (m *mvnRunner) Evaluate(pomFile, expression string, execRunner mavenExecRunner) (string, error) {
-	return maven.Evaluate(pomFile, expression, execRunner)
+func (m *mvnRunner) Evaluate(options *maven.Options, expression string, execRunner mavenExecRunner) (string, error) {
+	return maven.Evaluate(options, expression, execRunner)
 }
 
 var fileExists func(string) (bool, error)
@@ -87,12 +87,14 @@ func GetArtifact(buildTool, buildDescriptorFilePath string, opts *Options, execR
 			buildDescriptorFilePath = "pom.xml"
 		}
 		artifact = &Maven{
-			runner:              &mvnRunner{},
-			execRunner:          execRunner,
-			pomPath:             buildDescriptorFilePath,
-			projectSettingsFile: opts.ProjectSettingsFile,
-			globalSettingsFile:  opts.GlobalSettingsFile,
-			m2Path:              opts.M2Path,
+			runner:     &mvnRunner{},
+			execRunner: execRunner,
+			options: maven.Options{
+				PomPath:             buildDescriptorFilePath,
+				ProjectSettingsFile: opts.ProjectSettingsFile,
+				GlobalSettingsFile:  opts.GlobalSettingsFile,
+				M2Path:              opts.M2Path,
+			},
 		}
 	case "mta":
 		if len(buildDescriptorFilePath) == 0 {

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -20,7 +20,7 @@ type Artifact interface {
 	GetCoordinates() (Coordinates, error)
 }
 
-// Options define build tool specific settings in order to properly retrieve e.g. the version of an artifact
+// EvaluateOptions define build tool specific settings in order to properly retrieve e.g. the version of an artifact
 type Options struct {
 	ProjectSettingsFile string
 	GlobalSettingsFile  string
@@ -36,7 +36,7 @@ type mvnRunner struct{}
 func (m *mvnRunner) Execute(options *maven.ExecuteOptions, execRunner mavenExecRunner) (string, error) {
 	return maven.Execute(options, execRunner)
 }
-func (m *mvnRunner) Evaluate(options *maven.Options, expression string, execRunner mavenExecRunner) (string, error) {
+func (m *mvnRunner) Evaluate(options *maven.EvaluateOptions, expression string, execRunner mavenExecRunner) (string, error) {
 	return maven.Evaluate(options, expression, execRunner)
 }
 
@@ -89,7 +89,7 @@ func GetArtifact(buildTool, buildDescriptorFilePath string, opts *Options, execR
 		artifact = &Maven{
 			runner:     &mvnRunner{},
 			execRunner: execRunner,
-			options: maven.Options{
+			options: maven.EvaluateOptions{
 				PomPath:             buildDescriptorFilePath,
 				ProjectSettingsFile: opts.ProjectSettingsFile,
 				GlobalSettingsFile:  opts.GlobalSettingsFile,

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -20,7 +20,7 @@ type Artifact interface {
 	GetCoordinates() (Coordinates, error)
 }
 
-// EvaluateOptions define build tool specific settings in order to properly retrieve e.g. the version of an artifact
+// Options define build tool specific settings in order to properly retrieve e.g. the version of an artifact
 type Options struct {
 	ProjectSettingsFile string
 	GlobalSettingsFile  string

--- a/pkg/versioning/versioning_test.go
+++ b/pkg/versioning/versioning_test.go
@@ -75,10 +75,10 @@ func TestGetArtifact(t *testing.T) {
 
 		theType, ok := maven.(*Maven)
 		assert.True(t, ok)
-		assert.Equal(t, "pom.xml", theType.pomPath)
-		assert.Equal(t, opts.ProjectSettingsFile, theType.projectSettingsFile)
-		assert.Equal(t, opts.GlobalSettingsFile, theType.globalSettingsFile)
-		assert.Equal(t, opts.M2Path, theType.m2Path)
+		assert.Equal(t, "pom.xml", theType.options.PomPath)
+		assert.Equal(t, opts.ProjectSettingsFile, theType.options.ProjectSettingsFile)
+		assert.Equal(t, opts.GlobalSettingsFile, theType.options.GlobalSettingsFile)
+		assert.Equal(t, opts.M2Path, theType.options.M2Path)
 		assert.Equal(t, "maven", maven.VersioningScheme())
 	})
 


### PR DESCRIPTION
# Changes

Global maven options (m2Path, projectSettingsFile, globalSettingsFile), which most steps using maven already share via aliasing from the general config, need to be passed also to Evaluate().

This does actually fix problems in the artifactPrepareVersion step, depending on the project setup.

- [x] Tests
- [x] Documentation
