### PR TITLE
Introduce chmod in file utils

### DIFF
--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -70,6 +70,10 @@ func (f *kanikoFileMock) MkdirAll(path string, perm os.FileMode) error {
 	return nil
 }
 
+func (f *kanikoFileMock) Chmod(path string, mode os.FileMode) error {
+	return fmt.Errorf("not implemented. func is only present in order to fullfil the interface contract. Needs to be ajusted in case it gets used.")
+}
+
 func TestRunKanikoExecute(t *testing.T) {
 
 	t.Run("success case", func(t *testing.T) {

--- a/cmd/mtaBuild_test.go
+++ b/cmd/mtaBuild_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"fmt"
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/maven"
 	"github.com/SAP/jenkins-library/pkg/mock"
@@ -364,6 +365,10 @@ func (f *MtaTestFileUtilsMock) FileWrite(path string, content []byte, perm os.Fi
 
 func (f *MtaTestFileUtilsMock) MkdirAll(path string, perm os.FileMode) error {
 	return nil
+}
+
+func (f *MtaTestFileUtilsMock) Chmod(path string, mode os.FileMode) error {
+	return fmt.Errorf("not implemented. func is only present in order to fullfil the interface contract. Needs to be ajusted in case it gets used.")
 }
 
 func newNpmExecutor(execRunner *mock.ExecMockRunner) *npm.Execute {

--- a/cmd/xsDeploy_test.go
+++ b/cmd/xsDeploy_test.go
@@ -38,6 +38,10 @@ func (f *FileUtilsMock) MkdirAll(path string, perm os.FileMode) error {
 	return nil
 }
 
+func (f *FileUtilsMock) Chmod(path string, mode os.FileMode) error {
+	return fmt.Errorf("not implemented. func is only present in order to fullfil the interface contract. Needs to be ajusted in case it gets used.")
+}
+
 func TestDeploy(t *testing.T) {
 	myXsDeployOptions := xsDeployOptions{
 		APIURL:                "https://example.org:12345",

--- a/pkg/maven/settings_test.go
+++ b/pkg/maven/settings_test.go
@@ -200,3 +200,7 @@ func (f *fileUtilsMock) FileWrite(path string, content []byte, perm os.FileMode)
 func (f *fileUtilsMock) MkdirAll(path string, perm os.FileMode) error {
 	return nil
 }
+
+func (f *fileUtilsMock) Chmod(path string, mode os.FileMode) error {
+	return fmt.Errorf("not implemented. func is only present in order to fullfil the interface contract. Needs to be ajusted in case it gets used.")
+}

--- a/pkg/mock/fileUtils.go
+++ b/pkg/mock/fileUtils.go
@@ -301,3 +301,13 @@ func (f *FilesMock) Stat(name string) (os.FileInfo, error) {
 		isDir: props.content == &dirContent,
 	}, nil
 }
+
+//Chmod ...
+func (f *FilesMock) Chmod(path string, mode os.FileMode) error {
+	props, exists := f.files[f.toAbsPath(path)]
+	if !exists {
+		return fmt.Errorf("chmod: %s: No such file or directory", path)
+	}
+	props.mode = &mode
+	return nil
+}

--- a/pkg/piperutils/FileUtils.go
+++ b/pkg/piperutils/FileUtils.go
@@ -19,6 +19,7 @@ type FileUtils interface {
 	FileRead(path string) ([]byte, error)
 	FileWrite(path string, content []byte, perm os.FileMode) error
 	MkdirAll(path string, perm os.FileMode) error
+	Chmod(path string, mode os.FileMode) error
 }
 
 // Files ...
@@ -84,6 +85,11 @@ func (f Files) Copy(src, dst string) (int64, error) {
 	defer destination.Close()
 	nBytes, err := io.Copy(destination, source)
 	return nBytes, err
+}
+
+//Chmod ...
+func (f Files) Chmod(path string, mode os.FileMode) error {
+	return os.Chmod(path, mode)
 }
 
 // Unzip will decompress a zip archive, moving all files and folders


### PR DESCRIPTION
for

- `cmd/kanikoExecute_test.go`
- `cmd/xsDeploy_test.go`
-  `cmd/mtaBuild_test.go`
- `pkg/maven/settings_test.go`

we should switch to THE file mock. But I would like to suggest to do this in an dedicated PR.