### PR TITLE
Adapt mavenExecute example call to new api

### DIFF
--- a/documentation/docs/extensibility.md
+++ b/documentation/docs/extensibility.md
@@ -87,10 +87,10 @@ def call(Map parameters) {
 
     mavenExecute(
         script: parameters.script,
-        flags: '--batch-mode',
+        flags: ['--batch-mode'],
         pomPath: 'application/pom.xml',
         m2Path: s4SdkGlobals.m2Directory,
-        goals: 'checkstyle:checkstyle',
+        goals: ['checkstyle:checkstyle'],
     )
 
     recordIssues blameDisabled: true,


### PR DESCRIPTION
The old one won't work

# Changes

- [ ] Tests
- [ ] Documentation
