### PR TITLE
Improve newman blue-green app identification

### DIFF
--- a/src/com/sap/piper/integration/CloudFoundry.groovy
+++ b/src/com/sap/piper/integration/CloudFoundry.groovy
@@ -43,7 +43,7 @@ class CloudFoundry {
     def getAppRefUrl(String apiEndpoint, String org, String space, String bearerToken, String appName, boolean verbose){
         def orgGuid = getOrgGuid(apiEndpoint, org, bearerToken, verbose)
         def spaceGuid = getSpaceGuid(apiEndpoint, orgGuid, space, bearerToken, verbose)
-        def appInfo = script.httpRequest  url:"${apiEndpoint}/v3/apps?names=${appName},${appName}_blue,${appName}_green,space_guids=${spaceGuid}",  quiet: !verbose,
+        def appInfo = script.httpRequest  url:"${apiEndpoint}/v3/apps?names=${appName},${appName}-blue,${appName}-green,${appName}_blue,${appName}_green,space_guids=${spaceGuid}",  quiet: !verbose,
                             customHeaders:[[name: 'Authorization', value: "${bearerToken}"]]
         def responseJson = script.readJSON text:"${appInfo.content}"
         if (!responseJson.resources[0]) throw new Exception("Cannot find Application")

--- a/src/com/sap/piper/integration/CloudFoundry.groovy
+++ b/src/com/sap/piper/integration/CloudFoundry.groovy
@@ -43,7 +43,7 @@ class CloudFoundry {
     def getAppRefUrl(String apiEndpoint, String org, String space, String bearerToken, String appName, boolean verbose){
         def orgGuid = getOrgGuid(apiEndpoint, org, bearerToken, verbose)
         def spaceGuid = getSpaceGuid(apiEndpoint, orgGuid, space, bearerToken, verbose)
-        def appInfo = script.httpRequest  url:"${apiEndpoint}/v3/apps?names=${appName},${appName}-blue,${appName}-green,${appName}_blue,${appName}_green,space_guids=${spaceGuid}",  quiet: !verbose,
+        def appInfo = script.httpRequest  url:"${apiEndpoint}/v3/apps?names=${appName},${appName}_blue,${appName}_green,${appName}-blue,${appName}-green,space_guids=${spaceGuid}",  quiet: !verbose,
                             customHeaders:[[name: 'Authorization', value: "${bearerToken}"]]
         def responseJson = script.readJSON text:"${appInfo.content}"
         if (!responseJson.resources[0]) throw new Exception("Cannot find Application")


### PR DESCRIPTION
The `newmanExecute` relies on this part of the code to identify applications (for the `cfAppsWithSecrets` parameter).
However, the `cloudFoundryDeploy` step names them differently then expected:

- Deployed by `cloudFoundryDeploy`: `<appname>-green` and `<appname>-blue`
- Searched by this snippet: `<appname>_green` and `<appname>_blue`

So this change adds the actually deployed names in a backwards compatible way (in case someone relies on the `_green` suffix).

# Changes

- [ ] Tests
- [ ] Documentation
