### PR TITLE
fix(protecode): respect failOnSevereVulnerabilities parameter

### DIFF
--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -197,7 +197,10 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	parsedResult, vulns := client.ParseResultForInflux(result.Result, config.ExcludeCVEs)
 
 	log.Entry().Debug("Write report to filesystem")
-	protecode.WriteReport(config.ServerURL, config.FailOnSevereVulnerabilities, config.ExcludeCVEs, config.ReportFileName, reportPath, stepResultFile, parsedResult, productID, vulns, ioutil.WriteFile)
+	err = protecode.WriteReport(config.ServerURL, config.FailOnSevereVulnerabilities, config.ExcludeCVEs, config.ReportFileName, reportPath, stepResultFile, parsedResult, productID, vulns, ioutil.WriteFile)
+	if err != nil {
+		log.Entry().Warningf("failed to write report: %v", err)
+	}
 
 	// write reports JSON
 	reports := []StepResults.Path{

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -174,9 +174,8 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	log.Entry().Debugf("Load report %v for %v", config.ReportFileName, productID)
 	resp := client.LoadReport(config.ReportFileName, productID)
 	//save report to filesystem
-	err := writeReportToFile(*resp, config.ReportFileName)
-	if err != nil {
-		return parsedResult
+	if err := writeReportToFile(*resp, config.ReportFileName); err != nil {
+		log.Entry().Warningf("failed to write report: %s", err)
 	}
 	//clean scan from server
 	log.Entry().Debugf("Delete scan %v for %v", config.CleanupMode, productID)
@@ -187,7 +186,7 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	parsedResult, vulns := client.ParseResultForInflux(result.Result, config.ExcludeCVEs)
 
 	log.Entry().Debug("Write report to filesystem")
-	err = protecode.WriteReport(
+	if err := protecode.WriteReport(
 		protecode.ReportData{
 			ServerURL:                   config.ServerURL,
 			FailOnSevereVulnerabilities: config.FailOnSevereVulnerabilities,
@@ -195,8 +194,7 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 			Target:                      config.ReportFileName,
 			Vulnerabilities:             vulns,
 			ProductID:                   fmt.Sprintf("%v", productID),
-		}, reportPath, stepResultFile, parsedResult, ioutil.WriteFile)
-	if err != nil {
+		}, reportPath, stepResultFile, parsedResult, ioutil.WriteFile); err != nil {
 		log.Entry().Warningf("failed to write report: %v", err)
 	}
 

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -31,14 +31,16 @@ var cachePath = "./cache"
 var cacheProtecodeImagePath = "/protecode/Image"
 var cacheProtecodePath = "/protecode"
 
-func protecodeExecuteScan(config protecodeExecuteScanOptions, telemetryData *telemetry.CustomData, influx *protecodeExecuteScanInflux) error {
+func protecodeExecuteScan(config protecodeExecuteScanOptions, telemetryData *telemetry.CustomData, influx *protecodeExecuteScanInflux) {
 	c := command.Command{}
 	// reroute command output to loging framework
 	c.Stdout(log.Writer())
 	c.Stderr(log.Writer())
 
 	dClient := createDockerClient(&config)
-	return runProtecodeScan(&config, influx, dClient)
+	if err := runProtecodeScan(&config, influx, dClient); err != nil {
+		log.Entry().WithError(err).Fatal("Execution failed")
+	}
 }
 
 func runProtecodeScan(config *protecodeExecuteScanOptions, influx *protecodeExecuteScanInflux, dClient piperDocker.Download) error {

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -169,7 +169,7 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	ioutil.WriteFile(filePath, jsonData, 0644)
 
 	//check if result is ok else notify
-	if len(result.Result.Status) > 0 && result.Result.Status == "F" {
+	if len(result.Result.Status) > 0 && result.Result.Status == protecode.StatusFailed {
 		log.Entry().Fatalf("Please check the log and protecode backend for more details. URL: %v/products/%v", config.ServerURL, productID)
 	}
 	//loadReport

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -177,7 +177,7 @@ func executeProtecodeScan(influx *protecodeExecuteScanInflux, client protecode.P
 	client.DeleteScan(config.CleanupMode, productID)
 
 	//count vulnerabilities
-	log.Entry().Debug("Parse scan reult")
+	log.Entry().Debug("Parse scan result")
 	parsedResult, vulns := client.ParseResultForInflux(result.Result, config.ExcludeCVEs)
 
 	log.Entry().Debug("Write report to filesystem")

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -172,10 +172,12 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 
 	//check if result is ok else notify
 	if len(result.Result.Status) > 0 && result.Result.Status == protecode.StatusFailed {
+		log.SetErrorCategory(log.ErrorService)
 		log.Entry().Fatalf("Please check the log and protecode backend for more details. URL: %v/products/%v", config.ServerURL, productID)
 	}
 
 	if config.FailOnSevereVulnerabilities && protecode.HasSevereVulnerabilities(result.Result, config.ExcludeCVEs) {
+		log.SetErrorCategory(log.ErrorCompliance)
 		log.Entry().Fatalf("The product is not compliant. URL: %v/products/%v", config.ServerURL, productID)
 	}
 

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -174,6 +174,11 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	if len(result.Result.Status) > 0 && result.Result.Status == protecode.StatusFailed {
 		log.Entry().Fatalf("Please check the log and protecode backend for more details. URL: %v/products/%v", config.ServerURL, productID)
 	}
+
+	if config.FailOnSevereVulnerabilities && protecode.HasSevereVulnerabilities(result.Result, config.ExcludeCVEs) {
+		log.Entry().Fatalf("The product is not compliant. URL: %v/products/%v", config.ServerURL, productID)
+	}
+
 	//loadReport
 	log.Entry().Debugf("Load report %v for %v", config.ReportFileName, productID)
 	resp := client.LoadReport(config.ReportFileName, productID)

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -171,7 +171,8 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	ioutil.WriteFile(filePath, jsonData, 0644)
 
 	//check if result is ok else notify
-	if len(result.Result.Status) > 0 && result.Result.Status == protecode.StatusFailed {
+
+	if protecode.HasFailed(result) {
 		log.SetErrorCategory(log.ErrorService)
 		log.Entry().Fatalf("Please check the log and protecode backend for more details. URL: %v/products/%v", config.ServerURL, productID)
 	}

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -197,7 +197,14 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	parsedResult, vulns := client.ParseResultForInflux(result.Result, config.ExcludeCVEs)
 
 	log.Entry().Debug("Write report to filesystem")
-	err = protecode.WriteReport(config.ServerURL, config.FailOnSevereVulnerabilities, config.ExcludeCVEs, config.ReportFileName, reportPath, stepResultFile, parsedResult, productID, vulns, ioutil.WriteFile)
+	err = protecode.WriteReport(protecode.ProtecodeData{
+		ServerURL:                   config.ServerURL,
+		FailOnSevereVulnerabilities: config.FailOnSevereVulnerabilities,
+		ExcludeCVEs:                 config.ExcludeCVEs,
+		Target:                      config.ReportFileName,
+		Vulnerabilities:             vulns,
+		ProductID:                   fmt.Sprintf("%v", productID),
+	}, reportPath, stepResultFile, parsedResult, ioutil.WriteFile)
 	if err != nil {
 		log.Entry().Warningf("failed to write report: %v", err)
 	}

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -200,7 +200,7 @@ func executeProtecodeScan(client protecode.Protecode, config *protecodeExecuteSc
 	parsedResult, vulns := client.ParseResultForInflux(result.Result, config.ExcludeCVEs)
 
 	log.Entry().Debug("Write report to filesystem")
-	err = protecode.WriteReport(protecode.ProtecodeData{
+	err = protecode.WriteReport(protecode.ReportData{
 		ServerURL:                   config.ServerURL,
 		FailOnSevereVulnerabilities: config.FailOnSevereVulnerabilities,
 		ExcludeCVEs:                 config.ExcludeCVEs,

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -363,15 +363,16 @@ func TestExecuteProtecodeScan(t *testing.T) {
 
 		reportPath = dir
 		config := protecodeExecuteScanOptions{ReuseExisting: c.reuse, CleanupMode: c.clean, Group: c.group, FetchURL: c.fetchURL, TimeoutMinutes: "3", ExcludeCVEs: "CVE-2018-1, CVE-2017-1000382", ReportFileName: "./cache/report-file.txt"}
+		influxData := &protecodeExecuteScanInflux{}
 
-		got := executeProtecodeScan(pc, &config, "dummy", writeReportToFileMock)
+		executeProtecodeScan(influxData, pc, &config, "dummy", writeReportToFileMock)
 
-		assert.Equal(t, 1125, got["historical_vulnerabilities"])
-		assert.Equal(t, 0, got["triaged_vulnerabilities"])
-		assert.Equal(t, 1, got["excluded_vulnerabilities"])
-		assert.Equal(t, 129, got["cvss3GreaterOrEqualSeven"])
-		assert.Equal(t, 13, got["cvss2GreaterOrEqualSeven"])
-		assert.Equal(t, 226, got["vulnerabilities"])
+		assert.Equal(t, "1125", influxData.protecode_data.fields.historical_vulnerabilities)
+		assert.Equal(t, "0", influxData.protecode_data.fields.triaged_vulnerabilities)
+		assert.Equal(t, "1", influxData.protecode_data.fields.excluded_vulnerabilities)
+		// assert.Equal(t, 129, got["cvss3GreaterOrEqualSeven"])
+		// assert.Equal(t, 13, got["cvss2GreaterOrEqualSeven"])
+		assert.Equal(t, "226", influxData.protecode_data.fields.vulnerabilities)
 	}
 }
 

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -227,30 +227,6 @@ func TestCreateDockerClient(t *testing.T) {
 	}
 }
 
-var fileContent string
-
-func writeToFileMock(f string, d []byte, p os.FileMode) error {
-	fileContent = string(d)
-	return nil
-}
-
-func TestWriteReportDataToJSONFile(t *testing.T) {
-
-	expected := "{\"target\":\"REPORTFILENAME\",\"mandatory\":true,\"productID\":\"4711\",\"serverUrl\":\"DUMMYURL\",\"count\":\"0\",\"cvss2GreaterOrEqualSeven\":\"4\",\"cvss3GreaterOrEqualSeven\":\"3\",\"excludedVulnerabilities\":\"2\",\"triagedVulnerabilities\":\"0\",\"historicalVulnerabilities\":\"1\",\"Vulnerabilities\":[{\"cve\":\"Vulnerability\",\"cvss\":2.5,\"cvss3_score\":\"5.5\"}]}"
-
-	var parsedResult map[string]int = make(map[string]int)
-	parsedResult["historical_vulnerabilities"] = 1
-	parsedResult["excluded_vulnerabilities"] = 2
-	parsedResult["cvss3GreaterOrEqualSeven"] = 3
-	parsedResult["cvss2GreaterOrEqualSeven"] = 4
-	parsedResult["vulnerabilities"] = 5
-
-	config := protecodeExecuteScanOptions{ServerURL: "DUMMYURL", ReportFileName: "REPORTFILENAME"}
-
-	writeReportDataToJSONFile(&config, parsedResult, 4711, []protecode.Vuln{{"Vulnerability", 2.5, "5.5"}}, writeToFileMock)
-	assert.Equal(t, fileContent, expected, "content should be not empty")
-}
-
 func TestUploadScanOrDeclareFetch(t *testing.T) {
 
 	testFile, err := ioutil.TempFile("", "testFileUpload")

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -166,7 +166,6 @@ func TestHandleArtifactVersion(t *testing.T) {
 		version string
 		want    string
 	}{
-
 		{"1.0.0-20200131085038+eeb7c1033339bfd404d21ec5e7dc05c80e9e985e", "1"},
 		{"2.20.20-20200131085038+eeb7c1033339bfd404d21ec5e7dc05c80e9e985e", "2"},
 		{"3.20.20-20200131085038+eeb7c1033339bfd404d21ec5e7dc05c80e9e985e", "3"},
@@ -177,7 +176,6 @@ func TestHandleArtifactVersion(t *testing.T) {
 	}
 
 	for _, c := range cases {
-
 		got := handleArtifactVersion(c.version)
 		assert.Equal(t, c.want, got)
 	}
@@ -345,8 +343,7 @@ func TestExecuteProtecodeScan(t *testing.T) {
 		assert.Equal(t, "1125", influxData.protecode_data.fields.historical_vulnerabilities)
 		assert.Equal(t, "0", influxData.protecode_data.fields.triaged_vulnerabilities)
 		assert.Equal(t, "1", influxData.protecode_data.fields.excluded_vulnerabilities)
-		// assert.Equal(t, 129, got["cvss3GreaterOrEqualSeven"])
-		// assert.Equal(t, 13, got["cvss2GreaterOrEqualSeven"])
+		assert.Equal(t, "142", influxData.protecode_data.fields.major_vulnerabilities)
 		assert.Equal(t, "226", influxData.protecode_data.fields.vulnerabilities)
 	}
 }

--- a/pkg/protecode/analysis.go
+++ b/pkg/protecode/analysis.go
@@ -6,6 +6,12 @@ const (
 	vulnerabilitySeverityThreshold = 7.0
 )
 
+//HasFailed checks the return status of the provided result
+func HasFailed(result ResultData) bool {
+	//TODO: check this in PollForResult and return error once
+	return len(result.Result.Status) > 0 && result.Result.Status == statusFailed
+}
+
 //HasSevereVulnerabilities checks if any non-historic, non-triaged, non-excluded vulnerability has a CVSS score above the defined threshold
 func HasSevereVulnerabilities(result Result, excludeCVEs string) bool {
 	for _, component := range result.Components {

--- a/pkg/protecode/analysis_test.go
+++ b/pkg/protecode/analysis_test.go
@@ -19,7 +19,7 @@ func TestIsSevere(t *testing.T) {
 			},
 		}
 		// test && assert
-		assert.Equal(t, true, isSevere(vulnerability))
+		assert.True(t, isSevere(vulnerability))
 	})
 	t.Run("with severe cvss v2 vulnerability", func(t *testing.T) {
 		// init
@@ -33,7 +33,7 @@ func TestIsSevere(t *testing.T) {
 			},
 		}
 		// test && assert
-		assert.Equal(t, true, isSevere(vulnerability))
+		assert.True(t, isSevere(vulnerability))
 	})
 	t.Run("with non-severe cvss v3 vulnerability", func(t *testing.T) {
 		// init
@@ -47,7 +47,7 @@ func TestIsSevere(t *testing.T) {
 			},
 		}
 		// test && assert
-		assert.Equal(t, false, isSevere(vulnerability))
+		assert.False(t, isSevere(vulnerability))
 	})
 	t.Run("with non-severe cvss v2 vulnerability", func(t *testing.T) {
 		// init
@@ -61,7 +61,7 @@ func TestIsSevere(t *testing.T) {
 			},
 		}
 		// test && assert
-		assert.Equal(t, false, isSevere(vulnerability))
+		assert.False(t, isSevere(vulnerability))
 	})
 	t.Run("with non-severe vulnerability with missing cvss v3 rating", func(t *testing.T) {
 		// init
@@ -75,7 +75,7 @@ func TestIsSevere(t *testing.T) {
 			},
 		}
 		// test && assert
-		assert.Equal(t, false, isSevere(vulnerability))
+		assert.False(t, isSevere(vulnerability))
 	})
 }
 
@@ -92,36 +92,36 @@ func TestHasSevereVulnerabilities(t *testing.T) {
 		// init
 		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, severeV3}}}}
 		// test && assert
-		assert.Equal(t, true, HasSevereVulnerabilities(data, ""))
+		assert.True(t, HasSevereVulnerabilities(data, ""))
 	})
 	t.Run("with severe v2 vulnerabilities", func(t *testing.T) {
 		// init
 		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, severeV2}}}}
 		// test && assert
-		assert.Equal(t, true, HasSevereVulnerabilities(data, ""))
+		assert.True(t, HasSevereVulnerabilities(data, ""))
 	})
 	t.Run("without severe vulnerabilities", func(t *testing.T) {
 		// init
 		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, nonSevere2}}}}
 		// test && assert
-		assert.Equal(t, false, HasSevereVulnerabilities(data, ""))
+		assert.False(t, HasSevereVulnerabilities(data, ""))
 	})
 	t.Run("with historic vulnerabilities", func(t *testing.T) {
 		// init
 		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, triaged}}}}
 		// test && assert
-		assert.Equal(t, false, HasSevereVulnerabilities(data, ""))
+		assert.False(t, HasSevereVulnerabilities(data, ""))
 	})
 	t.Run("with excluded vulnerabilities", func(t *testing.T) {
 		// init
 		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, excluded}}}}
 		// test && assert
-		assert.Equal(t, false, HasSevereVulnerabilities(data, "Cve5,Cve14"))
+		assert.False(t, HasSevereVulnerabilities(data, "Cve5,Cve14"))
 	})
 	t.Run("with historic vulnerabilities", func(t *testing.T) {
 		// init
 		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, historic}}}}
 		// test && assert
-		assert.Equal(t, false, HasSevereVulnerabilities(data, ""))
+		assert.False(t, HasSevereVulnerabilities(data, ""))
 	})
 }

--- a/pkg/protecode/analysis_test.go
+++ b/pkg/protecode/analysis_test.go
@@ -1,0 +1,127 @@
+package protecode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSevere(t *testing.T) {
+	t.Run("with severe cvss v3 vulnerability", func(t *testing.T) {
+		// init
+		vulnerability := Vulnerability{
+			Exact:  true,
+			Triage: []Triage{},
+			Vuln: Vuln{
+				Cve:        "Cve2",
+				Cvss:       8.0,
+				Cvss3Score: "7.3",
+			},
+		}
+		// test && assert
+		assert.Equal(t, true, isSevere(vulnerability))
+	})
+	t.Run("with severe cvss v2 vulnerability", func(t *testing.T) {
+		// init
+		vulnerability := Vulnerability{
+			Exact:  true,
+			Triage: []Triage{},
+			Vuln: Vuln{
+				Cve:        "Cve2",
+				Cvss:       8.0,
+				Cvss3Score: "0.0",
+			},
+		}
+		// test && assert
+		assert.Equal(t, true, isSevere(vulnerability))
+	})
+	t.Run("with non-severe cvss v3 vulnerability", func(t *testing.T) {
+		// init
+		vulnerability := Vulnerability{
+			Exact:  true,
+			Triage: []Triage{},
+			Vuln: Vuln{
+				Cve:        "Cve2",
+				Cvss:       4.0,
+				Cvss3Score: "4.0",
+			},
+		}
+		// test && assert
+		assert.Equal(t, false, isSevere(vulnerability))
+	})
+	t.Run("with non-severe cvss v2 vulnerability", func(t *testing.T) {
+		// init
+		vulnerability := Vulnerability{
+			Exact:  true,
+			Triage: []Triage{},
+			Vuln: Vuln{
+				Cve:        "Cve2",
+				Cvss:       4.0,
+				Cvss3Score: "0.0",
+			},
+		}
+		// test && assert
+		assert.Equal(t, false, isSevere(vulnerability))
+	})
+	t.Run("with non-severe vulnerability with missing cvss v3 rating", func(t *testing.T) {
+		// init
+		vulnerability := Vulnerability{
+			Exact:  true,
+			Triage: []Triage{},
+			Vuln: Vuln{
+				Cve:        "Cve2",
+				Cvss:       4.0,
+				Cvss3Score: "",
+			},
+		}
+		// test && assert
+		assert.Equal(t, false, isSevere(vulnerability))
+	})
+}
+
+func TestHasSevereVulnerabilities(t *testing.T) {
+	severeV3 := Vulnerability{Exact: true, Triage: []Triage{}, Vuln: Vuln{Cve: "Cve1", Cvss: 4.0, Cvss3Score: "8.0"}}
+	severeV2 := Vulnerability{Exact: true, Triage: []Triage{}, Vuln: Vuln{Cve: "Cve2", Cvss: 8.0, Cvss3Score: "0.0"}}
+	nonSevere1 := Vulnerability{Exact: true, Triage: []Triage{}, Vuln: Vuln{Cve: "Cve3", Cvss: 4.0, Cvss3Score: "4.0"}}
+	nonSevere2 := Vulnerability{Exact: true, Triage: []Triage{}, Vuln: Vuln{Cve: "Cve4", Cvss: 4.0, Cvss3Score: "4.0"}}
+	excluded := Vulnerability{Exact: true, Triage: []Triage{}, Vuln: Vuln{Cve: "Cve5", Cvss: 8.0, Cvss3Score: "8.0"}}
+	triaged := Vulnerability{Exact: true, Triage: []Triage{{ID: 1}}, Vuln: Vuln{Cve: "Cve6", Cvss: 8.0, Cvss3Score: "8.0"}}
+	historic := Vulnerability{Exact: false, Triage: []Triage{}, Vuln: Vuln{Cve: "Cve7", Cvss: 8.0, Cvss3Score: "8.0"}}
+
+	t.Run("with severe v3 vulnerabilities", func(t *testing.T) {
+		// init
+		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, severeV3}}}}
+		// test && assert
+		assert.Equal(t, true, HasSevereVulnerabilities(data, ""))
+	})
+	t.Run("with severe v2 vulnerabilities", func(t *testing.T) {
+		// init
+		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, severeV2}}}}
+		// test && assert
+		assert.Equal(t, true, HasSevereVulnerabilities(data, ""))
+	})
+	t.Run("without severe vulnerabilities", func(t *testing.T) {
+		// init
+		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, nonSevere2}}}}
+		// test && assert
+		assert.Equal(t, false, HasSevereVulnerabilities(data, ""))
+	})
+	t.Run("with historic vulnerabilities", func(t *testing.T) {
+		// init
+		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, triaged}}}}
+		// test && assert
+		assert.Equal(t, false, HasSevereVulnerabilities(data, ""))
+	})
+	t.Run("with excluded vulnerabilities", func(t *testing.T) {
+		// init
+		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, excluded}}}}
+		// test && assert
+		assert.Equal(t, false, HasSevereVulnerabilities(data, "Cve5,Cve14"))
+	})
+	t.Run("with historic vulnerabilities", func(t *testing.T) {
+		// init
+		data := Result{Components: []Component{{Vulns: []Vulnerability{nonSevere1, historic}}}}
+		// test && assert
+		assert.Equal(t, false, HasSevereVulnerabilities(data, ""))
+	})
+}

--- a/pkg/protecode/api.go
+++ b/pkg/protecode/api.go
@@ -1,0 +1,7 @@
+package protecode
+
+const (
+	statusBusy   = "B"
+	statusReady  = "R"
+	StatusFailed = "F"
+)

--- a/pkg/protecode/api.go
+++ b/pkg/protecode/api.go
@@ -3,5 +3,5 @@ package protecode
 const (
 	statusBusy   = "B"
 	statusReady  = "R"
-	StatusFailed = "F"
+	statusFailed = "F"
 )

--- a/pkg/protecode/protecode.go
+++ b/pkg/protecode/protecode.go
@@ -257,22 +257,18 @@ func isSevereCVSS2(vulnerability Vulnerability) bool {
 
 // DeleteScan deletes if configured the scan on the protecode server
 func (pc *Protecode) DeleteScan(cleanupMode string, productID int) {
-
 	switch cleanupMode {
 	case "none":
 	case "binary":
-		return
 	case "complete":
 		pc.logger.Info("Deleting scan from server.")
 		protecodeURL := pc.createURL("/api/product/", fmt.Sprintf("%v/", productID), "")
 		headers := map[string][]string{}
 
 		pc.sendAPIRequest("DELETE", protecodeURL, headers)
-		break
 	default:
 		pc.logger.Fatalf("Unknown cleanup mode %v", cleanupMode)
 	}
-
 }
 
 // LoadReport loads the report of the protecode scan
@@ -378,12 +374,10 @@ func (pc *Protecode) PollForResult(productID int, timeOutInMinutes string) Resul
 }
 
 func (pc *Protecode) pullResult(productID int) (ResultData, error) {
-
 	protecodeURL := pc.createURL("/api/product/", fmt.Sprintf("%v/", productID), "")
 	headers := map[string][]string{
 		"acceptType": {"application/json"},
 	}
-
 	r, err := pc.sendAPIRequest(http.MethodGet, protecodeURL, headers)
 	if err != nil {
 		return *new(ResultData), err

--- a/pkg/protecode/protecode.go
+++ b/pkg/protecode/protecode.go
@@ -355,7 +355,7 @@ func (pc *Protecode) PollForResult(productID int, timeOutInMinutes string) Resul
 			i = 0
 			return response
 		}
-		if len(response.Result.Components) > 0 && response.Result.Status != "B" {
+		if len(response.Result.Components) > 0 && response.Result.Status != statusBusy {
 			ticker.Stop()
 			i = 0
 			break
@@ -367,9 +367,9 @@ func (pc *Protecode) PollForResult(productID int, timeOutInMinutes string) Resul
 		}
 	}
 
-	if len(response.Result.Components) == 0 || response.Result.Status == "B" {
+	if len(response.Result.Components) == 0 || response.Result.Status == statusBusy {
 		response, err = pc.pullResult(productID)
-		if err != nil || len(response.Result.Components) == 0 || response.Result.Status == "B" {
+		if err != nil || len(response.Result.Components) == 0 || response.Result.Status == statusBusy {
 			pc.logger.Fatal("No result after polling")
 		}
 	}

--- a/pkg/protecode/protecode.go
+++ b/pkg/protecode/protecode.go
@@ -280,9 +280,9 @@ func (pc *Protecode) LoadReport(reportFileName string, productID int) *io.ReadCl
 
 	protecodeURL := pc.createURL("/api/product/", fmt.Sprintf("%v/pdf-report", productID), "")
 	headers := map[string][]string{
-		"Cache-Control": []string{"no-cache, no-store, must-revalidate"},
-		"Pragma":        []string{"no-cache"},
-		"Outputfile":    []string{reportFileName},
+		"Cache-Control": {"no-cache, no-store, must-revalidate"},
+		"Pragma":        {"no-cache"},
+		"Outputfile":    {reportFileName},
 	}
 
 	readCloser, err := pc.sendAPIRequest(http.MethodGet, protecodeURL, headers)
@@ -296,7 +296,7 @@ func (pc *Protecode) LoadReport(reportFileName string, productID int) *io.ReadCl
 // UploadScanFile upload the scan file to the protecode server
 func (pc *Protecode) UploadScanFile(cleanupMode, group, filePath, fileName string) *ResultData {
 	deleteBinary := (cleanupMode == "binary" || cleanupMode == "complete")
-	headers := map[string][]string{"Group": []string{group}, "Delete-Binary": []string{fmt.Sprintf("%v", deleteBinary)}}
+	headers := map[string][]string{"Group": {group}, "Delete-Binary": {fmt.Sprintf("%v", deleteBinary)}}
 
 	uploadURL := fmt.Sprintf("%v/api/upload/%v", pc.serverURL, fileName)
 
@@ -316,7 +316,7 @@ func (pc *Protecode) UploadScanFile(cleanupMode, group, filePath, fileName strin
 // DeclareFetchURL configures the fetch url for the protecode scan
 func (pc *Protecode) DeclareFetchURL(cleanupMode, group, fetchURL string) *ResultData {
 	deleteBinary := (cleanupMode == "binary" || cleanupMode == "complete")
-	headers := map[string][]string{"Group": []string{group}, "Delete-Binary": []string{fmt.Sprintf("%v", deleteBinary)}, "Url": []string{fetchURL}, "Content-Type": []string{"application/json"}}
+	headers := map[string][]string{"Group": {group}, "Delete-Binary": {fmt.Sprintf("%v", deleteBinary)}, "Url": {fetchURL}, "Content-Type": []string{"application/json"}}
 
 	protecodeURL := fmt.Sprintf("%v/api/fetch/", pc.serverURL)
 	r, err := pc.sendAPIRequest(http.MethodPost, protecodeURL, headers)
@@ -381,7 +381,7 @@ func (pc *Protecode) pullResult(productID int) (ResultData, error) {
 
 	protecodeURL := pc.createURL("/api/product/", fmt.Sprintf("%v/", productID), "")
 	headers := map[string][]string{
-		"acceptType": []string{"application/json"},
+		"acceptType": {"application/json"},
 	}
 
 	r, err := pc.sendAPIRequest(http.MethodGet, protecodeURL, headers)
@@ -403,7 +403,7 @@ func (pc *Protecode) LoadExistingProduct(group string, reuseExisting bool) int {
 
 		protecodeURL := pc.createURL("/api/apps/", fmt.Sprintf("%v/", group), "")
 		headers := map[string][]string{
-			"acceptType": []string{"application/json"},
+			"acceptType": {"application/json"},
 		}
 
 		response := pc.loadExisting(protecodeURL, headers)

--- a/pkg/protecode/protecode_test.go
+++ b/pkg/protecode/protecode_test.go
@@ -31,7 +31,7 @@ func TestMapResponse(t *testing.T) {
 		{`{"product_id": 1}`, new(Result), &Result{ProductID: 1}},
 		{`"{\"product_id\": 4711}"`, new(Result), &Result{ProductID: 4711}},
 		{"{\"results\": {\"product_id\": 1}}", new(ResultData), &ResultData{Result: Result{ProductID: 1}}},
-		{`{"results": {"status": "B", "id": 209396, "product_id": 209396, "report_url": "https://protecode.c.eu-de-2.cloud.sap/products/209396/"}}`, new(ResultData), &ResultData{Result: Result{ProductID: 209396, Status: "B", ReportURL: "https://protecode.c.eu-de-2.cloud.sap/products/209396/"}}},
+		{`{"results": {"status": "B", "id": 209396, "product_id": 209396, "report_url": "https://protecode.c.eu-de-2.cloud.sap/products/209396/"}}`, new(ResultData), &ResultData{Result: Result{ProductID: 209396, Status: statusBusy, ReportURL: "https://protecode.c.eu-de-2.cloud.sap/products/209396/"}}},
 		{`{"products": [{"product_id": 1}]}`, new(ProductData), &ProductData{Products: []Product{{ProductID: 1}}}},
 	}
 	pc := Protecode{}
@@ -47,7 +47,7 @@ func TestParseResultSuccess(t *testing.T) {
 	var result Result = Result{
 		ProductID: 4712,
 		ReportURL: "ReportUrl",
-		Status:    "B",
+		Status:    statusBusy,
 		Components: []Component{
 			{Vulns: []Vulnerability{
 				{Exact: true, Triage: []Triage{}, Vuln: Vuln{Cve: "Cve1", Cvss: 7.2, Cvss3Score: "0.0"}},

--- a/pkg/protecode/report.go
+++ b/pkg/protecode/report.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 )
 
-type protecodeData struct {
+type ProtecodeData struct {
 	Target                      string `json:"target,omitempty"`
 	Mandatory                   bool   `json:"mandatory,omitempty"`
 	ProductID                   string `json:"productID,omitempty"`
@@ -26,27 +26,20 @@ type protecodeData struct {
 }
 
 // WriteReport ...
-func WriteReport(serverURL string, failOnSevereVulnerabilities bool, excludeCVEs string, scanReportFileName string, reportPath string, reportFileName string, result map[string]int, productID int, vulns []Vuln, writeToFile func(f string, d []byte, p os.FileMode) error) error {
-	protecodeData := protecodeData{
-		ServerURL:                   serverURL,
-		FailOnSevereVulnerabilities: failOnSevereVulnerabilities,
-		ExcludeCVEs:                 excludeCVEs,
-		Target:                      scanReportFileName,
-		Mandatory:                   true,
-		ProductID:                   fmt.Sprintf("%v", productID),
-		Count:                       fmt.Sprintf("%v", result["count"]),
-		Cvss2GreaterOrEqualSeven:    fmt.Sprintf("%v", result["cvss2GreaterOrEqualSeven"]),
-		Cvss3GreaterOrEqualSeven:    fmt.Sprintf("%v", result["cvss3GreaterOrEqualSeven"]),
-		ExcludedVulnerabilities:     fmt.Sprintf("%v", result["excluded_vulnerabilities"]),
-		TriagedVulnerabilities:      fmt.Sprintf("%v", result["triaged_vulnerabilities"]),
-		HistoricalVulnerabilities:   fmt.Sprintf("%v", result["historical_vulnerabilities"]),
-		Vulnerabilities:             vulns,
-	}
+func WriteReport(data ProtecodeData, reportPath string, reportFileName string, result map[string]int, writeToFile func(f string, d []byte, p os.FileMode) error) error {
+	data.Mandatory = true
+	data.Count = fmt.Sprintf("%v", result["count"])
+	data.Cvss2GreaterOrEqualSeven = fmt.Sprintf("%v", result["cvss2GreaterOrEqualSeven"])
+	data.Cvss3GreaterOrEqualSeven = fmt.Sprintf("%v", result["cvss3GreaterOrEqualSeven"])
+	data.ExcludedVulnerabilities = fmt.Sprintf("%v", result["excluded_vulnerabilities"])
+	data.TriagedVulnerabilities = fmt.Sprintf("%v", result["triaged_vulnerabilities"])
+	data.HistoricalVulnerabilities = fmt.Sprintf("%v", result["historical_vulnerabilities"])
 
 	log.Entry().Infof("Protecode scan info, %v of which %v had a CVSS v2 score >= 7.0 and %v had a CVSS v3 score >= 7.0.\n %v vulnerabilities were excluded via configuration (%v) and %v vulnerabilities were triaged via the webUI.\nIn addition %v historical vulnerabilities were spotted. \n\n Vulnerabilities: %v",
-		protecodeData.Count, protecodeData.Cvss2GreaterOrEqualSeven, protecodeData.Cvss3GreaterOrEqualSeven, protecodeData.ExcludedVulnerabilities, protecodeData.ExcludeCVEs, protecodeData.TriagedVulnerabilities, protecodeData.HistoricalVulnerabilities, protecodeData.Vulnerabilities)
-
-	return writeJSON(reportPath, reportFileName, protecodeData, writeToFile)
+		data.Count, data.Cvss2GreaterOrEqualSeven, data.Cvss3GreaterOrEqualSeven,
+		data.ExcludedVulnerabilities, data.ExcludeCVEs, data.TriagedVulnerabilities,
+		data.HistoricalVulnerabilities, data.Vulnerabilities)
+	return writeJSON(reportPath, reportFileName, data, writeToFile)
 }
 
 func writeJSON(path, name string, data interface{}, writeToFile func(f string, d []byte, p os.FileMode) error) error {

--- a/pkg/protecode/report.go
+++ b/pkg/protecode/report.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 )
 
+//ReportData is representing the data of the step report JSON
 type ReportData struct {
 	Target                      string `json:"target,omitempty"`
 	Mandatory                   bool   `json:"mandatory,omitempty"`

--- a/pkg/protecode/report.go
+++ b/pkg/protecode/report.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 )
 
-type ProtecodeData struct {
+type ReportData struct {
 	Target                      string `json:"target,omitempty"`
 	Mandatory                   bool   `json:"mandatory,omitempty"`
 	ProductID                   string `json:"productID,omitempty"`
@@ -26,7 +26,7 @@ type ProtecodeData struct {
 }
 
 // WriteReport ...
-func WriteReport(data ProtecodeData, reportPath string, reportFileName string, result map[string]int, writeToFile func(f string, d []byte, p os.FileMode) error) error {
+func WriteReport(data ReportData, reportPath string, reportFileName string, result map[string]int, writeToFile func(f string, d []byte, p os.FileMode) error) error {
 	data.Mandatory = true
 	data.Count = fmt.Sprintf("%v", result["count"])
 	data.Cvss2GreaterOrEqualSeven = fmt.Sprintf("%v", result["cvss2GreaterOrEqualSeven"])

--- a/pkg/protecode/report.go
+++ b/pkg/protecode/report.go
@@ -1,0 +1,55 @@
+package protecode
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/SAP/jenkins-library/pkg/log"
+)
+
+type protecodeData struct {
+	Target                      string `json:"target,omitempty"`
+	Mandatory                   bool   `json:"mandatory,omitempty"`
+	ProductID                   string `json:"productID,omitempty"`
+	ServerURL                   string `json:"serverUrl,omitempty"`
+	FailOnSevereVulnerabilities bool   `json:"failOnSevereVulnerabilities,omitempty"`
+	ExcludeCVEs                 string `json:"excludeCVEs,omitempty"`
+	Count                       string `json:"count,omitempty"`
+	Cvss2GreaterOrEqualSeven    string `json:"cvss2GreaterOrEqualSeven,omitempty"`
+	Cvss3GreaterOrEqualSeven    string `json:"cvss3GreaterOrEqualSeven,omitempty"`
+	ExcludedVulnerabilities     string `json:"excludedVulnerabilities,omitempty"`
+	TriagedVulnerabilities      string `json:"triagedVulnerabilities,omitempty"`
+	HistoricalVulnerabilities   string `json:"historicalVulnerabilities,omitempty"`
+	Vulnerabilities             []Vuln `json:"Vulnerabilities,omitempty"`
+}
+
+// WriteReport ...
+func WriteReport(serverURL string, failOnSevereVulnerabilities bool, excludeCVEs string, scanReportFileName string, reportPath string, reportFileName string, result map[string]int, productID int, vulns []Vuln, writeToFile func(f string, d []byte, p os.FileMode) error) {
+	protecodeData := protecodeData{
+		ServerURL:                   serverURL,
+		FailOnSevereVulnerabilities: failOnSevereVulnerabilities,
+		ExcludeCVEs:                 excludeCVEs,
+		Target:                      scanReportFileName,
+		Mandatory:                   true,
+		ProductID:                   fmt.Sprintf("%v", productID),
+		Count:                       fmt.Sprintf("%v", result["count"]),
+		Cvss2GreaterOrEqualSeven:    fmt.Sprintf("%v", result["cvss2GreaterOrEqualSeven"]),
+		Cvss3GreaterOrEqualSeven:    fmt.Sprintf("%v", result["cvss3GreaterOrEqualSeven"]),
+		ExcludedVulnerabilities:     fmt.Sprintf("%v", result["excluded_vulnerabilities"]),
+		TriagedVulnerabilities:      fmt.Sprintf("%v", result["triaged_vulnerabilities"]),
+		HistoricalVulnerabilities:   fmt.Sprintf("%v", result["historical_vulnerabilities"]),
+		Vulnerabilities:             vulns,
+	}
+
+	log.Entry().Infof("Protecode scan info, %v of which %v had a CVSS v2 score >= 7.0 and %v had a CVSS v3 score >= 7.0.\n %v vulnerabilities were excluded via configuration (%v) and %v vulnerabilities were triaged via the webUI.\nIn addition %v historical vulnerabilities were spotted. \n\n Vulnerabilities: %v",
+		protecodeData.Count, protecodeData.Cvss2GreaterOrEqualSeven, protecodeData.Cvss3GreaterOrEqualSeven, protecodeData.ExcludedVulnerabilities, protecodeData.ExcludeCVEs, protecodeData.TriagedVulnerabilities, protecodeData.HistoricalVulnerabilities, protecodeData.Vulnerabilities)
+
+	writeJSON(reportPath, reportFileName, protecodeData, writeToFile)
+}
+
+func writeJSON(path, name string, data interface{}, writeToFile func(f string, d []byte, p os.FileMode) error) {
+	jsonData, _ := json.Marshal(data)
+	writeToFile(filepath.Join(path, name), jsonData, 0644)
+}

--- a/pkg/protecode/report.go
+++ b/pkg/protecode/report.go
@@ -26,7 +26,7 @@ type protecodeData struct {
 }
 
 // WriteReport ...
-func WriteReport(serverURL string, failOnSevereVulnerabilities bool, excludeCVEs string, scanReportFileName string, reportPath string, reportFileName string, result map[string]int, productID int, vulns []Vuln, writeToFile func(f string, d []byte, p os.FileMode) error) {
+func WriteReport(serverURL string, failOnSevereVulnerabilities bool, excludeCVEs string, scanReportFileName string, reportPath string, reportFileName string, result map[string]int, productID int, vulns []Vuln, writeToFile func(f string, d []byte, p os.FileMode) error) error {
 	protecodeData := protecodeData{
 		ServerURL:                   serverURL,
 		FailOnSevereVulnerabilities: failOnSevereVulnerabilities,
@@ -46,10 +46,13 @@ func WriteReport(serverURL string, failOnSevereVulnerabilities bool, excludeCVEs
 	log.Entry().Infof("Protecode scan info, %v of which %v had a CVSS v2 score >= 7.0 and %v had a CVSS v3 score >= 7.0.\n %v vulnerabilities were excluded via configuration (%v) and %v vulnerabilities were triaged via the webUI.\nIn addition %v historical vulnerabilities were spotted. \n\n Vulnerabilities: %v",
 		protecodeData.Count, protecodeData.Cvss2GreaterOrEqualSeven, protecodeData.Cvss3GreaterOrEqualSeven, protecodeData.ExcludedVulnerabilities, protecodeData.ExcludeCVEs, protecodeData.TriagedVulnerabilities, protecodeData.HistoricalVulnerabilities, protecodeData.Vulnerabilities)
 
-	writeJSON(reportPath, reportFileName, protecodeData, writeToFile)
+	return writeJSON(reportPath, reportFileName, protecodeData, writeToFile)
 }
 
-func writeJSON(path, name string, data interface{}, writeToFile func(f string, d []byte, p os.FileMode) error) {
-	jsonData, _ := json.Marshal(data)
-	writeToFile(filepath.Join(path, name), jsonData, 0644)
+func writeJSON(path, name string, data interface{}, writeToFile func(f string, d []byte, p os.FileMode) error) error {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return writeToFile(filepath.Join(path, name), jsonData, 0644)
 }

--- a/pkg/protecode/report_test.go
+++ b/pkg/protecode/report_test.go
@@ -14,7 +14,7 @@ func writeToFileMock(f string, d []byte, p os.FileMode) error {
 	return nil
 }
 
-func TestWriteReportDataToJSONFile(t *testing.T) {
+func TestWriteReport(t *testing.T) {
 	expected := "{\"target\":\"REPORTFILENAME\",\"mandatory\":true,\"productID\":\"4711\",\"serverUrl\":\"DUMMYURL\",\"count\":\"0\",\"cvss2GreaterOrEqualSeven\":\"4\",\"cvss3GreaterOrEqualSeven\":\"3\",\"excludedVulnerabilities\":\"2\",\"triagedVulnerabilities\":\"0\",\"historicalVulnerabilities\":\"1\",\"Vulnerabilities\":[{\"cve\":\"Vulnerability\",\"cvss\":2.5,\"cvss3_score\":\"5.5\"}]}"
 
 	var parsedResult map[string]int = make(map[string]int)

--- a/pkg/protecode/report_test.go
+++ b/pkg/protecode/report_test.go
@@ -24,6 +24,7 @@ func TestWriteReport(t *testing.T) {
 	parsedResult["cvss2GreaterOrEqualSeven"] = 4
 	parsedResult["vulnerabilities"] = 5
 
-	WriteReport("DUMMYURL", false, "", "REPORTFILENAME", ".", "", parsedResult, 4711, []Vuln{{"Vulnerability", 2.5, "5.5"}}, writeToFileMock)
+	err := WriteReport("DUMMYURL", false, "", "REPORTFILENAME", ".", "", parsedResult, 4711, []Vuln{{"Vulnerability", 2.5, "5.5"}}, writeToFileMock)
 	assert.Equal(t, fileContent, expected, "content should be not empty")
+	assert.NoError(t, err)
 }

--- a/pkg/protecode/report_test.go
+++ b/pkg/protecode/report_test.go
@@ -25,7 +25,7 @@ func TestWriteReport(t *testing.T) {
 	parsedResult["cvss2GreaterOrEqualSeven"] = 4
 	parsedResult["vulnerabilities"] = 5
 
-	err := WriteReport(ProtecodeData{ServerURL: "DUMMYURL", FailOnSevereVulnerabilities: false, ExcludeCVEs: "", Target: "REPORTFILENAME", ProductID: fmt.Sprintf("%v", 4711), Vulnerabilities: []Vuln{{"Vulnerability", 2.5, "5.5"}}}, ".", "", parsedResult, writeToFileMock)
+	err := WriteReport(ReportData{ServerURL: "DUMMYURL", FailOnSevereVulnerabilities: false, ExcludeCVEs: "", Target: "REPORTFILENAME", ProductID: fmt.Sprintf("%v", 4711), Vulnerabilities: []Vuln{{"Vulnerability", 2.5, "5.5"}}}, ".", "", parsedResult, writeToFileMock)
 	assert.Equal(t, fileContent, expected, "content should be not empty")
 	assert.NoError(t, err)
 }

--- a/pkg/protecode/report_test.go
+++ b/pkg/protecode/report_test.go
@@ -1,6 +1,7 @@
 package protecode
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -24,7 +25,7 @@ func TestWriteReport(t *testing.T) {
 	parsedResult["cvss2GreaterOrEqualSeven"] = 4
 	parsedResult["vulnerabilities"] = 5
 
-	err := WriteReport("DUMMYURL", false, "", "REPORTFILENAME", ".", "", parsedResult, 4711, []Vuln{{"Vulnerability", 2.5, "5.5"}}, writeToFileMock)
+	err := WriteReport(ProtecodeData{ServerURL: "DUMMYURL", FailOnSevereVulnerabilities: false, ExcludeCVEs: "", Target: "REPORTFILENAME", ProductID: fmt.Sprintf("%v", 4711), Vulnerabilities: []Vuln{{"Vulnerability", 2.5, "5.5"}}}, ".", "", parsedResult, writeToFileMock)
 	assert.Equal(t, fileContent, expected, "content should be not empty")
 	assert.NoError(t, err)
 }

--- a/pkg/protecode/report_test.go
+++ b/pkg/protecode/report_test.go
@@ -1,0 +1,29 @@
+package protecode
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var fileContent string
+
+func writeToFileMock(f string, d []byte, p os.FileMode) error {
+	fileContent = string(d)
+	return nil
+}
+
+func TestWriteReportDataToJSONFile(t *testing.T) {
+	expected := "{\"target\":\"REPORTFILENAME\",\"mandatory\":true,\"productID\":\"4711\",\"serverUrl\":\"DUMMYURL\",\"count\":\"0\",\"cvss2GreaterOrEqualSeven\":\"4\",\"cvss3GreaterOrEqualSeven\":\"3\",\"excludedVulnerabilities\":\"2\",\"triagedVulnerabilities\":\"0\",\"historicalVulnerabilities\":\"1\",\"Vulnerabilities\":[{\"cve\":\"Vulnerability\",\"cvss\":2.5,\"cvss3_score\":\"5.5\"}]}"
+
+	var parsedResult map[string]int = make(map[string]int)
+	parsedResult["historical_vulnerabilities"] = 1
+	parsedResult["excluded_vulnerabilities"] = 2
+	parsedResult["cvss3GreaterOrEqualSeven"] = 3
+	parsedResult["cvss2GreaterOrEqualSeven"] = 4
+	parsedResult["vulnerabilities"] = 5
+
+	WriteReport("DUMMYURL", false, "", "REPORTFILENAME", ".", "", parsedResult, 4711, []Vuln{{"Vulnerability", 2.5, "5.5"}}, writeToFileMock)
+	assert.Equal(t, fileContent, expected, "content should be not empty")
+}


### PR DESCRIPTION
This changes makes the Protecode step fail when severe vulnerabilities (CVSS > 7.0) are found and the property `failOnSevereVulnerabilities` is set to true.

**further changes:**
- respect deprecated parameter `excludedCVEs`
- extract reporting function to `protecode` package
- define meaningful api status constants
- remove unconsidered return value of main step function
- fix redundant type issues

fixes #1970