### PR TITLE
piper: Use stageName from parametersJSON, log value and source

### DIFF
--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -33,6 +33,7 @@ func ConfigCommand() *cobra.Command {
 			path, _ := os.Getwd()
 			fatalHook := &log.FatalHook{CorrelationID: GeneralConfig.CorrelationID, Path: path}
 			log.RegisterHook(fatalHook)
+			initStageName(false)
 		},
 		Run: func(cmd *cobra.Command, _ []string) {
 			err := generateConfig()

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -134,11 +134,11 @@ func initStageName() {
 		// Means it was given as command line argument and has the highest precedence
 		stageNameSource = "command line arguments"
 		return
-	} else {
-		// Use stageName from ENV as fall-back, when extracting it from parametersJSON fails below
-		GeneralConfig.StageName = os.Getenv(stageNameEnvKey)
-		stageNameSource = fmt.Sprintf("env variable '%s'", stageNameEnvKey)
 	}
+
+	// Use stageName from ENV as fall-back, for when extracting it from parametersJSON fails below
+	GeneralConfig.StageName = os.Getenv(stageNameEnvKey)
+	stageNameSource = fmt.Sprintf("env variable '%s'", stageNameEnvKey)
 
 	if len(GeneralConfig.ParametersJSON) == 0 {
 		return

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -149,7 +149,9 @@ func initStageName(outputToLog bool) {
 	var params map[string]interface{}
 	err := json.Unmarshal([]byte(GeneralConfig.ParametersJSON), &params)
 	if err != nil {
-		// Ignore here, will be logged later anyway
+		if outputToLog {
+			log.Entry().Infof("Failed to extract 'stageName' from parametersJSON: %v", err)
+		}
 		return
 	}
 

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -124,11 +124,13 @@ const stageNameEnvKey = "STAGE_NAME"
 
 // initStageName initializes GeneralConfig.StageName from either GeneralConfig.ParametersJSON
 // or the environment variable 'STAGE_NAME', unless it has been provided as command line option.
-func initStageName() {
+func initStageName(outputToLog bool) {
 	var stageNameSource string
-	defer func() {
-		log.Entry().Infof("Using stageName '%s' from %s", GeneralConfig.StageName, stageNameSource)
-	}()
+	if outputToLog {
+		defer func() {
+			log.Entry().Infof("Using stageName '%s' from %s", GeneralConfig.StageName, stageNameSource)
+		}()
+	}
 
 	if GeneralConfig.StageName != "" {
 		// Means it was given as command line argument and has the highest precedence
@@ -167,7 +169,7 @@ func PrepareConfig(cmd *cobra.Command, metadata *config.StepData, stepName strin
 
 	log.SetFormatter(GeneralConfig.LogFormat)
 
-	initStageName()
+	initStageName(true)
 
 	filters := metadata.GetParameterFilters()
 

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -124,6 +124,7 @@ const stageNameEnvKey = "STAGE_NAME"
 
 // initStageName initializes GeneralConfig.StageName from either GeneralConfig.ParametersJSON
 // or the environment variable 'STAGE_NAME', unless it has been provided as command line option.
+// Log output needs to be suppressed via outputToLog by the getConfig step.
 func initStageName(outputToLog bool) {
 	var stageNameSource string
 	if outputToLog {

--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -123,7 +123,7 @@ func TestPrepareConfig(t *testing.T) {
 			}
 
 			err := PrepareConfig(testCmd, &metadata, "testStep", &testOptions, mock.OpenFileMock)
-			assert.NoError(t, err, "no error expected but error occured")
+			assert.NoError(t, err, "no error expected but error occurred")
 
 			//assert config
 			assert.Equal(t, "testValue", testOptions.TestParam, "wrong value retrieved from config")
@@ -143,7 +143,7 @@ func TestPrepareConfig(t *testing.T) {
 			metadata := config.StepData{}
 
 			err := PrepareConfig(testCmd, &metadata, "testStep", &testOptions, mock.OpenFileMock)
-			assert.Error(t, err, "error expected but none occured")
+			assert.Error(t, err, "error expected but none occurred")
 		})
 	})
 }

--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -31,6 +31,47 @@ func TestAddRootFlags(t *testing.T) {
 
 }
 
+func TestAdoptStageNameFromParametersJSON(t *testing.T) {
+	tt := []struct {
+		name      string
+		stageName string
+	}{
+		{name: "no stageName", stageName: ""},
+		{name: "stage name given", stageName: "technicalIdentifier"},
+	}
+
+	for _, test := range tt {
+		t.Run(test.name, func(t *testing.T) {
+			// init
+			GeneralConfig.StageName = "stageLabel"
+
+			const envKey = "STAGE_NAME"
+			resetValue := os.Getenv(envKey)
+			defer func() { _ = os.Setenv(envKey, resetValue) }()
+
+			err := os.Setenv(envKey, GeneralConfig.StageName)
+			if err != nil {
+				t.Fatalf("could not set env var %s", envKey)
+			}
+
+			if test.stageName != "" {
+				GeneralConfig.ParametersJSON = fmt.Sprintf("{\"stageName\":\"%s\"}", test.stageName)
+			} else {
+				GeneralConfig.ParametersJSON = "{}"
+			}
+			// test
+			adoptStageNameFromParametersJSON()
+
+			// assert
+			if test.stageName != "" {
+				assert.Equal(t, test.stageName, GeneralConfig.StageName)
+			} else {
+				assert.Equal(t, "stageLabel", GeneralConfig.StageName)
+			}
+		})
+	}
+}
+
 func TestPrepareConfig(t *testing.T) {
 	defaultsBak := GeneralConfig.DefaultConfig
 	GeneralConfig.DefaultConfig = []string{"testDefaults.yml"}

--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -64,7 +64,7 @@ func TestAdoptStageNameFromParametersJSON(t *testing.T) {
 				GeneralConfig.ParametersJSON = "{}"
 			}
 			// test
-			initStageName()
+			initStageName(false)
 
 			// assert
 			// Order of if-clauses reflects wanted precedence.


### PR DESCRIPTION
# Changes

stageName from parametersJSON was ignored up until now and there was a TODO in the code. The precedence from the TODO is not clear to me. It said "first env.STAGE_NAME, second: parametersJSON, third: flag". So maybe I implemented it wrongly, but it would be easy to change. Right now, STAGE_NAME is always in the ENV when piper is called from Jenkins, but to mimic the behavior of being able to pass `stageName` in the parameters and override the ENV value, this is what happens in go as well now.

The reason why `stageName` needs to be evaluated before other step parameters is that it affects config evaluation. So I've added a function which is called first in `PrepareConfig()`.

- [x] Tests
- [x] Documentation
