### PR TITLE
Correction in abaputils

### DIFF
--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -130,14 +130,12 @@ func GetHTTPResponse(requestType string, connectionDetails ConnectionDetailsHTTP
 	return req, err
 }
 
-/* HandleHTTPError handles ABAP error messages which can occur when using OData services
-
-The point of this function is to enrich the error received from a HTTP Request (which is passed as a parameter to this function).
-Further error details may be present in the response body of the HTTP response.
-If the response body is parseable, the included details are wrapped arround the original error from the HTTP repsponse.
-If this is not possible, the original error is returned.
-
-*/
+// HandleHTTPError handles ABAP error messages which can occur when using OData services
+//
+// The point of this function is to enrich the error received from a HTTP Request (which is passed as a parameter to this function).
+// Further error details may be present in the response body of the HTTP response.
+// If the response body is parseable, the included details are wrapped arround the original error from the HTTP repsponse.
+// If this is not possible, the original error is returned.
 func HandleHTTPError(resp *http.Response, err error, message string, connectionDetails ConnectionDetailsHTTP) error {
 	if resp == nil {
 		// Response is nil in case of a timeout

--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -141,30 +141,46 @@ func HandleHTTPError(resp *http.Response, err error, message string, connectionD
 		// Response is nil in case of a timeout
 		log.Entry().WithError(err).WithField("ABAP Endpoint", connectionDetails.URL).Error("Request failed")
 	} else {
+
 		defer resp.Body.Close()
+
 		log.Entry().WithField("StatusCode", resp.Status).Error(message)
 
-		// Include the error message of the ABAP Environment system, if available
-		var abapErrorResponse AbapError
-		bodyText, readError := ioutil.ReadAll(resp.Body)
-		if readError != nil {
+		errorDetails, parsingError := getErrorDetailsFromResponse(resp)
+		if parsingError != nil {
 			return err
 		}
-		var abapResp map[string]*json.RawMessage
-		errUnmarshal := json.Unmarshal(bodyText, &abapResp)
-		if errUnmarshal != nil {
-			return err
-		}
-		if _, ok := abapResp["error"]; ok {
-			json.Unmarshal(*abapResp["error"], &abapErrorResponse)
-			if (AbapError{}) != abapErrorResponse {
-				log.Entry().WithField("ErrorCode", abapErrorResponse.Code).Error(abapErrorResponse.Message.Value)
-				abapError := errors.New(abapErrorResponse.Code + " - " + abapErrorResponse.Message.Value)
-				err = errors.Wrap(abapError, err.Error())
-			}
-		}
+		abapError := errors.New(errorDetails)
+		err = errors.Wrap(abapError, err.Error())
+
 	}
 	return err
+}
+
+func getErrorDetailsFromResponse(resp *http.Response) (errorString string, err error) {
+
+	// Include the error message of the ABAP Environment system, if available
+	var abapErrorResponse AbapError
+	bodyText, readError := ioutil.ReadAll(resp.Body)
+	if readError != nil {
+		return errorString, readError
+	}
+	var abapResp map[string]*json.RawMessage
+	errUnmarshal := json.Unmarshal(bodyText, &abapResp)
+	if errUnmarshal != nil {
+		return errorString, errUnmarshal
+	}
+	if _, ok := abapResp["error"]; ok {
+		json.Unmarshal(*abapResp["error"], &abapErrorResponse)
+		if (AbapError{}) != abapErrorResponse {
+			log.Entry().WithField("ErrorCode", abapErrorResponse.Code).Error(abapErrorResponse.Message.Value)
+			errorString = fmt.Sprintf("%s - %s", abapErrorResponse.Code, abapErrorResponse.Message.Value)
+			return errorString, nil
+		}
+	}
+
+	return errorString, errors.New("Could not parse the JSON error response")
+
 }
 
 // ConvertTime formats an ABAP timestamp string from format /Date(1585576807000+0000)/ into a UNIX timestamp and returns it

--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -142,10 +142,13 @@ func HandleHTTPError(resp *http.Response, err error, message string, connectionD
 		var abapErrorResponse AbapError
 		bodyText, readError := ioutil.ReadAll(resp.Body)
 		if readError != nil {
-			return readError
+			return errors.Wrap(readError, err.Error())
 		}
 		var abapResp map[string]*json.RawMessage
-		json.Unmarshal(bodyText, &abapResp)
+		errUnmarshal := json.Unmarshal(bodyText, &abapResp)
+		if errUnmarshal != nil {
+			return errors.Wrap(errUnmarshal, err.Error())
+		}
 		json.Unmarshal(*abapResp["error"], &abapErrorResponse)
 		if (AbapError{}) != abapErrorResponse {
 			log.Entry().WithField("ErrorCode", abapErrorResponse.Code).Error(abapErrorResponse.Message.Value)

--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -142,12 +142,12 @@ func HandleHTTPError(resp *http.Response, err error, message string, connectionD
 		var abapErrorResponse AbapError
 		bodyText, readError := ioutil.ReadAll(resp.Body)
 		if readError != nil {
-			return errors.Wrap(readError, err.Error())
+			return err
 		}
 		var abapResp map[string]*json.RawMessage
 		errUnmarshal := json.Unmarshal(bodyText, &abapResp)
 		if errUnmarshal != nil {
-			return errors.Wrap(errUnmarshal, err.Error())
+			return err
 		}
 		json.Unmarshal(*abapResp["error"], &abapErrorResponse)
 		if (AbapError{}) != abapErrorResponse {

--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -130,7 +130,14 @@ func GetHTTPResponse(requestType string, connectionDetails ConnectionDetailsHTTP
 	return req, err
 }
 
-// HandleHTTPError handles ABAP error messages which can occur when using OData services
+/* HandleHTTPError handles ABAP error messages which can occur when using OData services
+
+The point of this function is to enrich the error received from a HTTP Request (which is passed as a parameter to this function).
+Further error details may be present in the response body of the HTTP response.
+If the response body is parseable, the included details are wrapped arround the original error from the HTTP repsponse.
+If this is not possible, the original error is returned.
+
+*/
 func HandleHTTPError(resp *http.Response, err error, message string, connectionDetails ConnectionDetailsHTTP) error {
 	if resp == nil {
 		// Response is nil in case of a timeout

--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -136,6 +136,7 @@ func HandleHTTPError(resp *http.Response, err error, message string, connectionD
 		// Response is nil in case of a timeout
 		log.Entry().WithError(err).WithField("ABAP Endpoint", connectionDetails.URL).Error("Request failed")
 	} else {
+		defer resp.Body.Close()
 		log.Entry().WithField("StatusCode", resp.Status).Error(message)
 
 		// Include the error message of the ABAP Environment system, if available
@@ -157,7 +158,6 @@ func HandleHTTPError(resp *http.Response, err error, message string, connectionD
 				err = errors.Wrap(abapError, err.Error())
 			}
 		}
-		resp.Body.Close()
 	}
 	return err
 }

--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -149,11 +149,13 @@ func HandleHTTPError(resp *http.Response, err error, message string, connectionD
 		if errUnmarshal != nil {
 			return err
 		}
-		json.Unmarshal(*abapResp["error"], &abapErrorResponse)
-		if (AbapError{}) != abapErrorResponse {
-			log.Entry().WithField("ErrorCode", abapErrorResponse.Code).Error(abapErrorResponse.Message.Value)
-			abapError := errors.New(abapErrorResponse.Code + " - " + abapErrorResponse.Message.Value)
-			err = errors.Wrap(abapError, err.Error())
+		if _, ok := abapResp["error"]; ok {
+			json.Unmarshal(*abapResp["error"], &abapErrorResponse)
+			if (AbapError{}) != abapErrorResponse {
+				log.Entry().WithField("ErrorCode", abapErrorResponse.Code).Error(abapErrorResponse.Message.Value)
+				abapError := errors.New(abapErrorResponse.Code + " - " + abapErrorResponse.Message.Value)
+				err = errors.Wrap(abapError, err.Error())
+			}
 		}
 		resp.Body.Close()
 	}

--- a/pkg/abaputils/abaputils_test.go
+++ b/pkg/abaputils/abaputils_test.go
@@ -327,7 +327,7 @@ func TestHandleHTTPError(t *testing.T) {
 
 		err := HandleHTTPError(&resp, receivedErr, message, ConnectionDetailsHTTP{})
 		assert.Error(t, err, "Error was expected")
-		assert.EqualError(t, err, fmt.Sprintf("%s: %s - %s", errorValue, abapErrorCode, abapErrorMessage))
+		assert.EqualError(t, err, fmt.Sprintf("%s: %s - %s", receivedErr.Error(), abapErrorCode, abapErrorMessage))
 		log.Entry().Info(err.Error())
 	})
 
@@ -347,7 +347,7 @@ func TestHandleHTTPError(t *testing.T) {
 
 		err := HandleHTTPError(&resp, receivedErr, message, ConnectionDetailsHTTP{})
 		assert.Error(t, err, "Error was expected")
-		assert.EqualError(t, err, fmt.Sprintf("%s", errorValue))
+		assert.EqualError(t, err, fmt.Sprintf("%s", receivedErr.Error()))
 		log.Entry().Info(err.Error())
 	})
 
@@ -367,7 +367,7 @@ func TestHandleHTTPError(t *testing.T) {
 
 		err := HandleHTTPError(&resp, receivedErr, message, ConnectionDetailsHTTP{})
 		assert.Error(t, err, "Error was expected")
-		assert.EqualError(t, err, fmt.Sprintf("%s", errorValue))
+		assert.EqualError(t, err, fmt.Sprintf("%s", receivedErr.Error()))
 		log.Entry().Info(err.Error())
 	})
 }

--- a/pkg/abaputils/abaputils_test.go
+++ b/pkg/abaputils/abaputils_test.go
@@ -311,7 +311,7 @@ repositories:
 func TestHandleHTTPError(t *testing.T) {
 	t.Run("Test", func(t *testing.T) {
 
-		errorValue := "HTTP 400"
+		errorValue := "Received Error"
 		abapErrorCode := "abapErrorCode"
 		abapErrorMessage := "abapErrorMessage"
 		bodyString := `{"error" : { "code" : "` + abapErrorCode + `", "message" : { "lang" : "en", "value" : "` + abapErrorMessage + `" } } }`
@@ -328,6 +328,26 @@ func TestHandleHTTPError(t *testing.T) {
 		err := HandleHTTPError(&resp, receivedErr, message, ConnectionDetailsHTTP{})
 		assert.Error(t, err, "Error was expected")
 		assert.EqualError(t, err, fmt.Sprintf("%s: %s - %s", errorValue, abapErrorCode, abapErrorMessage))
+		log.Entry().Info(err.Error())
+	})
+
+	t.Run("Non JSON Error", func(t *testing.T) {
+
+		errorValue := "Received Error"
+		bodyString := `Error message`
+		body := []byte(bodyString)
+
+		resp := http.Response{
+			Status:     "400 Bad Request",
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+		}
+		receivedErr := errors.New(errorValue)
+		message := "Custom Error Message"
+
+		err := HandleHTTPError(&resp, receivedErr, message, ConnectionDetailsHTTP{})
+		assert.Error(t, err, "Error was expected")
+		assert.EqualError(t, err, fmt.Sprintf("%s", errorValue))
 		log.Entry().Info(err.Error())
 	})
 }

--- a/pkg/abaputils/abaputils_test.go
+++ b/pkg/abaputils/abaputils_test.go
@@ -350,4 +350,24 @@ func TestHandleHTTPError(t *testing.T) {
 		assert.EqualError(t, err, fmt.Sprintf("%s", errorValue))
 		log.Entry().Info(err.Error())
 	})
+
+	t.Run("Different JSON Error", func(t *testing.T) {
+
+		errorValue := "Received Error"
+		bodyString := `{"abap" : { "key" : "value" } }`
+		body := []byte(bodyString)
+
+		resp := http.Response{
+			Status:     "400 Bad Request",
+			StatusCode: 400,
+			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+		}
+		receivedErr := errors.New(errorValue)
+		message := "Custom Error Message"
+
+		err := HandleHTTPError(&resp, receivedErr, message, ConnectionDetailsHTTP{})
+		assert.Error(t, err, "Error was expected")
+		assert.EqualError(t, err, fmt.Sprintf("%s", errorValue))
+		log.Entry().Info(err.Error())
+	})
 }


### PR DESCRIPTION
# Changes

- [X] Tests
- [X] Documentation

This change aims to avoid a runtime error, which was caused by an unsuccessful unmarshal.