### PR TITLE
Fix error Handling in DefaultValueCache

### DIFF
--- a/src/com/sap/piper/DefaultValueCache.groovy
+++ b/src/com/sap/piper/DefaultValueCache.groovy
@@ -81,8 +81,8 @@ class DefaultValueCache implements Serializable {
                     "that the response body only contains valid YAML. " +
                     "If you use a file from a GitHub repository, make sure you've used the 'raw' link, " +
                     "for example https://my.github.local/raw/someorg/shared-config/master/backend-service.yml\n" +
-                    "File path: ${configFileName}\n" +
-                    "Content: ${steps.readFile file: configFileName}\n" +
+                    "File path: .pipeline/${configFileName}\n" +
+                    "Content: ${steps.readFile file: ".pipeline/${configFileName}"}\n" +
                     "Exeption message: ${e.getMessage()}\n" +
                     "Exception stacktrace: ${Arrays.toString(e.getStackTrace())}"
             }


### PR DESCRIPTION
# Changes
This change fixes the error handling in addDefaultsFromFiles(), i.e.,
using the correct path when calling the readFile step to return the
content of the unsuccessfully parsed yaml file.


- [ ] Tests
- [ ] Documentation
