### PR TITLE
GitHub steps: convenience updates

### DIFF
--- a/cmd/githubCheckBranchProtection.go
+++ b/cmd/githubCheckBranchProtection.go
@@ -41,7 +41,7 @@ func runGithubCheckBranchProtection(ctx context.Context, config *githubCheckBran
 		var found bool
 		requiredStatusChecks := ghProtection.GetRequiredStatusChecks()
 		foundContexts := []string{}
-		if requiredStatusChecks != nil {
+		if requiredStatusChecks := ghProtection.GetRequiredStatusChecks(); requiredStatusChecks != nil {
 			foundContexts = requiredStatusChecks.Contexts
 		}
 		for _, context := range foundContexts {

--- a/cmd/githubCheckBranchProtection.go
+++ b/cmd/githubCheckBranchProtection.go
@@ -39,7 +39,6 @@ func runGithubCheckBranchProtection(ctx context.Context, config *githubCheckBran
 	// validate required status checks
 	for _, check := range config.RequiredChecks {
 		var found bool
-		requiredStatusChecks := ghProtection.GetRequiredStatusChecks()
 		foundContexts := []string{}
 		if requiredStatusChecks := ghProtection.GetRequiredStatusChecks(); requiredStatusChecks != nil {
 			foundContexts = requiredStatusChecks.Contexts

--- a/cmd/githubCheckBranchProtection.go
+++ b/cmd/githubCheckBranchProtection.go
@@ -42,7 +42,7 @@ func runGithubCheckBranchProtection(ctx context.Context, config *githubCheckBran
 		requiredStatusChecks := ghProtection.GetRequiredStatusChecks()
 		foundContexts := []string{}
 		if requiredStatusChecks != nil {
-			foundContexts = ghProtection.GetRequiredStatusChecks().Contexts
+			foundContexts = requiredStatusChecks.Contexts
 		}
 		for _, context := range foundContexts {
 			if check == context {

--- a/cmd/githubCheckBranchProtection.go
+++ b/cmd/githubCheckBranchProtection.go
@@ -39,7 +39,11 @@ func runGithubCheckBranchProtection(ctx context.Context, config *githubCheckBran
 	// validate required status checks
 	for _, check := range config.RequiredChecks {
 		var found bool
-		foundContexts := ghProtection.GetRequiredStatusChecks().Contexts
+		requiredStatusChecks := ghProtection.GetRequiredStatusChecks()
+		foundContexts := []string{}
+		if requiredStatusChecks != nil {
+			foundContexts = ghProtection.GetRequiredStatusChecks().Contexts
+		}
 		for _, context := range foundContexts {
 			if check == context {
 				found = true

--- a/cmd/githubCheckBranchProtection_generated.go
+++ b/cmd/githubCheckBranchProtection_generated.go
@@ -83,7 +83,7 @@ It can for example be used to verify if certain status checks are mandatory. Thi
 
 func addGithubCheckBranchProtectionFlags(cmd *cobra.Command, stepConfig *githubCheckBranchProtectionOptions) {
 	cmd.Flags().StringVar(&stepConfig.APIURL, "apiUrl", `https://api.github.com`, "Set the GitHub API url.")
-	cmd.Flags().StringVar(&stepConfig.Branch, "branch", os.Getenv("PIPER_branch"), "The name of the branch for which the protection settings should be checked.")
+	cmd.Flags().StringVar(&stepConfig.Branch, "branch", `master`, "The name of the branch for which the protection settings should be checked.")
 	cmd.Flags().StringVar(&stepConfig.Owner, "owner", os.Getenv("PIPER_owner"), "Name of the GitHub organization.")
 	cmd.Flags().StringVar(&stepConfig.Repository, "repository", os.Getenv("PIPER_repository"), "Name of the GitHub repository.")
 	cmd.Flags().StringSliceVar(&stepConfig.RequiredChecks, "requiredChecks", []string{}, "List of checks which have to be set to 'required' in the GitHub repository configuration.")
@@ -126,7 +126,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 					},
 					{
 						Name:        "owner",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "github/owner"}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
@@ -134,7 +134,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 					},
 					{
 						Name:        "repository",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "github/repository"}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,

--- a/cmd/githubCheckBranchProtection_test.go
+++ b/cmd/githubCheckBranchProtection_test.go
@@ -69,6 +69,15 @@ func TestRunGithubCheckBranchProtection(t *testing.T) {
 		assert.Equal(t, config.Repository, ghRepo.repo)
 	})
 
+	t.Run("no status checks", func(t *testing.T) {
+		config := githubCheckBranchProtectionOptions{
+			RequiredChecks: []string{"check1", "check2"},
+		}
+		ghRepo := ghCheckBranchRepoService{protection: github.Protection{}}
+		err := runGithubCheckBranchProtection(ctx, &config, &telemetryData, &ghRepo)
+		assert.Contains(t, fmt.Sprint(err), "required status check 'check1' not found")
+	})
+
 	t.Run("status check missing", func(t *testing.T) {
 		config := githubCheckBranchProtectionOptions{
 			RequiredChecks: []string{"check1", "check2"},

--- a/cmd/githubCreatePullRequest_generated.go
+++ b/cmd/githubCreatePullRequest_generated.go
@@ -160,7 +160,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 					},
 					{
 						Name:        "owner",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "github/owner"}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
@@ -168,7 +168,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 					},
 					{
 						Name:        "repository",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "github/repository"}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,

--- a/cmd/githubSetCommitStatus.go
+++ b/cmd/githubSetCommitStatus.go
@@ -29,7 +29,7 @@ func githubSetCommitStatus(config githubSetCommitStatusOptions, telemetryData *t
 }
 
 func runGithubSetCommitStatus(ctx context.Context, config *githubSetCommitStatusOptions, telemetryData *telemetry.CustomData, ghRepositoriesService gitHubCommitStatusRepositoriesService) error {
-	status := github.RepoStatus{State: &config.Status, TargetURL: &config.TargetURL}
+	status := github.RepoStatus{Context: &config.Context, Description: &config.Description, State: &config.Status, TargetURL: &config.TargetURL}
 	_, _, err := ghRepositoriesService.CreateStatus(ctx, config.Owner, config.Repository, config.CommitID, &status)
 	if err != nil {
 		return errors.Wrapf(err, "failed to set status '%v' on commitId '%v'", config.Status, config.CommitID)

--- a/cmd/githubSetCommitStatus_generated.go
+++ b/cmd/githubSetCommitStatus_generated.go
@@ -129,7 +129,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 					},
 					{
 						Name:        "commitId",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "git/commitId"}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
@@ -153,7 +153,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 					},
 					{
 						Name:        "owner",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "github/owner"}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
@@ -161,7 +161,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 					},
 					{
 						Name:        "repository",
-						ResourceRef: []config.ResourceReference{},
+						ResourceRef: []config.ResourceReference{{Name: "commonPipelineEnvironment", Param: "github/repository"}},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,

--- a/cmd/githubSetCommitStatus_test.go
+++ b/cmd/githubSetCommitStatus_test.go
@@ -33,10 +33,10 @@ func TestRunGithubSetCommitStatus(t *testing.T) {
 	telemetryData := telemetry.CustomData{}
 
 	t.Run("success case", func(t *testing.T) {
-		config := githubSetCommitStatusOptions{CommitID: "testSha", Owner: "testOrg", Repository: "testRepo", Status: "success", TargetURL: "https://test.url"}
+		config := githubSetCommitStatusOptions{CommitID: "testSha", Context: "test /context", Description: "testDescription", Owner: "testOrg", Repository: "testRepo", Status: "success", TargetURL: "https://test.url"}
 		ghRepo := ghSetCommitRepoService{}
 		err := runGithubSetCommitStatus(ctx, &config, &telemetryData, &ghRepo)
-		expectedStatus := github.RepoStatus{State: &config.Status, TargetURL: &config.TargetURL}
+		expectedStatus := github.RepoStatus{Context: &config.Context, Description: &config.Description, State: &config.Status, TargetURL: &config.TargetURL}
 		assert.NoError(t, err)
 		assert.Equal(t, config.CommitID, ghRepo.ref)
 		assert.Equal(t, config.Owner, ghRepo.owner)

--- a/documentation/docs/steps/githubCreatePullRequest.md
+++ b/documentation/docs/steps/githubCreatePullRequest.md
@@ -1,0 +1,13 @@
+# ${docGenStepName}
+
+## Prerequisites
+
+You need to create a personal access token within GitHub and add this to the Jenkins credentials store.
+
+Please see [GitHub documentation for details about creating the personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
+
+## ${docGenParameters}
+
+## ${docGenConfiguration}
+
+## ${docGenDescription}

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
         - gctsExecuteABAPUnitTests: steps/gctsExecuteABAPUnitTests.md
         - gctsRollback: steps/gctsRollback.md
         - githubCheckBranchProtection: steps/githubCheckBranchProtection.md
+        - githubCreatePullRequest: steps/githubCreatePullRequest.md
         - githubPublishRelease: steps/githubPublishRelease.md
         - githubSetCommitStatus: steps/githubSetCommitStatus.md
         - hadolintExecute: steps/hadolintExecute.md

--- a/resources/metadata/githubbranchprotection.yaml
+++ b/resources/metadata/githubbranchprotection.yaml
@@ -31,11 +31,15 @@ spec:
           - STAGES
           - STEPS
         type: string
+        default: master
         mandatory: true
       - name: owner
         aliases:
           - name: githubOrg
         description: Name of the GitHub organization.
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: github/owner
         scope:
           - PARAMETERS
           - STAGES
@@ -46,6 +50,9 @@ spec:
         aliases:
           - name: githubRepo
         description: Name of the GitHub repository.
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: github/repository
         scope:
           - PARAMETERS
           - STAGES

--- a/resources/metadata/githubcreatepr.yaml
+++ b/resources/metadata/githubcreatepr.yaml
@@ -59,6 +59,9 @@ spec:
         aliases:
           - name: githubOrg
         description: Name of the GitHub organization.
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: github/owner
         scope:
           - PARAMETERS
           - STAGES
@@ -69,6 +72,9 @@ spec:
         aliases:
           - name: githubRepo
         description: Name of the GitHub repository.
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: github/repository
         scope:
           - PARAMETERS
           - STAGES

--- a/resources/metadata/githubstatus.yaml
+++ b/resources/metadata/githubstatus.yaml
@@ -33,6 +33,9 @@ spec:
         mandatory: true
       - name: commitId
         description: The commitId for which the status should be set.
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: git/commitId
         scope:
           - PARAMETERS
           - STAGES
@@ -58,6 +61,9 @@ spec:
         aliases:
           - name: githubOrg
         description: Name of the GitHub organization.
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: github/owner
         scope:
           - PARAMETERS
           - STAGES
@@ -68,6 +74,9 @@ spec:
         aliases:
           - name: githubRepo
         description: Name of the GitHub repository.
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: github/repository
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
# Changes

Convenience updates to GitHub steps:

* use information from `commonPipelineEnvironment`
* update default

Add additional information to check status

Add missing documentation

Fix `nil de-reference` error when no checks are maintained

- [x] Tests
- [x] Documentation
