### PR TITLE
Add sysadmin capabilities to npmExecuteScripts

### DIFF
--- a/vars/npmExecuteScripts.groovy
+++ b/vars/npmExecuteScripts.groovy
@@ -15,6 +15,7 @@ void call(Map parameters = [:]) {
 
     // No credentials required/supported as of now
     List credentials = []
+    parameters.dockerOptions = ['--cap-add=SYS_ADMIN'].plus(parameters.dockerOptions?:[])
     parameters = DownloadCacheUtils.injectDownloadCacheInParameters(script, parameters, BuildTool.NPM)
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes

Add sysadmin capabilities to npmExecuteScripts is it is only then possible to start chrome with sandbox mode.

- [ ] Tests
- [ ] Documentation
