### PR TITLE
kubernetesDeploy: categorize known errors & fix #1732

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -16,7 +16,16 @@ import (
 )
 
 func kubernetesDeploy(config kubernetesDeployOptions, telemetryData *telemetry.CustomData) {
-	c := command.Command{}
+	c := command.Command{
+		ErrorCategoryMapping: map[string][]string{
+			"config": {
+				"Error: unknown flag",
+				"Invalid value: \"\": field is immutable",
+				"Error: path * not found",
+				"Error: UPGRADE FAILED: query: failed to query with labels:",
+			},
+		},
+	}
 	// reroute stderr output to logging framework, stdout will be used for command interactions
 	c.Stderr(log.Writer())
 	runKubernetesDeploy(config, &c, log.Writer())

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -102,6 +102,8 @@ func runHelmDeploy(config kubernetesDeployOptions, command execRunner, stdout io
 	if err := json.Unmarshal(dockerRegistrySecret.Bytes(), &dockerRegistrySecretData); err != nil {
 		log.Entry().WithError(err).Fatal("Reading docker registry secret json failed")
 	}
+	// make sure that secret is hidden in log output
+	log.RegisterSecret(dockerRegistrySecretData.Data.DockerConfJSON)
 
 	ingressHosts := ""
 	for i, h := range config.IngressHosts {

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -242,12 +242,25 @@ func scanShortLines(data []byte, atEOF bool) (advance int, token []byte, err err
 func (c *Command) parseConsoleErrors(logLine string) {
 	for category, categoryErrors := range c.ErrorCategoryMapping {
 		for _, errorPart := range categoryErrors {
-			if strings.Contains(logLine, errorPart) {
+			if matchPattern(logLine, errorPart) {
 				log.SetErrorCategory(log.ErrorCategoryByString(category))
 				return
 			}
 		}
 	}
+}
+
+func matchPattern(text, pattern string) bool {
+	if len(pattern) == 0 && len(text) != 0 {
+		return false
+	}
+	parts := strings.Split(pattern, "*")
+	for _, part := range parts {
+		if !strings.Contains(text, part) {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *Command) runCmd(cmd *exec.Cmd) error {

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -182,6 +182,28 @@ func TestParseConsoleErrors(t *testing.T) {
 	log.SetErrorCategory(log.ErrorUndefined)
 }
 
+func TestMatchPattern(t *testing.T) {
+	tt := []struct {
+		text     string
+		pattern  string
+		expected bool
+	}{
+		{text: "", pattern: "", expected: true},
+		{text: "simple test", pattern: "", expected: false},
+		{text: "simple test", pattern: "no", expected: false},
+		{text: "simple test", pattern: "simple", expected: true},
+		{text: "simple test", pattern: "test", expected: true},
+		{text: "advanced pattern test", pattern: "advanced * test", expected: true},
+		{text: "advanced pattern failed", pattern: "advanced * test", expected: false},
+		{text: "advanced pattern with multiple placeholders", pattern: "advanced * with * placeholders", expected: true},
+		{text: "advanced pattern lacking multiple placeholders", pattern: "advanced * with * placeholders", expected: false},
+	}
+
+	for _, test := range tt {
+		assert.Equalf(t, test.expected, matchPattern(test.text, test.pattern), test.text)
+	}
+}
+
 func TestCmdPipes(t *testing.T) {
 	cmd := helperCommand("echo", "foo bar", "baz")
 	defer func() { ExecCommand = exec.Command }()


### PR DESCRIPTION
# Changes

* add known error category mapping for step `kubernetesDeploy`
* enhance error parsing to support patterns
* fixes #1732

- [x] Tests
- ~[ ] Documentation~ not applicable
