### PR TITLE
Hotfix: Check env.BRANCH_NAME before using

### DIFF
--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -52,7 +52,7 @@ void call(Map parameters = [:]) {
                 environment.add("PIPER_changeId=${env.CHANGE_ID}")
                 environment.add("PIPER_changeBranch=${env.CHANGE_BRANCH}")
                 environment.add("PIPER_changeTarget=${env.CHANGE_TARGET}")
-            } else if (!isProductiveBranch(script)) {
+            } else if (!isProductiveBranch(script) && env.BRANCH_NAME) {
                 environment.add("PIPER_branchName=${env.BRANCH_NAME}")
             }
             try {


### PR DESCRIPTION
# Changes

If env.BRANCH_NAME is null, the env variable will be `PIPER_branchName=null`, i.e. pass "null" as the branch name.

The idea behind the original change was, if `sonarExecuteScan` is being run in a non-productive branch, it needs the branchName parameter. I am not sure if we should also check if the "branch plugin" is installed before setting this property, or if it actually means that the setup is wrong and the pipeline should rightfully fail. (The error message is then "To use the property "sonar.branch.name", the branch plugin is required but not installed.")

Or to word it differently: Is it a valid use-case to *not* pass `branchName` if the pipeline runs a non-productive branches?

- [ ] Tests
- [ ] Documentation
