### PR TITLE
Separate log folders for neo deployments

### DIFF
--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -647,7 +647,7 @@ class NeoDeployTest extends BasePiperTest {
 
         helper.registerAllowedMethod("sh", [String],
             { cmd ->
-                if (cmd == 'cat logs/neo/*')
+                if (cmd.toString().contains('cat logs/neo/'))
                     throw new AbortException('Cannot provide logs.')
                 if (cmd.toString().contains('neo.sh deploy-mta'))
                     throw new AbortException('Something went wrong during neo deployment.')

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -217,7 +217,7 @@ void call(parameters = [:]) {
 
 private deploy(script, Map configuration, NeoCommandHelper neoCommandHelper, dockerImage, DeployMode deployMode) {
 
-    String logFolder = 'logs/neo'
+    String logFolder = "logs/neo/${UUID.randomUUID()}"
 
     try {
         sh "mkdir -p ${logFolder}"


### PR DESCRIPTION
Previously, all logs were stored in the same folder and in case of an
error all logs in that folder would be returned to the user. Thus, it
is possible that unrelated logs, i.e., from different deployments (e.g. 
parallel deployments) are returned to the user.

# Changes

- [x] Tests
- [ ] Documentation
