### PR TITLE
refactor(protecode): remove unused parameter

### DIFF
--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -23,7 +23,6 @@ type protecodeExecuteScanOptions struct {
 	CleanupMode                 string `json:"cleanupMode,omitempty"`
 	FilePath                    string `json:"filePath,omitempty"`
 	IncludeLayers               bool   `json:"includeLayers,omitempty"`
-	AddSideBarLink              bool   `json:"addSideBarLink,omitempty"`
 	TimeoutMinutes              string `json:"timeoutMinutes,omitempty"`
 	ServerURL                   string `json:"serverUrl,omitempty"`
 	ReportFileName              string `json:"reportFileName,omitempty"`
@@ -148,7 +147,6 @@ func addProtecodeExecuteScanFlags(cmd *cobra.Command, stepConfig *protecodeExecu
 	cmd.Flags().StringVar(&stepConfig.CleanupMode, "cleanupMode", `binary`, "Decides which parts are removed from the Protecode backend after the scan")
 	cmd.Flags().StringVar(&stepConfig.FilePath, "filePath", os.Getenv("PIPER_filePath"), "The path to the file from local workspace to scan with Protecode")
 	cmd.Flags().BoolVar(&stepConfig.IncludeLayers, "includeLayers", false, "Flag if the docker layers should be included")
-	cmd.Flags().BoolVar(&stepConfig.AddSideBarLink, "addSideBarLink", true, "Whether to create a side bar link pointing to the report produced by Protecode or not")
 	cmd.Flags().StringVar(&stepConfig.TimeoutMinutes, "timeoutMinutes", `60`, "The timeout to wait for the scan to finish")
 	cmd.Flags().StringVar(&stepConfig.ServerURL, "serverUrl", os.Getenv("PIPER_serverUrl"), "The URL to the Protecode backend")
 	cmd.Flags().StringVar(&stepConfig.ReportFileName, "reportFileName", `protecode_report.pdf`, "The file name of the report to be created")
@@ -226,14 +224,6 @@ func protecodeExecuteScanMetadata() config.StepData {
 					},
 					{
 						Name:        "includeLayers",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "bool",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-					},
-					{
-						Name:        "addSideBarLink",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",

--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -79,14 +79,6 @@ spec:
       - PARAMETERS
       - STAGES
       - STEPS
-    - name: addSideBarLink
-      type: bool
-      description: Whether to create a side bar link pointing to the report produced by Protecode or not
-      scope:
-      - PARAMETERS
-      - STAGES
-      - STEPS
-      default: true
     - name: timeoutMinutes
       aliases:
       - name: protecodeTimeoutMinutes


### PR DESCRIPTION
This PR removes the `addSideBarLink` as it is not used anywhere. Also the publication of reports should be handled by StepResults completely in the future (#1891).