### PR TITLE
checkmarxExecuteScan: Add two (deprecated) aliases

### DIFF
--- a/cmd/checkmarxExecuteScan_generated.go
+++ b/cmd/checkmarxExecuteScan_generated.go
@@ -334,7 +334,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
-						Aliases:     []config.Alias{{Name: "checkmarxProject"}},
+						Aliases:     []config.Alias{{Name: "checkmarxProject"}, {Name: "checkMarxProjectName"}},
 					},
 					{
 						Name:        "pullRequestName",
@@ -366,7 +366,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "checkmarxGroupId"}},
+						Aliases:     []config.Alias{{Name: "checkmarxGroupId"}, {Name: "groupId"}},
 					},
 					{
 						Name:        "teamName",

--- a/resources/metadata/checkmarx.yaml
+++ b/resources/metadata/checkmarx.yaml
@@ -99,6 +99,8 @@ spec:
     - name: projectName
       aliases:
         - name: checkmarxProject
+        - name: checkMarxProjectName
+          deprecated: true
       type: string
       description: The name of the Checkmarx project to scan into
       mandatory: true
@@ -137,6 +139,8 @@ spec:
     - name: teamId
       aliases:
         - name: checkmarxGroupId
+        - name: groupId
+          deprecated: true
       type: string
       description: The group ID related to your team which can be obtained via the Pipeline Syntax plugin as described in the `Details` section
       mandatory: false


### PR DESCRIPTION
# Changes

Adds an alias "groupId" to the parameter "teamId", and an alias "checkMarxProjectName" to "projectName".
Allows the Cloud SDK Pipeline to switch to the step without a breaking change.

- [ ] Tests (does not apply)
- [x] Documentation
