### PR TITLE
Add npmExecuteScripts to piperPipelineStageAdditionalUnitTests

### DIFF
--- a/documentation/docs/pipelines/cloud-sdk/build-tools.md
+++ b/documentation/docs/pipelines/cloud-sdk/build-tools.md
@@ -81,15 +81,13 @@ Please pick the corresponding version for your deployment target and rename it p
 
 #### Frontend Unit Tests
 
-The command `npm run ci-frontend-unit-test` will be executed in this stage.
+For each `package.json` where the script `ci-frontend-unit-test` is defined the command `npm run ci-frontend-unit-test` will be executed in this stage.
 Furthermore, the test results have to be stored in the folder `./s4hana_pipeline/reports/frontend-unit` in the root directory.
 The required format of the test result report is the JUnit format as an `.xml` file.
 The code coverage report can be published as html report and in the cobertura format.
 The cobertura report as html report has to be stored in the directory `./s4hana_pipeline/reports/coverage-reports/frontend-unit/report-html/ut/` as an `index.html` file.
 These coverage reports will then be published in Jenkins.
 Furthermore, if configured in the `.pipeline/config.yml`, the pipeline ensures the configured level of code coverage.
-
-In MTA projects Frontend Unit Tests are executed for every module of type `html5`.
 
 #### Frontend Integration Tests
 

--- a/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
@@ -26,9 +26,8 @@ stages:
           - 'ci-it-frontend'
   frontendUnitTests:
     stepConditions:
-      frontendUnitTests:
+      npmExecuteScripts:
         npmScripts:
-          - 'ci-test'
           - 'ci-frontend-unit-test'
   npmAudit:
     stepConditions:

--- a/test/groovy/templates/PiperPipelineStageAdditionalUnitTestsTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageAdditionalUnitTestsTest.groovy
@@ -49,6 +49,10 @@ class PiperPipelineStageAdditionalUnitTestsTest extends BasePiperTest {
             stepsCalled.add('karmaExecuteTests')
         })
 
+        helper.registerAllowedMethod('npmExecuteScripts', [Map.class], {m ->
+            stepsCalled.add('npmExecuteScripts')
+        })
+
         helper.registerAllowedMethod('testsPublishResults', [Map.class], {m ->
             stepsCalled.add('testsPublishResults')
         })
@@ -59,7 +63,7 @@ class PiperPipelineStageAdditionalUnitTestsTest extends BasePiperTest {
 
         jsr.step.piperPipelineStageAdditionalUnitTests(script: nullScript, juStabUtils: utils)
 
-        assertThat(stepsCalled, not(anyOf(hasItem('batsExecuteTests'), hasItem('karmaExecuteTests'), hasItem('testsPublishResults'))))
+        assertThat(stepsCalled, not(anyOf(hasItem('batsExecuteTests'), hasItem('karmaExecuteTests'), hasItem('npmExecuteScripts'), hasItem('testsPublishResults'))))
     }
 
     @Test
@@ -80,5 +84,15 @@ class PiperPipelineStageAdditionalUnitTestsTest extends BasePiperTest {
         jsr.step.piperPipelineStageAdditionalUnitTests(script: nullScript, juStabUtils: utils)
 
         assertThat(stepsCalled, hasItems('batsExecuteTests', 'testsPublishResults'))
+    }
+
+    @Test
+    void testAdditionalUnitTestsWithNpm() {
+
+        nullScript.commonPipelineEnvironment.configuration = [runStep: ['Additional Unit Tests': [npmExecuteScripts: true]]]
+
+        jsr.step.piperPipelineStageAdditionalUnitTests(script: nullScript, juStabUtils: utils)
+
+        assertThat(stepsCalled, hasItems('npmExecuteScripts', 'testsPublishResults'))
     }
 }

--- a/vars/piperPipelineStageAdditionalUnitTests.groovy
+++ b/vars/piperPipelineStageAdditionalUnitTests.groovy
@@ -15,6 +15,8 @@ import static com.sap.piper.Prerequisites.checkScript
     'batsExecuteTests',
     /** Executes karma tests which are for example suitable for OPA5 testing as well as QUnit testing of SAP UI5 apps.*/
     'karmaExecuteTests',
+    /** Executes npm scripts to run frontend unit tests */
+    'npmExecuteScripts',
     /** Publishes test results to Jenkins. It will automatically be active in cases tests are executed. */
     'testsPublishResults'
 ]
@@ -39,6 +41,7 @@ void call(Map parameters = [:]) {
         .mixin(parameters, PARAMETER_KEYS)
         .addIfEmpty('batsExecuteTests', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.batsExecuteTests)
         .addIfEmpty('karmaExecuteTests', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.karmaExecuteTests)
+        .addIfEmpty('npmExecuteScripts', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.npmExecuteScripts)
         .use()
 
     piperStageWrapper (script: script, stageName: stageName) {
@@ -56,6 +59,13 @@ void call(Map parameters = [:]) {
         if (config.karmaExecuteTests) {
             durationMeasure(script: script, measurementName: 'karma_duration') {
                 karmaExecuteTests script: script
+                testsPublishResults script: script
+            }
+        }
+
+        if (config.npmExecuteScripts) {
+            durationMeasure(script: script, measurementName: 'npmExecuteScripts_duration') {
+                npmExecuteScripts script: script
                 testsPublishResults script: script
             }
         }


### PR DESCRIPTION
# Changes
This change adds the support for running frontend unit tests using the
`npmExecuteScripts` step in the `piperPipelineStageAdditionalUnitTests`.

- [x] Tests
- [x] Documentation
