### PR TITLE
CfAPIOpts: remove leftovers

### DIFF
--- a/pkg/cloudfoundry/Authentication.go
+++ b/pkg/cloudfoundry/Authentication.go
@@ -92,7 +92,6 @@ type LoginOptions struct {
 	CfSpace       string
 	Username      string
 	Password      string
-	CfAPIOpts     []string
 	CfLoginOpts   []string
 }
 

--- a/pkg/cloudfoundry/CloudFoundry_test.go
+++ b/pkg/cloudfoundry/CloudFoundry_test.go
@@ -136,9 +136,6 @@ func TestCloudFoundryLogin(t *testing.T) {
 				"--skip-ssl-validation",
 				"--origin", "ldap",
 			},
-			CfAPIOpts: []string{
-				"--skip-ssl-validation",
-			},
 		}
 		cf := CFUtils{Exec: m}
 		err := cf.Login(cfconfig)


### PR DESCRIPTION
we don't have any cf api calls anymore in the context of cf login.

