### PR TITLE
Add optional wrapper for cloudFoundryDeploy go-implementation

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -80,6 +80,17 @@ func runCloudFoundryDeploy(config *cloudFoundryDeployOptions, telemetryData *tel
 		return err
 	}
 
+	if config.DeployTool == "" && config.BuildTool != "" {
+		switch config.BuildTool {
+		case "mta":
+			config.DeployTool = "mtaDeployPlugin"
+		default:
+			config.DeployTool = "cf_native"
+		}
+		log.Entry().Infof("Deploy tool unspecified. Using '%s' for buildTool '%s'.",
+			config.DeployTool, config.BuildTool)
+	}
+
 	var deployTriggered bool
 
 	if config.DeployTool == "mtaDeployPlugin" {

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -87,8 +87,8 @@ func runCloudFoundryDeploy(config *cloudFoundryDeployOptions, telemetryData *tel
 		default:
 			config.DeployTool = "cf_native"
 		}
-		log.Entry().Infof("Deploy tool unspecified. Using '%s' for buildTool '%s'.",
-			config.DeployTool, config.BuildTool)
+		log.Entry().Infof("Parameter deployTool not specified - deriving from buildTool '%s': '%s'",
+			config.BuildTool, config.DeployTool)
 	}
 
 	var deployTriggered bool

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -80,16 +80,7 @@ func runCloudFoundryDeploy(config *cloudFoundryDeployOptions, telemetryData *tel
 		return err
 	}
 
-	if config.DeployTool == "" && config.BuildTool != "" {
-		switch config.BuildTool {
-		case "mta":
-			config.DeployTool = "mtaDeployPlugin"
-		default:
-			config.DeployTool = "cf_native"
-		}
-		log.Entry().Infof("Parameter deployTool not specified - deriving from buildTool '%s': '%s'",
-			config.BuildTool, config.DeployTool)
-	}
+	validateDeployTool(config)
 
 	var deployTriggered bool
 
@@ -108,6 +99,21 @@ func runCloudFoundryDeploy(config *cloudFoundryDeployOptions, telemetryData *tel
 	}
 
 	return err
+}
+
+func validateDeployTool(config *cloudFoundryDeployOptions) {
+	if config.DeployTool != "" || config.BuildTool == "" {
+		return
+	}
+
+	switch config.BuildTool {
+	case "mta":
+		config.DeployTool = "mtaDeployPlugin"
+	default:
+		config.DeployTool = "cf_native"
+	}
+	log.Entry().Infof("Parameter deployTool not specified - deriving from buildTool '%s': '%s'",
+		config.BuildTool, config.DeployTool)
 }
 
 func validateAppName(appName string) error {

--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -24,6 +24,7 @@ type cloudFoundryDeployOptions struct {
 	CfPluginHome             string   `json:"cfPluginHome,omitempty"`
 	DeployDockerImage        string   `json:"deployDockerImage,omitempty"`
 	DeployTool               string   `json:"deployTool,omitempty"`
+	BuildTool                string   `json:"buildTool,omitempty"`
 	DeployType               string   `json:"deployType,omitempty"`
 	DockerPassword           string   `json:"dockerPassword,omitempty"`
 	DockerUsername           string   `json:"dockerUsername,omitempty"`
@@ -160,6 +161,7 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.CfPluginHome, "cfPluginHome", os.Getenv("PIPER_cfPluginHome"), "The cf plugin home folder used by the cf cli. If not provided the default assumed by the cf cli is used.")
 	cmd.Flags().StringVar(&stepConfig.DeployDockerImage, "deployDockerImage", os.Getenv("PIPER_deployDockerImage"), "Docker image deployments are supported (via manifest file in general)[https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#docker]. If no manifest is used, this parameter defines the image to be deployed. The specified name of the image is passed to the `--docker-image` parameter of the cf CLI and must adhere it's naming pattern (e.g. REPO/IMAGE:TAG). See (cf CLI documentation)[https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html] for details. Note: The used Docker registry must be visible for the targeted Cloud Foundry instance.")
 	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", os.Getenv("PIPER_deployTool"), "Defines the tool which should be used for deployment.")
+	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", os.Getenv("PIPER_buildTool"), "Defines the tool which is used for building the artifact. If provided, `deployTool` is automatically derived from it. For MTA projects, `deployTool` defaults to `mtaDeployPlugin`. For other projects `cf_native` will be used.")
 	cmd.Flags().StringVar(&stepConfig.DeployType, "deployType", `standard`, "Defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.If 'cf_native' as deployType and 'blue-green' as deployTool is used in combination, your manifest.yaml may only contain one application. If this application has the option 'no-route' active the deployType will be changed to 'standard'.")
 	cmd.Flags().StringVar(&stepConfig.DockerPassword, "dockerPassword", os.Getenv("PIPER_dockerPassword"), "If the specified image in `deployDockerImage` is contained in a Docker registry, which requires authorization, this defines the password to be used.")
 	cmd.Flags().StringVar(&stepConfig.DockerUsername, "dockerUsername", os.Getenv("PIPER_dockerUsername"), "If the specified image in `deployDockerImage` is contained in a Docker registry, which requires authorization, this defines the username to be used.")
@@ -179,7 +181,6 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.Username, "username", os.Getenv("PIPER_username"), "User")
 
 	cmd.MarkFlagRequired("apiEndpoint")
-	cmd.MarkFlagRequired("deployTool")
 	cmd.MarkFlagRequired("org")
 	cmd.MarkFlagRequired("password")
 	cmd.MarkFlagRequired("space")
@@ -257,7 +258,15 @@ func cloudFoundryDeployMetadata() config.StepData {
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
-						Mandatory:   true,
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "buildTool",
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "buildTool"}},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
+						Type:        "string",
+						Mandatory:   false,
 						Aliases:     []config.Alias{},
 					},
 					{

--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -92,7 +92,7 @@ func (i *cloudFoundryDeployInflux) persist(path, resourceName string) {
 	}
 }
 
-// CloudFoundryDeployCommand Deploys an application to cloud foundry
+// CloudFoundryDeployCommand Deploys an application to Cloud Foundry
 func CloudFoundryDeployCommand() *cobra.Command {
 	const STEP_NAME = "cloudFoundryDeploy"
 
@@ -103,7 +103,7 @@ func CloudFoundryDeployCommand() *cobra.Command {
 
 	var createCloudFoundryDeployCmd = &cobra.Command{
 		Use:   STEP_NAME,
-		Short: "Deploys an application to cloud foundry",
+		Short: "Deploys an application to Cloud Foundry",
 		Long:  `Deploys an application to a test or production space within Cloud Foundry.`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			startTime = time.Now()
@@ -161,10 +161,10 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.DeployDockerImage, "deployDockerImage", os.Getenv("PIPER_deployDockerImage"), "Docker image deployments are supported (via manifest file in general)[https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#docker]. If no manifest is used, this parameter defines the image to be deployed. The specified name of the image is passed to the `--docker-image` parameter of the cf CLI and must adhere it's naming pattern (e.g. REPO/IMAGE:TAG). See (cf CLI documentation)[https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html] for details. Note: The used Docker registry must be visible for the targeted Cloud Foundry instance.")
 	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", os.Getenv("PIPER_deployTool"), "Defines the tool which should be used for deployment.")
 	cmd.Flags().StringVar(&stepConfig.DeployType, "deployType", `standard`, "Defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.If 'cf_native' as deployType and 'blue-green' as deployTool is used in combination, your manifest.yaml may only contain one application. If this application has the option 'no-route' active the deployType will be changed to 'standard'.")
-	cmd.Flags().StringVar(&stepConfig.DockerPassword, "dockerPassword", os.Getenv("PIPER_dockerPassword"), "dockerPassword")
-	cmd.Flags().StringVar(&stepConfig.DockerUsername, "dockerUsername", os.Getenv("PIPER_dockerUsername"), "dockerUserName")
+	cmd.Flags().StringVar(&stepConfig.DockerPassword, "dockerPassword", os.Getenv("PIPER_dockerPassword"), "If the specified image in `deployDockerImage` is contained in a Docker registry, which requires authorization, this defines the password to be used.")
+	cmd.Flags().StringVar(&stepConfig.DockerUsername, "dockerUsername", os.Getenv("PIPER_dockerUsername"), "If the specified image in `deployDockerImage` is contained in a Docker registry, which requires authorization, this defines the username to be used.")
 	cmd.Flags().BoolVar(&stepConfig.KeepOldInstance, "keepOldInstance", false, "In case of a `blue-green` deployment the old instance will be deleted by default. If this option is set to true the old instance will remain stopped in the Cloud Foundry space.")
-	cmd.Flags().StringVar(&stepConfig.LoginParameters, "loginParameters", os.Getenv("PIPER_loginParameters"), "Addition command line options for cf login command. No escaping/quoting is performed. Not recommanded for productive environments.")
+	cmd.Flags().StringVar(&stepConfig.LoginParameters, "loginParameters", os.Getenv("PIPER_loginParameters"), "Addition command line options for cf login command. No escaping/quoting is performed. Not recommended for productive environments.")
 	cmd.Flags().StringVar(&stepConfig.Manifest, "manifest", os.Getenv("PIPER_manifest"), "Defines the manifest to be used for deployment to Cloud Foundry.")
 	cmd.Flags().StringSliceVar(&stepConfig.ManifestVariables, "manifestVariables", []string{}, "Defines a list of variables as key-value Map objects used for variable substitution within the file given by manifest. Defaults to an empty list, if not specified otherwise. This can be used to set variables like it is provided by 'cf push --var key=value'. The order of the maps of variables given in the list is relevant in case there are conflicting variable names and value between maps contained within the list. In case of conflicts, the last specified map in the list will win. Though each map entry in the list can contain more than one key-value pair for variable substitution, it is recommended to stick to one entry per map, and rather declare more maps within the list. The reason is that if a map in the list contains more than one key-value entry, and the entries are conflicting, the conflict resolution behavior is undefined (since map entries have no sequence). Note: variables defined via 'manifestVariables' always win over conflicting variables defined via any file given by 'manifestVariablesFiles' - no matter what is declared before. This is the same behavior as can be observed when using 'cf push --var' in combination with 'cf push --vars-file'.")
 	cmd.Flags().StringSliceVar(&stepConfig.ManifestVariablesFiles, "manifestVariablesFiles", []string{`manifest-variables.yml`}, "path(s) of the Yaml file(s) containing the variable values to use as a replacement in the manifest file. The order of the files is relevant in case there are conflicting variable names and values within variable files. In such a case, the values of the last file win.")
@@ -199,7 +199,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "apiEndpoint",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{{Name: "cfApiEndpoint"}, {Name: "cloudFoundry/apiEndpoint"}},
@@ -207,7 +207,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "appName",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cfAppName"}, {Name: "cloudFoundry/appName"}},
@@ -215,7 +215,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "artifactVersion",
 						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "artifactVersion"}},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -223,7 +223,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "cfHome",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -231,7 +231,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "cfNativeDeployParameters",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -239,7 +239,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "cfPluginHome",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -247,7 +247,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "deployDockerImage",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -255,7 +255,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "deployTool",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
@@ -263,7 +263,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "deployType",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -295,7 +295,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "loginParameters",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -303,7 +303,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "manifest",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cfManifest"}, {Name: "cloudFoundry/manifest"}},
@@ -311,7 +311,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "manifestVariables",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cfManifestVariables"}, {Name: "cloudFoundry/manifestVariables"}},
@@ -319,7 +319,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "manifestVariablesFiles",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cfManifestVariablesFiles"}, {Name: "cloudFoundry/manifestVariablesFiles"}},
@@ -327,7 +327,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "mtaDeployParameters",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -335,7 +335,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "mtaExtensionDescriptor",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/mtaExtensionDescriptor"}},
@@ -343,7 +343,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "mtaPath",
 						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "mtarFilePath"}},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -351,7 +351,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "org",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{{Name: "cfOrg"}, {Name: "cloudFoundry/org"}},
@@ -367,7 +367,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "smokeTestScript",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -375,7 +375,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "smokeTestStatusCode",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "int",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -383,7 +383,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 					{
 						Name:        "space",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{{Name: "cfSpace"}, {Name: "cloudFoundry/space"}},

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -985,6 +985,32 @@ func TestCfDeployment(t *testing.T) {
 	})
 }
 
+func TestValidateDeployTool(t *testing.T) {
+	testCases := []struct {
+		runName            string
+		deployToolGiven    string
+		buildTool          string
+		deployToolExpected string
+	}{
+		{"no params", "", "", ""},
+		{"build tool MTA", "", "mta", "mtaDeployPlugin"},
+		{"build tool other", "", "other", "cf_native"},
+		{"deploy and build tool given", "given", "unknown", "given"},
+		{"only deploy tool given", "given", "", "given"},
+	}
+
+	t.Parallel()
+
+	for _, test := range testCases {
+		t.Run(test.runName, func(t *testing.T) {
+			config := cloudFoundryDeployOptions{BuildTool: test.buildTool, DeployTool: test.deployToolGiven}
+			validateDeployTool(&config)
+			assert.Equal(t, test.deployToolExpected, config.DeployTool,
+				"expected different deployTool result")
+		})
+	}
+}
+
 func TestManifestVariableFiles(t *testing.T) {
 
 	defer func() {

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -1,18 +1,30 @@
 metadata:
   name: cloudFoundryDeploy
-  description: Deploys an application to cloud foundry
+  description: "Deploys an application to Cloud Foundry"
   longDescription: |
     Deploys an application to a test or production space within Cloud Foundry.
 spec:
   inputs:
+    secrets:
+      - name: cfCredentialsId
+        description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Foundry API"
+        type: jenkins
+        aliases:
+          - name: cloudFoundry/credentialsId
+      - name: dockerCredentialsId
+        description: "Jenkins credentials ID containing user and password to authenticate to the Docker registry"
+        type: jenkins
+        aliases:
+          - name: cloudFoundry/credentialsId
     params:
       - name: apiEndpoint
         type: string
         description: "Cloud Foundry API endpoint"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: true
         default: "https://api.cf.eu10.hana.ondemand.com"
         aliases:
@@ -22,9 +34,10 @@ spec:
         type: string
         description: "Defines the name of the application to be deployed to the Cloud Foundry space"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cfAppName
@@ -33,9 +46,10 @@ spec:
         type: string
         description: "The artifact version, used for influx reporting"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         resourceRef:
           - name: commonPipelineEnvironment
@@ -44,113 +58,154 @@ spec:
         type: string
         description: "The cf home folder used by the cf cli. If not provided the default assumed by the cf cli is used."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
       - name: cfNativeDeployParameters
         type: string
         description: "Additional parameters passed to cf native deployment command"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
       - name: cfPluginHome
         type: string
-        description: "The cf plugin home folder used by the cf cli. If not provided the default assumed by the cf cli is used."
+        description: "The cf plugin home folder used by the cf cli.
+          If not provided the default assumed by the cf cli is used."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
       - name: deployDockerImage
         type: string
-        description: "Docker image deployments are supported (via manifest file in general)[https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#docker]. If no manifest is used, this parameter defines the image to be deployed. The specified name of the image is passed to the `--docker-image` parameter of the cf CLI and must adhere it's naming pattern (e.g. REPO/IMAGE:TAG). See (cf CLI documentation)[https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html] for details. Note: The used Docker registry must be visible for the targeted Cloud Foundry instance."
+        description: "Docker image deployments are supported
+          (via manifest file in general)[https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#docker].
+          If no manifest is used, this parameter defines the image to be deployed.
+          The specified name of the image is passed to the `--docker-image` parameter of the cf CLI and must
+          adhere it's naming pattern (e.g. REPO/IMAGE:TAG).
+          See (cf CLI documentation)[https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html]
+          for details.
+          Note: The used Docker registry must be visible for the targeted Cloud Foundry instance."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
       - name: deployTool
         type: string
         description: "Defines the tool which should be used for deployment."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: true
       - name: deployType
         type: string
-        description: "Defines the type of deployment, either `standard` deployment which results in a system downtime or a zero-downtime `blue-green` deployment.If 'cf_native' as deployType and 'blue-green' as deployTool is used in combination, your manifest.yaml may only contain one application. If this application has the option 'no-route' active the deployType will be changed to 'standard'."
+        description: "Defines the type of deployment, either `standard` deployment which results in a system
+          downtime or a zero-downtime `blue-green` deployment.If 'cf_native' as deployType and 'blue-green'
+          as deployTool is used in combination, your manifest.yaml may only contain one application.
+          If this application has the option 'no-route' active the deployType will be changed to 'standard'."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         default: "standard"
       - name: dockerPassword
         type: string
-        description: "dockerPassword"
+        description: "If the specified image in `deployDockerImage` is contained in a Docker registry,
+          which requires authorization, this defines the password to be used."
         secret: true
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         mandatory: false
       - name: dockerUsername
         type: string
-        description: "dockerUserName"
+        description: "If the specified image in `deployDockerImage` is contained in a Docker registry,
+          which requires authorization, this defines the username to be used."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         mandatory: false
       - name: keepOldInstance
         type: bool
-        description: "In case of a `blue-green` deployment the old instance will be deleted by default. If this option is set to true the old instance will remain stopped in the Cloud Foundry space."
+        description: "In case of a `blue-green` deployment the old instance will be deleted by default.
+          If this option is set to true the old instance will remain stopped in the Cloud Foundry space."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         mandatory: false
       - name: loginParameters
         type: string
-        description: "Addition command line options for cf login command. No escaping/quoting is performed. Not recommanded for productive environments."
+        description: "Addition command line options for cf login command. No escaping/quoting is performed.
+          Not recommended for productive environments."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
       - name: manifest
         type: string
         description: "Defines the manifest to be used for deployment to Cloud Foundry."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cfManifest
           - name: cloudFoundry/manifest
       - name: manifestVariables
         type: "[]string"
-        description: "Defines a list of variables as key-value Map objects used for variable substitution within the file given by manifest. Defaults to an empty list, if not specified otherwise. This can be used to set variables like it is provided by 'cf push --var key=value'. The order of the maps of variables given in the list is relevant in case there are conflicting variable names and value between maps contained within the list. In case of conflicts, the last specified map in the list will win. Though each map entry in the list can contain more than one key-value pair for variable substitution, it is recommended to stick to one entry per map, and rather declare more maps within the list. The reason is that if a map in the list contains more than one key-value entry, and the entries are conflicting, the conflict resolution behavior is undefined (since map entries have no sequence). Note: variables defined via 'manifestVariables' always win over conflicting variables defined via any file given by 'manifestVariablesFiles' - no matter what is declared before. This is the same behavior as can be observed when using 'cf push --var' in combination with 'cf push --vars-file'."
+        description: "Defines a list of variables as key-value Map objects used for variable substitution
+          within the file given by manifest. Defaults to an empty list, if not specified otherwise.
+          This can be used to set variables like it is provided by 'cf push --var key=value'.
+          The order of the maps of variables given in the list is relevant in case there are conflicting
+          variable names and value between maps contained within the list. In case of conflicts, the last
+          specified map in the list will win. Though each map entry in the list can contain more than one
+          key-value pair for variable substitution, it is recommended to stick to one entry per map,
+          and rather declare more maps within the list. The reason is that if a map in the list contains
+          more than one key-value entry, and the entries are conflicting, the conflict resolution behavior
+          is undefined (since map entries have no sequence).
+          Note: variables defined via 'manifestVariables' always win over conflicting variables defined
+          via any file given by 'manifestVariablesFiles' - no matter what is declared before.
+          This is the same behavior as can be observed when using 'cf push --var' in combination
+          with 'cf push --vars-file'."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cfManifestVariables
           - name: cloudFoundry/manifestVariables
       - name: manifestVariablesFiles
         type: "[]string"
-        description: "path(s) of the Yaml file(s) containing the variable values to use as a replacement in the manifest file. The order of the files is relevant in case there are conflicting variable names and values within variable files. In such a case, the values of the last file win."
+        description: "path(s) of the Yaml file(s) containing the variable values to use as a
+          replacement in the manifest file. The order of the files is relevant in case there are
+          conflicting variable names and values within variable files.
+          In such a case, the values of the last file win."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         default: "manifest-variables.yml"
         mandatory: false
         aliases:
@@ -160,18 +215,20 @@ spec:
         type: string
         description: "Additional parameters passed to mta deployment command"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         default: "-f"
       - name: mtaExtensionDescriptor
         type: string
         description: "Defines additional extension descriptor file for deployment with the mtaDeployPlugin"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         aliases:
           - name: cloudFoundry/mtaExtensionDescriptor
@@ -179,9 +236,10 @@ spec:
         type: string
         description: "Defines the path to *.mtar for deployment with the mtaDeployPlugin"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         resourceRef:
           - name: commonPipelineEnvironment
@@ -190,9 +248,10 @@ spec:
         type: string
         description: "Cloud Foundry target organization."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         aliases:
           - name: cfOrg
           - name: cloudFoundry/org
@@ -202,36 +261,43 @@ spec:
         type: string
         description: "Password"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         mandatory: true
         secret: true
       - name: smokeTestScript
         type: string
-        description: "Allows to specify a script which performs a check during blue-green deployment. The script gets the FQDN as parameter and returns `exit code 0` in case check returned `smokeTestStatusCode`. More details can be found [here](https://github.com/bluemixgaragelondon/cf-blue-green-deploy#how-to-use). Currently this option is only considered for deployTool `cf_native`."
+        description: "Allows to specify a script which performs a check during blue-green deployment.
+          The script gets the FQDN as parameter and returns `exit code 0` in case check returned
+          `smokeTestStatusCode`.
+          More details can be found [here](https://github.com/bluemixgaragelondon/cf-blue-green-deploy#how-to-use).
+          Currently this option is only considered for deployTool `cf_native`."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         default: "blueGreenCheckScript.sh"
       - name: smokeTestStatusCode
         type: int
         description: "Expected status code returned by the check."
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         mandatory: false
         default: 200
       - name: space
         type: string
         description: "Cloud Foundry target space"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
         aliases:
           - name: cfSpace
           - name: cloudFoundry/space
@@ -241,9 +307,9 @@ spec:
         type: string
         description: "User"
         scope:
-        - PARAMETERS
-        - STAGES
-        - STEPS
+          - PARAMETERS
+          - STAGES
+          - STEPS
         mandatory: true
         secret: true
   containers:

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -14,8 +14,6 @@ spec:
       - name: dockerCredentialsId
         description: "Jenkins credentials ID containing user and password to authenticate to the Docker registry"
         type: jenkins
-        aliases:
-          - name: cloudFoundry/credentialsId
     params:
       - name: apiEndpoint
         type: string

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -104,7 +104,20 @@ spec:
           - STAGES
           - STEPS
           - GENERAL
-        mandatory: true
+      - name: buildTool
+        type: string
+        description: "Defines the tool which is used for building the artifact.
+          If provided, `deployTool` is automatically derived from it.
+          For MTA projects, `deployTool` defaults to `mtaDeployPlugin`.
+          For other projects `cf_native` will be used."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: buildTool
       - name: deployType
         type: string
         description: "Defines the type of deployment, either `standard` deployment which results in a system
@@ -300,7 +313,6 @@ spec:
           - name: cfSpace
           - name: cloudFoundry/space
         mandatory: true
-        secret: false
       - name: username
         type: string
         description: "User"

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -96,27 +96,27 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testNoTool() throws Exception {
         nullScript.commonPipelineEnvironment.configuration = [
             general: [
-                camSystemRole  : 'testRole',
+                camSystemRole: 'testRole',
                 cfCredentialsId: 'test_cfCredentialsId'
             ],
-            stages : [
+            stages: [
                 acceptance: [
-                    cfOrg     : 'testOrg',
-                    cfSpace   : 'testSpace',
+                    cfOrg: 'testOrg',
+                    cfSpace: 'testSpace',
                     deployUser: 'testUser',
                 ]
             ],
-            steps  : [
+            steps: [
                 cloudFoundryDeploy: []
             ]
         ]
         nullScript.commonPipelineEnvironment.setBuildTool('mta')
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            mtaPath         : 'target/test.mtar',
-            stageName       : 'acceptance',
+            mtaPath: 'target/test.mtar',
+            stageName: 'acceptance',
         ])
         // asserts
         assertThat(loggingRule.log, containsString('[cloudFoundryDeploy] General parameters: deployTool=mtaDeployPlugin, deployType=standard, cfApiEndpoint=https://api.cf.eu10.hana.ondemand.com, cfOrg=testOrg, cfSpace=testSpace, cfCredentialsId=test_cfCredentialsId'))
@@ -130,27 +130,28 @@ class CloudFoundryDeployTest extends BasePiperTest {
             ],
             stages: [
                 acceptance: [
-                    cfOrg     : 'testOrg',
-                    cfSpace   : 'testSpace',
+                    cfOrg: 'testOrg',
+                    cfSpace: 'testSpace',
                     deployUser: 'testUser',
                 ]
             ],
-            steps : [
+            steps: [
                 cloudFoundryDeploy: []
             ]
         ]
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'notAvailable',
-            stageName       : 'acceptance'
+            deployTool: 'notAvailable',
+            stageName: 'acceptance'
         ])
         // asserts
         assertThat(loggingRule.log, containsString('[cloudFoundryDeploy] General parameters: deployTool=notAvailable, deployType=standard, cfApiEndpoint=https://api.cf.eu10.hana.ondemand.com, cfOrg=testOrg, cfSpace=testSpace, cfCredentialsId=myCreds'))
         assertThat(loggingRule.log, containsString('[cloudFoundryDeploy] WARNING! Found unsupported deployTool. Skipping deployment.'))
     }
+
 
 
     @Test
@@ -161,15 +162,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
         // asserts
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -188,16 +189,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cfApiEndpoint   : 'https://customApi',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            cfApiEndpoint: 'https://customApi',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
         // asserts
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://customApi -o "testOrg" -s "testSpace"')))
@@ -211,16 +212,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cloudFoundry    : [
-                org          : 'testOrg',
-                space        : 'testSpace',
+            deployTool: 'cf_native',
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName      : 'testAppName',
-                manifest     : 'test.yml'
+                appName: 'testAppName',
+                manifest: 'test.yml'
             ]
         ])
         // asserts
@@ -242,16 +243,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script           : nullScript,
-            juStabUtils      : utils,
-            jenkinsUtilsStub : new JenkinsUtilsMock(),
-            deployTool       : 'cf_native',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
             deployDockerImage: 'repo/image:tag',
-            cloudFoundry     : [
-                org          : 'testOrg',
-                space        : 'testSpace',
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName      : 'testAppName'
+                appName: 'testAppName'
             ]
         ])
 
@@ -270,17 +271,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script             : nullScript,
-            juStabUtils        : utils,
-            jenkinsUtilsStub   : new JenkinsUtilsMock(),
-            deployTool         : 'cf_native',
-            deployDockerImage  : 'repo/image:tag',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            deployDockerImage: 'repo/image:tag',
             dockerCredentialsId: 'test_cfDockerCredentialsId',
-            cloudFoundry       : [
-                org          : 'testOrg',
-                space        : 'testSpace',
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName      : 'testAppName'
+                appName: 'testAppName'
             ]
         ])
         assertThat(dockerExecuteRule.dockerParams.dockerEnvVars, hasEntry(equalTo('CF_DOCKER_PASSWORD'), equalTo("${'********'}")))
@@ -302,17 +303,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script             : nullScript,
-            juStabUtils        : utils,
-            jenkinsUtilsStub   : new JenkinsUtilsMock(),
-            deployTool         : 'cf_native',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
             dockerCredentialsId: 'test_cfDockerCredentialsId',
-            cloudFoundry       : [
-                org          : 'testOrg',
-                space        : 'testSpace',
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName      : 'testAppName',
-                manifest     : 'manifest.yml'
+                appName: 'testAppName',
+                manifest: 'manifest.yml'
             ]
         ])
         assertThat(dockerExecuteRule.dockerParams.dockerEnvVars, hasEntry(equalTo('CF_DOCKER_PASSWORD'), equalTo("${'********'}")))
@@ -334,18 +335,18 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script             : nullScript,
-            juStabUtils        : utils,
-            jenkinsUtilsStub   : new JenkinsUtilsMock(),
-            deployTool         : 'cf_native',
-            deployType         : 'blue-green',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
             dockerCredentialsId: 'test_cfDockerCredentialsId',
-            cloudFoundry       : [
-                org          : 'testOrg',
-                space        : 'testSpace',
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName      : 'testAppName',
-                manifest     : 'manifest.yml'
+                appName: 'testAppName',
+                manifest: 'manifest.yml'
             ]
         ])
         assertThat(dockerExecuteRule.dockerParams.dockerEnvVars, hasEntry(equalTo('CF_DOCKER_PASSWORD'), equalTo("${'********'}")))
@@ -364,14 +365,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfManifest: 'test.yml'
         ])
         // asserts
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
@@ -391,14 +392,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: No appName available in manifest test.yml.')
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfManifest: 'test.yml'
         ])
     }
 
@@ -408,16 +409,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'blue-green',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -435,17 +436,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'blue-green',
-            keepOldInstance : false,
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            keepOldInstance: false,
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -464,17 +465,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'blue-green',
-            keepOldInstance : true,
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            keepOldInstance: true,
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -496,16 +497,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage("[cloudFoundryDeploy] Your manifest contains more than one application. For blue green deployments your manifest file may contain only one application.")
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'blue-green',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
     }
 
@@ -515,23 +516,23 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.registerExistingFile('test.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'blue-green',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(shellRule.shell, hasItem(containsString("cf push testAppName -f 'test.yml'")))
     }
 
     @Test
-    void testCfNativeBlueGreenKeepOldInstanceShouldThrowErrorOnStopError() {
+    void testCfNativeBlueGreenKeepOldInstanceShouldThrowErrorOnStopError(){
         new File(tmpDir, '1-cfStopOutput.txt').write('any error message')
 
         helper.registerAllowedMethod("sh", [String], { cmd ->
@@ -545,17 +546,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage("[cloudFoundryDeploy] ERROR: Could not stop application testAppName-old. Error: any error message")
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'blue-green',
-            keepOldInstance : true,
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            keepOldInstance: true,
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -572,17 +573,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'standard',
-            keepOldInstance : true,
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'standard',
+            keepOldInstance: true,
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(shellRule.shell, not(hasItem(containsString("cf stop testAppName-old &>"))))
@@ -598,15 +599,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: Blue-green plugin requires app name to be passed (see https://github.com/bluemixgaragelondon/cf-blue-green-deploy/issues/27)')
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            deployType      : 'blue-green',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfManifest: 'test.yml'
         ])
     }
 
@@ -626,15 +627,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: The execution of the deploy command failed, see the log for details.')
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
@@ -646,14 +647,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void testMta() {
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            deployTool      : 'mtaDeployPlugin',
-            mtaPath         : 'target/test.mtar'
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            mtaPath: 'target/test.mtar'
         ])
         // asserts
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -668,13 +669,13 @@ class CloudFoundryDeployTest extends BasePiperTest {
         environmentRule.env.mtarFilePath = 'target/test.mtar'
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            deployTool      : 'mtaDeployPlugin'
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin'
         ])
         // asserts
         assertThat(shellRule.shell, hasItem(containsString('cf deploy target/test.mtar -f')))
@@ -684,15 +685,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testMtaBlueGreen() {
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            deployTool      : 'mtaDeployPlugin',
-            deployType      : 'blue-green',
-            mtaPath         : 'target/test.mtar'
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            deployType: 'blue-green',
+            mtaPath: 'target/test.mtar'
         ])
 
         assertThat(shellRule.shell, hasItem(stringContainsInOrder(["cf login -u \"test_cf\"", 'cf bg-deploy', '-f', '--no-confirm'])))
@@ -707,19 +708,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
         nullScript.commonPipelineEnvironment.setArtifactVersion('1.2.3')
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
         // asserts
         assertThat(writeInfluxMap.customDataMap.deployment_data.artifactUrl, is('n/a'))
-        assertThat(writeInfluxMap.customDataMap.deployment_data.deployTime, containsString(new Date().format('MMM dd, yyyy')))
+        assertThat(writeInfluxMap.customDataMap.deployment_data.deployTime, containsString(new Date().format( 'MMM dd, yyyy')))
         assertThat(writeInfluxMap.customDataMap.deployment_data.jobTrigger, is('USER'))
 
         assertThat(writeInfluxMap.customDataMapTags.deployment_data.artifactVersion, is('1.2.3'))
@@ -737,15 +738,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.registerExistingFile('vars.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script                  : nullScript,
-            juStabUtils             : utils,
-            jenkinsUtilsStub        : new JenkinsUtilsMock(),
-            deployTool              : 'cf_native',
-            cfOrg                   : 'testOrg',
-            cfSpace                 : 'testSpace',
-            cfCredentialsId         : 'test_cfCredentialsId',
-            cfAppName               : 'testAppName',
-            cfManifest              : 'test.yml',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml',
             cfManifestVariablesFiles: ['vars.yml']
         ])
 
@@ -755,8 +756,8 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(shellRule.shell, hasItem(containsString("cf push testAppName --vars-file 'vars.yml' -f 'test.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))
-        assertThat(loggingRule.log, containsString("We will add the following string to the cf push call: --vars-file 'vars.yml' !"))
-        assertThat(loggingRule.log, not(containsString("We will add the following string to the cf push call:  !")))
+        assertThat(loggingRule.log,containsString("We will add the following string to the cf push call: --vars-file 'vars.yml' !"))
+        assertThat(loggingRule.log,not(containsString("We will add the following string to the cf push call:  !")))
     }
 
     @Test
@@ -765,15 +766,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.registerExistingFile('test.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script                  : nullScript,
-            juStabUtils             : utils,
-            jenkinsUtilsStub        : new JenkinsUtilsMock(),
-            deployTool              : 'cf_native',
-            cfOrg                   : 'testOrg',
-            cfSpace                 : 'testSpace',
-            cfCredentialsId         : 'test_cfCredentialsId',
-            cfAppName               : 'testAppName',
-            cfManifest              : 'test.yml',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml',
             cfManifestVariablesFiles: ['vars.yml']
         ])
 
@@ -785,18 +786,18 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void testCfPushDeploymentWithVariableSubstitutionFromVarsList() {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
-        List varsList = [["appName": "testApplicationFromVarsList"]]
+        List varsList = [["appName" : "testApplicationFromVarsList"]]
 
         stepRule.step.cloudFoundryDeploy([
-            script             : nullScript,
-            juStabUtils        : utils,
-            jenkinsUtilsStub   : new JenkinsUtilsMock(),
-            deployTool         : 'cf_native',
-            cfOrg              : 'testOrg',
-            cfSpace            : 'testSpace',
-            cfCredentialsId    : 'test_cfCredentialsId',
-            cfAppName          : 'testAppName',
-            cfManifest         : 'test.yml',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml',
             cfManifestVariables: varsList
         ])
 
@@ -807,8 +808,8 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(shellRule.shell, hasItem(containsString("cf push testAppName --var appName='testApplicationFromVarsList' -f 'test.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))
-        assertThat(loggingRule.log, containsString("We will add the following string to the cf push call: --var appName='testApplicationFromVarsList' !"))
-        assertThat(loggingRule.log, not(containsString("We will add the following string to the cf push call:  !")))
+        assertThat(loggingRule.log,containsString("We will add the following string to the cf push call: --var appName='testApplicationFromVarsList' !"))
+        assertThat(loggingRule.log,not(containsString("We will add the following string to the cf push call:  !")))
     }
 
     @Test
@@ -819,15 +820,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: Parameter config.cloudFoundry.manifestVariables is not a List!')
 
         stepRule.step.cloudFoundryDeploy([
-            script             : nullScript,
-            juStabUtils        : utils,
-            jenkinsUtilsStub   : new JenkinsUtilsMock(),
-            deployTool         : 'cf_native',
-            cfOrg              : 'testOrg',
-            cfSpace            : 'testSpace',
-            cfCredentialsId    : 'test_cfCredentialsId',
-            cfAppName          : 'testAppName',
-            cfManifest         : 'test.yml',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml',
             cfManifestVariables: 'notAList'
         ])
 
@@ -836,21 +837,21 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void testCfPushDeploymentWithVariableSubstitutionFromVarsListAndVarsFile() {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
-        List varsList = [["appName": "testApplicationFromVarsList"]]
+        List varsList = [["appName" : "testApplicationFromVarsList"]]
         fileExistsRule.registerExistingFile('vars.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script                  : nullScript,
-            juStabUtils             : utils,
-            jenkinsUtilsStub        : new JenkinsUtilsMock(),
-            deployTool              : 'cf_native',
-            cfOrg                   : 'testOrg',
-            cfSpace                 : 'testSpace',
-            cfCredentialsId         : 'test_cfCredentialsId',
-            cfAppName               : 'testAppName',
-            cfManifest              : 'test.yml',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml',
             cfManifestVariablesFiles: ['vars.yml'],
-            cfManifestVariables     : varsList
+            cfManifestVariables: varsList
         ])
 
         // asserts
@@ -867,15 +868,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool      : 'cf_native',
-            cfOrg           : 'testOrg',
-            cfSpace         : 'testSpace',
-            cfCredentialsId : 'test_cfCredentialsId',
-            cfAppName       : 'testAppName',
-            cfManifest      : 'test.yml'
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         // asserts
@@ -906,16 +907,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script                  : nullScript,
-            juStabUtils             : utils,
-            jenkinsUtilsStub        : new JenkinsUtilsMock(),
-            deployTool              : 'cf_native',
-            deployType              : 'blue-green',
-            cfOrg                   : 'testOrg',
-            cfSpace                 : 'testSpace',
-            cfCredentialsId         : 'test_cfCredentialsId',
-            cfAppName               : 'testAppName',
-            cfManifest              : 'test.yml',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml',
             cfManifestVariablesFiles: ['vars.yml']
         ])
 
@@ -936,7 +937,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testCfBlueGreenDeploymentWithVariableSubstitutionFromVarsList() {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
         readYamlRule.registerYaml('vars.yml', "[appName: 'testApplication']")
-        List varsList = [["appName": "testApplicationFromVarsList"]]
+        List varsList = [["appName" : "testApplicationFromVarsList"]]
 
         fileExistsRule.registerExistingFile("test.yml")
         fileExistsRule.registerExistingFile("vars.yml")
@@ -951,18 +952,18 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script                  : nullScript,
-            juStabUtils             : utils,
-            jenkinsUtilsStub        : new JenkinsUtilsMock(),
-            deployTool              : 'cf_native',
-            deployType              : 'blue-green',
-            cfOrg                   : 'testOrg',
-            cfSpace                 : 'testSpace',
-            cfCredentialsId         : 'test_cfCredentialsId',
-            cfAppName               : 'testAppName',
-            cfManifest              : 'test.yml',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            deployType: 'blue-green',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml',
             cfManifestVariablesFiles: ['vars.yml'],
-            cfManifestVariables     : varsList
+            cfManifestVariables: varsList
         ])
 
         // asserts
@@ -990,17 +991,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
         readYamlRule.registerYaml('test.yml', "applications: [{name: 'manifestAppName'}]")
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry    : [
-                org     : 'testOrg',
-                space   : 'testSpace',
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 manifest: 'test.yml',
-            ],
-            deployTool      : 'cf_native',
-            cfCredentialsId : 'test_cfCredentialsId',
-            verbose         : true
+                ],
+            deployTool: 'cf_native',
+            cfCredentialsId: 'test_cfCredentialsId',
+            verbose: true
         ])
 
         assertThat(loggingRule.log, allOf(
@@ -1018,17 +1019,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
         readYamlRule.registerYaml('test.yml', "applications: [{name: 'manifestAppName'}]")
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry    : [
-                org     : 'testOrg',
-                space   : 'testSpace',
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 manifest: 'test.yml',
-            ],
-            deployTool      : 'cf_native',
-            cfCredentialsId : 'test_cfCredentialsId',
-            verbose         : true
+                ],
+            deployTool: 'cf_native',
+            cfCredentialsId: 'test_cfCredentialsId',
+            verbose: true
         ])
 
         assertThat(loggingRule.log, containsString('No trace file found'))
@@ -1044,17 +1045,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
         nullScript.commonPipelineEnvironment.setArtifactVersion('1.2.3')
         stepRule.step.cloudFoundryDeploy([
-            script                  : nullScript,
-            juStabUtils             : utils,
-            jenkinsUtilsStub        : new JenkinsUtilsMock(),
-            deployTool              : 'cf_native',
-            cfOrg                   : 'testOrg',
-            cfSpace                 : 'testSpace',
-            loginParameters         : '--some-login-opt value',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            deployTool: 'cf_native',
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            loginParameters: '--some-login-opt value',
             cfNativeDeployParameters: '--some-deploy-opt cf-value',
-            cfCredentialsId         : 'test_cfCredentialsId',
-            cfAppName               : 'testAppName',
-            cfManifest              : 'test.yml'
+            cfCredentialsId: 'test_cfCredentialsId',
+            cfAppName: 'testAppName',
+            cfManifest: 'test.yml'
         ])
 
         assertThat(shellRule.shell, hasItem(
@@ -1068,20 +1069,20 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testAdditionMtaOpts() {
 
         stepRule.step.cloudFoundryDeploy([
-            script             : nullScript,
-            juStabUtils        : utils,
-            jenkinsUtilsStub   : new JenkinsUtilsMock(),
-            cloudFoundry       : [
-                org  : 'testOrg',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            cloudFoundry: [
+                org: 'testOrg',
                 space: 'testSpace',
             ],
-            apiParameters      : '--some-api-opt value',
-            loginParameters    : '--some-login-opt value',
+            apiParameters: '--some-api-opt value',
+            loginParameters: '--some-login-opt value',
             mtaDeployParameters: '--some-deploy-opt mta-value',
-            cfCredentialsId    : 'test_cfCredentialsId',
-            deployTool         : 'mtaDeployPlugin',
-            deployType         : 'blue-green',
-            mtaPath            : 'target/test.mtar'
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            deployType: 'blue-green',
+            mtaPath: 'target/test.mtar'
         ])
 
         assertThat(shellRule.shell, hasItem(
@@ -1097,19 +1098,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
         String expected = "Your application name my_invalid_app_name contains a '_' (underscore) which is not allowed, only letters, dashes and numbers can be used. Please change the name to fit this requirement.\n" +
             "For more details please visit https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#basic-settings."
         String actual = ""
-        helper.registerAllowedMethod('error', [String.class], { s -> actual = s })
+        helper.registerAllowedMethod('error', [String.class], {s -> actual = s})
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry    : [
-                org    : 'irrelevant',
-                space  : 'irrelevant',
+            cloudFoundry: [
+                org: 'irrelevant',
+                space: 'irrelevant',
                 appName: 'my_invalid_app_name'
             ],
-            cfCredentialsId : 'test_cfCredentialsId',
-            mtaPath         : 'irrelevant'
+            cfCredentialsId: 'test_cfCredentialsId',
+            mtaPath: 'irrelevant'
         ])
 
         assertEquals(expected, actual)
@@ -1119,19 +1120,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void 'appName with alpha-numeric chars and leading dash should throw an error'() {
         String expected = "Your application name -my-Invalid-AppName123 contains a starts or ends with a '-' (dash) which is not allowed, only letters, dashes and numbers can be used. Please change the name to fit this requirement.\nFor more details please visit https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#basic-settings."
         String actual = ""
-        helper.registerAllowedMethod('error', [String.class], { s -> actual = s })
+        helper.registerAllowedMethod('error', [String.class], {s -> actual = s})
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry    : [
-                org    : 'irrelevant',
-                space  : 'irrelevant',
+            cloudFoundry: [
+                org: 'irrelevant',
+                space: 'irrelevant',
                 appName: '-my-Invalid-AppName123'
             ],
-            cfCredentialsId : 'test_cfCredentialsId',
-            mtaPath         : 'irrelevant'
+            cfCredentialsId: 'test_cfCredentialsId',
+            mtaPath: 'irrelevant'
         ])
 
         assertEquals(expected, actual)
@@ -1141,19 +1142,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void 'appName with alpha-numeric chars and trailing dash should throw an error'() {
         String expected = "Your application name my-Invalid-AppName123- contains a starts or ends with a '-' (dash) which is not allowed, only letters, dashes and numbers can be used. Please change the name to fit this requirement.\nFor more details please visit https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#basic-settings."
         String actual = ""
-        helper.registerAllowedMethod('error', [String.class], { s -> actual = s })
+        helper.registerAllowedMethod('error', [String.class], {s -> actual = s})
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry    : [
-                org    : 'irrelevant',
-                space  : 'irrelevant',
+            cloudFoundry: [
+                org: 'irrelevant',
+                space: 'irrelevant',
                 appName: 'my-Invalid-AppName123-'
             ],
-            cfCredentialsId : 'test_cfCredentialsId',
-            mtaPath         : 'irrelevant'
+            cfCredentialsId: 'test_cfCredentialsId',
+            mtaPath: 'irrelevant'
         ])
 
         assertEquals(expected, actual)
@@ -1162,17 +1163,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void 'appName with alpha-numeric chars should work'() {
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry    : [
-                org    : 'irrelevant',
-                space  : 'irrelevant',
+            cloudFoundry: [
+                org: 'irrelevant',
+                space: 'irrelevant',
                 appName: 'myValidAppName123'
             ],
-            deployTool      : 'cf_native',
-            cfCredentialsId : 'test_cfCredentialsId',
-            mtaPath         : 'irrelevant'
+            deployTool: 'cf_native',
+            cfCredentialsId: 'test_cfCredentialsId',
+            mtaPath: 'irrelevant'
         ])
 
         assertTrue(loggingRule.log.contains("cfAppName=myValidAppName123"))
@@ -1181,17 +1182,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void 'appName with alpha-numeric chars and dash should work'() {
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry    : [
-                org    : 'irrelevant',
-                space  : 'irrelevant',
+            cloudFoundry: [
+                org: 'irrelevant',
+                space: 'irrelevant',
                 appName: 'my-Valid-AppName123'
             ],
-            deployTool      : 'cf_native',
-            cfCredentialsId : 'test_cfCredentialsId',
-            mtaPath         : 'irrelevant'
+            deployTool: 'cf_native',
+            cfCredentialsId: 'test_cfCredentialsId',
+            mtaPath: 'irrelevant'
         ])
 
         assertTrue(loggingRule.log.contains("cfAppName=my-Valid-AppName123"))
@@ -1203,19 +1204,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
             'globalMtaDescriptor.mtaext',
         )
         stepRule.step.cloudFoundryDeploy([
-            script                : nullScript,
-            juStabUtils           : utils,
-            jenkinsUtilsStub      : new JenkinsUtilsMock(),
-            cloudFoundry          : [
-                org  : 'testOrg',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            cloudFoundry: [
+                org: 'testOrg',
                 space: 'testSpace'
             ],
             mtaExtensionDescriptor: 'globalMtaDescriptor.mtaext',
-            mtaDeployParameters   : '--some-deploy-opt mta-value',
-            cfCredentialsId       : 'test_cfCredentialsId',
-            deployTool            : 'mtaDeployPlugin',
-            deployType            : 'blue-green',
-            mtaPath               : 'target/test.mtar'
+            mtaDeployParameters: '--some-deploy-opt mta-value',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            deployType: 'blue-green',
+            mtaPath: 'target/test.mtar'
         ])
 
         assertThat(shellRule.shell, hasItem(containsString("-e globalMtaDescriptor.mtaext")))
@@ -1227,19 +1228,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
             'targetMtaDescriptor.mtaext',
         )
         stepRule.step.cloudFoundryDeploy([
-            script             : nullScript,
-            juStabUtils        : utils,
-            jenkinsUtilsStub   : new JenkinsUtilsMock(),
-            cloudFoundry       : [
-                org                   : 'testOrg',
-                space                 : 'testSpace',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            cloudFoundry: [
+                org: 'testOrg',
+                space: 'testSpace',
                 mtaExtensionDescriptor: 'targetMtaDescriptor.mtaext'
             ],
             mtaDeployParameters: '--some-deploy-opt mta-value',
-            cfCredentialsId    : 'test_cfCredentialsId',
-            deployTool         : 'mtaDeployPlugin',
-            deployType         : 'blue-green',
-            mtaPath            : 'target/test.mtar'
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            deployType: 'blue-green',
+            mtaPath: 'target/test.mtar'
         ])
         assertThat(shellRule.shell, hasItem(containsString("-e targetMtaDescriptor.mtaext")))
     }
@@ -1249,9 +1250,9 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.existingFiles.addAll(
             'mtaext.mtaext',
         )
-        credentialsRule.withCredentials("mtaExtCredTest", "token")
+        credentialsRule.withCredentials("mtaExtCredTest","token")
 
-        helper.registerAllowedMethod('readFile', [String], { file ->
+        helper.registerAllowedMethod('readFile', [String], {file ->
             if (file == 'mtaext.mtaext') {
                 return '_schema-version: \'3.1\'\n' +
                     'ID: test.ext\n' +
@@ -1264,15 +1265,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script                 : nullScript,
-            juStabUtils            : utils,
-            jenkinsUtilsStub       : new JenkinsUtilsMock(),
-            cfOrg                  : 'testOrg',
-            cfSpace                : 'testSpace',
-            cfCredentialsId        : 'test_cfCredentialsId',
-            deployTool             : 'mtaDeployPlugin',
-            mtaPath                : 'target/test.mtar',
-            mtaExtensionDescriptor : "mtaext.mtaext",
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            mtaPath: 'target/test.mtar',
+            mtaExtensionDescriptor: "mtaext.mtaext",
             mtaExtensionCredentials: [
                 testCred: 'mtaExtCredTest'
             ]
@@ -1294,14 +1295,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] The mta extension descriptor file mtaext.mtaext does not exist at the configured location.')
 
         stepRule.step.cloudFoundryDeploy([
-            script                : nullScript,
-            juStabUtils           : utils,
-            jenkinsUtilsStub      : new JenkinsUtilsMock(),
-            cfOrg                 : 'testOrg',
-            cfSpace               : 'testSpace',
-            cfCredentialsId       : 'test_cfCredentialsId',
-            deployTool            : 'mtaDeployPlugin',
-            mtaPath               : 'target/test.mtar',
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            mtaPath: 'target/test.mtar',
             mtaExtensionDescriptor: "mtaext.mtaext"
         ])
     }
@@ -1316,22 +1317,20 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] Unable to read mta extension file mtaext.mtaext.')
 
         stepRule.step.cloudFoundryDeploy([
-            script                 : nullScript,
-            juStabUtils            : utils,
-            jenkinsUtilsStub       : new JenkinsUtilsMock(),
-            cfOrg                  : 'testOrg',
-            cfSpace                : 'testSpace',
-            cfCredentialsId        : 'test_cfCredentialsId',
-            deployTool             : 'mtaDeployPlugin',
-            mtaPath                : 'target/test.mtar',
-            mtaExtensionDescriptor : "mtaext.mtaext",
+            script: nullScript,
+            juStabUtils: utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            cfOrg: 'testOrg',
+            cfSpace: 'testSpace',
+            cfCredentialsId: 'test_cfCredentialsId',
+            deployTool: 'mtaDeployPlugin',
+            mtaPath: 'target/test.mtar',
+            mtaExtensionDescriptor: "mtaext.mtaext",
             mtaExtensionCredentials: [
                 testCred: 'mtaExtCredTest'
             ],
         ])
-    }
-
-    @Test
+    }    @Test
     void testGoStepFeatureToggleOn() {
         String calledStep = ''
         String usedMetadataFile = ''
@@ -1343,14 +1342,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            useGoStep       : true,
-            deployTool      : 'irrelevant',
-            cfOrg           : 'irrelevant',
-            cfSpace         : 'irrelevant',
-            cfCredentialsId : 'irrelevant',
+            useGoStep: true,
+            deployTool: 'irrelevant',
+            cfOrg: 'irrelevant',
+            cfSpace: 'irrelevant',
+            cfCredentialsId: 'irrelevant',
         ])
 
         assertEquals('cloudFoundryDeploy', calledStep)
@@ -1369,14 +1368,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script          : nullScript,
-            juStabUtils     : utils,
+            script: nullScript,
+            juStabUtils: utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            useGoStep       : 'false',
-            deployTool      : 'irrelevant',
-            cfOrg           : 'irrelevant',
-            cfSpace         : 'irrelevant',
-            cfCredentialsId : 'irrelevant',
+            useGoStep: 'false',
+            deployTool: 'irrelevant',
+            cfOrg: 'irrelevant',
+            cfSpace: 'irrelevant',
+            cfCredentialsId: 'irrelevant',
         ])
 
         assertEquals('', calledStep)

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -1330,7 +1330,9 @@ class CloudFoundryDeployTest extends BasePiperTest {
                 testCred: 'mtaExtCredTest'
             ],
         ])
-    }    @Test
+    }
+
+    @Test
     void testGoStepFeatureToggleOn() {
         String calledStep = ''
         String usedMetadataFile = ''

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -96,27 +96,27 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testNoTool() throws Exception {
         nullScript.commonPipelineEnvironment.configuration = [
             general: [
-                camSystemRole: 'testRole',
+                camSystemRole  : 'testRole',
                 cfCredentialsId: 'test_cfCredentialsId'
             ],
-            stages: [
+            stages : [
                 acceptance: [
-                    cfOrg: 'testOrg',
-                    cfSpace: 'testSpace',
+                    cfOrg     : 'testOrg',
+                    cfSpace   : 'testSpace',
                     deployUser: 'testUser',
                 ]
             ],
-            steps: [
+            steps  : [
                 cloudFoundryDeploy: []
             ]
         ]
         nullScript.commonPipelineEnvironment.setBuildTool('mta')
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            mtaPath: 'target/test.mtar',
-            stageName: 'acceptance',
+            mtaPath         : 'target/test.mtar',
+            stageName       : 'acceptance',
         ])
         // asserts
         assertThat(loggingRule.log, containsString('[cloudFoundryDeploy] General parameters: deployTool=mtaDeployPlugin, deployType=standard, cfApiEndpoint=https://api.cf.eu10.hana.ondemand.com, cfOrg=testOrg, cfSpace=testSpace, cfCredentialsId=test_cfCredentialsId'))
@@ -130,28 +130,27 @@ class CloudFoundryDeployTest extends BasePiperTest {
             ],
             stages: [
                 acceptance: [
-                    cfOrg: 'testOrg',
-                    cfSpace: 'testSpace',
+                    cfOrg     : 'testOrg',
+                    cfSpace   : 'testSpace',
                     deployUser: 'testUser',
                 ]
             ],
-            steps: [
+            steps : [
                 cloudFoundryDeploy: []
             ]
         ]
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'notAvailable',
-            stageName: 'acceptance'
+            deployTool      : 'notAvailable',
+            stageName       : 'acceptance'
         ])
         // asserts
         assertThat(loggingRule.log, containsString('[cloudFoundryDeploy] General parameters: deployTool=notAvailable, deployType=standard, cfApiEndpoint=https://api.cf.eu10.hana.ondemand.com, cfOrg=testOrg, cfSpace=testSpace, cfCredentialsId=myCreds'))
         assertThat(loggingRule.log, containsString('[cloudFoundryDeploy] WARNING! Found unsupported deployTool. Skipping deployment.'))
     }
-
 
 
     @Test
@@ -162,15 +161,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
         // asserts
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -189,16 +188,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfApiEndpoint: 'https://customApi',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            cfApiEndpoint   : 'https://customApi',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
         // asserts
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://customApi -o "testOrg" -s "testSpace"')))
@@ -212,16 +211,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            deployTool      : 'cf_native',
+            cloudFoundry    : [
+                org          : 'testOrg',
+                space        : 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName: 'testAppName',
-                manifest: 'test.yml'
+                appName      : 'testAppName',
+                manifest     : 'test.yml'
             ]
         ])
         // asserts
@@ -243,16 +242,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
+            script           : nullScript,
+            juStabUtils      : utils,
+            jenkinsUtilsStub : new JenkinsUtilsMock(),
+            deployTool       : 'cf_native',
             deployDockerImage: 'repo/image:tag',
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            cloudFoundry     : [
+                org          : 'testOrg',
+                space        : 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName: 'testAppName'
+                appName      : 'testAppName'
             ]
         ])
 
@@ -271,17 +270,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployDockerImage: 'repo/image:tag',
+            script             : nullScript,
+            juStabUtils        : utils,
+            jenkinsUtilsStub   : new JenkinsUtilsMock(),
+            deployTool         : 'cf_native',
+            deployDockerImage  : 'repo/image:tag',
             dockerCredentialsId: 'test_cfDockerCredentialsId',
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            cloudFoundry       : [
+                org          : 'testOrg',
+                space        : 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName: 'testAppName'
+                appName      : 'testAppName'
             ]
         ])
         assertThat(dockerExecuteRule.dockerParams.dockerEnvVars, hasEntry(equalTo('CF_DOCKER_PASSWORD'), equalTo("${'********'}")))
@@ -303,17 +302,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
+            script             : nullScript,
+            juStabUtils        : utils,
+            jenkinsUtilsStub   : new JenkinsUtilsMock(),
+            deployTool         : 'cf_native',
             dockerCredentialsId: 'test_cfDockerCredentialsId',
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            cloudFoundry       : [
+                org          : 'testOrg',
+                space        : 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName: 'testAppName',
-                manifest: 'manifest.yml'
+                appName      : 'testAppName',
+                manifest     : 'manifest.yml'
             ]
         ])
         assertThat(dockerExecuteRule.dockerParams.dockerEnvVars, hasEntry(equalTo('CF_DOCKER_PASSWORD'), equalTo("${'********'}")))
@@ -335,18 +334,18 @@ class CloudFoundryDeployTest extends BasePiperTest {
             data = parameters.data
         })
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
+            script             : nullScript,
+            juStabUtils        : utils,
+            jenkinsUtilsStub   : new JenkinsUtilsMock(),
+            deployTool         : 'cf_native',
+            deployType         : 'blue-green',
             dockerCredentialsId: 'test_cfDockerCredentialsId',
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            cloudFoundry       : [
+                org          : 'testOrg',
+                space        : 'testSpace',
                 credentialsId: 'test_cfCredentialsId',
-                appName: 'testAppName',
-                manifest: 'manifest.yml'
+                appName      : 'testAppName',
+                manifest     : 'manifest.yml'
             ]
         ])
         assertThat(dockerExecuteRule.dockerParams.dockerEnvVars, hasEntry(equalTo('CF_DOCKER_PASSWORD'), equalTo("${'********'}")))
@@ -365,14 +364,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfManifest      : 'test.yml'
         ])
         // asserts
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
@@ -392,14 +391,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: No appName available in manifest test.yml.')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfManifest      : 'test.yml'
         ])
     }
 
@@ -409,16 +408,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'blue-green',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -436,17 +435,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            keepOldInstance: false,
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'blue-green',
+            keepOldInstance : false,
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -465,17 +464,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            keepOldInstance: true,
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'blue-green',
+            keepOldInstance : true,
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -497,16 +496,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage("[cloudFoundryDeploy] Your manifest contains more than one application. For blue green deployments your manifest file may contain only one application.")
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'blue-green',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
     }
 
@@ -516,23 +515,23 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.registerExistingFile('test.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'blue-green',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         assertThat(shellRule.shell, hasItem(containsString("cf push testAppName -f 'test.yml'")))
     }
 
     @Test
-    void testCfNativeBlueGreenKeepOldInstanceShouldThrowErrorOnStopError(){
+    void testCfNativeBlueGreenKeepOldInstanceShouldThrowErrorOnStopError() {
         new File(tmpDir, '1-cfStopOutput.txt').write('any error message')
 
         helper.registerAllowedMethod("sh", [String], { cmd ->
@@ -546,17 +545,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage("[cloudFoundryDeploy] ERROR: Could not stop application testAppName-old. Error: any error message")
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            keepOldInstance: true,
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'blue-green',
+            keepOldInstance : true,
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -573,17 +572,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'standard',
-            keepOldInstance: true,
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'standard',
+            keepOldInstance : true,
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         assertThat(shellRule.shell, not(hasItem(containsString("cf stop testAppName-old &>"))))
@@ -599,15 +598,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: Blue-green plugin requires app name to be passed (see https://github.com/bluemixgaragelondon/cf-blue-green-deploy/issues/27)')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            deployType      : 'blue-green',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfManifest      : 'test.yml'
         ])
     }
 
@@ -627,15 +626,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: The execution of the deploy command failed, see the log for details.')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
@@ -647,14 +646,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void testMta() {
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            mtaPath: 'target/test.mtar'
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            deployTool      : 'mtaDeployPlugin',
+            mtaPath         : 'target/test.mtar'
         ])
         // asserts
         assertThat(dockerExecuteRule.dockerParams, hasEntry('dockerImage', 'ppiper/cf-cli'))
@@ -669,13 +668,13 @@ class CloudFoundryDeployTest extends BasePiperTest {
         environmentRule.env.mtarFilePath = 'target/test.mtar'
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin'
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            deployTool      : 'mtaDeployPlugin'
         ])
         // asserts
         assertThat(shellRule.shell, hasItem(containsString('cf deploy target/test.mtar -f')))
@@ -685,15 +684,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testMtaBlueGreen() {
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            deployType: 'blue-green',
-            mtaPath: 'target/test.mtar'
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            deployTool      : 'mtaDeployPlugin',
+            deployType      : 'blue-green',
+            mtaPath         : 'target/test.mtar'
         ])
 
         assertThat(shellRule.shell, hasItem(stringContainsInOrder(["cf login -u \"test_cf\"", 'cf bg-deploy', '-f', '--no-confirm'])))
@@ -708,19 +707,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
         nullScript.commonPipelineEnvironment.setArtifactVersion('1.2.3')
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
         // asserts
         assertThat(writeInfluxMap.customDataMap.deployment_data.artifactUrl, is('n/a'))
-        assertThat(writeInfluxMap.customDataMap.deployment_data.deployTime, containsString(new Date().format( 'MMM dd, yyyy')))
+        assertThat(writeInfluxMap.customDataMap.deployment_data.deployTime, containsString(new Date().format('MMM dd, yyyy')))
         assertThat(writeInfluxMap.customDataMap.deployment_data.jobTrigger, is('USER'))
 
         assertThat(writeInfluxMap.customDataMapTags.deployment_data.artifactVersion, is('1.2.3'))
@@ -738,15 +737,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.registerExistingFile('vars.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml',
+            script                  : nullScript,
+            juStabUtils             : utils,
+            jenkinsUtilsStub        : new JenkinsUtilsMock(),
+            deployTool              : 'cf_native',
+            cfOrg                   : 'testOrg',
+            cfSpace                 : 'testSpace',
+            cfCredentialsId         : 'test_cfCredentialsId',
+            cfAppName               : 'testAppName',
+            cfManifest              : 'test.yml',
             cfManifestVariablesFiles: ['vars.yml']
         ])
 
@@ -756,8 +755,8 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(shellRule.shell, hasItem(containsString("cf push testAppName --vars-file 'vars.yml' -f 'test.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))
-        assertThat(loggingRule.log,containsString("We will add the following string to the cf push call: --vars-file 'vars.yml' !"))
-        assertThat(loggingRule.log,not(containsString("We will add the following string to the cf push call:  !")))
+        assertThat(loggingRule.log, containsString("We will add the following string to the cf push call: --vars-file 'vars.yml' !"))
+        assertThat(loggingRule.log, not(containsString("We will add the following string to the cf push call:  !")))
     }
 
     @Test
@@ -766,15 +765,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.registerExistingFile('test.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml',
+            script                  : nullScript,
+            juStabUtils             : utils,
+            jenkinsUtilsStub        : new JenkinsUtilsMock(),
+            deployTool              : 'cf_native',
+            cfOrg                   : 'testOrg',
+            cfSpace                 : 'testSpace',
+            cfCredentialsId         : 'test_cfCredentialsId',
+            cfAppName               : 'testAppName',
+            cfManifest              : 'test.yml',
             cfManifestVariablesFiles: ['vars.yml']
         ])
 
@@ -786,18 +785,18 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void testCfPushDeploymentWithVariableSubstitutionFromVarsList() {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
-        List varsList = [["appName" : "testApplicationFromVarsList"]]
+        List varsList = [["appName": "testApplicationFromVarsList"]]
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml',
+            script             : nullScript,
+            juStabUtils        : utils,
+            jenkinsUtilsStub   : new JenkinsUtilsMock(),
+            deployTool         : 'cf_native',
+            cfOrg              : 'testOrg',
+            cfSpace            : 'testSpace',
+            cfCredentialsId    : 'test_cfCredentialsId',
+            cfAppName          : 'testAppName',
+            cfManifest         : 'test.yml',
             cfManifestVariables: varsList
         ])
 
@@ -808,8 +807,8 @@ class CloudFoundryDeployTest extends BasePiperTest {
         assertThat(shellRule.shell, hasItem(containsString('cf login -u "test_cf" -p \'********\' -a https://api.cf.eu10.hana.ondemand.com -o "testOrg" -s "testSpace"')))
         assertThat(shellRule.shell, hasItem(containsString("cf push testAppName --var appName='testApplicationFromVarsList' -f 'test.yml'")))
         assertThat(shellRule.shell, hasItem(containsString("cf logout")))
-        assertThat(loggingRule.log,containsString("We will add the following string to the cf push call: --var appName='testApplicationFromVarsList' !"))
-        assertThat(loggingRule.log,not(containsString("We will add the following string to the cf push call:  !")))
+        assertThat(loggingRule.log, containsString("We will add the following string to the cf push call: --var appName='testApplicationFromVarsList' !"))
+        assertThat(loggingRule.log, not(containsString("We will add the following string to the cf push call:  !")))
     }
 
     @Test
@@ -820,15 +819,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] ERROR: Parameter config.cloudFoundry.manifestVariables is not a List!')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml',
+            script             : nullScript,
+            juStabUtils        : utils,
+            jenkinsUtilsStub   : new JenkinsUtilsMock(),
+            deployTool         : 'cf_native',
+            cfOrg              : 'testOrg',
+            cfSpace            : 'testSpace',
+            cfCredentialsId    : 'test_cfCredentialsId',
+            cfAppName          : 'testAppName',
+            cfManifest         : 'test.yml',
             cfManifestVariables: 'notAList'
         ])
 
@@ -837,21 +836,21 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void testCfPushDeploymentWithVariableSubstitutionFromVarsListAndVarsFile() {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
-        List varsList = [["appName" : "testApplicationFromVarsList"]]
+        List varsList = [["appName": "testApplicationFromVarsList"]]
         fileExistsRule.registerExistingFile('vars.yml')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml',
+            script                  : nullScript,
+            juStabUtils             : utils,
+            jenkinsUtilsStub        : new JenkinsUtilsMock(),
+            deployTool              : 'cf_native',
+            cfOrg                   : 'testOrg',
+            cfSpace                 : 'testSpace',
+            cfCredentialsId         : 'test_cfCredentialsId',
+            cfAppName               : 'testAppName',
+            cfManifest              : 'test.yml',
             cfManifestVariablesFiles: ['vars.yml'],
-            cfManifestVariables: varsList
+            cfManifestVariables     : varsList
         ])
 
         // asserts
@@ -868,15 +867,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            deployTool      : 'cf_native',
+            cfOrg           : 'testOrg',
+            cfSpace         : 'testSpace',
+            cfCredentialsId : 'test_cfCredentialsId',
+            cfAppName       : 'testAppName',
+            cfManifest      : 'test.yml'
         ])
 
         // asserts
@@ -907,16 +906,16 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml',
+            script                  : nullScript,
+            juStabUtils             : utils,
+            jenkinsUtilsStub        : new JenkinsUtilsMock(),
+            deployTool              : 'cf_native',
+            deployType              : 'blue-green',
+            cfOrg                   : 'testOrg',
+            cfSpace                 : 'testSpace',
+            cfCredentialsId         : 'test_cfCredentialsId',
+            cfAppName               : 'testAppName',
+            cfManifest              : 'test.yml',
             cfManifestVariablesFiles: ['vars.yml']
         ])
 
@@ -937,7 +936,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testCfBlueGreenDeploymentWithVariableSubstitutionFromVarsList() {
         readYamlRule.registerYaml('test.yml', "applications: [{name: '((appName))'}]")
         readYamlRule.registerYaml('vars.yml', "[appName: 'testApplication']")
-        List varsList = [["appName" : "testApplicationFromVarsList"]]
+        List varsList = [["appName": "testApplicationFromVarsList"]]
 
         fileExistsRule.registerExistingFile("test.yml")
         fileExistsRule.registerExistingFile("vars.yml")
@@ -952,18 +951,18 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            deployType: 'blue-green',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml',
+            script                  : nullScript,
+            juStabUtils             : utils,
+            jenkinsUtilsStub        : new JenkinsUtilsMock(),
+            deployTool              : 'cf_native',
+            deployType              : 'blue-green',
+            cfOrg                   : 'testOrg',
+            cfSpace                 : 'testSpace',
+            cfCredentialsId         : 'test_cfCredentialsId',
+            cfAppName               : 'testAppName',
+            cfManifest              : 'test.yml',
             cfManifestVariablesFiles: ['vars.yml'],
-            cfManifestVariables: varsList
+            cfManifestVariables     : varsList
         ])
 
         // asserts
@@ -991,17 +990,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
         readYamlRule.registerYaml('test.yml', "applications: [{name: 'manifestAppName'}]")
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            cloudFoundry    : [
+                org     : 'testOrg',
+                space   : 'testSpace',
                 manifest: 'test.yml',
-                ],
-            deployTool: 'cf_native',
-            cfCredentialsId: 'test_cfCredentialsId',
-            verbose: true
+            ],
+            deployTool      : 'cf_native',
+            cfCredentialsId : 'test_cfCredentialsId',
+            verbose         : true
         ])
 
         assertThat(loggingRule.log, allOf(
@@ -1019,17 +1018,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
 
         readYamlRule.registerYaml('test.yml', "applications: [{name: 'manifestAppName'}]")
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            cloudFoundry    : [
+                org     : 'testOrg',
+                space   : 'testSpace',
                 manifest: 'test.yml',
-                ],
-            deployTool: 'cf_native',
-            cfCredentialsId: 'test_cfCredentialsId',
-            verbose: true
+            ],
+            deployTool      : 'cf_native',
+            cfCredentialsId : 'test_cfCredentialsId',
+            verbose         : true
         ])
 
         assertThat(loggingRule.log, containsString('No trace file found'))
@@ -1045,17 +1044,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
         nullScript.commonPipelineEnvironment.setArtifactVersion('1.2.3')
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            deployTool: 'cf_native',
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            loginParameters: '--some-login-opt value',
+            script                  : nullScript,
+            juStabUtils             : utils,
+            jenkinsUtilsStub        : new JenkinsUtilsMock(),
+            deployTool              : 'cf_native',
+            cfOrg                   : 'testOrg',
+            cfSpace                 : 'testSpace',
+            loginParameters         : '--some-login-opt value',
             cfNativeDeployParameters: '--some-deploy-opt cf-value',
-            cfCredentialsId: 'test_cfCredentialsId',
-            cfAppName: 'testAppName',
-            cfManifest: 'test.yml'
+            cfCredentialsId         : 'test_cfCredentialsId',
+            cfAppName               : 'testAppName',
+            cfManifest              : 'test.yml'
         ])
 
         assertThat(shellRule.shell, hasItem(
@@ -1069,20 +1068,20 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void testAdditionMtaOpts() {
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'testOrg',
+            script             : nullScript,
+            juStabUtils        : utils,
+            jenkinsUtilsStub   : new JenkinsUtilsMock(),
+            cloudFoundry       : [
+                org  : 'testOrg',
                 space: 'testSpace',
             ],
-            apiParameters: '--some-api-opt value',
-            loginParameters: '--some-login-opt value',
+            apiParameters      : '--some-api-opt value',
+            loginParameters    : '--some-login-opt value',
             mtaDeployParameters: '--some-deploy-opt mta-value',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            deployType: 'blue-green',
-            mtaPath: 'target/test.mtar'
+            cfCredentialsId    : 'test_cfCredentialsId',
+            deployTool         : 'mtaDeployPlugin',
+            deployType         : 'blue-green',
+            mtaPath            : 'target/test.mtar'
         ])
 
         assertThat(shellRule.shell, hasItem(
@@ -1098,19 +1097,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
         String expected = "Your application name my_invalid_app_name contains a '_' (underscore) which is not allowed, only letters, dashes and numbers can be used. Please change the name to fit this requirement.\n" +
             "For more details please visit https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#basic-settings."
         String actual = ""
-        helper.registerAllowedMethod('error', [String.class], {s -> actual = s})
+        helper.registerAllowedMethod('error', [String.class], { s -> actual = s })
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'irrelevant',
-                space: 'irrelevant',
+            cloudFoundry    : [
+                org    : 'irrelevant',
+                space  : 'irrelevant',
                 appName: 'my_invalid_app_name'
             ],
-            cfCredentialsId: 'test_cfCredentialsId',
-            mtaPath: 'irrelevant'
+            cfCredentialsId : 'test_cfCredentialsId',
+            mtaPath         : 'irrelevant'
         ])
 
         assertEquals(expected, actual)
@@ -1120,19 +1119,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void 'appName with alpha-numeric chars and leading dash should throw an error'() {
         String expected = "Your application name -my-Invalid-AppName123 contains a starts or ends with a '-' (dash) which is not allowed, only letters, dashes and numbers can be used. Please change the name to fit this requirement.\nFor more details please visit https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#basic-settings."
         String actual = ""
-        helper.registerAllowedMethod('error', [String.class], {s -> actual = s})
+        helper.registerAllowedMethod('error', [String.class], { s -> actual = s })
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'irrelevant',
-                space: 'irrelevant',
+            cloudFoundry    : [
+                org    : 'irrelevant',
+                space  : 'irrelevant',
                 appName: '-my-Invalid-AppName123'
             ],
-            cfCredentialsId: 'test_cfCredentialsId',
-            mtaPath: 'irrelevant'
+            cfCredentialsId : 'test_cfCredentialsId',
+            mtaPath         : 'irrelevant'
         ])
 
         assertEquals(expected, actual)
@@ -1142,19 +1141,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
     void 'appName with alpha-numeric chars and trailing dash should throw an error'() {
         String expected = "Your application name my-Invalid-AppName123- contains a starts or ends with a '-' (dash) which is not allowed, only letters, dashes and numbers can be used. Please change the name to fit this requirement.\nFor more details please visit https://docs.cloudfoundry.org/devguide/deploy-apps/deploy-app.html#basic-settings."
         String actual = ""
-        helper.registerAllowedMethod('error', [String.class], {s -> actual = s})
+        helper.registerAllowedMethod('error', [String.class], { s -> actual = s })
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'irrelevant',
-                space: 'irrelevant',
+            cloudFoundry    : [
+                org    : 'irrelevant',
+                space  : 'irrelevant',
                 appName: 'my-Invalid-AppName123-'
             ],
-            cfCredentialsId: 'test_cfCredentialsId',
-            mtaPath: 'irrelevant'
+            cfCredentialsId : 'test_cfCredentialsId',
+            mtaPath         : 'irrelevant'
         ])
 
         assertEquals(expected, actual)
@@ -1163,17 +1162,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void 'appName with alpha-numeric chars should work'() {
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'irrelevant',
-                space: 'irrelevant',
+            cloudFoundry    : [
+                org    : 'irrelevant',
+                space  : 'irrelevant',
                 appName: 'myValidAppName123'
             ],
-            deployTool: 'cf_native',
-            cfCredentialsId: 'test_cfCredentialsId',
-            mtaPath: 'irrelevant'
+            deployTool      : 'cf_native',
+            cfCredentialsId : 'test_cfCredentialsId',
+            mtaPath         : 'irrelevant'
         ])
 
         assertTrue(loggingRule.log.contains("cfAppName=myValidAppName123"))
@@ -1182,17 +1181,17 @@ class CloudFoundryDeployTest extends BasePiperTest {
     @Test
     void 'appName with alpha-numeric chars and dash should work'() {
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
+            script          : nullScript,
+            juStabUtils     : utils,
             jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'irrelevant',
-                space: 'irrelevant',
+            cloudFoundry    : [
+                org    : 'irrelevant',
+                space  : 'irrelevant',
                 appName: 'my-Valid-AppName123'
             ],
-            deployTool: 'cf_native',
-            cfCredentialsId: 'test_cfCredentialsId',
-            mtaPath: 'irrelevant'
+            deployTool      : 'cf_native',
+            cfCredentialsId : 'test_cfCredentialsId',
+            mtaPath         : 'irrelevant'
         ])
 
         assertTrue(loggingRule.log.contains("cfAppName=my-Valid-AppName123"))
@@ -1204,19 +1203,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
             'globalMtaDescriptor.mtaext',
         )
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'testOrg',
+            script                : nullScript,
+            juStabUtils           : utils,
+            jenkinsUtilsStub      : new JenkinsUtilsMock(),
+            cloudFoundry          : [
+                org  : 'testOrg',
                 space: 'testSpace'
             ],
             mtaExtensionDescriptor: 'globalMtaDescriptor.mtaext',
-            mtaDeployParameters: '--some-deploy-opt mta-value',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            deployType: 'blue-green',
-            mtaPath: 'target/test.mtar'
+            mtaDeployParameters   : '--some-deploy-opt mta-value',
+            cfCredentialsId       : 'test_cfCredentialsId',
+            deployTool            : 'mtaDeployPlugin',
+            deployType            : 'blue-green',
+            mtaPath               : 'target/test.mtar'
         ])
 
         assertThat(shellRule.shell, hasItem(containsString("-e globalMtaDescriptor.mtaext")))
@@ -1228,19 +1227,19 @@ class CloudFoundryDeployTest extends BasePiperTest {
             'targetMtaDescriptor.mtaext',
         )
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cloudFoundry: [
-                org: 'testOrg',
-                space: 'testSpace',
+            script             : nullScript,
+            juStabUtils        : utils,
+            jenkinsUtilsStub   : new JenkinsUtilsMock(),
+            cloudFoundry       : [
+                org                   : 'testOrg',
+                space                 : 'testSpace',
                 mtaExtensionDescriptor: 'targetMtaDescriptor.mtaext'
             ],
             mtaDeployParameters: '--some-deploy-opt mta-value',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            deployType: 'blue-green',
-            mtaPath: 'target/test.mtar'
+            cfCredentialsId    : 'test_cfCredentialsId',
+            deployTool         : 'mtaDeployPlugin',
+            deployType         : 'blue-green',
+            mtaPath            : 'target/test.mtar'
         ])
         assertThat(shellRule.shell, hasItem(containsString("-e targetMtaDescriptor.mtaext")))
     }
@@ -1250,9 +1249,9 @@ class CloudFoundryDeployTest extends BasePiperTest {
         fileExistsRule.existingFiles.addAll(
             'mtaext.mtaext',
         )
-        credentialsRule.withCredentials("mtaExtCredTest","token")
+        credentialsRule.withCredentials("mtaExtCredTest", "token")
 
-        helper.registerAllowedMethod('readFile', [String], {file ->
+        helper.registerAllowedMethod('readFile', [String], { file ->
             if (file == 'mtaext.mtaext') {
                 return '_schema-version: \'3.1\'\n' +
                     'ID: test.ext\n' +
@@ -1265,15 +1264,15 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            mtaPath: 'target/test.mtar',
-            mtaExtensionDescriptor: "mtaext.mtaext",
+            script                 : nullScript,
+            juStabUtils            : utils,
+            jenkinsUtilsStub       : new JenkinsUtilsMock(),
+            cfOrg                  : 'testOrg',
+            cfSpace                : 'testSpace',
+            cfCredentialsId        : 'test_cfCredentialsId',
+            deployTool             : 'mtaDeployPlugin',
+            mtaPath                : 'target/test.mtar',
+            mtaExtensionDescriptor : "mtaext.mtaext",
             mtaExtensionCredentials: [
                 testCred: 'mtaExtCredTest'
             ]
@@ -1295,14 +1294,14 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] The mta extension descriptor file mtaext.mtaext does not exist at the configured location.')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            mtaPath: 'target/test.mtar',
+            script                : nullScript,
+            juStabUtils           : utils,
+            jenkinsUtilsStub      : new JenkinsUtilsMock(),
+            cfOrg                 : 'testOrg',
+            cfSpace               : 'testSpace',
+            cfCredentialsId       : 'test_cfCredentialsId',
+            deployTool            : 'mtaDeployPlugin',
+            mtaPath               : 'target/test.mtar',
             mtaExtensionDescriptor: "mtaext.mtaext"
         ])
     }
@@ -1317,18 +1316,70 @@ class CloudFoundryDeployTest extends BasePiperTest {
         thrown.expectMessage('[cloudFoundryDeploy] Unable to read mta extension file mtaext.mtaext.')
 
         stepRule.step.cloudFoundryDeploy([
-            script: nullScript,
-            juStabUtils: utils,
-            jenkinsUtilsStub: new JenkinsUtilsMock(),
-            cfOrg: 'testOrg',
-            cfSpace: 'testSpace',
-            cfCredentialsId: 'test_cfCredentialsId',
-            deployTool: 'mtaDeployPlugin',
-            mtaPath: 'target/test.mtar',
-            mtaExtensionDescriptor: "mtaext.mtaext",
+            script                 : nullScript,
+            juStabUtils            : utils,
+            jenkinsUtilsStub       : new JenkinsUtilsMock(),
+            cfOrg                  : 'testOrg',
+            cfSpace                : 'testSpace',
+            cfCredentialsId        : 'test_cfCredentialsId',
+            deployTool             : 'mtaDeployPlugin',
+            mtaPath                : 'target/test.mtar',
+            mtaExtensionDescriptor : "mtaext.mtaext",
             mtaExtensionCredentials: [
                 testCred: 'mtaExtCredTest'
             ],
         ])
+    }
+
+    @Test
+    void testGoStepFeatureToggleOn() {
+        String calledStep = ''
+        String usedMetadataFile = ''
+        helper.registerAllowedMethod('piperExecuteBin', [Map, String, String, List], {
+            Map parameters, String stepName,
+            String metadataFile, List credentialInfo ->
+                calledStep = stepName
+                usedMetadataFile = metadataFile
+        })
+
+        stepRule.step.cloudFoundryDeploy([
+            script          : nullScript,
+            juStabUtils     : utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            useGoStep       : true,
+            deployTool      : 'irrelevant',
+            cfOrg           : 'irrelevant',
+            cfSpace         : 'irrelevant',
+            cfCredentialsId : 'irrelevant',
+        ])
+
+        assertEquals('cloudFoundryDeploy', calledStep)
+        assertEquals('metadata/cloudFoundryDeploy.yaml', usedMetadataFile)
+    }
+
+    @Test
+    void testGoStepFeatureToggleOff() {
+        String calledStep = ''
+        String usedMetadataFile = ''
+        helper.registerAllowedMethod('piperExecuteBin', [Map, String, String, List], {
+            Map parameters, String stepName,
+            String metadataFile, List credentialInfo ->
+                calledStep = stepName
+                usedMetadataFile = metadataFile
+        })
+
+        stepRule.step.cloudFoundryDeploy([
+            script          : nullScript,
+            juStabUtils     : utils,
+            jenkinsUtilsStub: new JenkinsUtilsMock(),
+            useGoStep       : 'false',
+            deployTool      : 'irrelevant',
+            cfOrg           : 'irrelevant',
+            cfSpace         : 'irrelevant',
+            cfCredentialsId : 'irrelevant',
+        ])
+
+        assertEquals('', calledStep)
+        assertEquals('', usedMetadataFile)
     }
 }

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -156,15 +156,14 @@ import static com.sap.piper.Prerequisites.checkScript
      * this defines the credentials to be used.
      */
     'dockerCredentialsId',
-]
-@Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS
-@Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus([
     /**
      * Activates using the new go-implementation of the step. Off by default.
      * @possibleValues true, false
      */
     'useGoStep',
-])
+]
+@Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS
+@Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
 
 @Field Map CONFIG_KEY_COMPATIBILITY = [
     cloudFoundry: [

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -9,6 +9,7 @@ import groovy.transform.Field
 import static com.sap.piper.Prerequisites.checkScript
 
 @Field String STEP_NAME = getClass().getName()
+@Field String METADATA_FILE = 'metadata/cloudFoundryDeploy.yaml'
 
 @Field Set GENERAL_CONFIG_KEYS = [
     'buildTool',
@@ -157,7 +158,13 @@ import static com.sap.piper.Prerequisites.checkScript
     'dockerCredentialsId',
 ]
 @Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS
-@Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
+@Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.plus([
+    /**
+     * Activates using the new go-implementation of the step. Off by default.
+     * @possibleValues true, false
+     */
+    'useGoStep',
+])
 
 @Field Map CONFIG_KEY_COMPATIBILITY = [
     cloudFoundry: [
@@ -199,6 +206,15 @@ import static com.sap.piper.Prerequisites.checkScript
  */
 @GenerateDocumentation
 void call(Map parameters = [:]) {
+
+    if (parameters.useGoStep == true) {
+        List credentials = [
+            [type: 'usernamePassword', id: 'cfCredentialsId', env: ['PIPER_username', 'PIPER_password']],
+            [type: 'usernamePassword', id: 'dockerCredentialsId', env: ['PIPER_dockerUsername', 'PIPER_dockerPassword']]
+        ]
+        piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
+        return
+    }
 
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
 

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -9,7 +9,6 @@ import groovy.transform.Field
 import static com.sap.piper.Prerequisites.checkScript
 
 @Field String STEP_NAME = getClass().getName()
-@Field String METADATA_FILE = 'metadata/cloudFoundryDeploy.yaml'
 
 @Field Set GENERAL_CONFIG_KEYS = [
     'buildTool',
@@ -233,7 +232,7 @@ void call(Map parameters = [:]) {
                 [type: 'usernamePassword', id: 'cfCredentialsId', env: ['PIPER_username', 'PIPER_password']],
                 [type: 'usernamePassword', id: 'dockerCredentialsId', env: ['PIPER_dockerUsername', 'PIPER_dockerPassword']]
             ]
-            piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
+            piperExecuteBin(parameters, STEP_NAME, 'metadata/cloudFoundryDeploy.yaml', credentials)
             return
         }
 

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -156,7 +156,7 @@ import static com.sap.piper.Prerequisites.checkScript
      */
     'dockerCredentialsId',
     /**
-     * Activates using the new go-implementation of the step. Off by default.
+     * Toggle to activate the new go-implementation of the step. Off by default.
      * @possibleValues true, false
      */
     'useGoStep',

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -206,15 +206,6 @@ import static com.sap.piper.Prerequisites.checkScript
 @GenerateDocumentation
 void call(Map parameters = [:]) {
 
-    if (parameters.useGoStep == true) {
-        List credentials = [
-            [type: 'usernamePassword', id: 'cfCredentialsId', env: ['PIPER_username', 'PIPER_password']],
-            [type: 'usernamePassword', id: 'dockerCredentialsId', env: ['PIPER_dockerUsername', 'PIPER_dockerPassword']]
-        ]
-        piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
-        return
-    }
-
     handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
 
         def utils = parameters.juStabUtils ?: new Utils()
@@ -236,6 +227,15 @@ void call(Map parameters = [:]) {
             .withMandatoryProperty('cloudFoundry/space')
             .withMandatoryProperty('cloudFoundry/credentialsId')
             .use()
+
+        if (config.useGoStep == true) {
+            List credentials = [
+                [type: 'usernamePassword', id: 'cfCredentialsId', env: ['PIPER_username', 'PIPER_password']],
+                [type: 'usernamePassword', id: 'dockerCredentialsId', env: ['PIPER_dockerUsername', 'PIPER_dockerPassword']]
+            ]
+            piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
+            return
+        }
 
         utils.pushToSWA([
             step: STEP_NAME,

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -180,6 +180,7 @@ class commonPipelineEnvironment implements Serializable {
 
     def files = [
         [filename: '.pipeline/commonPipelineEnvironment/artifactVersion', property: 'artifactVersion'],
+        [filename: '.pipeline/commonPipelineEnvironment/buildTool', property: 'buildTool'],
         [filename: '.pipeline/commonPipelineEnvironment/originalArtifactVersion', property: 'originalArtifactVersion'],
         [filename: '.pipeline/commonPipelineEnvironment/github/owner', property: 'githubOrg'],
         [filename: '.pipeline/commonPipelineEnvironment/github/repository', property: 'githubRepo'],


### PR DESCRIPTION
# Changes

* Adds an off-by-default feature-toggle to the Groovy implementation of `cloudFoundryDeploy` to use the new go implementation.
* Fixes the go metadata's parameter scopes and adds the inputs for the Jenkins credentials IDs.
* Adds writing "buildTool" resource to common pipeline environment.
* Makes deployTool parameter optional, adds buildTool parameter, derived from CPE,  and filling deployTool from buildTool if necessary.

- [x] Tests
- [x] Documentation
