### PR TITLE
mavenExecuteIntegration: Remove test collection

### DIFF
--- a/test/groovy/MavenExecuteIntegrationTest.groovy
+++ b/test/groovy/MavenExecuteIntegrationTest.groovy
@@ -54,12 +54,11 @@ class MavenExecuteIntegrationTest extends BasePiperTest {
     }
 
     @Test
-    void testWithSidecar() {
+    void testParameterPassing() {
         stepRule.step.mavenExecuteIntegration(
             juStabUtils: utils,
             jenkinsUtilsStub: jenkinsUtils,
             testParam: 'This is test content',
-            sidecarImage: 'some/image',
             script: nullScript,
         )
         // asserts

--- a/vars/mavenExecuteIntegration.groovy
+++ b/vars/mavenExecuteIntegration.groovy
@@ -7,25 +7,12 @@ import static com.sap.piper.Prerequisites.checkScript
 @Field String STEP_NAME = getClass().getName()
 @Field String METADATA_FILE = 'metadata/mavenExecuteIntegration.yaml'
 
-@Field Set GENERAL_CONFIG_KEYS = []
-@Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS
-@Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus([
-    /**
-     * Specify a glob pattern where test result files will be located.
-     */
-    'reportLocationPattern',
-])
-
 //Metadata maintained in file project://resources/metadata/mavenExecuteIntegration.yaml
 
 void call(Map parameters = [:]) {
     final script = checkScript(this, parameters) ?: this
     parameters = DownloadCacheUtils.injectDownloadCacheInParameters(script, parameters, BuildTool.MAVEN)
 
-    try {
-        List credentials = []
-        piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
-    } finally {
-        testsPublishResults(script: script, junit: [allowEmptyResults: true, pattern: parameters.reportLocationPattern])
-    }
+    List credentials = []
+    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes

The collection of test results is not supposed to happen within the step/wrapper.

- [ ] Tests (does not apply)
- [ ] Documentation (does not apply)
