### PR TITLE
fix(protecode): correct project naming

### DIFF
--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -130,16 +130,6 @@ func getDockerImage(dClient piperDocker.Download, config *protecodeExecuteScanOp
 	return fileName, resultFilePath
 }
 
-func getTarName(config *protecodeExecuteScanOptions) string {
-	// remove original version
-	fileName := strings.TrimSuffix(config.ScanImage, ":"+config.ArtifactVersion)
-	// append trimmed version
-	fileName = fileName + "_" + handleArtifactVersion(config.ArtifactVersion)
-	// replace unwanted chars
-	fileName = strings.ReplaceAll(fileName, "/", "_")
-	return fileName + ".tar"
-}
-
 func executeProtecodeScan(influx *protecodeExecuteScanInflux, client protecode.Protecode, config *protecodeExecuteScanOptions, fileName string, writeReportToFile func(resp io.ReadCloser, reportFileName string) error) error {
 	//load existing product by filename
 	log.Entry().Debugf("Load existing product Group:%v Reuse:%v", config.Group, config.ReuseExisting)
@@ -326,4 +316,16 @@ func correctDockerConfigEnvVar(config *protecodeExecuteScanOptions) {
 	} else {
 		log.Entry().Info("Docker credentials configuration: NONE")
 	}
+}
+
+func getTarName(config *protecodeExecuteScanOptions) string {
+	// remove original version
+	fileName := strings.TrimSuffix(config.ScanImage, ":"+config.ArtifactVersion)
+	// append trimmed version
+	if version := handleArtifactVersion(config.ArtifactVersion); len(version) > 0 {
+		fileName = fileName + "_" + version
+	}
+	// replace unwanted chars
+	fileName = strings.ReplaceAll(fileName, "/", "_")
+	return fileName + ".tar"
 }

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -382,3 +382,28 @@ func TestCorrectDockerConfigEnvVar(t *testing.T) {
 		assert.Equal(t, resetValue, os.Getenv("DOCKER_CONFIG"))
 	})
 }
+
+func TestGetTarName(t *testing.T) {
+	cases := map[string]struct {
+		image   string
+		version string
+		expect  string
+	}{
+		"with version suffix": {
+			"com.sap.piper/sample-k8s-app-multistage:1.11-20200902040158_97a5cc34f1796ad735159f020dd55c0f3670a4cb",
+			"1.11-20200902040158_97a5cc34f1796ad735159f020dd55c0f3670a4cb",
+			"com.sap.piper_sample-k8s-app-multistage_1.tar",
+		},
+		"without version suffix": {
+			"abc",
+			"3.20.20-20200131085038+eeb7c1033339bfd404d21ec5e7dc05c80e9e985e",
+			"abc_3.tar",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.expect, getTarName(&protecodeExecuteScanOptions{ScanImage: c.image, ArtifactVersion: c.version}))
+		})
+	}
+}

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -150,13 +150,13 @@ func TestRunProtecodeScan(t *testing.T) {
 	t.Run("With tar as scan image", func(t *testing.T) {
 		config := protecodeExecuteScanOptions{ServerURL: server.URL, TimeoutMinutes: "1", ReuseExisting: false, CleanupMode: "none", Group: "13", FetchURL: "/api/fetch/", ExcludeCVEs: "CVE-2018-1, CVE-2017-1000382", ReportFileName: "./cache/report-file.txt"}
 		err = runProtecodeScan(&config, &influx, dClient)
-		assert.Nil(t, err, "There should be no Error")
+		assert.NoError(t, err)
 	})
 
 	t.Run("Without tar as scan image", func(t *testing.T) {
 		config := protecodeExecuteScanOptions{ServerURL: server.URL, ScanImage: "t", FilePath: path, TimeoutMinutes: "1", ReuseExisting: false, CleanupMode: "none", Group: "13", ExcludeCVEs: "CVE-2018-1, CVE-2017-1000382", ReportFileName: "./cache/report-file.txt"}
 		err = runProtecodeScan(&config, &influx, dClient)
-		assert.Nil(t, err, "There should be no Error")
+		assert.NoError(t, err)
 	})
 
 }
@@ -398,6 +398,11 @@ func TestGetTarName(t *testing.T) {
 			"abc",
 			"3.20.20-20200131085038+eeb7c1033339bfd404d21ec5e7dc05c80e9e985e",
 			"abc_3.tar",
+		},
+		"without version ": {
+			"abc",
+			"",
+			"abc.tar",
 		},
 	}
 


### PR DESCRIPTION
This PR fixes an issue with the naming of the artifact to scan. Before it was named `<artifactName>:<artifactVersion><majorVersionDigit>.tar`, it is now correctly named `<artifactName>_<majorVersionDigit>.tar`. 

<img width="701" alt="Bildschirmfoto 2020-09-02 um 11 45 06" src="https://user-images.githubusercontent.com/26137398/91966165-c6937180-ed11-11ea-9764-a510af09d01d.png">

fixes #1972