### PR TITLE
cf login additional opts

### DIFF
--- a/pkg/cloudfoundry/Authentication.go
+++ b/pkg/cloudfoundry/Authentication.go
@@ -23,7 +23,7 @@ func LoginCheck(options LoginOptions) (bool, error) {
 	}
 
 	//Check if logged in --> Cf api command responds with "not logged in" if positive
-	var cfCheckLoginScript = []string{"api", options.CfAPIEndpoint}
+	var cfCheckLoginScript = append([]string{"api", options.CfAPIEndpoint}, options.CfAPIOpts...)
 
 	var cfLoginBytes bytes.Buffer
 	c.Stdout(&cfLoginBytes)
@@ -71,7 +71,14 @@ func Login(options LoginOptions) error {
 	if err == nil {
 		log.Entry().Info("Logging in to Cloud Foundry")
 
-		var cfLoginScript = []string{"login", "-a", options.CfAPIEndpoint, "-o", options.CfOrg, "-s", options.CfSpace, "-u", options.Username, "-p", options.Password}
+		var cfLoginScript = []string{
+			"login",
+			"-a", options.CfAPIEndpoint,
+			"-o", options.CfOrg,
+			"-s", options.CfSpace,
+			"-u", options.Username,
+			"-p", options.Password,
+		}
 
 		log.Entry().WithField("cfAPI:", options.CfAPIEndpoint).WithField("cfOrg", options.CfOrg).WithField("space", options.CfSpace).Info("Logging into Cloud Foundry..")
 
@@ -107,4 +114,5 @@ type LoginOptions struct {
 	CfSpace       string
 	Username      string
 	Password      string
+	CfAPIOpts     []string
 }

--- a/pkg/cloudfoundry/Authentication.go
+++ b/pkg/cloudfoundry/Authentication.go
@@ -71,14 +71,14 @@ func Login(options LoginOptions) error {
 	if err == nil {
 		log.Entry().Info("Logging in to Cloud Foundry")
 
-		var cfLoginScript = []string{
+		var cfLoginScript = append([]string{
 			"login",
 			"-a", options.CfAPIEndpoint,
 			"-o", options.CfOrg,
 			"-s", options.CfSpace,
 			"-u", options.Username,
 			"-p", options.Password,
-		}
+		}, options.CfLoginOpts...)
 
 		log.Entry().WithField("cfAPI:", options.CfAPIEndpoint).WithField("cfOrg", options.CfOrg).WithField("space", options.CfSpace).Info("Logging into Cloud Foundry..")
 
@@ -115,4 +115,5 @@ type LoginOptions struct {
 	Username      string
 	Password      string
 	CfAPIOpts     []string
+	CfLoginOpts   []string
 }

--- a/pkg/cloudfoundry/Authentication.go
+++ b/pkg/cloudfoundry/Authentication.go
@@ -10,7 +10,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 )
 
-var c = command.Command{}
+var c command.ExecRunner = &command.Command{}
 
 //LoginCheck checks if user is logged in to Cloud Foundry.
 //If user is not logged in 'cf api' command will return string that contains 'User is not logged in' only if user is not logged in.

--- a/pkg/cloudfoundry/CloudFoundry_test.go
+++ b/pkg/cloudfoundry/CloudFoundry_test.go
@@ -57,6 +57,29 @@ func TestCloudFoundryLoginCheck(t *testing.T) {
 			assert.Equal(t, []mock.ExecCall{mock.ExecCall{Exec: "cf", Params: []string{"api", "https://api.endpoint.com"}}}, m.Calls)
 		}
 	})
+
+	t.Run("CF Login check: with additional API options", func(t *testing.T) {
+
+		defer loginMockCleanup(m)
+
+		cfconfig := LoginOptions{
+			CfAPIEndpoint: "https://api.endpoint.com",
+			// should never used in productive environment, but it is useful for rapid prototyping/troubleshooting
+			CfAPIOpts: []string{"--skip-ssl-validation"},
+		}
+		loggedIn, err := LoginCheck(cfconfig)
+		if assert.NoError(t, err) {
+			assert.True(t, loggedIn)
+			assert.Equal(t, []mock.ExecCall{
+				mock.ExecCall{
+					Exec: "cf",
+					Params: []string{
+						"api",
+						"https://api.endpoint.com",
+						"--skip-ssl-validation",
+					}}}, m.Calls)
+		}
+	})
 }
 
 func TestCloudFoundryLogin(t *testing.T) {


### PR DESCRIPTION
`cf` command line tool provides additional options for `api` subcommand (`--skip-ssl-validation`)  and `login` subcommand (`--skip-ssl-validation`, `--origin`). We need to be able to pass these additional options.

Nota bene: `--skip-ssl-validation` should not be used for productive scenarios. Nevertheless it is useful for rapid prototyping and troubleshooting.