### PR TITLE
Fortify authEntityIds flag and refactoring

### DIFF
--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -832,7 +832,8 @@ func appendToOptions(config *fortifyExecuteScanOptions, options []string, t map[
 		if len(t["sourcepath"]) > 0 {
 			options = append(options, "-sourcepath", t["sourcepath"])
 		}
-
+	case "gradle":
+		options = append(options, "-gradle", `gradle assemble`)
 	case "pip":
 		if len(t["autoClasspath"]) > 0 {
 			options = append(options, "-python-path", t["autoClasspath"])
@@ -852,9 +853,7 @@ func appendToOptions(config *fortifyExecuteScanOptions, options []string, t map[
 		options = append(options, "-exclude", t["exclude"])
 	}
 
-	log.Entry().Info("Splitting src:", t)
-	options = append(options, strings.Split(t["src"], ":")...)
-	return options
+	return append(options, strings.Split(t["src"], ":")...)
 }
 
 func getSuppliedOrDefaultList(suppliedList, defaultList []string) []string {
@@ -895,17 +894,17 @@ func ensureAuthEntitiesExist(projectVersionId int64, sys fortify.System, config 
 	}
 
 	// For each ensureId in config.AuthEntityIDs, ensure that it exists in the current project version's collection of auth entities.
-	for _, ensureIdStr := range strings.Split(config.AuthEntityIDs, ",") {
+	for _, ensureIDStr := range strings.Split(config.AuthEntityIDs, ",") {
 		found := false
-		ensureIdStr = strings.TrimSpace(ensureIdStr)
-		ensureId, err := strconv.Atoi(ensureIdStr)
+		ensureIDStr = strings.TrimSpace(ensureIDStr)
+		ensureID, err := strconv.Atoi(ensureIDStr)
 
 		if err != nil {
-			log.Entry().WithError(err).Fatalf("Failed to convert entity ID to int: %s", ensureIdStr)
+			log.Entry().WithError(err).Fatalf("Failed to convert entity ID to int: %s", ensureIDStr)
 		}
 
 		for _, entity := range entityList {
-			if entity.ID == int64(ensureId) {
+			if entity.ID == int64(ensureID) {
 				found = true
 				break
 			}
@@ -913,7 +912,7 @@ func ensureAuthEntitiesExist(projectVersionId int64, sys fortify.System, config 
 
 		if !found {
 			newEntity := &models.AuthenticationEntity{
-				ID:     int64(ensureId),
+				ID:     int64(ensureID),
 				IsLdap: true,
 			}
 			err := sys.UpdateCollectionAuthEntityOfProjectVersion(projectVersionId, []*models.AuthenticationEntity{newEntity})

--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -81,7 +81,7 @@ func runFortifyScan(config fortifyExecuteScanOptions, sys fortify.System, comman
 		return fmt.Errorf("Failed to load project version %v: %w", fortifyProjectVersion, err)
 	}
 
-	if config.AuthEntityIDs != "" {
+	if len(config.AuthEntityIDs) > 0 {
 		ensureAuthEntitiesExist(projectVersion.ID, sys, &config)
 	}
 

--- a/cmd/fortifyExecuteScan_generated.go
+++ b/cmd/fortifyExecuteScan_generated.go
@@ -20,6 +20,7 @@ type fortifyExecuteScanOptions struct {
 	GithubToken                     string   `json:"githubToken,omitempty"`
 	AutoCreate                      bool     `json:"autoCreate,omitempty"`
 	ModulePath                      string   `json:"modulePath,omitempty"`
+	AuthEntityIDs                   string   `json:"authEntityIds,omitempty"`
 	PythonRequirementsFile          string   `json:"pythonRequirementsFile,omitempty"`
 	AutodetectClasspath             bool     `json:"autodetectClasspath,omitempty"`
 	MustAuditIssueGroups            string   `json:"mustAuditIssueGroups,omitempty"`
@@ -191,6 +192,7 @@ func addFortifyExecuteScanFlags(cmd *cobra.Command, stepConfig *fortifyExecuteSc
 	cmd.Flags().StringVar(&stepConfig.GithubToken, "githubToken", os.Getenv("PIPER_githubToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line")
 	cmd.Flags().BoolVar(&stepConfig.AutoCreate, "autoCreate", false, "Whether Fortify project and project version shall be implicitly auto created in case they cannot be found in the backend")
 	cmd.Flags().StringVar(&stepConfig.ModulePath, "modulePath", `./`, "Allows providing the path for the module to scan")
+	cmd.Flags().StringVar(&stepConfig.AuthEntityIDs, "authEntityIds", ``, "Comma separated list of AuthEntity IDs to attach to the project for access")
 	cmd.Flags().StringVar(&stepConfig.PythonRequirementsFile, "pythonRequirementsFile", os.Getenv("PIPER_pythonRequirementsFile"), "The requirements file used in `buildTool: 'pip'` to populate the build environment with the necessary dependencies")
 	cmd.Flags().BoolVar(&stepConfig.AutodetectClasspath, "autodetectClasspath", true, "Whether the classpath is automatically determined via build tool i.e. maven or pip or not at all")
 	cmd.Flags().StringVar(&stepConfig.MustAuditIssueGroups, "mustAuditIssueGroups", `Corporate Security Requirements, Audit All`, "Comma separated list of issue groups that must be audited completely")
@@ -275,6 +277,14 @@ func fortifyExecuteScanMetadata() config.StepData {
 					},
 					{
 						Name:        "modulePath",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "authEntityIds",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",

--- a/pkg/fortify/fortify.go
+++ b/pkg/fortify/fortify.go
@@ -62,6 +62,8 @@ type System interface {
 	UploadResultFile(endpoint, file string, projectVersionID int64) error
 	DownloadReportFile(endpoint string, projectVersionID int64) ([]byte, error)
 	DownloadResultFile(endpoint string, projectVersionID int64) ([]byte, error)
+	GetAuthEntityOfProjectVersion(id int64) ([]*models.AuthenticationEntity, error)
+	UpdateCollectionAuthEntityOfProjectVersion(id int64, data []*models.AuthenticationEntity) error
 }
 
 // SystemInstance is the specific instance
@@ -363,7 +365,7 @@ func (sys *SystemInstance) ProjectVersionCopyCurrentState(sourceID, targetID int
 	return nil
 }
 
-func (sys *SystemInstance) getAuthEntityOfProjectVersion(id int64) ([]*models.AuthenticationEntity, error) {
+func (sys *SystemInstance) GetAuthEntityOfProjectVersion(id int64) ([]*models.AuthenticationEntity, error) {
 	embed := "roles"
 	params := &auth_entity_of_project_version_controller.ListAuthEntityOfProjectVersionParams{Embed: &embed, ParentID: id}
 	params.WithTimeout(sys.timeout)
@@ -374,7 +376,7 @@ func (sys *SystemInstance) getAuthEntityOfProjectVersion(id int64) ([]*models.Au
 	return result.GetPayload().Data, nil
 }
 
-func (sys *SystemInstance) updateCollectionAuthEntityOfProjectVersion(id int64, data []*models.AuthenticationEntity) error {
+func (sys *SystemInstance) UpdateCollectionAuthEntityOfProjectVersion(id int64, data []*models.AuthenticationEntity) error {
 	params := &auth_entity_of_project_version_controller.UpdateCollectionAuthEntityOfProjectVersionParams{ParentID: id, Data: data}
 	params.WithTimeout(sys.timeout)
 	_, err := sys.client.AuthEntityOfProjectVersionController.UpdateCollectionAuthEntityOfProjectVersion(params, sys)
@@ -386,11 +388,11 @@ func (sys *SystemInstance) updateCollectionAuthEntityOfProjectVersion(id int64, 
 
 // ProjectVersionCopyPermissions copies the authentication entity of the project version addressed by sourceID to the one of targetID
 func (sys *SystemInstance) ProjectVersionCopyPermissions(sourceID, targetID int64) error {
-	result, err := sys.getAuthEntityOfProjectVersion(sourceID)
+	result, err := sys.GetAuthEntityOfProjectVersion(sourceID)
 	if err != nil {
 		return err
 	}
-	err = sys.updateCollectionAuthEntityOfProjectVersion(targetID, result)
+	err = sys.UpdateCollectionAuthEntityOfProjectVersion(targetID, result)
 	if err != nil {
 		return err
 	}

--- a/resources/metadata/fortify.yaml
+++ b/resources/metadata/fortify.yaml
@@ -65,6 +65,14 @@ spec:
         - STAGES
         - STEPS
       default: './'
+    - name: authEntityIds
+      type: string
+      description: "Comma separated list of AuthEntity IDs to attach to the project for access"
+      scope:
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      default: ''
     - name: pythonRequirementsFile
       type: string
       description: "The requirements file used in `buildTool: 'pip'` to populate


### PR DESCRIPTION
# Changes

- Adds `--authEntityIDs` flag for users to attach LDAP entities to project in fortify backend.
- Only determines project coordinates with GAV if config.ProjectName or config.PullRequestName is left empty.
- Adds MVP support for scanning `npm` and `gradle` scans.