### PR TITLE
Fix for SonarQube: Remove check for non-productive branch

### DIFF
--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -52,8 +52,6 @@ void call(Map parameters = [:]) {
                 environment.add("PIPER_changeId=${env.CHANGE_ID}")
                 environment.add("PIPER_changeBranch=${env.CHANGE_BRANCH}")
                 environment.add("PIPER_changeTarget=${env.CHANGE_TARGET}")
-            } else if (!isProductiveBranch(script) && env.BRANCH_NAME) {
-                environment.add("PIPER_branchName=${env.BRANCH_NAME}")
             }
             try {
                 // load certificates into cacerts file
@@ -98,11 +96,6 @@ private void checkMandatoryParameter(config, key){
 
 private Boolean isPullRequest(){
     return env.CHANGE_ID
-}
-
-private Boolean isProductiveBranch(Script script) {
-    def productiveBranch = script.commonPipelineEnvironment?.getStepConfiguration('', '')?.productiveBranch
-    return env.BRANCH_NAME == productiveBranch
 }
 
 private void loadCertificates(Map config) {


### PR DESCRIPTION
# Changes

It became clear that it is too inflexible if the step infers when to pass the `branchName` parameter. There are project which change the sonar project name in each branch, other projects make a sonar scan only in one of their branches, but that is not the productive branch.

-> Revert the recent change and rely on the users of the step to avoid scanning into the same sonar project from multiple branches.

- [ ] Tests
- [ ] Documentation
