### PR TITLE
Default source for maven deployments to neo

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -328,6 +328,7 @@ steps:
     deployMode: 'mta'
     warAction: 'deploy'
     extensions: []
+    mavenDeploymentModule: '.'
     neo:
       size: 'lite'
       credentialsId: 'CI_CREDENTIALS_ID'

--- a/test/groovy/MulticloudDeployTest.groovy
+++ b/test/groovy/MulticloudDeployTest.groovy
@@ -130,20 +130,6 @@ class MulticloudDeployTest extends BasePiperTest {
     }
 
     @Test
-    void errorNoSourceForNeoDeploymentTest() {
-
-        nullScript.commonPipelineEnvironment.configuration.general.neoTargets = [neo1]
-        nullScript.commonPipelineEnvironment.configuration.general.cfTargets = []
-
-        thrown.expect(Exception)
-        thrown.expectMessage('ERROR - NO VALUE AVAILABLE FOR source')
-
-        stepRule.step.multicloudDeploy(
-            script: nullScript
-        )
-    }
-
-    @Test
     void neoDeploymentTest() {
 
         nullScript.commonPipelineEnvironment.configuration.general.neoTargets = [neo1]

--- a/test/groovy/NeoDeployTest.groovy
+++ b/test/groovy/NeoDeployTest.groovy
@@ -356,7 +356,8 @@ class NeoDeployTest extends BasePiperTest {
             allOf(
                 containsString('ERROR - NO VALUE AVAILABLE FOR:'),
                 containsString('neo/host'),
-                containsString('neo/account')))
+                containsString('neo/account'),
+                containsString('source')))
 
         nullScript.commonPipelineEnvironment.configuration = [:]
 

--- a/vars/multicloudDeploy.groovy
+++ b/vars/multicloudDeploy.groovy
@@ -66,9 +66,6 @@ void call(parameters = [:]) {
 
         Map config = configHelper.use()
 
-        configHelper
-            .withMandatoryProperty('source', null, { config.neoTargets })
-
         utils.pushToSWA([
             step         : STEP_NAME,
             stepParamKey1: 'enableZeroDowntimeDeployment',

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -97,9 +97,15 @@ import static com.sap.piper.Prerequisites.checkScript
       */
     'extensions',
     /**
-     * The path to the archive for deployment to SAP CP. If not provided `mtarFilePath` from commom pipeline environment is used instead.
+     * The path to the archive for deployment to SAP CP. If not provided the following defaults are used based on the deployMode:
+     * *`'mta'` - The `mtarFilePath` from common pipeline environment is used instead.
+     * *`'warParams'` and `'warPropertiesFile'` - The following template will be used "<mavenDeploymentModule>/target/<artifactId>.<packaging>"
      */
-    'source'
+    'source',
+    /**
+     * Path to the maven module which contains the deployment artifact.
+     */
+    'mavenDeploymentModule'
 ])
 
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus([
@@ -127,7 +133,6 @@ void call(parameters = [:]) {
             .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
             .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
             .mixinStageConfig(script.commonPipelineEnvironment, parameters.stageName ?: env.STAGE_NAME, STEP_CONFIG_KEYS)
-            .addIfEmpty('source', script.commonPipelineEnvironment.getMtarFilePath())
             .mixin(parameters, PARAMETER_KEYS)
             .collectValidationFailures()
             .withPropertyInValues('deployMode', DeployMode.stringValues())
@@ -139,7 +144,11 @@ void call(parameters = [:]) {
         def isWarParamsDeployMode = { deployMode == DeployMode.WAR_PARAMS },
             isNotWarPropertiesDeployMode = {deployMode != DeployMode.WAR_PROPERTIES_FILE}
 
-        configHelper
+        if(!configuration.source){
+            configHelper.mixin([source: getDefaultSource(script, configuration, deployMode)])
+        }
+
+        configuration = configHelper
             .withMandatoryProperty('source')
             .withMandatoryProperty('neo/credentialsId')
             .withMandatoryProperty('neo/application', null, isWarParamsDeployMode)
@@ -147,9 +156,6 @@ void call(parameters = [:]) {
             .withMandatoryProperty('neo/runtimeVersion', null, isWarParamsDeployMode)
             .withMandatoryProperty('neo/host', null, isNotWarPropertiesDeployMode)
             .withMandatoryProperty('neo/account', null, isNotWarPropertiesDeployMode)
-            //
-            // call 'use()' a second time in order to get the collected validation failures
-            // since the map did not change, it is not required to replace the previous configuration map.
             .use()
 
         Set extensionFileNames
@@ -286,4 +292,22 @@ private assertPasswordRules(String password) {
             "Please consult the documentation for the neo command line tool for more information: " +
             "https://help.sap.com/viewer/65de2977205c403bbc107264b8eccf4b/Cloud/en-US/8900b22376f84c609ee9baf5bf67130a.html")
     }
+}
+
+private getDefaultSource(Script script, Map configuration, DeployMode deployMode){
+    if(deployMode == DeployMode.MTA) {
+        return script.commonPipelineEnvironment.getMtarFilePath()
+    }
+
+    String pomFile = "${configuration.mavenDeploymentModule}/pom.xml"
+
+    if(!fileExists(pomFile)){
+        error("The configured mavenDeploymentModule (${configuration.mavenDeploymentModule}) does not contain a pom file.")
+    }
+
+    def pom = readMavenPom file: pomFile
+
+    String source = "${configuration.mavenDeploymentModule}/target/${pom.artifactId}.${pom.packaging}"
+
+    return source
 }


### PR DESCRIPTION
# Changes

Before the neoDeploy step already had a default / fallback value for source for mta but not for maven /war. 

With this change the neoDeploy step also tries for maven to automatically detect the deployable artifact.

- [x] Tests
- [x] Documentation
