### PR TITLE
Make aliasing more resilient

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/http"
@@ -98,6 +99,12 @@ func getDeepAliasValue(configMap map[string]interface{}, key string) interface{}
 	parts := strings.Split(key, "/")
 	if len(parts) > 1 {
 		if configMap[parts[0]] == nil {
+			return nil
+		}
+
+		paramValueType := reflect.ValueOf(configMap[parts[0]])
+		if paramValueType.Kind() != reflect.Map {
+			log.Entry().Debugf("Ignoring alias '%v' as '%v' is not pointing to a map.", key, parts[0])
 			return nil
 		}
 		return getDeepAliasValue(configMap[parts[0]].(map[string]interface{}), strings.Join(parts[1:], "/"))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -258,6 +258,21 @@ steps:
 		assert.Equal(t, "p1_conf", stepConfig.Config["p1"])
 	})
 
+	t.Run("Ignore alias if wrong type", func(t *testing.T) {
+		var c Config
+
+		stepParams := []StepParameters{
+			StepParameters{Name: "p0", Scope: []string{"GENERAL"}, Type: "bool", Aliases: []Alias{}},
+			StepParameters{Name: "p1", Scope: []string{"GENERAL"}, Type: "string", Aliases: []Alias{{Name: "p0/subParam"}}}}
+		testConf := "general:\n p0: true"
+
+		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConf)), nil, false, StepFilters{General: []string{"p0", "p1"}}, stepParams, nil, nil, "stage1", "step1", []Alias{{}})
+
+		assert.NoError(t, err, "Error occurred but no error expected")
+		assert.Equal(t, true, stepConfig.Config["p0"])
+		assert.Equal(t, nil, stepConfig.Config["p1"])
+	})
+
 	t.Run("Failure case config", func(t *testing.T) {
 		var c Config
 		myConfig := ioutil.NopCloser(strings.NewReader("invalid config"))


### PR DESCRIPTION
# Changes
Before if there is an alias p0/oldParam but p0 was configured as non map type, e.g. p0: true the configure resolution failed with a panic.
`panic: interface conversion: interface {} is bool, not map[string]interface {}`

- [x] Tests
- [x] Documentation
