### PR TITLE
refactor(protecode): align Docker config.json parameter name

### DIFF
--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -173,8 +173,11 @@ spec:
     secrets:
     - name: protecodeCredentialsId
       type: jenkins
-    - name: dockerCredentialsId
+    - name: dockerConfigJsonCredentialsId
       type: jenkins
+      aliases:
+        - name: dockerCredentialsId
+          deprecated: true
   outputs:
     resources:
       - name: influx

--- a/vars/protecodeExecuteScan.groovy
+++ b/vars/protecodeExecuteScan.groovy
@@ -12,7 +12,7 @@ void call(Map parameters = [:]) {
 
     List credentials = [
         [type: 'usernamePassword', id: 'protecodeCredentialsId', env: ['PIPER_username', 'PIPER_password']],
-        [type: 'file', id: 'dockerCredentialsId', env: ['DOCKER_CONFIG']],
+        [type: 'file', id: 'dockerConfigJsonCredentialsId', env: ['DOCKER_CONFIG']],
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
We have different approaches of authenticating against a Docker registry. 
- `kubernetesDeploy` uses username/password via the `dockerCredentialsId` parameter
- `kenikoExecute` uses a `config.json` file via the `dockerConfigJsonCredentialsId ` parameter
- `protecodeExecuteScan` uses a `config.json` file via the `dockerCredentialsId` parameter

This PR aligns the parameter name for a `config.json` file in the protecode step with the [`kaniko`](https://github.com/SAP/jenkins-library/blob/master/resources/metadata/kaniko.yaml#L8) step.

mind #1914