### PR TITLE
Extend testsPublishResults step to support publishing of HTML reports

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -543,6 +543,14 @@ steps:
       allowEmptyResults: true
       archive: false
       active: false
+    htmlPublisher:
+      allowMissing: true
+      alwaysLinkToLastBuild: false
+      keepAll: true
+      reportDir: ""
+      pattern: "**/reports/coverage-reports/**/index.html"
+      reportName: "Results"
+      active: false
   checkChangeInDevelopment:
       failIfStatusIsNotInDevelopment: true
   tmsUpload:

--- a/test/groovy/TestsPublishResultsTest.groovy
+++ b/test/groovy/TestsPublishResultsTest.groovy
@@ -48,6 +48,9 @@ class TestsPublishResultsTest extends BasePiperTest {
         helper.registerAllowedMethod('cucumber', [Map.class], {
             parameters -> publisherStepOptions['cucumber'] = parameters
         })
+        helper.registerAllowedMethod('publishHTML', [Map.class], {
+            parameters -> publisherStepOptions['htmlPublisher'] = parameters
+        })
         helper.registerAllowedMethod('archiveArtifacts', [Map.class], {
             parameters -> archiveStepPatterns.push(parameters.artifacts)
         })
@@ -63,11 +66,12 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('DryPublisher options not empty', publisherStepOptions.cobertura == null)
         assertTrue('FindBugsPublisher options not empty', publisherStepOptions.jmeter == null)
         assertTrue('Cucumber options not empty', publisherStepOptions.cucumber == null)
+        assertTrue('HtmlPublisher options not empty', publisherStepOptions.htmlPublisher == null)
     }
 
     @Test
     void testPublishNothingWithAllDisabled() throws Exception {
-        stepRule.step.testsPublishResults(script: nullScript, junit: false, jacoco: false, cobertura: false, jmeter: false, cucumber: false)
+        stepRule.step.testsPublishResults(script: nullScript, junit: false, jacoco: false, cobertura: false, jmeter: false, cucumber: false, htmlPublisher: false)
 
         // ensure nothing is published
         assertTrue('WarningsPublisher options not empty', publisherStepOptions.junit == null)
@@ -75,6 +79,7 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('DryPublisher options not empty', publisherStepOptions.cobertura == null)
         assertTrue('FindBugsPublisher options not empty', publisherStepOptions.jmeter == null)
         assertTrue('Cucumber options not empty', publisherStepOptions.cucumber == null)
+        assertTrue('HtmlPublisher options not empty', publisherStepOptions.htmlPublisher == null)
     }
 
     @Test
@@ -90,6 +95,7 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('Cobertura options are not empty', publisherStepOptions.cobertura == null)
         assertTrue('JMeter options are not empty', publisherStepOptions.jmeter == null)
         assertTrue('Cucumber options not empty', publisherStepOptions.cucumber == null)
+        assertTrue('HtmlPublisher options not empty', publisherStepOptions.htmlPublisher == null)
     }
 
     @Test
@@ -103,6 +109,7 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('JUnit options are not empty', publisherStepOptions.junit == null)
         assertTrue('JMeter options are not empty', publisherStepOptions.jmeter == null)
         assertTrue('Cucumber options not empty', publisherStepOptions.cucumber == null)
+        assertTrue('HtmlPublisher options not empty', publisherStepOptions.htmlPublisher == null)
 
         assertTrue('Cobertura options are empty', publisherStepOptions.cobertura != null)
         assertTrue('Cobertura default pattern is empty', publisherStepOptions.cobertura.coberturaReportFile != null)
@@ -127,6 +134,7 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('JaCoCo options are not empty', publisherStepOptions.jacoco == null)
         assertTrue('Cobertura options are not empty', publisherStepOptions.cobertura == null)
         assertTrue('Cucumber options not empty', publisherStepOptions.cucumber == null)
+        assertTrue('HtmlPublisher options not empty', publisherStepOptions.htmlPublisher == null)
     }
 
     @Test
@@ -144,6 +152,7 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('Cobertura options are not empty', publisherStepOptions.cobertura == null)
         assertTrue('JMeter options are not empty', publisherStepOptions.jmeter == null)
         assertTrue('Cucumber options not empty', publisherStepOptions.cucumber == null)
+        assertTrue('HtmlPublisher options not empty', publisherStepOptions.htmlPublisher == null)
     }
 
     @Test
@@ -158,6 +167,22 @@ class TestsPublishResultsTest extends BasePiperTest {
         assertTrue('JaCoCo options are not empty', publisherStepOptions.jacoco == null)
         assertTrue('Cobertura options are not empty', publisherStepOptions.cobertura == null)
         assertTrue('JMeter options are not empty', publisherStepOptions.jmeter == null)
+        assertTrue('HtmlPublisher options not empty', publisherStepOptions.htmlPublisher == null)
+    }
+
+    @Test
+    void testPublishHtmlResults() throws Exception {
+        stepRule.step.testsPublishResults(script: nullScript, htmlPublisher: [pattern: 'fancy/file/path', active: true])
+
+        assertTrue('HtmlPublisher options are empty', publisherStepOptions.htmlPublisher != null)
+        assertEquals('HtmlPublisher pattern not set correct',
+            'fancy/file/path', publisherStepOptions.htmlPublisher.target.reportFiles)
+
+        assertTrue('JUnit options are not empty', publisherStepOptions.junit == null)
+        assertTrue('JaCoCo options are not empty', publisherStepOptions.jacoco == null)
+        assertTrue('Cobertura options are not empty', publisherStepOptions.cobertura == null)
+        assertTrue('JMeter options are not empty', publisherStepOptions.jmeter == null)
+        assertTrue('Cucumber options not empty', publisherStepOptions.cucumber == null)
     }
 
     @Test

--- a/vars/testsPublishResults.groovy
+++ b/vars/testsPublishResults.groovy
@@ -184,15 +184,14 @@ def publishCucumberReport(Map settings = [:]) {
 def publishHtmlReport(Map settings = [:]) {
     if (settings.active) {
         def pattern = settings.get('pattern')
-        def reportDir = settings.get('reportDir')
-        def reportName = settings.get('reportName')
+
         publishHTML(target: [
-            allowMissing         : true,
-            alwaysLinkToLastBuild: false,
-            keepAll              : true,
-            reportDir            : reportDir,
+            allowMissing         : settings.get('allowMissing'),
+            alwaysLinkToLastBuild: settings.get('alwaysLinkToLastBuild'),
+            keepAll              : settings.get('keepAll'),
+            reportDir            : settings.get('reportDir'),
             reportFiles          : pattern,
-            reportName           : reportName
+            reportName           : settings.get('reportName')
         ])
     }
 }

--- a/vars/testsPublishResults.groovy
+++ b/vars/testsPublishResults.groovy
@@ -184,12 +184,14 @@ def publishCucumberReport(Map settings = [:]) {
 def publishHtmlReport(Map settings = [:]) {
     if (settings.active) {
         def pattern = settings.get('pattern')
+        def reportDir = settings.get('reportDir')
         def reportName = settings.get('reportName')
         publishHTML(target: [
             allowMissing         : true,
             alwaysLinkToLastBuild: false,
             keepAll              : true,
-            reportDir            : pattern,
+            reportDir            : reportDir,
+            reportFiles          : pattern,
             reportName           : reportName
         ])
     }

--- a/vars/testsPublishResults.groovy
+++ b/vars/testsPublishResults.groovy
@@ -183,14 +183,12 @@ def publishCucumberReport(Map settings = [:]) {
 
 def publishHtmlReport(Map settings = [:]) {
     if (settings.active) {
-        def pattern = settings.get('pattern')
-
         publishHTML(target: [
             allowMissing         : settings.get('allowMissing'),
             alwaysLinkToLastBuild: settings.get('alwaysLinkToLastBuild'),
             keepAll              : settings.get('keepAll'),
             reportDir            : settings.get('reportDir'),
-            reportFiles          : pattern,
+            reportFiles          : settings.get('pattern'),
             reportName           : settings.get('reportName')
         ])
     }

--- a/vars/testsPublishResults.groovy
+++ b/vars/testsPublishResults.groovy
@@ -32,7 +32,12 @@ import groovy.transform.Field
      * Publishes test results with the [Cucumber plugin](https://plugins.jenkins.io/cucumber-testresult-plugin/).
      * @possibleValues `true`, `false`, `Map`
      */
-    'cucumber'
+    'cucumber',
+    /**
+     * Publishes test results with the [HTML Publisher plugin](https://plugins.jenkins.io/htmlpublisher/).
+     * @possibleValues `true`, `false`, `Map`
+     */
+    'htmlPublisher'
 ]
 
 @Field def STEP_NAME = getClass().getName()
@@ -80,6 +85,7 @@ void call(Map parameters = [:]) {
         publishCoberturaReport(configuration.get('cobertura'))
         publishJMeterReport(configuration.get('jmeter'))
         publishCucumberReport(configuration.get('cucumber'))
+        publishHtmlReport(configuration.get('htmlPublisher'))
 
         if (configuration.failOnError && JenkinsUtils.hasTestFailures(script.currentBuild)) {
             script.currentBuild.result = 'FAILURE'
@@ -172,6 +178,20 @@ def publishCucumberReport(Map settings = [:]) {
             testResults: pattern
         )
         archiveResults(settings.get('archive'), pattern, allowEmpty)
+    }
+}
+
+def publishHtmlReport(Map settings = [:]) {
+    if (settings.active) {
+        def pattern = settings.get('pattern')
+        def reportName = settings.get('reportName')
+        publishHTML(target: [
+            allowMissing         : true,
+            alwaysLinkToLastBuild: false,
+            keepAll              : true,
+            reportDir            : pattern,
+            reportName           : reportName
+        ])
     }
 }
 


### PR DESCRIPTION
# Changes

This change extends the testsPublishResults step to support publishing
of HTML reports using the HTML publisher plugin. This change is a
preparation for the migration of frontend unit tests as already existing
in the SAP Cloud SDK Pipeline to the
piperPipelineStageAdditionalUnitTests.

- [x] Tests
- [x] Documentation
