### PR TITLE
Enable extensions for piperPipelineStageInit

### DIFF
--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -46,11 +46,12 @@ void call(Map parameters = [:]) {
     def script = checkScript(this, parameters) ?: this
     def utils = parameters.juStabUtils ?: new Utils()
     def stageName = StageNameProvider.instance.getStageName(script, parameters, this)
-
+    def scmInfo
+    
     node(parameters.nodeLabel?:'master') {
         deleteDir()
 
-        def scmInfo = checkout scm
+        scmInfo = checkout scm
 
         setupCommonPipelineEnvironment script: script, customDefaults: parameters.customDefaults
 

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -55,7 +55,7 @@ void call(Map parameters = [:]) {
         setupCommonPipelineEnvironment script: script, customDefaults: parameters.customDefaults
 
         stash allowEmpty: true, excludes: '', includes: '**', useDefaultExcludes: false, name: 'INIT'
-        script.commonPipelineEnvironment.configuration.stageStashes[stageName] = [ unstash : ["INIT"]]
+        script.commonPipelineEnvironment.configuration.stageStashes = [ (stageName): [ unstash : ["INIT"]]]
     }
 
     piperStageWrapper (script: script, stageName: stageName, stashContent: [], ordinal: 1, telemetryDisabled: true) {


### PR DESCRIPTION
# Changes
This change enables pipeline users to provide and use extensions for the
`piperPipelineStageInit`. Previously, it was not possible to provide an
extension for the `piperPipelineStageInit`, since the `piperStageWrapper` is
called before the scm checkout and the configuration initialization with
the `setupCommonPipelineEnvironment` step.
This is a feature required by the Cloud SDK pipeline and this PR is a 
preparation for the migration to the piperPipelineStageInit in the Cloud
SDK Pipeline. As a reference you can have a look at the current 
implementation of the [Cloud SDK pipeline's init stage](https://github.com/SAP/cloud-s4-sdk-pipeline-lib/blob/master/vars/stageInitS4sdkPipeline.groovy).

- [ ] Tests
- [ ] Documentation
