### PR TITLE
Add mavenExecuteIntegration and writeTemporaryCredentials to piperPipelineStageIntegration

### DIFF
--- a/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
@@ -47,6 +47,9 @@ stages:
           - 'githubTokenCredentialsId'
   backendIntegrationTests:
     stepConditions:
+      npmExecuteScripts:
+        configKeys:
+          - 'runScripts'
       mavenExecuteIntegration:
         fileExists:
           filePattern: 'integration-tests/pom.xml'

--- a/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
@@ -45,3 +45,8 @@ stages:
       githubPublishRelease:
         configKeys:
           - 'githubTokenCredentialsId'
+  backendIntegrationTests:
+    stepConditions:
+      mavenExecuteIntegration:
+        fileExists:
+          filePattern: 'integration-tests/pom.xml'

--- a/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
@@ -51,5 +51,4 @@ stages:
         configKeys:
           - 'runScripts'
       mavenExecuteIntegration:
-        fileExists:
-          filePattern: 'integration-tests/pom.xml'
+        filePattern: 'integration-tests/pom.xml'

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -578,6 +578,10 @@ steps:
       - 'tests'
     testOptions: ''
     runCommand: "uiveri5 --seleniumAddress='http://${config.seleniumHost}:${config.seleniumPort}/wd/hub'"
+  writeTemporaryCredentials:
+    credentialsDirectories:
+      - './'
+      - 'integration-tests/src/test/resources'
 
   #defaults for stage wrapper
   piperStageWrapper:

--- a/src/com/sap/piper/TemporaryCredentialsUtils.groovy
+++ b/src/com/sap/piper/TemporaryCredentialsUtils.groovy
@@ -8,47 +8,63 @@ class TemporaryCredentialsUtils implements Serializable {
         this.script = script
     }
 
-    void handleTemporaryCredentials(List credentialItems, String credentialsDirectory, Closure body) {
+    void handleTemporaryCredentials(List credentialItems, List credentialsDirectories, Closure body) {
         final String credentialsFileName = 'credentials.json'
 
-        if (!credentialsDirectory) {
-            script.error("This should not happen: Directory for credentials file not specified.")
+        if (!credentialsDirectories) {
+            script.error("This should not happen: Directories for credentials files not specified.")
         }
 
         final boolean useCredentials = credentialItems
         try {
             if (useCredentials) {
-                writeCredentials(credentialItems, credentialsDirectory, credentialsFileName)
+                writeCredentials(credentialItems, credentialsDirectories, credentialsFileName)
             }
             body()
         }
         finally {
             if (useCredentials) {
-                deleteCredentials(credentialsDirectory, credentialsFileName)
+                deleteCredentials(credentialsDirectories, credentialsFileName)
             }
         }
     }
 
-    private void writeCredentials(List credentialItems, String credentialsDirectory, String credentialsFileName) {
+    private void writeCredentials(List credentialItems, List credentialsDirectories, String credentialsFileName) {
         if (!credentialItems) {
             script.echo "Not writing any credentials."
             return
         }
 
-        assertSystemsFileExists(credentialsDirectory)
+        Boolean systemsFileFound = false
+        for (int i = 0; i < credentialsDirectories.size(); i++) {
+            if (!credentialsDirectories[i].endsWith("/")) {
+                credentialsDirectories[i] += '/'
+            }
+            if (script.fileExists("${credentialsDirectories[i]}systems.yml") || script.fileExists("${credentialsDirectories[i]}systems.yaml") || script.fileExists("${credentialsDirectories[i]}systems.json")) {
+                String credentialJson = returnCredentialsAsJSON(credentialItems)
 
-        String credentialJson = returnCredentialsAsJSON(credentialItems)
+                script.echo "Writing credentials file with ${credentialItems.size()} items to ${credentialsDirectories[i]}."
+                script.writeFile file: credentialsDirectories[i] + credentialsFileName, text: credentialJson
 
-        script.echo "Writing credentials file with ${credentialItems.size()} items."
-        script.dir(credentialsDirectory) {
-            script.writeFile file: credentialsFileName, text: credentialJson
+                systemsFileFound = true
+            }
+        }
+        if (!systemsFileFound) {
+            script.error("None of the directories ${credentialsDirectories} contains any of the files systems.yml, systems.yaml or systems.json. " +
+                "One of those files is required in order to activate the integration test credentials configured in the pipeline configuration file of this project. " +
+                "Please add the file as explained in the SAP Cloud SDK documentation.")
         }
     }
 
-    private void deleteCredentials(String credentialsDirectory, String credentialsFileName) {
-        script.echo "Deleting credentials file."
-        script.dir(credentialsDirectory) {
-            script.sh "rm -f ${credentialsFileName}"
+    private void deleteCredentials(List credentialsDirectories, String credentialsFileName) {
+        for (int i = 0; i < credentialsDirectories.size(); i++) {
+            if(!credentialsDirectories[i].endsWith('/'))
+                credentialsDirectories[i] += '/'
+
+            if (script.fileExists(credentialsDirectories[i] + credentialsFileName)) {
+                script.echo "Deleting credentials file in ${credentialsDirectories[i]}."
+                script.sh "rm -f ${credentialsDirectories[i] + credentialsFileName}"
+            }
         }
     }
 
@@ -67,15 +83,5 @@ class TemporaryCredentialsUtils implements Serializable {
             }
         }
         return new JsonUtils().groovyObjectToJsonString(credentialCollection)
-    }
-
-    private assertSystemsFileExists(String credentialsDirectory){
-        script.dir(credentialsDirectory) {
-            if (!script.fileExists("systems.yml") && !script.fileExists("systems.yaml") && !script.fileExists("systems.json")) {
-                script.error("The directory ${credentialsDirectory} does not contain any of the files systems.yml, systems.yaml or systems.json. " +
-                    "One of those files is required in order to activate the integration test credentials configured in the pipeline configuration file of this project. " +
-                    "Please add the file as explained in the SAP Cloud SDK documentation.")
-            }
-        }
     }
 }

--- a/src/com/sap/piper/TemporaryCredentialsUtils.groovy
+++ b/src/com/sap/piper/TemporaryCredentialsUtils.groovy
@@ -37,7 +37,10 @@ class TemporaryCredentialsUtils implements Serializable {
 
         Boolean systemsFileFound = false
         for (int i = 0; i < credentialsDirectories.size(); i++) {
-            if (credentialsDirectories[i] && !credentialsDirectories[i].endsWith("/")) {
+            if (!credentialsDirectories[i]) {
+                continue
+            }
+            if (!credentialsDirectories[i].endsWith("/")) {
                 credentialsDirectories[i] += '/'
             }
             if (script.fileExists("${credentialsDirectories[i]}systems.yml") || script.fileExists("${credentialsDirectories[i]}systems.yaml") || script.fileExists("${credentialsDirectories[i]}systems.json")) {
@@ -58,6 +61,9 @@ class TemporaryCredentialsUtils implements Serializable {
 
     private void deleteCredentials(List credentialsDirectories, String credentialsFileName) {
         for (int i = 0; i < credentialsDirectories.size(); i++) {
+            if (!credentialsDirectories[i]) {
+                continue
+            }
             if(!credentialsDirectories[i].endsWith('/'))
                 credentialsDirectories[i] += '/'
 

--- a/src/com/sap/piper/TemporaryCredentialsUtils.groovy
+++ b/src/com/sap/piper/TemporaryCredentialsUtils.groovy
@@ -37,7 +37,7 @@ class TemporaryCredentialsUtils implements Serializable {
 
         Boolean systemsFileFound = false
         for (int i = 0; i < credentialsDirectories.size(); i++) {
-            if (!credentialsDirectories[i].endsWith("/")) {
+            if (credentialsDirectories[i] && !credentialsDirectories[i].endsWith("/")) {
                 credentialsDirectories[i] += '/'
             }
             if (script.fileExists("${credentialsDirectories[i]}systems.yml") || script.fileExists("${credentialsDirectories[i]}systems.yaml") || script.fileExists("${credentialsDirectories[i]}systems.json")) {

--- a/test/groovy/WriteTemporaryCredentialsTest.groovy
+++ b/test/groovy/WriteTemporaryCredentialsTest.groovy
@@ -93,7 +93,8 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
         def credential = [alias: 'ERP', credentialId: 'erp-credentials']
 
         nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
-            credentials: [credential]
+            credentials: [credential],
+            credentialsDirectories: []
         ]]]
 
         thrown.expect(hudson.AbortException)

--- a/test/groovy/WriteTemporaryCredentialsTest.groovy
+++ b/test/groovy/WriteTemporaryCredentialsTest.groovy
@@ -150,5 +150,6 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
         assertTrue(bodyExecuted)
         assertThat(writeFileRule.files['./credentials.json'], containsString('"alias":"ERP","username":"test_user","password":"********"'))
         assertThat(shellRule.shell, hasItem('rm -f ./credentials.json'))
+        assertThat(writeFileRule.files.size(), is(1))
     }
 }

--- a/test/groovy/WriteTemporaryCredentialsTest.groovy
+++ b/test/groovy/WriteTemporaryCredentialsTest.groovy
@@ -55,7 +55,7 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
     @Test
     void noCredentials() {
         nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
-            credentialsDirectory: './',
+            credentialsDirectories: ['./', 'integration-test/'],
         ]]]
         stepRule.step.writeTemporaryCredentials(
             script: nullScript,
@@ -89,7 +89,7 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
     }
 
     @Test
-    void noCredentialsDirectory() {
+    void noCredentialsDirectories() {
         def credential = [alias: 'ERP', credentialId: 'erp-credentials']
 
         nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
@@ -97,7 +97,28 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
         ]]]
 
         thrown.expect(hudson.AbortException)
-        thrown.expectMessage("[writeTemporaryCredentials] The execution failed, since no credentialsDirectory is defined. Please provide the path for the credentials file.")
+        thrown.expectMessage("[writeTemporaryCredentials] The execution failed, since no credentialsDirectories are defined. Please provide a list of paths for the credentials files.")
+
+        stepRule.step.writeTemporaryCredentials(
+            script: nullScript,
+            stageName: "myStage",
+        ){
+            bodyExecuted = true
+        }
+        assertFalse(bodyExecuted)
+    }
+
+    @Test
+    void credentialsDirectoriesNoList() {
+        def credential = [alias: 'ERP', credentialId: 'erp-credentials']
+
+        nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
+            credentials: [credential],
+            credentialsDirectories: './',
+        ]]]
+
+        thrown.expect(hudson.AbortException)
+        thrown.expectMessage("[writeTemporaryCredentials] The execution failed, since credentialsDirectories is not a list. Please provide credentialsDirectories as a list of paths.")
 
         stepRule.step.writeTemporaryCredentials(
             script: nullScript,
@@ -111,11 +132,12 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
     @Test
     void credentialsFileWrittenAndRemoved() {
         def credential = [alias: 'ERP', credentialId: 'erp-credentials']
-        fileExistsRule.registerExistingFile('systems.yml')
+        fileExistsRule.registerExistingFile('./systems.yml')
+        fileExistsRule.registerExistingFile('./credentials.json')
 
         nullScript.commonPipelineEnvironment.configuration = [stages: [myStage:[
             credentials: [credential],
-            credentialsDirectory: './',
+            credentialsDirectories: ['./', 'integration-test/'],
         ]]]
 
         stepRule.step.writeTemporaryCredentials(
@@ -126,7 +148,7 @@ class WriteTemporaryCredentialsTest extends BasePiperTest {
         }
 
         assertTrue(bodyExecuted)
-        assertThat(writeFileRule.files['credentials.json'], containsString('"alias":"ERP","username":"test_user","password":"********"'))
-        assertThat(shellRule.shell, hasItem('rm -f credentials.json'))
+        assertThat(writeFileRule.files['./credentials.json'], containsString('"alias":"ERP","username":"test_user","password":"********"'))
+        assertThat(shellRule.shell, hasItem('rm -f ./credentials.json'))
     }
 }

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -11,6 +11,8 @@ import static com.sap.piper.Prerequisites.checkScript
 @Field STAGE_STEP_KEYS = [
     /** Runs npm scripts to run generic integration tests written on JavaScript */
     'npmExecuteScripts',
+    /** Runs backend integration tests via the Jacoco Maven-plugin */
+    'mavenExecuteIntegration',
     /** Publishes test results to Jenkins. It will automatically be active in cases tests are executed. */
     'testsPublishResults',
 ]
@@ -45,19 +47,14 @@ void call(Map parameters = [:]) {
 
         boolean publishResults = false
         try {
-            if (config.npmExecuteScripts) {
-                publishResults = true
-                String credentialsFilePath = "./"
-
-                writeTemporaryCredentials(script: script, credentialsDirectory: credentialsFilePath) {
+            List credentialsDirectories = ['./', 'integration-tests/src/test/resources']
+            writeTemporaryCredentials(script: script, credentialsDirectories: credentialsDirectories) {
+                if (config.npmExecuteScripts) {
+                    publishResults = true
                     npmExecuteScripts script: script, stageName: stageName
                 }
-            }
-            if (config.mavenExecuteIntegration) {
-                publishResults = true
-                String credentialsFilePath = "integration-tests/src/test/resources"
-
-                writeTemporaryCredentials(script: script, credentialsDirectory: credentialsFilePath) {
+                if (config.mavenExecuteIntegration) {
+                    publishResults = true
                     mavenExecuteIntegration script: script, stageName: stageName
                 }
             }

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -35,6 +35,7 @@ void call(Map parameters = [:]) {
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)
         .mixin(parameters, PARAMETER_KEYS)
         .addIfEmpty('npmExecuteScripts', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.npmExecuteScripts)
+        .addIfEmpty('mavenExecuteIntegration', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.mavenExecuteIntegration)
         .use()
 
     piperStageWrapper (script: script, stageName: stageName) {
@@ -46,7 +47,19 @@ void call(Map parameters = [:]) {
         try {
             if (config.npmExecuteScripts) {
                 publishResults = true
-                npmExecuteScripts script: script, stageName: stageName
+                String credentialsFilePath = "./"
+
+                writeTemporaryCredentials(script: script, credentialsDirectory: credentialsFilePath) {
+                    npmExecuteScripts script: script, stageName: stageName
+                }
+            }
+            if (config.mavenExecuteIntegration) {
+                publishResults = true
+                String credentialsFilePath = "integration-tests/src/test/resources"
+
+                writeTemporaryCredentials(script: script, credentialsDirectory: credentialsFilePath) {
+                    mavenExecuteIntegration script: script, stageName: stageName
+                }
             }
         }
         finally {

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -47,8 +47,7 @@ void call(Map parameters = [:]) {
 
         boolean publishResults = false
         try {
-            List credentialsDirectories = ['./', 'integration-tests/src/test/resources']
-            writeTemporaryCredentials(script: script, credentialsDirectories: credentialsDirectories) {
+            writeTemporaryCredentials(script: script) {
                 if (config.npmExecuteScripts) {
                     publishResults = true
                     npmExecuteScripts script: script

--- a/vars/writeTemporaryCredentials.groovy
+++ b/vars/writeTemporaryCredentials.groovy
@@ -20,9 +20,9 @@ import static com.sap.piper.Prerequisites.checkScript
      */
     'credentials',
     /**
-     * The path to the directory where the credentials file has to be placed.
+     * The list of paths to directories where credentials files need to be placed.
      */
-    'credentialsDirectory'
+    'credentialsDirectories'
 ]
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
 
@@ -55,13 +55,16 @@ void call(Map parameters = [:], Closure body) {
             error "[${STEP_NAME}] The execution failed, since credentials is not a list. Please provide credentials as a list of maps. For example:\n" +
                 "credentials: \n" + "  - alias: 'ERP'\n" + "    credentialId: 'erp-credentials'"
         }
-        if (!config.credentialsDirectory) {
-            error "[${STEP_NAME}] The execution failed, since no credentialsDirectory is defined. Please provide the path for the credentials file.\n"
+        if (!config.credentialsDirectories) {
+            error "[${STEP_NAME}] The execution failed, since no credentialsDirectories are defined. Please provide a list of paths for the credentials files.\n"
+        }
+        if (!(config.credentialsDirectories  instanceof List)) {
+            error "[${STEP_NAME}] The execution failed, since credentialsDirectories is not a list. Please provide credentialsDirectories as a list of paths.\n"
         }
 
         TemporaryCredentialsUtils credUtils = new TemporaryCredentialsUtils(script)
 
-        credUtils.handleTemporaryCredentials(config.credentials, config.credentialsDirectory) {
+        credUtils.handleTemporaryCredentials(config.credentials, config.credentialsDirectories) {
             body()
         }
     }


### PR DESCRIPTION
# Changes

This change add the support for running integration tests using the
recently introduced step mavenExecuteIntegration in
piperPipelineStageIntegration. In addition, capabilities to provide
temporary credentials to these tests is added using the
writeTemporaryCredentials step.

- [x] Tests
- [x] Documentation
