### PR TITLE
Allow retrieving exit code from command execution

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -271,6 +271,9 @@ func (c *Command) runCmd(cmd *exec.Cmd) error {
 	}
 
 	if err != nil {
+		// provide fallback to ensure a non 0 exit code in case of an error
+		c.exitCode = 1
+		// try to identify the detailed error code
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 				c.exitCode = status.ExitStatus()

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/pkg/errors"
@@ -20,6 +21,7 @@ type Command struct {
 	stdout               io.Writer
 	stderr               io.Writer
 	env                  []string
+	exitCode             int
 }
 
 // SetDir sets the working directory for the execution
@@ -117,6 +119,11 @@ func (c *Command) RunExecutableInBackground(executable string, params ...string)
 	}
 
 	return execution, nil
+}
+
+// GetExitCode allows to retrieve the exit code of a command execution
+func (c *Command) GetExitCode() int {
+	return c.exitCode
 }
 
 func appendEnvironment(cmd *exec.Cmd, env []string) {
@@ -264,9 +271,14 @@ func (c *Command) runCmd(cmd *exec.Cmd) error {
 	}
 
 	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				c.exitCode = status.ExitStatus()
+			}
+		}
 		return errors.Wrap(err, "cmd.Run() failed")
 	}
-
+	c.exitCode = 0
 	return nil
 }
 

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -52,7 +52,7 @@ func TestShellRun(t *testing.T) {
 
 func TestExecutableRun(t *testing.T) {
 
-	t.Run("test shell", func(t *testing.T) {
+	t.Run("test executable", func(t *testing.T) {
 		ExecCommand = helperCommand
 		defer func() { ExecCommand = exec.Command }()
 		stdout := new(bytes.Buffer)
@@ -61,6 +61,8 @@ func TestExecutableRun(t *testing.T) {
 		t.Run("success case", func(t *testing.T) {
 			ex := Command{stdout: stdout, stderr: stderr}
 			ex.RunExecutable("echo", []string{"foo bar", "baz"}...)
+
+			assert.Equal(t, 0, ex.GetExitCode())
 
 			t.Run("stdin", func(t *testing.T) {
 				expectedOut := "foo bar baz\n"

--- a/pkg/mock/runner.go
+++ b/pkg/mock/runner.go
@@ -3,16 +3,18 @@
 package mock
 
 import (
-	"github.com/SAP/jenkins-library/pkg/command"
 	"io"
 	"io/ioutil"
 	"regexp"
 	"strings"
+
+	"github.com/SAP/jenkins-library/pkg/command"
 )
 
 type ExecMockRunner struct {
 	Dir                 []string
 	Env                 []string
+	ExitCode            int
 	Calls               []ExecCall
 	stdout              io.Writer
 	stderr              io.Writer
@@ -34,6 +36,7 @@ type Execution struct {
 type ShellMockRunner struct {
 	Dir                 string
 	Env                 []string
+	ExitCode            int
 	Calls               []string
 	Shell               []string
 	stdout              io.Writer
@@ -58,6 +61,10 @@ func (m *ExecMockRunner) RunExecutable(e string, p ...string) error {
 	c := strings.Join(append([]string{e}, p...), " ")
 
 	return handleCall(c, m.StdoutReturn, m.ShouldFailOnCommand, m.stdout)
+}
+
+func (m *ExecMockRunner) GetExitCode() int {
+	return m.ExitCode
 }
 
 func (m *ExecMockRunner) RunExecutableInBackground(e string, p ...string) (command.Execution, error) {
@@ -101,6 +108,10 @@ func (m *ShellMockRunner) RunShell(s string, c string) error {
 	m.Calls = append(m.Calls, c)
 
 	return handleCall(c, m.StdoutReturn, m.ShouldFailOnCommand, m.stdout)
+}
+
+func (m *ShellMockRunner) GetExitCode() int {
+	return m.ExitCode
 }
 
 func (e *Execution) Kill() error {

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -62,6 +62,10 @@ import static com.sap.piper.Prerequisites.checkScript
          */
         'manifestVariables',
         /**
+         * Defines additional extension descriptor file for deployment with the mtaDeployPlugin.
+         */
+        'mtaExtensionDescriptor',
+        /**
          * Cloud Foundry target organization.
          * @parentConfigKey cloudFoundry
          */


### PR DESCRIPTION
# Changes

enhancing the command/shell execution with capability to retrieve the exit code.

This will be helpful to derive error categories in case
an executable provides context-specific error codes.

- [x] Tests
- ~[ ] Documentation~ not applicable
