### PR TITLE
cloudFoundryCreateService: Fix parameter scopes

### DIFF
--- a/cmd/cloudFoundryCreateService_generated.go
+++ b/cmd/cloudFoundryCreateService_generated.go
@@ -160,7 +160,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "cfSpace",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
@@ -168,7 +168,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "cfService",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/service"}},
@@ -176,7 +176,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "cfServicePlan",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/servicePlan"}},
@@ -184,7 +184,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "cfServiceInstanceName",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstanceName"}},
@@ -192,7 +192,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "cfServiceBroker",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceBroker"}},
@@ -200,7 +200,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "cfCreateServiceConfig",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/createServiceConfig"}},
@@ -208,7 +208,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "cfServiceTags",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceTags"}},
@@ -216,7 +216,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "serviceManifest",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceManifest"}, {Name: "cfServiceManifest"}},
@@ -224,7 +224,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "manifestVariables",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/manifestVariables"}, {Name: "cfManifestVariables"}},
@@ -232,7 +232,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 					{
 						Name:        "manifestVariablesFiles",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/manifestVariablesFiles"}, {Name: "cfManifestVariablesFiles"}},

--- a/resources/metadata/cloudFoundryCreateService.yaml
+++ b/resources/metadata/cloudFoundryCreateService.yaml
@@ -25,10 +25,10 @@ spec:
         type: string
         description: Cloud Foundry API endpoint
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
-        - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: true
         aliases:
           - name: cloudFoundry/apiEndpoint
@@ -37,28 +37,28 @@ spec:
         type: string
         description: User or E-Mail for CF
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         secret: true
         mandatory: true
       - name: password
         type: string
         description: Password for Cloud Foundry User
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         mandatory: true
         secret: true
       - name: cfOrg
         type: string
         description: Cloud Foundry org
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
-        - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: true
         aliases:
           - name: cloudFoundry/org
@@ -66,9 +66,10 @@ spec:
         type: string
         description: Cloud Foundry Space
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: true
         aliases:
           - name: cloudFoundry/space
@@ -76,9 +77,10 @@ spec:
         type: string
         description: Parameter for Cloud Foundry Service to be used for creating Cloud Foundry Service
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/service
@@ -86,9 +88,10 @@ spec:
         type: string
         description: Parameter for Cloud Foundry Service Plan to be used when creating a Cloud Foundry Service
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/servicePlan
@@ -96,9 +99,10 @@ spec:
         type: string
         description: Parameter for naming the Service Instance when creating a Cloud Foundry Service
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/serviceInstanceName
@@ -106,9 +110,10 @@ spec:
         type: string
         description: Parameter for Service Broker to be used when creating a Cloud Foundry Service
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/serviceBroker
@@ -116,9 +121,10 @@ spec:
         type: string
         description: Path to JSON file or JSON in-line string for a Cloud Foundry Service creation
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/createServiceConfig
@@ -126,9 +132,10 @@ spec:
         type: string
         description: Flat list of Tags to be used when creating a Cloud Foundry Service in a single string
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/serviceTags
@@ -136,9 +143,10 @@ spec:
         type: string
         description: Path to Cloud Foundry Service Manifest in YAML format for multiple service creations that are being passed to a Create-Service-Push Cloud Foundry cli plugin
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/serviceManifest
@@ -148,9 +156,10 @@ spec:
         type: '[]string'
         description: Defines a List of variables as key-value Map objects used for variable substitution within the file given by the Manifest. Defaults to an empty list, if not specified otherwise. This can be used to set variables like it is provided by `cf push --var key=value`. The order of the maps of variables given in the list is relevant in case there are conflicting variable names and values between maps contained within the list. In case of conflicts, the last specified map in the list will win. Though each map entry in the list can contain more than one key-value pair for variable substitution, it is recommended to stick to one entry per map, and rather declare more maps within the list. The reason is that if a map in the list contains more than one key-value entry, and the entries are conflicting, the conflict resolution behavior is undefined (since map entries have no sequence). Variables defined via `manifestVariables` always win over conflicting variables defined via any file given by `manifestVariablesFiles` - no matter what is declared before. This is the same behavior as can be observed when using `cf push --var` in combination with `cf push --vars-file`
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/manifestVariables
@@ -159,9 +168,10 @@ spec:
         type: '[]string'
         description: Defines the manifest variables Yaml files to be used to replace variable references in manifest. This parameter is optional and will default to `manifest-variables.yml`. This can be used to set variable files like it is provided by `cf push --vars-file <file>`. If the manifest is present and so are all variable files, a variable substitution will be triggered that uses the `cfManifestSubstituteVariables` step before deployment. The format of variable references follows the Cloud Foundry standard in `https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#variable-substitution`
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/manifestVariablesFiles


### PR DESCRIPTION
# Changes

Projects used to be able to configure cloudFoundry in the general section of .pipeline/config.yml. This is a follow up to https://github.com/SAP/jenkins-library/pull/1649, which introduced a breaking change.

- [ ] Tests
- [ ] Documentation
