### PR TITLE
Allow setting a preconfigured execRunner for cf authentication

### DIFF
--- a/pkg/cloudfoundry/Authentication.go
+++ b/pkg/cloudfoundry/Authentication.go
@@ -10,7 +10,8 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 )
 
-var c command.ExecRunner = &command.Command{}
+// ExecRunner ...
+var ExecRunner command.ExecRunner = &command.Command{}
 
 //LoginCheck checks if user is logged in to Cloud Foundry.
 //If user is not logged in 'cf api' command will return string that contains 'User is not logged in' only if user is not logged in.
@@ -26,11 +27,11 @@ func LoginCheck(options LoginOptions) (bool, error) {
 	var cfCheckLoginScript = append([]string{"api", options.CfAPIEndpoint}, options.CfAPIOpts...)
 
 	var cfLoginBytes bytes.Buffer
-	c.Stdout(&cfLoginBytes)
+	ExecRunner.Stdout(&cfLoginBytes)
 
 	var result string
 
-	err = c.RunExecutable("cf", cfCheckLoginScript...)
+	err = ExecRunner.RunExecutable("cf", cfCheckLoginScript...)
 
 	if err != nil {
 		return false, fmt.Errorf("Failed to check if logged in: %w", err)
@@ -82,7 +83,7 @@ func Login(options LoginOptions) error {
 
 		log.Entry().WithField("cfAPI:", options.CfAPIEndpoint).WithField("cfOrg", options.CfOrg).WithField("space", options.CfSpace).Info("Logging into Cloud Foundry..")
 
-		err = c.RunExecutable("cf", cfLoginScript...)
+		err = ExecRunner.RunExecutable("cf", cfLoginScript...)
 	}
 
 	if err != nil {
@@ -99,7 +100,7 @@ func Logout() error {
 
 	log.Entry().Info("Logging out of Cloud Foundry")
 
-	err := c.RunExecutable("cf", cfLogoutScript)
+	err := ExecRunner.RunExecutable("cf", cfLogoutScript)
 	if err != nil {
 		return fmt.Errorf("Failed to Logout of Cloud Foundry: %w", err)
 	}

--- a/pkg/cloudfoundry/Services.go
+++ b/pkg/cloudfoundry/Services.go
@@ -27,14 +27,14 @@ func ReadServiceKeyAbapEnvironment(options ServiceKeyOptions, cfLogoutOption boo
 
 	err = Login(config)
 	var serviceKeyBytes bytes.Buffer
-	c.Stdout(&serviceKeyBytes)
+	ExecRunner.Stdout(&serviceKeyBytes)
 	if err == nil {
 		//Reading Service Key
 		log.Entry().WithField("cfServiceInstance", options.CfServiceInstance).WithField("cfServiceKey", options.CfServiceKey).Info("Read service key for service instance")
 
 		cfReadServiceKeyScript := []string{"service-key", options.CfServiceInstance, options.CfServiceKey}
 
-		err = c.RunExecutable("cf", cfReadServiceKeyScript...)
+		err = ExecRunner.RunExecutable("cf", cfReadServiceKeyScript...)
 	}
 	if err == nil {
 		var serviceKeyJSON string


### PR DESCRIPTION
**This pull request is not ready to merge, but I would like to start a discussion about the issue adressed here**

The cf cli can be configured environment variables (e.g. `CF_TRACE`). The current approach used here is to have a non-public instance of `command.ExecRunner`. With that approach it is not possible to set additional environment variables from outside controlling the behaviour of cf cli.

We have at least two options for fixing this.

1.) Provide the option to set an execRunner from outside. This is basically the approach sketched here.
2.) Extend the signatures of the functions so that we can hand over environment variables. These environment variables needs to be set on the non-public instance of `command.ExecRunner`.
3.) Switch to a receiver approach. The instance for `command.Command` is defined in the receiver.
4.) ...

Reason why this PR is not ready for being merged: When we use the approach sketched here we need to ensure that there is not status change of the exec runner after returning from the functions here. E.g. currently we set the `stdout` stream in order to be able to scan the output of the command. This needs to be set back via a `defer`. In order to get this we need to enhance the execRunner so that we can obtain a currently set output stream handle in order to be able to set it back afterwards.

I would like to suggest to add other approaches here in this PR so that we can discuss the pros and the cons.
