### PR TITLE
Align stage name

### DIFF
--- a/test/groovy/PiperStageWrapperTest.groovy
+++ b/test/groovy/PiperStageWrapperTest.groovy
@@ -129,7 +129,42 @@ class PiperStageWrapperTest extends BasePiperTest {
         }
         assertThat(executed, is(true))
         assertThat(executedOnKubernetes, is(true))
-        assertThat(customEnv[0].toString(), is("POD_NAME=test"))
+        assertThat(customEnv[1].toString(), is("POD_NAME=test"))
+    }
+
+    @Test
+    void testStageNameInEnv() {
+        def executed = false
+
+        binding.variables.env.STAGE_NAME = 'label'
+
+        stepRule.step.piperStageWrapper(
+            script: nullScript,
+            juStabUtils: utils,
+            stageName: 'test',
+            ordinal: 10
+        ) {
+            executed = true
+        }
+        assertThat(executed, is(true))
+        assertThat(customEnv[0].toString(), is("STAGE_NAME=test"))
+    }
+
+    @Test
+    void testStageNameAlreadyInEnv() {
+        def executed = false
+
+        binding.variables.env.STAGE_NAME = 'test'
+
+        stepRule.step.piperStageWrapper(
+            script: nullScript,
+            juStabUtils: utils,
+            ordinal: 10
+        ) {
+            executed = true
+        }
+        assertThat(executed, is(true))
+        assertThat(customEnv.size(), is(0))
     }
 
     @Test

--- a/vars/piperPipelineStageAcceptance.groovy
+++ b/vars/piperPipelineStageAcceptance.groovy
@@ -78,19 +78,19 @@ void call(Map parameters = [:]) {
         } else {
             if (config.cloudFoundryDeploy) {
                 durationMeasure(script: script, measurementName: 'deploy_test_cf_duration') {
-                    cloudFoundryDeploy script: script, stageName: stageName
+                    cloudFoundryDeploy script: script
                 }
             }
 
             if (config.neoDeploy) {
                 durationMeasure(script: script, measurementName: 'deploy_test_neo_duration') {
-                    neoDeploy script: script, stageName: stageName
+                    neoDeploy script: script
                 }
             }
         }
 
         if (config.healthExecuteCheck) {
-            healthExecuteCheck script: script, stageName: stageName
+            healthExecuteCheck script: script
         }
 
 
@@ -100,7 +100,7 @@ void call(Map parameters = [:]) {
         if (config.gaugeExecuteTests) {
             durationMeasure(script: script, measurementName: 'gauge_duration') {
                 publishResults = true
-                gaugeExecuteTests script: script, stageName: stageName
+                gaugeExecuteTests script: script
                 publishMap += [gauge: [archive: true]]
             }
         }
@@ -108,14 +108,14 @@ void call(Map parameters = [:]) {
         if (config.newmanExecute) {
             durationMeasure(script: script, measurementName: 'newman_duration') {
                 publishResults = true
-                newmanExecute script: script, stageName: stageName
+                newmanExecute script: script
             }
         }
 
         if (config.uiVeri5ExecuteTests) {
             durationMeasure(script: script, measurementName: 'uiveri5_duration') {
                 publishResults = true
-                uiVeri5ExecuteTests script: script, stageName: stageName
+                uiVeri5ExecuteTests script: script
             }
         }
 
@@ -126,7 +126,6 @@ void call(Map parameters = [:]) {
         }
 
         if (publishResults) {
-            publishMap.stageName = stageName
             testsPublishResults publishMap
         }
     }

--- a/vars/piperPipelineStageBuild.groovy
+++ b/vars/piperPipelineStageBuild.groovy
@@ -54,11 +54,11 @@ void call(Map parameters = [:]) {
 
         durationMeasure(script: script, measurementName: 'build_duration') {
 
-            buildExecute script: script, stageName: stageName
-            pipelineStashFilesAfterBuild script: script, stageName: stageName
+            buildExecute script: script
+            pipelineStashFilesAfterBuild script: script
 
-            testsPublishResults script: script, junit: [updateResults: true], stageName: stageName
-            checksPublishResults script: script, stageName: stageName
+            testsPublishResults script: script, junit: [updateResults: true]
+            checksPublishResults script: script
         }
     }
 }

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -46,12 +46,12 @@ void call(Map parameters = [:]) {
         try {
             if (config.npmExecuteScripts) {
                 publishResults = true
-                npmExecuteScripts script: script, stageName: stageName
+                npmExecuteScripts script: script
             }
         }
         finally {
             if (publishResults) {
-                testsPublishResults script: script, stageName: stageName
+                testsPublishResults script: script
             }
         }
     }

--- a/vars/piperPipelineStageRelease.groovy
+++ b/vars/piperPipelineStageRelease.groovy
@@ -65,25 +65,25 @@ void call(Map parameters = [:]) {
         } else {
             if (config.cloudFoundryDeploy) {
                 durationMeasure(script: script, measurementName: 'deploy_release_cf_duration') {
-                    cloudFoundryDeploy script: script, stageName: stageName
+                    cloudFoundryDeploy script: script
                 }
             }
 
             if (config.neoDeploy) {
                 durationMeasure(script: script, measurementName: 'deploy_release_neo_duration') {
-                    neoDeploy script: script, stageName: stageName
+                    neoDeploy script: script
                 }
             }
         }
 
         if (config.tmsUpload) {
             durationMeasure(script: script, measurementName: 'upload_release_tms_duration') {
-                tmsUpload script: script, stageName: stageName
+                tmsUpload script: script
             }
         }
 
         if (config.healthExecuteCheck) {
-            healthExecuteCheck script: script, stageName: stageName
+            healthExecuteCheck script: script
         }
 
         if (config.npmExecuteEndToEndTests) {
@@ -93,7 +93,7 @@ void call(Map parameters = [:]) {
         }
 
         if (config.githubPublishRelease) {
-            githubPublishRelease script: script, stageName: stageName
+            githubPublishRelease script: script
         }
 
     }

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -32,6 +32,12 @@ void call(Map parameters = [:], body) {
     stageLocking(config) {
         def containerMap = ContainerMap.instance.getMap().get(stageName) ?: [:]
         List environment = []
+        if (stageName && stageName != env.STAGE_NAME) {
+            // Avoid two sources of truth with regards to stageName.
+            // env.STAGE_NAME is filled from stage('Display name') {, it only serves the purpose of
+            // easily getting to the stage name from steps.
+            environment.add("STAGE_NAME=${stageName}")
+        }
         if (config.sidecarImage) {
             echo "sidecarImage configured for stage '${stageName}': '${config.sidecarImage}'"
             environment.add("SIDECAR_IMAGE=${config.sidecarImage}")


### PR DESCRIPTION
# Changes

Make sure to avoid problems with conflicting sources of truth about the current stage name by setting env.STAGE_NAME to the name from the parameters in piperStageWrapper.

Reverts #1796, which did not have any effect without #1920. With this PR, it is no longer needed.

- [x] Tests
- [ ] Documentation
