### PR TITLE
No parallel test exec for file tests

### DIFF
--- a/pkg/piperutils/fileUtils_test.go
+++ b/pkg/piperutils/fileUtils_test.go
@@ -29,7 +29,6 @@ func TestFileExists(t *testing.T) {
 }
 
 func TestCopy(t *testing.T) {
-	t.Parallel()
 	runInTempDir(t, "copying file succeeds", "dir2", func(t *testing.T) {
 		file := "testFile"
 		err := ioutil.WriteFile(file, []byte{byte(1), byte(2), byte(3)}, 0700)

--- a/pkg/piperutils/fileUtils_test.go
+++ b/pkg/piperutils/fileUtils_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestFileExists(t *testing.T) {
-	t.Parallel()
 	runInTempDir(t, "testing dir returns false", "dir", func(t *testing.T) {
 		err := os.Mkdir("test", 0777)
 		if err != nil {


### PR DESCRIPTION
On my local environment I get 

```
ok  	github.com/SAP/jenkins-library/pkg/piperenv	2.858s
[{"name":"","target":"testFile1.json","mandatory":true,"scope":""},{"name":"","target":"testFile2.json","mandatory":false,"scope":""}]
[{"name":"Weblink","target":"https://1234568.com/test","mandatory":false,"scope":""}]
--- FAIL: TestCopy (0.00s)
    --- FAIL: TestCopy/copying_file_succeeds (0.00s)
        fileUtils_test.go:41: 
            	Error Trace:	fileUtils_test.go:41
            	Error:      	Received unexpected error:
            	            	Source file 'testFile' does not exist
            	Test:       	TestCopy/copying_file_succeeds
            	Messages:   	Didn't expert error but got one
        fileUtils_test.go:42: 
            	Error Trace:	fileUtils_test.go:42
            	Error:      	Not equal: 
            	            	expected: 3
            	            	actual  : 0
            	Test:       	TestCopy/copying_file_succeeds
            	Messages:   	Expected true but got false
FAIL
FAIL	github.com/SAP/jenkins-library/pkg/piperutils	2.403s

```

When removing the parallel statements (especially that in the earlier commit) this does not happen. I guess this is caused by the statements in the defer function of `runInTempDir`:

```
	defer func() {
		_ = os.Chdir(oldCWD)
		_ = os.RemoveAll(dir)
```

Here the state is restored for the complete test execution. The first test which is finished resets the environment. Other tests - not yet finished - are working upon the resettet environment rather than on the environment expected by the test.

Since the test execution is cheap in terms of time I guess it is not a big deal not to use the `Parallel`  statement.