### PR TITLE
Make stage locking more flexible

### DIFF
--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -6,6 +6,9 @@ import groovy.json.JsonOutput
 
 class commonPipelineEnvironment implements Serializable {
 
+    //Project identifier which might be used to distinguish resources which are available globally, e.g. for locking
+    def projectName
+
     //stores version of the artifact which is build during pipeline run
     def artifactVersion
     def originalArtifactVersion
@@ -57,6 +60,8 @@ class commonPipelineEnvironment implements Serializable {
     String changeDocumentId
 
     def reset() {
+
+        projectName = null
 
         abapRepositoryNames = null
 


### PR DESCRIPTION
# Changes

For the cloud sdk pipeline we need more flexibility to define the locks. 
E.g. env.JOB_NAME does not work as it also contains the branch name. However, we have stages which should be locked across branches, e.g. when running end to end tests from multiple non productive branches.
Also having an ordinal does not always work, e.g. when a stage is run in parallel.


- [ ] Tests
- [ ] Documentation
