### PR TITLE
versioning: fix panic when using go.mod

### DIFF
--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -87,7 +87,7 @@ func GetArtifact(buildTool, buildDescriptorFilePath string, opts *Options, execR
 
 		switch buildDescriptorFilePath {
 		case "go.mod":
-			artifact = &GoMod{path: buildDescriptorFilePath}
+			artifact = &GoMod{path: buildDescriptorFilePath, fileExists: fileExists}
 			break
 		default:
 			artifact = &Versionfile{path: buildDescriptorFilePath}


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9830a6]
goroutine 1 [running]:
github.com/SAP/jenkins-library/pkg/versioning.searchDescriptor(0xc00067c060, 0x2, 0x2, 0x0, 0x0, 0xc0006549c0, 0xc0006413a0, 0x982ce0)
/home/runner/work/jenkins-library/jenkins-library/pkg/versioning/versioning.go:156 +0x76
github.com/SAP/jenkins-library/pkg/versioning.(*GoMod).GetVersion(0xc0006549c0, 0x6, 0x18089f1, 0x6, 0xc000664a80)
/home/runner/work/jenkins-library/jenkins-library/pkg/versioning/gomodfile.go:52 +0x18a
...
```

