### PR TITLE
Add command for command line completion scripts

### DIFF
--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"os"
+)
+
+// CommandLineCompletionCommand allows to generate convenience scripts for using the piper cli in a shell.
+// See https://github.com/spf13/cobra/blob/master/shell_completions.md for docs on the subject.
+func CommandLineCompletionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `To load completions:
+
+Bash:
+
+$ source <(piper completion bash)
+
+# To load completions for each session, execute once:
+Linux:
+  $ piper completion bash > /etc/bash_completion.d/piper
+MacOS:
+  $ piper completion bash > /usr/local/etc/bash_completion.d/piper
+
+Zsh:
+
+# If shell completion is not already enabled in your environment you will need
+# to enable it.  You can execute the following once:
+
+$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# To load completions for each session, execute once:
+$ piper completion zsh > "${fpath[1]}/_piper"
+
+# You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ piper completion fish | source
+
+# To load completions for each session, execute once:
+$ piper completion fish > ~/.config/fish/completions/piper.fish
+`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				cmd.Root().GenPowerShellCompletion(os.Stdout)
+			}
+		},
+	}
+}

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -63,6 +63,7 @@ func Execute() {
 	rootCmd.AddCommand(ArtifactPrepareVersionCommand())
 	rootCmd.AddCommand(ConfigCommand())
 	rootCmd.AddCommand(ContainerSaveImageCommand())
+	rootCmd.AddCommand(CommandLineCompletionCommand())
 	rootCmd.AddCommand(VersionCommand())
 	rootCmd.AddCommand(DetectExecuteScanCommand())
 	rootCmd.AddCommand(KarmaExecuteTestsCommand())


### PR DESCRIPTION
# Changes

Small change to allow better interactive cli usage of piper. This makes use of cobra's feature as described here https://github.com/spf13/cobra/blob/master/shell_completions.md

 Usage example after typing `piper maven<tab><tab>`:

![image](https://user-images.githubusercontent.com/2292245/92384759-f4f9be00-f110-11ea-8026-623c557712e5.png)
