### PR TITLE
refactor(protecode): add explicit parameter for Docker config.json file

### DIFF
--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -53,7 +53,7 @@ func protecodeExecuteScan(config protecodeExecuteScanOptions, telemetryData *tel
 
 func runProtecodeScan(config *protecodeExecuteScanOptions, influx *protecodeExecuteScanInflux, dClient piperDocker.Download) error {
 
-	correctDockerConfigEnvVar()
+	correctDockerConfigEnvVar(config)
 
 	var fileName, filePath string
 	//create client for sending api request
@@ -349,8 +349,8 @@ var writeReportToFile = func(resp io.ReadCloser, reportFileName string) error {
 	return err
 }
 
-func correctDockerConfigEnvVar() {
-	path := os.Getenv("DOCKER_CONFIG")
+func correctDockerConfigEnvVar(config *protecodeExecuteScanOptions) {
+	path := config.DockerConfigJSON
 	if len(path) > 0 {
 		log.Entry().Infof("Docker credentials configuration: %v", path)
 		path, _ := filepath.Abs(path)

--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -211,7 +211,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 					},
 					{
 						Name:        "dockerConfigJSON",
-						ResourceRef: []config.ResourceReference{{Name: "dockerCredentialsId", Param: ""}},
+						ResourceRef: []config.ResourceReference{{Name: "dockerConfigJsonCredentialsId", Param: ""}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,

--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -211,7 +211,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 					},
 					{
 						Name:        "dockerConfigJSON",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "dockerCredentialsId", Param: ""}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,

--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -20,6 +20,7 @@ type protecodeExecuteScanOptions struct {
 	FailOnSevereVulnerabilities bool   `json:"failOnSevereVulnerabilities,omitempty"`
 	ScanImage                   string `json:"scanImage,omitempty"`
 	DockerRegistryURL           string `json:"dockerRegistryUrl,omitempty"`
+	DockerConfigJSON            string `json:"dockerConfigJSON,omitempty"`
 	CleanupMode                 string `json:"cleanupMode,omitempty"`
 	FilePath                    string `json:"filePath,omitempty"`
 	IncludeLayers               bool   `json:"includeLayers,omitempty"`
@@ -108,6 +109,7 @@ func ProtecodeExecuteScanCommand() *cobra.Command {
 				log.SetErrorCategory(log.ErrorConfiguration)
 				return err
 			}
+			log.RegisterSecret(stepConfig.DockerConfigJSON)
 			log.RegisterSecret(stepConfig.Username)
 			log.RegisterSecret(stepConfig.Password)
 
@@ -144,6 +146,7 @@ func addProtecodeExecuteScanFlags(cmd *cobra.Command, stepConfig *protecodeExecu
 	cmd.Flags().BoolVar(&stepConfig.FailOnSevereVulnerabilities, "failOnSevereVulnerabilities", true, "Whether to fail the job on severe vulnerabilties or not")
 	cmd.Flags().StringVar(&stepConfig.ScanImage, "scanImage", os.Getenv("PIPER_scanImage"), "The reference to the docker image to scan with Protecode")
 	cmd.Flags().StringVar(&stepConfig.DockerRegistryURL, "dockerRegistryUrl", os.Getenv("PIPER_dockerRegistryUrl"), "The reference to the docker registry to scan with Protecode")
+	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")
 	cmd.Flags().StringVar(&stepConfig.CleanupMode, "cleanupMode", `binary`, "Decides which parts are removed from the Protecode backend after the scan")
 	cmd.Flags().StringVar(&stepConfig.FilePath, "filePath", os.Getenv("PIPER_filePath"), "The path to the file from local workspace to scan with Protecode")
 	cmd.Flags().BoolVar(&stepConfig.IncludeLayers, "includeLayers", false, "Flag if the docker layers should be included")
@@ -202,6 +205,14 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Name:        "dockerRegistryUrl",
 						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "container/registryUrl"}},
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "dockerConfigJSON",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -7,24 +7,8 @@
 1. Create a Username / Password credential with the Protecode user in your Jenkins credential store
 1. Lookup your Group ID using REST API via `curl -u <username> "https://<protecode host>/api/groups/"`.
 
-## Example
-
-Usage of pipeline step:
-
-Workspace based:
-```groovy
-executeProtecodeScan script: this, filePath: 'dockerImage.tar'
-```
-
-Fetch URL:
-```groovy
-executeProtecodeScan script: this, fetchUrl: 'https://nexusrel.wdf.sap.corp:8443/nexus/service/local/repositories/build.releases.3rd-party.proxy.2018.04.13/content/org/alfresco/surf/spring-cmis-framework/6.11/spring-cmis-framework-6.11.jar'
-```
-
-Docker image:
-```groovy
-executeProtecodeScan script: this, dockerRegistryUrl: 'https://docker.wdf.sap.corp:50000', dockerImage: 'piper/yeoman:1.0-20180321110554'
-```
+If the image is on a protected registry you can provide a Docker `config.json` file containing the credential information for the registry.
+You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).
 
 ## ${docGenParameters}
 
@@ -32,14 +16,10 @@ executeProtecodeScan script: this, dockerRegistryUrl: 'https://docker.wdf.sap.co
 
 * The Protecode scan step is able to send a file addressed via parameter `filePath` to the backend for scanning it for known vulnerabilities.
 * Alternatively an HTTP URL can be specified via `fetchUrl`. Protecode will then download the artifact from there and scan it.
-* To support docker image scanning please provide `dockerImage` with a docker like URL poiting to the image tag within the docker registry being used. Our step uses [skopeo](https://github.com/containers/skopeo) to download the image and sends it to Protecode for scanning.
+* To support docker image scanning please provide `scanImage` with a docker like URL poiting to the image tag within the docker registry being used.
 * To receive the result it polls until the job completes.
 * Once the job has completed a PDF report is pulled from the backend and archived in the build
-* Finally the scan result is being analysed for critical findings with a CVSS v3 score >= 7.0 and if such findings are detected the build is failed based on the configuration setting `protecodeFailOnSevereVulnerabilities`.
-* During the analysis all CVEs which are either triaged in the Protecode backend or which are excluded via configuration parameter `protecodeExcludeCVEs` are ignored and will not provoke the build to fail.
-
-### FAQs
-
-* In case of `dockerImage` and the step still tries to pull and save it via docker daemon, please make sure your JaaS environment has the variable `ON_K8S` declared and set to `true`.
+* Finally the scan result is being analysed for critical findings with a CVSS v3 score >= 7.0 and if such findings are detected the build is failed based on the configuration setting `failOnSevereVulnerabilities`.
+* During the analysis all CVEs which are triaged are ignored and will not provoke the build to fail.
 
 ## ${docGenConfiguration}

--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -53,6 +53,14 @@ spec:
       - PARAMETERS
       - STAGES
       - STEPS
+    - name: dockerConfigJSON
+      type: string
+      description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).
+      scope:
+        - PARAMETERS
+        - STAGES
+        - STEPS
+      secret: true
     - name: cleanupMode
       type: string
       description: Decides which parts are removed from the Protecode backend after the scan

--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -62,7 +62,7 @@ spec:
         - STEPS
       secret: true
       resourceRef:
-        - name: dockerCredentialsId
+        - name: dockerConfigJsonCredentialsId
           type: secret
     - name: cleanupMode
       type: string
@@ -187,7 +187,7 @@ spec:
     - name: dockerConfigJsonCredentialsId
       type: jenkins
       aliases:
-        - name: dockerConfigJsonCredentialsId
+        - name: dockerCredentialsId
           deprecated: true
   outputs:
     resources:

--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -61,6 +61,9 @@ spec:
         - STAGES
         - STEPS
       secret: true
+      resourceRef:
+        - name: dockerCredentialsId
+          type: secret
     - name: cleanupMode
       type: string
       description: Decides which parts are removed from the Protecode backend after the scan

--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -187,7 +187,7 @@ spec:
     - name: dockerConfigJsonCredentialsId
       type: jenkins
       aliases:
-        - name: dockerCredentialsId
+        - name: dockerConfigJsonCredentialsId
           deprecated: true
   outputs:
     resources:

--- a/vars/protecodeExecuteScan.groovy
+++ b/vars/protecodeExecuteScan.groovy
@@ -12,7 +12,7 @@ void call(Map parameters = [:]) {
 
     List credentials = [
         [type: 'usernamePassword', id: 'protecodeCredentialsId', env: ['PIPER_username', 'PIPER_password']],
-        [type: 'file', id: 'dockerCredentialsId', env: ['DOCKER_CONFIG']],
+        [type: 'file', id: 'dockerCredentialsId', env: ['PIPER_dockerConfigJSON']],
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
This PR adds a new parameter `dockerConfigJSON` to reflect the usage of `dockerConfigJsonCredentialsId` in the docs.

mind #1915 