### PR TITLE
Allow trigger IT via GitHub UI

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - it/**
+  workflow_dispatch:
 
 jobs:
 


### PR DESCRIPTION
Allow triggering IT via `workflow_dispatch` which adds a UI element that allows to chose a branch on which the IT should be run.

This has advantages over both ways we already have:

- no need to push an `it/foo` branch
- no emails/notifications for people typing `/it` comments (and also I still can't use this method for some unknown reason)

cf https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow\#manually-running-a-workflow

I tried this out in this repo https://github.com/fwilhe/test-ghact-expression-syntax, so I'm somewhat confident that it works as expected. Choosing the branch name/commit id should exactly do what is expected, given you chose the right branch to run the test on in the dropdown.

![image](https://user-images.githubusercontent.com/2292245/88225594-0b37e180-cc6b-11ea-8b29-c70f18f49fb5.png)
