### PR TITLE
build tool for cf deploy

### DIFF
--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -19,6 +19,7 @@ type cloudFoundryDeployOptions struct {
 	APIEndpoint              string   `json:"apiEndpoint,omitempty"`
 	AppName                  string   `json:"appName,omitempty"`
 	ArtifactVersion          string   `json:"artifactVersion,omitempty"`
+	BuildTool                string   `json:"buildTool,omitempty"`
 	CfHome                   string   `json:"cfHome,omitempty"`
 	CfNativeDeployParameters string   `json:"cfNativeDeployParameters,omitempty"`
 	CfPluginHome             string   `json:"cfPluginHome,omitempty"`
@@ -155,11 +156,12 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.APIEndpoint, "apiEndpoint", `https://api.cf.eu10.hana.ondemand.com`, "Cloud Foundry API endpoint")
 	cmd.Flags().StringVar(&stepConfig.AppName, "appName", os.Getenv("PIPER_appName"), "Defines the name of the application to be deployed to the Cloud Foundry space")
 	cmd.Flags().StringVar(&stepConfig.ArtifactVersion, "artifactVersion", os.Getenv("PIPER_artifactVersion"), "The artifact version, used for influx reporting")
+	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", os.Getenv("PIPER_buildTool"), "Used for deriving the build tool")
 	cmd.Flags().StringVar(&stepConfig.CfHome, "cfHome", os.Getenv("PIPER_cfHome"), "The cf home folder used by the cf cli. If not provided the default assumed by the cf cli is used.")
 	cmd.Flags().StringVar(&stepConfig.CfNativeDeployParameters, "cfNativeDeployParameters", os.Getenv("PIPER_cfNativeDeployParameters"), "Additional parameters passed to cf native deployment command")
 	cmd.Flags().StringVar(&stepConfig.CfPluginHome, "cfPluginHome", os.Getenv("PIPER_cfPluginHome"), "The cf plugin home folder used by the cf cli. If not provided the default assumed by the cf cli is used.")
 	cmd.Flags().StringVar(&stepConfig.DeployDockerImage, "deployDockerImage", os.Getenv("PIPER_deployDockerImage"), "Docker image deployments are supported (via manifest file in general)[https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#docker]. If no manifest is used, this parameter defines the image to be deployed. The specified name of the image is passed to the `--docker-image` parameter of the cf CLI and must adhere it's naming pattern (e.g. REPO/IMAGE:TAG). See (cf CLI documentation)[https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html] for details. Note: The used Docker registry must be visible for the targeted Cloud Foundry instance.")
-	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", os.Getenv("PIPER_deployTool"), "Defines the tool which should be used for deployment.")
+	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", `mtaDeployPlugin`, "Defines the tool which should be used for deployment.")
 	cmd.Flags().StringVar(&stepConfig.DeployType, "deployType", `standard`, "Defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.If 'cf_native' as deployType and 'blue-green' as deployTool is used in combination, your manifest.yaml may only contain one application. If this application has the option 'no-route' active the deployType will be changed to 'standard'.")
 	cmd.Flags().StringVar(&stepConfig.DockerPassword, "dockerPassword", os.Getenv("PIPER_dockerPassword"), "dockerPassword")
 	cmd.Flags().StringVar(&stepConfig.DockerUsername, "dockerUsername", os.Getenv("PIPER_dockerUsername"), "dockerUserName")
@@ -179,7 +181,6 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.Username, "username", os.Getenv("PIPER_username"), "User")
 
 	cmd.MarkFlagRequired("apiEndpoint")
-	cmd.MarkFlagRequired("deployTool")
 	cmd.MarkFlagRequired("org")
 	cmd.MarkFlagRequired("password")
 	cmd.MarkFlagRequired("space")
@@ -215,6 +216,14 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "artifactVersion",
 						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "artifactVersion"}},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "buildTool",
+						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
@@ -257,7 +266,39 @@ func cloudFoundryDeployMetadata() config.StepData {
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
-						Mandatory:   true,
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "deployTool",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "deployTool",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "deployTool",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "deployTool",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
 						Aliases:     []config.Alias{},
 					},
 					{

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -40,6 +40,14 @@ spec:
         resourceRef:
           - name: commonPipelineEnvironment
             param: artifactVersion
+      - name: buildTool
+        type: string
+        description: "Used for deriving the build tool"
+        scope:
+        - PARAMETERS
+        - STAGES
+        - STEPS
+        mandatory: false
       - name: cfHome
         type: string
         description: "The cf home folder used by the cf cli. If not provided the default assumed by the cf cli is used."
@@ -79,7 +87,69 @@ spec:
         - PARAMETERS
         - STAGES
         - STEPS
-        mandatory: true
+        mandatory: false
+        default: mtaDeployPlugin
+        conditions:
+        - conditionRef: strings-equal
+          params:
+          - name: buildTool
+            value: mta
+      - name: deployTool
+        type: string
+        description: "Defines the tool which should be used for deployment."
+        scope:
+        - PARAMETERS
+        - STAGES
+        - STEPS
+        mandatory: false
+        default: cf_native
+        conditions:
+        - conditionRef: strings-equal
+          params:
+          - name: buildTool
+            value: maven
+      - name: deployTool
+        type: string
+        description: "Defines the tool which should be used for deployment."
+        scope:
+        - PARAMETERS
+        - STAGES
+        - STEPS
+        mandatory: false
+        default: cf_native
+        conditions:
+        - conditionRef: strings-equal
+          params:
+          - name: buildTool
+            value: npm
+      - name: deployTool
+        type: string
+        description: "Defines the tool which should be used for deployment."
+        scope:
+        - PARAMETERS
+        - STAGES
+        - STEPS
+        mandatory: false
+        default: cf_native
+        conditions:
+        - conditionRef: strings-equal
+          params:
+          - name: buildTool
+            value: docker
+      - name: deployTool
+        type: string
+        description: "Defines the tool which should be used for deployment."
+        scope:
+        - PARAMETERS
+        - STAGES
+        - STEPS
+        mandatory: false
+        default: cf_native
+        conditions:
+        - conditionRef: strings-equal
+          params:
+          - name: buildTool
+            value: kaniko
       - name: deployType
         type: string
         description: "Defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.If 'cf_native' as deployType and 'blue-green' as deployTool is used in combination, your manifest.yaml may only contain one application. If this application has the option 'no-route' active the deployType will be changed to 'standard'."


### PR DESCRIPTION
This has been introduced in the groovy layer with commit c8ca3ea5224af294674f9eca1c4406b49551478a.

I tried to use the `conditions` in the metadata, but this **does not work** apparently. --> should be investigate before we merge, of course. Maybe the mistake is on my side, I tried to do it similar to `whitesourceExecuteScan`.

When building the piper lib and run it any of the buildTools (e..g maven) it defaults always to the `mtaDeployPlugin`instead using `cf_native`, which would be the expected value for e.g. `maven`.

Just as a side note: I'm not satisfied with the way the metadata looks like in this case, e.g. `resources/metadata/whitesource.yaml` where e.g. the parameter `buildDescriptorFile` is repeated again and again with different default for all the (different conditions). I think the parameter should be defined once and there should be conditions on the level of the default value.