### PR TITLE
proper stream handling

### DIFF
--- a/pkg/cloudfoundry/Authentication.go
+++ b/pkg/cloudfoundry/Authentication.go
@@ -29,18 +29,9 @@ func (cf *CFUtils) LoginCheck(options LoginOptions) (bool, error) {
 	//Check if logged in --> Cf api command responds with "not logged in" if positive
 	var cfCheckLoginScript = append([]string{"api", options.CfAPIEndpoint}, options.CfAPIOpts...)
 
+	oldStdout := _c.GetStdout()
 	defer func() {
-		// We set it back to what is set from the generated stub. Of course this is not
-		// fully accurate in case we create our own instance above (nothing handed in via
-		// the receiver).
-		// Would be better to remember the old stdout and set back to this.
-		// But command.Command does not allow to get the currently set
-		// stdout handler.
-		// Reason for changing the output stream here: we need to parse the output
-		// of the command issued here in order to check if we are already logged in.
-		// This is expected to change soon to a boolean variable where we remember the
-		// login state.
-		_c.Stdout(log.Writer())
+		_c.Stdout(oldStdout)
 	}()
 
 	var cfLoginBytes bytes.Buffer

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -29,6 +29,8 @@ type runner interface {
 	SetEnv(e []string)
 	Stdout(out io.Writer)
 	Stderr(err io.Writer)
+	GetStdout() io.Writer
+	GetStderr() io.Writer
 }
 
 // ExecRunner mock for intercepting calls to executables
@@ -64,6 +66,15 @@ func (c *Command) Stderr(stderr io.Writer) {
 	c.stderr = stderr
 }
 
+// GetStdout ...
+func (c *Command) GetStdout() io.Writer {
+	return c.stdout
+}
+
+//GetStderr ...
+func(c *Command) GetStderr() io.Writer {
+	return c.stderr
+}
 // ExecCommand defines how to execute os commands
 var ExecCommand = exec.Command
 

--- a/pkg/mock/runner.go
+++ b/pkg/mock/runner.go
@@ -86,8 +86,16 @@ func (m *ExecMockRunner) Stdout(out io.Writer) {
 	m.stdout = out
 }
 
+func (m *ExecMockRunner) GetStdout() io.Writer {
+	return m.stdout
+}
+
 func (m *ExecMockRunner) Stderr(err io.Writer) {
 	m.stderr = err
+}
+
+func (m *ExecMockRunner) GetStderr() io.Writer {
+	return m.stderr
 }
 
 func (m *ShellMockRunner) SetDir(d string) {
@@ -183,6 +191,14 @@ func handleCall(call string, stdoutReturn map[string]string, shouldFailOnCommand
 
 func (m *ShellMockRunner) Stdout(out io.Writer) {
 	m.stdout = out
+}
+
+func (m *ShellMockRunner) GetStdout() io.Writer {
+	return m.stdout
+}
+
+func (m *ShellMockRunner) GetStderr() io.Writer {
+	return m.stderr
 }
 
 func (m *ShellMockRunner) Stderr(err io.Writer) {


### PR DESCRIPTION
Reset `stdout` at end of `LoginCheck` call. Otherwise log issued afterwards will not be recorded.

This PR is based upon PR #1787 which should be reviewed and merged first.

This is an alternate approach to #1785 . The other PR removes the `cf api` call. Here we keep that call, but improve the stream handling.