### PR TITLE
Step generation: allow usage of go generate

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -97,7 +97,7 @@ docker rm piper
 ## Generating step framework
 
 The steps are generated based on the yaml files in `resources/metadata/` with the following command
-`go run pkg/generator/step-metadata.go`.
+`go generate ./...` from the root of the project.
 
 The yaml format is kept pretty close to Tekton's [task format](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md).
 Where the Tekton format was not sufficient some extenstions have been made.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -99,7 +99,7 @@ docker rm piper
 The steps are generated based on the yaml files in `resources/metadata/` with the following command from the root of the project:
 
 ```bash
-go generate ./...
+go generate
 ```
 
 The yaml format is kept pretty close to Tekton's [task format](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -96,8 +96,11 @@ docker rm piper
 
 ## Generating step framework
 
-The steps are generated based on the yaml files in `resources/metadata/` with the following command
-`go generate ./...` from the root of the project.
+The steps are generated based on the yaml files in `resources/metadata/` with the following command from the root of the project:
+
+```bash
+go generate ./...
+```
 
 The yaml format is kept pretty close to Tekton's [task format](https://github.com/tektoncd/pipeline/blob/master/docs/tasks.md).
 Where the Tekton format was not sufficient some extenstions have been made.

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -1,5 +1,7 @@
 package cmd
 
+//go:generate go run ../pkg/generator/step-metadata.go --metadataDir=../resources/metadata/ --targetDir=../cmd/
+
 import (
 	"encoding/json"
 	"fmt"

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -1,7 +1,5 @@
 package cmd
 
-//go:generate go run ../pkg/generator/step-metadata.go --metadataDir=../resources/metadata/ --targetDir=../cmd/
-
 import (
 	"encoding/json"
 	"fmt"

--- a/integration/contracts_test.go
+++ b/integration/contracts_test.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/SAP/jenkins-library/pkg/generator/helper"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/SAP/jenkins-library/pkg/generator/helper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCommandContract(t *testing.T) {
@@ -70,6 +71,6 @@ func TestGenerator(t *testing.T) {
 	metadataFiles, err := helper.MetadataFiles(dir)
 	assert.NoError(t, err)
 
-	err = helper.ProcessMetaFiles(metadataFiles, stepHelperData, docuHelperData)
+	err = helper.ProcessMetaFiles(metadataFiles, "./cmd", stepHelperData, docuHelperData)
 	assert.NoError(t, err)
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-//go:generate go run pkg/generator/step-metadata.go --metadataDir=resources/metadata/ --targetDir=./cmd/
+//go:generate go run pkg/generator/step-metadata.go --metadataDir=./resources/metadata/ --targetDir=./cmd/
 
 import (
 	"github.com/SAP/jenkins-library/cmd"

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 package main
 
+//go:generate go run pkg/generator/step-metadata.go --metadataDir=resources/metadata/ --targetDir=./cmd/
+
 import (
 	"github.com/SAP/jenkins-library/cmd"
 )

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -218,7 +218,8 @@ func run{{.StepName | title}}(config *{{ .StepName }}Options, telemetryData *tel
 `
 
 // ProcessMetaFiles generates step coding based on step configuration provided in yaml files
-func ProcessMetaFiles(metadataFiles []string, stepHelperData StepHelperData, docuHelperData DocuHelperData) error {
+func ProcessMetaFiles(metadataFiles []string, targetDir string, stepHelperData StepHelperData, docuHelperData DocuHelperData) error {
+
 	for key := range metadataFiles {
 
 		var stepData config.StepData
@@ -246,17 +247,17 @@ func ProcessMetaFiles(metadataFiles []string, stepHelperData StepHelperData, doc
 			checkError(err)
 
 			step := stepTemplate(myStepInfo)
-			err = stepHelperData.WriteFile(fmt.Sprintf("cmd/%v_generated.go", stepData.Metadata.Name), step, 0644)
+			err = stepHelperData.WriteFile(filepath.Join(targetDir, fmt.Sprintf("%v_generated.go", stepData.Metadata.Name)), step, 0644)
 			checkError(err)
 
 			test := stepTestTemplate(myStepInfo)
-			err = stepHelperData.WriteFile(fmt.Sprintf("cmd/%v_generated_test.go", stepData.Metadata.Name), test, 0644)
+			err = stepHelperData.WriteFile(filepath.Join(targetDir, fmt.Sprintf("%v_generated_test.go", stepData.Metadata.Name)), test, 0644)
 			checkError(err)
 
-			exists, _ := piperutils.FileExists(fmt.Sprintf("cmd/%v.go", stepData.Metadata.Name))
+			exists, _ := piperutils.FileExists(filepath.Join(targetDir, fmt.Sprintf("%v.go", stepData.Metadata.Name)))
 			if !exists {
 				impl := stepImplementation(myStepInfo)
-				err = stepHelperData.WriteFile(fmt.Sprintf("cmd/%v.go", stepData.Metadata.Name), impl, 0644)
+				err = stepHelperData.WriteFile(filepath.Join(targetDir, fmt.Sprintf("%v.go", stepData.Metadata.Name)), impl, 0644)
 				checkError(err)
 			}
 		} else {

--- a/pkg/generator/helper/helper_test.go
+++ b/pkg/generator/helper/helper_test.go
@@ -85,7 +85,7 @@ func TestProcessMetaFiles(t *testing.T) {
 
 	stepHelperData := StepHelperData{configOpenFileMock, writeFileMock, ""}
 	docuHelperData := DocuHelperData{IsGenerateDocu: false}
-	ProcessMetaFiles([]string{"test.yaml"}, stepHelperData, docuHelperData)
+	ProcessMetaFiles([]string{"test.yaml"}, "./cmd", stepHelperData, docuHelperData)
 
 	t.Run("step code", func(t *testing.T) {
 		goldenFilePath := filepath.Join("testdata", t.Name()+"_generated.golden")
@@ -93,8 +93,9 @@ func TestProcessMetaFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed reading %v", goldenFilePath)
 		}
-		assert.Equal(t, string(expected), string(files["cmd/testStep_generated.go"]))
-		t.Log(string(files["cmd/testStep_generated.go"]))
+		resultFilePath := filepath.Join("cmd", "testStep_generated.go")
+		assert.Equal(t, string(expected), string(files[resultFilePath]))
+		t.Log(string(files[resultFilePath]))
 	})
 
 	t.Run("test code", func(t *testing.T) {
@@ -103,20 +104,22 @@ func TestProcessMetaFiles(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed reading %v", goldenFilePath)
 		}
-		assert.Equal(t, string(expected), string(files["cmd/testStep_generated_test.go"]))
+		resultFilePath := filepath.Join("cmd", "testStep_generated_test.go")
+		assert.Equal(t, string(expected), string(files[resultFilePath]))
 	})
 
 	t.Run("custom step code", func(t *testing.T) {
 		stepHelperData = StepHelperData{configOpenFileMock, writeFileMock, "piperOsCmd"}
-		ProcessMetaFiles([]string{"test.yaml"}, stepHelperData, docuHelperData)
+		ProcessMetaFiles([]string{"test.yaml"}, "./cmd", stepHelperData, docuHelperData)
 
 		goldenFilePath := filepath.Join("testdata", t.Name()+"_generated.golden")
 		expected, err := ioutil.ReadFile(goldenFilePath)
 		if err != nil {
 			t.Fatalf("failed reading %v", goldenFilePath)
 		}
-		assert.Equal(t, string(expected), string(files["cmd/testStep_generated.go"]))
-		t.Log(string(files["cmd/testStep_generated.go"]))
+		resultFilePath := filepath.Join("cmd", "testStep_generated.go")
+		assert.Equal(t, string(expected), string(files[resultFilePath]))
+		t.Log(string(files[resultFilePath]))
 	})
 }
 

--- a/pkg/generator/step-metadata.go
+++ b/pkg/generator/step-metadata.go
@@ -12,25 +12,28 @@ import (
 )
 
 func main() {
+	var metadataPath string
+	var targetDir string
 	var docTemplatePath string
 	var isGenerateDocu bool
 
-	flag.StringVar(&docTemplatePath, "docuDir", "./documentation/docs/steps/", "The directory containing the docu stubs. Default points to \\'documentation/docs/steps.\\'")
-	flag.BoolVar(&isGenerateDocu, "docuGen", false, "Boolean to generate Documentation or Step-MetaData. Default is false")
+	flag.StringVar(&metadataPath, "metadataDir", "./resources/metadata", "The directory containing the step metadata. Default points to \\'resources/metadata\\'.")
+	flag.StringVar(&targetDir, "targetDir", "./cmd", "The target directory for the generated commands.")
+	flag.StringVar(&docTemplatePath, "docuDir", "./documentation/docs/steps/", "The directory containing the docu stubs. Default points to \\'documentation/docs/steps/\\'.")
+	flag.BoolVar(&isGenerateDocu, "docuGen", false, "Boolean to generate Documentation or Step-MetaData. Default is false.")
 	flag.Parse()
 
-	fmt.Printf("docuDir: %v, genDocu: %v \n", docTemplatePath, isGenerateDocu)
-
-	metadataPath := "./resources/metadata"
+	fmt.Printf("metadataDir: %v\n, targetDir: %v\n, docuDir: %v\n, genDocu: %v\n", metadataPath, targetDir, docTemplatePath, isGenerateDocu)
 
 	metadataFiles, err := helper.MetadataFiles(metadataPath)
 	checkError(err)
 	docuHelperData := helper.DocuHelperData{isGenerateDocu, docTemplatePath, openDocTemplate, docFileWriter}
 	stepHelperData := helper.StepHelperData{openMetaFile, fileWriter, ""}
-	err = helper.ProcessMetaFiles(metadataFiles, stepHelperData, docuHelperData)
+	err = helper.ProcessMetaFiles(metadataFiles, targetDir, stepHelperData, docuHelperData)
 	checkError(err)
 
-	cmd := exec.Command("go", "fmt", "./cmd")
+	fmt.Printf("Running go fmt %v\n", targetDir)
+	cmd := exec.Command("go", "fmt", targetDir)
 	err = cmd.Run()
 	checkError(err)
 


### PR DESCRIPTION
# Changes

allows now to use native golang means for code generation:

use `go generate` in folder `cmd/` in order to generate the step framework based on the step.yaml files

- [x] Tests
- [x] Documentation
