### PR TITLE
Add npmExecuteLint and mavenExecuteStaticCodeChecks to build stage

### DIFF
--- a/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
@@ -1,12 +1,9 @@
 stages:
-  mavenExecuteStaticCodeChecks:
+  build:
     stepConditions:
       mavenExecuteStaticCodeChecks:
         filePattern: 'pom.xml'
-  lint:
-    extensionExists: true
-    stepConditions:
-      lint:
+      npmExecuteLint:
         filePattern:
           - '**/*.js'
           - '**/*.jsx'

--- a/test/groovy/templates/PiperPipelineStageBuildTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageBuildTest.groovy
@@ -10,8 +10,14 @@ import util.JenkinsReadYamlRule
 import util.JenkinsStepRule
 import util.Rules
 
+import static org.hamcrest.Matchers.anyOf
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.hasItem
+import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.hasItems
 import static org.hamcrest.Matchers.is
+import static org.hamcrest.Matchers.not
 import static org.junit.Assert.assertThat
 
 class PiperPipelineStageBuildTest extends BasePiperTest {
@@ -54,6 +60,14 @@ class PiperPipelineStageBuildTest extends BasePiperTest {
             stepsCalled.add('testsPublishResults')
             stepParameters.testsPublishResults = m
         })
+
+        helper.registerAllowedMethod('mavenExecuteStaticCodeChecks', [Map.class], {m ->
+            stepsCalled.add('mavenExecuteStaticCodeChecks')
+        })
+
+        helper.registerAllowedMethod('npmExecuteLint', [Map.class], {m ->
+            stepsCalled.add('npmExecuteLint')
+        })
     }
 
     @Test
@@ -63,5 +77,26 @@ class PiperPipelineStageBuildTest extends BasePiperTest {
 
         assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults', 'pipelineStashFilesAfterBuild', 'testsPublishResults'))
         assertThat(stepParameters.testsPublishResults.junit.updateResults, is(true))
+        assertThat(stepsCalled, not(anyOf(hasItem('mavenExecuteStaticCodeChecks'), hasItem('npmExecuteLint'))))
+    }
+
+    @Test
+    void testBuildWithLinting() {
+
+        nullScript.commonPipelineEnvironment.configuration = [runStep: ['Build': [npmExecuteLint: true]]]
+
+        jsr.step.piperPipelineStageBuild(script: nullScript, juStabUtils: utils)
+
+        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults', 'pipelineStashFilesAfterBuild', 'testsPublishResults', 'npmExecuteLint'))
+    }
+
+    @Test
+    void testBuildWithMavenStaticCodeChecks() {
+
+        nullScript.commonPipelineEnvironment.configuration = [runStep: ['Build': [mavenExecuteStaticCodeChecks: true]]]
+
+        jsr.step.piperPipelineStageBuild(script: nullScript, juStabUtils: utils)
+
+        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults', 'pipelineStashFilesAfterBuild', 'testsPublishResults', 'mavenExecuteStaticCodeChecks'))
     }
 }

--- a/vars/piperPipelineStageBuild.groovy
+++ b/vars/piperPipelineStageBuild.groovy
@@ -23,7 +23,11 @@ import static com.sap.piper.Prerequisites.checkScript
     /** Publishes test results to Jenkins. It will always be active. */
     'testsPublishResults',
     /** Publishes check results to Jenkins. It will always be active. */
-    'checksPublishResults'
+    'checksPublishResults',
+    /** Executes static code checks for Maven based projects. The plugins SpotBugs and PMD are used. */
+    'mavenExecuteStaticCodeChecks',
+    /** Executes linting for npm projects. */
+    'npmExecuteLint'
 ]
 @Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS.plus(STAGE_STEP_KEYS)
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
@@ -46,6 +50,8 @@ void call(Map parameters = [:]) {
         .mixinGeneralConfig(script.commonPipelineEnvironment, GENERAL_CONFIG_KEYS)
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)
         .mixin(parameters, PARAMETER_KEYS)
+        .addIfEmpty('npmExecuteLint', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.npmExecuteLint)
+        .addIfEmpty('mavenExecuteStaticCodeChecks', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.mavenExecuteStaticCodeChecks)
         .use()
 
     piperStageWrapper (script: script, stageName: stageName) {
@@ -60,6 +66,18 @@ void call(Map parameters = [:]) {
 
             testsPublishResults script: script, junit: [updateResults: true]
             checksPublishResults script: script
+        }
+
+        if (config.mavenExecuteStaticCodeChecks) {
+            durationMeasure(script: script, measurementName: 'staticCodeChecks_duration') {
+                mavenExecuteStaticCodeChecks(script: script)
+            }
+        }
+
+        if (config.npmExecuteLint) {
+            durationMeasure(script: script, measurementName: 'npmExecuteLint_duration') {
+                npmExecuteLint script: script
+            }
         }
     }
 }


### PR DESCRIPTION
This change adds the support for executing maven static code checks and
linting using the mavenExecuteStaticCodeChecks and npmExecuteLint steps
as part of the piperPipelineStageBuild.

# Changes

- [x] Tests
- [x] Documentation
