### PR TITLE
Add groovy wrapper for TemporaryCredentialsUtils

### DIFF
--- a/documentation/docs/steps/writeTemporaryCredentials.md
+++ b/documentation/docs/steps/writeTemporaryCredentials.md
@@ -1,0 +1,7 @@
+# ${docGenStepName}
+
+## ${docGenDescription}
+
+## ${docGenParameters}
+
+## ${docGenConfiguration}

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
         - transportRequestUploadFile: steps/transportRequestUploadFile.md
         - uiVeri5ExecuteTests: steps/uiVeri5ExecuteTests.md
         - whitesourceExecuteScan: steps/whitesourceExecuteScan.md
+        - writeTemporaryCredentials: steps/writeTemporaryCredentials.md
         - xsDeploy: steps/xsDeploy.md
     - 'Library Steps (deprecated)':
         - artifactSetVersion: steps/artifactSetVersion.md

--- a/test/groovy/WriteTemporaryCredentialsTest.groovy
+++ b/test/groovy/WriteTemporaryCredentialsTest.groovy
@@ -15,6 +15,7 @@ import util.Rules
 import static org.junit.Assert.assertThat
 import static org.hamcrest.Matchers.*
 import static org.junit.Assert.assertTrue
+import static org.junit.Assert.assertFalse
 
 class WriteTemporaryCredentialsTest extends BasePiperTest {
     private JenkinsStepRule stepRule = new JenkinsStepRule(this)
@@ -84,6 +85,7 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
         ){
             bodyExecuted = true
         }
+        assertFalse(bodyExecuted)
     }
 
     @Test
@@ -103,6 +105,7 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
         ){
             bodyExecuted = true
         }
+        assertFalse(bodyExecuted)
     }
 
     @Test
@@ -122,6 +125,7 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
             bodyExecuted = true
         }
 
+        assertTrue(bodyExecuted)
         assertThat(writeFileRule.files['credentials.json'], containsString('"alias":"ERP","username":"test_user","password":"********"'))
         assertThat(shellRule.shell, hasItem('rm -f credentials.json'))
     }

--- a/test/groovy/WriteTemporaryCredentialsTest.groovy
+++ b/test/groovy/WriteTemporaryCredentialsTest.groovy
@@ -1,0 +1,124 @@
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+import org.junit.rules.RuleChain
+import util.BasePiperTest
+import util.JenkinsCredentialsRule
+import util.JenkinsFileExistsRule
+import util.JenkinsReadFileRule
+import util.JenkinsReadYamlRule
+import util.JenkinsShellCallRule
+import util.JenkinsStepRule
+import util.JenkinsWriteFileRule
+import util.Rules
+import static org.junit.Assert.assertThat
+import static org.hamcrest.Matchers.*
+
+class WriteTemporaryCredentialsTest extends BasePiperTest {
+    private JenkinsStepRule stepRule = new JenkinsStepRule(this)
+    private ExpectedException thrown = ExpectedException.none()
+    private JenkinsCredentialsRule credentialsRule = new JenkinsCredentialsRule(this)
+    private JenkinsWriteFileRule writeFileRule = new JenkinsWriteFileRule(this)
+    private JenkinsFileExistsRule fileExistsRule = new JenkinsFileExistsRule(this, [])
+    private JenkinsReadFileRule readFileRule = new JenkinsReadFileRule(this, null)
+    private JenkinsReadYamlRule readYamlRule = new JenkinsReadYamlRule(this)
+    private JenkinsShellCallRule shellRule = new JenkinsShellCallRule(this)
+
+    def bodyExecuted
+
+    @Rule
+    public RuleChain ruleChain = Rules
+        .getCommonRules(this)
+        .around(thrown)
+        .around(readYamlRule)
+        .around(credentialsRule)
+        .around(stepRule)
+        .around(writeFileRule)
+        .around(fileExistsRule)
+        .around(readFileRule)
+        .around(shellRule)
+
+    @Before
+    void init() {
+        bodyExecuted = false
+
+        helper.registerAllowedMethod("deleteDir", [], null)
+
+        credentialsRule.reset()
+            .withCredentials('erp-credentials', 'test_user', '********')
+            .withCredentials('testCred2', 'test_other', '**')
+    }
+
+    @Test
+    void noCredentials() {
+        thrown.expect(hudson.AbortException)
+        thrown.expectMessage('[writeTemporaryCredentials] The execution failed, since no credentials are defined. Please provide credentials as a list of maps.')
+
+        stepRule.step.writeTemporaryCredentials(
+            script: nullScript,
+            stageName: "myStage",
+        ){
+            bodyExecuted = true
+        }
+    }
+
+    @Test
+    void credentialsNoList() {
+        def credential = "id"
+
+        nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
+            credentials: credential
+        ]]]
+
+        thrown.expect(hudson.AbortException)
+        thrown.expectMessage('[writeTemporaryCredentials] The execution failed, since credentials is not a list. Please provide credentials as a list of maps.')
+
+        stepRule.step.writeTemporaryCredentials(
+            script: nullScript,
+            stageName: "myStage",
+        ){
+            bodyExecuted = true
+        }
+    }
+
+    @Test
+    void noCredentialsDirectory() {
+        def credential = [alias: 'ERP', credentialId: 'erp-credentials']
+
+        nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
+            credentials: [credential]
+        ]]]
+
+        thrown.expect(hudson.AbortException)
+        thrown.expectMessage("[writeTemporaryCredentials] The execution failed, since no credentialsDirectory is defined. Please provide the path for the credentials file.")
+
+        stepRule.step.writeTemporaryCredentials(
+            script: nullScript,
+            stageName: "myStage",
+        ){
+            bodyExecuted = true
+        }
+    }
+
+    @Test
+    void credentialsFileWrittenAndRemoved() {
+        def credential = [alias: 'ERP', credentialId: 'erp-credentials']
+        fileExistsRule.registerExistingFile('systems.yml')
+
+        nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
+            credentials: [credential],
+            credentialsDirectory: './',
+        ]]]
+
+        stepRule.step.writeTemporaryCredentials(
+            script: nullScript,
+            stageName: "myStage",
+        ){
+            bodyExecuted = true
+        }
+
+        assertThat(writeFileRule.files['credentials.json'], containsString('"alias":"ERP","username":"test_user","password":"********"'))
+        assertThat(shellRule.shell, hasItem('rm -f credentials.json'))
+    }
+}

--- a/test/groovy/WriteTemporaryCredentialsTest.groovy
+++ b/test/groovy/WriteTemporaryCredentialsTest.groovy
@@ -53,6 +53,9 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
 
     @Test
     void noCredentials() {
+        nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
+            credentialsDirectory: './',
+        ]]]
         stepRule.step.writeTemporaryCredentials(
             script: nullScript,
             stageName: "myStage",

--- a/test/groovy/WriteTemporaryCredentialsTest.groovy
+++ b/test/groovy/WriteTemporaryCredentialsTest.groovy
@@ -14,6 +14,7 @@ import util.JenkinsWriteFileRule
 import util.Rules
 import static org.junit.Assert.assertThat
 import static org.hamcrest.Matchers.*
+import static org.junit.Assert.assertTrue
 
 class WriteTemporaryCredentialsTest extends BasePiperTest {
     private JenkinsStepRule stepRule = new JenkinsStepRule(this)
@@ -52,15 +53,15 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
 
     @Test
     void noCredentials() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage('[writeTemporaryCredentials] The execution failed, since no credentials are defined. Please provide credentials as a list of maps.')
-
         stepRule.step.writeTemporaryCredentials(
             script: nullScript,
             stageName: "myStage",
         ){
             bodyExecuted = true
         }
+        assertTrue(bodyExecuted)
+        assertThat(writeFileRule.files.keySet(), hasSize(0))
+        assertThat(shellRule.shell, hasSize(0))
     }
 
     @Test

--- a/vars/writeTemporaryCredentials.groovy
+++ b/vars/writeTemporaryCredentials.groovy
@@ -1,0 +1,71 @@
+import com.sap.piper.ConfigurationHelper
+import com.sap.piper.ConfigurationLoader
+import com.sap.piper.GenerateDocumentation
+import com.sap.piper.JsonUtils
+import com.sap.piper.TemporaryCredentialsUtils
+import com.sap.piper.Utils
+
+import groovy.transform.Field
+
+import static com.sap.piper.Prerequisites.checkScript
+
+@Field String STEP_NAME = getClass().getName()
+
+@Field Set GENERAL_CONFIG_KEYS = []
+@Field Set STEP_CONFIG_KEYS = [
+    /**
+     * The list of credentials that are written to a temporary file for the execution of the body.
+     * Each element of credentials must be a map containing a property alias and a property credentialId.
+     * You have to ensure that corresponding credential entries exist in your Jenkins configuration.
+     */
+    'credentials',
+    /**
+     * The path to the directory where the credentials file has to be placed.
+     */
+    'credentialsDirectory'
+]
+@Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
+
+/**
+ * Writes credentials to a temporary file and deletes it after the body has been executed.
+ */
+@GenerateDocumentation
+void call(Map parameters = [:], Closure body) {
+    handlePipelineStepErrors(stepName: STEP_NAME, stepParameters: parameters) {
+        def script = checkScript(this, parameters) ?: this
+        def stageName = parameters.stageName ?: env.STAGE_NAME
+
+        Map config = ConfigurationHelper.newInstance(this)
+            .loadStepDefaults()
+            .mixin(ConfigurationLoader.defaultStageConfiguration(script, stageName))
+            .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
+            .mixinStepConfig(script.commonPipelineEnvironment, STEP_CONFIG_KEYS)
+            .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)
+            .mixin(parameters, PARAMETER_KEYS)
+            .use()
+
+        // telemetry reporting
+        new Utils().pushToSWA([
+            step: STEP_NAME,
+            stepParamKey1: 'scriptMissing',
+            stepParam1: parameters?.script == null
+        ], config)
+
+        if (!config.credentials) {
+            error "[${STEP_NAME}] The execution failed, since no credentials are defined. Please provide credentials as a list of maps.\n"
+        }
+        if (!(config.credentials instanceof List)) {
+            error "[${STEP_NAME}] The execution failed, since credentials is not a list. Please provide credentials as a list of maps. For example:\n" +
+                "credentials: \n" + "  - alias: 'ERP'\n" + "    credentialId: 'erp-credentials'"
+        }
+        if (!config.credentialsDirectory) {
+            error "[${STEP_NAME}] The execution failed, since no credentialsDirectory is defined. Please provide the path for the credentials file.\n"
+        }
+
+        TemporaryCredentialsUtils credUtils = new TemporaryCredentialsUtils(script)
+
+        credUtils.handleTemporaryCredentials(config.credentials, config.credentialsDirectory) {
+            body()
+        }
+    }
+}

--- a/vars/writeTemporaryCredentials.groovy
+++ b/vars/writeTemporaryCredentials.groovy
@@ -51,10 +51,7 @@ void call(Map parameters = [:], Closure body) {
             stepParam1: parameters?.script == null
         ], config)
 
-        if (!config.credentials) {
-            error "[${STEP_NAME}] The execution failed, since no credentials are defined. Please provide credentials as a list of maps.\n"
-        }
-        if (!(config.credentials instanceof List)) {
+        if (config.credentials && !(config.credentials instanceof List)) {
             error "[${STEP_NAME}] The execution failed, since credentials is not a list. Please provide credentials as a list of maps. For example:\n" +
                 "credentials: \n" + "  - alias: 'ERP'\n" + "    credentialId: 'erp-credentials'"
         }


### PR DESCRIPTION
# Changes

This change adds the groovy step writeTemporaryCredentials, in order to
avoid resolving configuration parameters within the piperPipelineStageIntegration
in the future.
For the integration tests functionality provided by the SAP Cloud SDK
Pipeline it needs be possible to configure a credential id pointing to
Jenkins credentials, which are then temporarily written to a file to be
available during the execution of the integration tests.
With the previous implementation solely in the TemporaryCredentialsUtils
class, it would be required to resolve the credentialId from the
configuratuion within the piperPipelineStageIntegration, once we fully
migrate the Cloud SDK integration tests stage.

- [x] Tests
- [x] Documentation
