### PR TITLE
fix(sonar): correct type for custom TLS certificates

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -202,7 +202,7 @@ func loadSonarScanner(url string, client piperhttp.Downloader) error {
 	return nil
 }
 
-func loadCertificates(certificateString string, client piperhttp.Downloader, runner command.ExecRunner) error {
+func loadCertificates(certificateList []string, client piperhttp.Downloader, runner command.ExecRunner) error {
 	trustStoreFile := filepath.Join(getWorkingDir(), ".certificates", "cacerts")
 
 	if exists, _ := fileUtilsExists(trustStoreFile); exists {
@@ -212,7 +212,7 @@ func loadCertificates(certificateString string, client piperhttp.Downloader, run
 	} else
 	//TODO: certificate loading is deactivated due to the missing JAVA keytool
 	// see https://github.com/SAP/jenkins-library/issues/1072
-	if os.Getenv("PIPER_SONAR_LOAD_CERTIFICATES") == "true" && len(certificateString) > 0 {
+	if os.Getenv("PIPER_SONAR_LOAD_CERTIFICATES") == "true" && len(certificateList) > 0 {
 		// use local created trust store with downloaded certificates
 		keytoolOptions := []string{
 			"-import",
@@ -222,7 +222,6 @@ func loadCertificates(certificateString string, client piperhttp.Downloader, run
 		}
 		tmpFolder := getTempDir()
 		defer os.RemoveAll(tmpFolder) // clean up
-		certificateList := strings.Split(certificateString, ",")
 
 		for _, certificate := range certificateList {
 			filename := path.Base(certificate) // decode?

--- a/cmd/sonarExecuteScan_generated.go
+++ b/cmd/sonarExecuteScan_generated.go
@@ -20,7 +20,7 @@ type sonarExecuteScanOptions struct {
 	Host                      string   `json:"host,omitempty"`
 	Token                     string   `json:"token,omitempty"`
 	Organization              string   `json:"organization,omitempty"`
-	CustomTLSCertificateLinks string   `json:"customTlsCertificateLinks,omitempty"`
+	CustomTLSCertificateLinks []string `json:"customTlsCertificateLinks,omitempty"`
 	SonarScannerDownloadURL   string   `json:"sonarScannerDownloadUrl,omitempty"`
 	ProjectVersion            string   `json:"projectVersion,omitempty"`
 	Options                   []string `json:"options,omitempty"`
@@ -133,7 +133,7 @@ func addSonarExecuteScanFlags(cmd *cobra.Command, stepConfig *sonarExecuteScanOp
 	cmd.Flags().StringVar(&stepConfig.Host, "host", os.Getenv("PIPER_host"), "The URL to the Sonar backend.")
 	cmd.Flags().StringVar(&stepConfig.Token, "token", os.Getenv("PIPER_token"), "Token used to authenticate with the Sonar Server.")
 	cmd.Flags().StringVar(&stepConfig.Organization, "organization", os.Getenv("PIPER_organization"), "SonarCloud.io only: Organization that the project will be assigned to in SonarCloud.io.")
-	cmd.Flags().StringVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", os.Getenv("PIPER_customTlsCertificateLinks"), "List of comma-separated download links to custom TLS certificates. This is required to ensure trusted connections to instances with custom certificates.")
+	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List of comma-separated download links to custom TLS certificates. This is required to ensure trusted connections to instances with custom certificates.")
 	cmd.Flags().StringVar(&stepConfig.SonarScannerDownloadURL, "sonarScannerDownloadUrl", `https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.4.0.2170-linux.zip`, "URL to the sonar-scanner-cli archive.")
 	cmd.Flags().StringVar(&stepConfig.ProjectVersion, "projectVersion", os.Getenv("PIPER_projectVersion"), "The project version that is reported to SonarQube.")
 	cmd.Flags().StringSliceVar(&stepConfig.Options, "options", []string{}, "A list of options which are passed to the sonar-scanner.")
@@ -197,7 +197,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Name:        "customTlsCertificateLinks",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
+						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 					},

--- a/cmd/sonarExecuteScan_generated.go
+++ b/cmd/sonarExecuteScan_generated.go
@@ -133,7 +133,7 @@ func addSonarExecuteScanFlags(cmd *cobra.Command, stepConfig *sonarExecuteScanOp
 	cmd.Flags().StringVar(&stepConfig.Host, "host", os.Getenv("PIPER_host"), "The URL to the Sonar backend.")
 	cmd.Flags().StringVar(&stepConfig.Token, "token", os.Getenv("PIPER_token"), "Token used to authenticate with the Sonar Server.")
 	cmd.Flags().StringVar(&stepConfig.Organization, "organization", os.Getenv("PIPER_organization"), "SonarCloud.io only: Organization that the project will be assigned to in SonarCloud.io.")
-	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List of comma-separated download links to custom TLS certificates. This is required to ensure trusted connections to instances with custom certificates.")
+	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List of download links to custom TLS certificates. This is required to ensure trusted connections to instances with custom certificates.")
 	cmd.Flags().StringVar(&stepConfig.SonarScannerDownloadURL, "sonarScannerDownloadUrl", `https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.4.0.2170-linux.zip`, "URL to the sonar-scanner-cli archive.")
 	cmd.Flags().StringVar(&stepConfig.ProjectVersion, "projectVersion", os.Getenv("PIPER_projectVersion"), "The project version that is reported to SonarQube.")
 	cmd.Flags().StringSliceVar(&stepConfig.Options, "options", []string{}, "A list of options which are passed to the sonar-scanner.")

--- a/cmd/sonarExecuteScan_test.go
+++ b/cmd/sonarExecuteScan_test.go
@@ -89,7 +89,7 @@ func TestRunSonar(t *testing.T) {
 			options:     []string{},
 		}
 		options := sonarExecuteScanOptions{
-			CustomTLSCertificateLinks: "",
+			CustomTLSCertificateLinks: []string{},
 			Token:                     "secret-ABC",
 			Host:                      "https://sonar.sap.com",
 			Organization:              "SAP",
@@ -272,7 +272,7 @@ func TestSonarLoadCertificates(t *testing.T) {
 		fileUtilsExists = mockFileUtilsExists(true)
 		defer func() { fileUtilsExists = FileUtils.FileExists }()
 		// test
-		err := loadCertificates("", &mockClient, &mockRunner)
+		err := loadCertificates([]string{}, &mockClient, &mockRunner)
 		// assert
 		assert.NoError(t, err)
 		assert.Contains(t, sonar.environment, "SONAR_SCANNER_OPTS=-Djavax.net.ssl.trustStore="+filepath.Join(getWorkingDir(), ".certificates", "cacerts"))
@@ -293,7 +293,7 @@ func TestSonarLoadCertificates(t *testing.T) {
 			os.Unsetenv("PIPER_SONAR_LOAD_CERTIFICATES")
 		}()
 		// test
-		err := loadCertificates("https://sap.com/custom-1.crt,https://sap.com/custom-2.crt", &mockClient, &mockRunner)
+		err := loadCertificates([]string{"https://sap.com/custom-1.crt", "https://sap.com/custom-2.crt"}, &mockClient, &mockRunner)
 		// assert
 		assert.NoError(t, err)
 		assert.Equal(t, "https://sap.com/custom-1.crt", mockClient.requestedURL[0])
@@ -314,7 +314,7 @@ func TestSonarLoadCertificates(t *testing.T) {
 		require.Empty(t, os.Getenv("PIPER_SONAR_LOAD_CERTIFICATES"), "PIPER_SONAR_LOAD_CERTIFICATES must not be set")
 		defer func() { fileUtilsExists = FileUtils.FileExists }()
 		// test
-		err := loadCertificates("any-certificate-url", &mockClient, &mockRunner)
+		err := loadCertificates([]string{"any-certificate-url"}, &mockClient, &mockRunner)
 		// assert
 		assert.NoError(t, err)
 		assert.NotContains(t, sonar.environment, "SONAR_SCANNER_OPTS=-Djavax.net.ssl.trustStore="+filepath.Join(getWorkingDir(), ".certificates", "cacerts"))
@@ -335,7 +335,7 @@ func TestSonarLoadCertificates(t *testing.T) {
 			os.Unsetenv("PIPER_SONAR_LOAD_CERTIFICATES")
 		}()
 		// test
-		err := loadCertificates("", &mockClient, &mockRunner)
+		err := loadCertificates([]string{}, &mockClient, &mockRunner)
 		// assert
 		assert.NoError(t, err)
 		assert.Empty(t, sonar.environment)

--- a/resources/metadata/sonar.yaml
+++ b/resources/metadata/sonar.yaml
@@ -42,7 +42,7 @@ spec:
           - STEPS
       - name: customTlsCertificateLinks
         type: "[]string"
-        description: List of comma-separated download links to custom TLS certificates. This is required to ensure trusted connections to instances with custom certificates.
+        description: List of download links to custom TLS certificates. This is required to ensure trusted connections to instances with custom certificates.
         scope:
           - PARAMETERS
           - STAGES

--- a/resources/metadata/sonar.yaml
+++ b/resources/metadata/sonar.yaml
@@ -41,7 +41,7 @@ spec:
           - STAGES
           - STEPS
       - name: customTlsCertificateLinks
-        type: string
+        type: "[]string"
         description: List of comma-separated download links to custom TLS certificates. This is required to ensure trusted connections to instances with custom certificates.
         scope:
           - PARAMETERS


### PR DESCRIPTION
This PR corrects the type of `customTlsCertificateLinks` to be a List of URLs.


fixes #1838
