### PR TITLE
Introduce interface for manifest

### DIFF
--- a/pkg/cloudfoundry/ManifestUtils.go
+++ b/pkg/cloudfoundry/ManifestUtils.go
@@ -79,7 +79,7 @@ func (m *manifest) WriteManifest() error {
 	return err
 }
 
-// GetName Returns the file name of the manifest.
+// GetFileName returns the file name of the manifest.
 func (m manifest) GetFileName() string {
 	return m.name
 }

--- a/pkg/cloudfoundry/ManifestUtils.go
+++ b/pkg/cloudfoundry/ManifestUtils.go
@@ -80,14 +80,14 @@ func (m *manifest) WriteManifest() error {
 }
 
 // GetFileName returns the file name of the manifest.
-func (m manifest) GetFileName() string {
+func (m *manifest) GetFileName() string {
 	return m.name
 }
 
 // GetApplications Returns all applications denoted in the manifest file.
 // The applications are returned as a slice of maps. Each app is represented by
 // a map.
-func (m manifest) GetApplications() ([]map[string]interface{}, error) {
+func (m *manifest) GetApplications() ([]map[string]interface{}, error) {
 	apps, err := toSlice(m.self["applications"])
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (m manifest) GetApplications() ([]map[string]interface{}, error) {
 }
 
 // ApplicationHasProperty Checks if the application denoted by 'index' has the property 'name'
-func (m manifest) ApplicationHasProperty(index int, name string) (bool, error) {
+func (m *manifest) ApplicationHasProperty(index int, name string) (bool, error) {
 
 	sliced, err := toSlice(m.self[constPropApplications])
 	if err != nil {
@@ -128,7 +128,7 @@ func (m manifest) ApplicationHasProperty(index int, name string) (bool, error) {
 }
 
 // GetApplicationProperty ...
-func (m manifest) GetApplicationProperty(index int, name string) (interface{}, error) {
+func (m *manifest) GetApplicationProperty(index int, name string) (interface{}, error) {
 
 	sliced, err := toSlice(m.self[constPropApplications])
 	if err != nil {
@@ -153,7 +153,7 @@ func (m manifest) GetApplicationProperty(index int, name string) (interface{}, e
 }
 
 // GetAppName Gets the name of the app at 'index'
-func (m manifest) GetAppName(index int) (string, error) {
+func (m *manifest) GetAppName(index int) (string, error) {
 
 	appName, err := m.GetApplicationProperty(index, "name")
 	if err != nil {
@@ -228,7 +228,7 @@ func transformApp(app map[string]interface{}, m *manifest) error {
 }
 
 // IsModified ...
-func (m manifest) IsModified() bool {
+func (m *manifest) IsModified() bool {
 	return m.modified
 }
 

--- a/pkg/cloudfoundry/ManifestUtils_test.go
+++ b/pkg/cloudfoundry/ManifestUtils_test.go
@@ -132,7 +132,7 @@ func TestGetManifestName(t *testing.T) {
 	manifest, err := ReadManifest("myManifest.yaml")
 
 	if assert.NoError(t, err) {
-		assert.Equal(t, "myManifest.yaml", manifest.GetName())
+		assert.Equal(t, "myManifest.yaml", manifest.GetFileName())
 	}
 }
 


### PR DESCRIPTION
makes it more easy to test other code with the interface
since we can inject a mock.

As a small side story improved function name, basically unrelated. `GetName` on the Manifest is now `GetFileName` in order to avoid misunderstandings with getting an application name.
