### PR TITLE
Add a milestone for Confirm stage

### DIFF
--- a/resources/com.sap.piper/pipeline/stageOrdinals.yml
+++ b/resources/com.sap.piper/pipeline/stageOrdinals.yml
@@ -17,6 +17,8 @@ stages:
     ordinal: 60
   Compliance:
     ordinal: 70
+  Confirm:
+    ordinal: 75
   Promote:
     ordinal: 80
   Release:

--- a/test/groovy/templates/PiperPipelineStageConfirmTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageConfirmTest.groovy
@@ -16,6 +16,7 @@ class PiperPipelineStageConfirmTest extends BasePiperTest {
 
     private Map timeoutSettings
     private Map inputSettings
+    private boolean piperStageWrapperExecuted = false
 
     @Rule
     public RuleChain rules = Rules
@@ -27,6 +28,12 @@ class PiperPipelineStageConfirmTest extends BasePiperTest {
     @Before
     void init()  {
         binding.variables.env.STAGE_NAME = 'Confirm'
+
+        helper.registerAllowedMethod('piperStageWrapper', [Map.class, Closure.class], {m, body ->
+            assertThat(m.stageLocking, is(false))
+            piperStageWrapperExecuted = true
+            return body()
+        })
 
         helper.registerAllowedMethod('timeout', [Map.class, Closure.class], {m, body ->
             timeoutSettings = m
@@ -48,6 +55,7 @@ class PiperPipelineStageConfirmTest extends BasePiperTest {
         assertThat(timeoutSettings.unit, is('HOURS'))
         assertThat(timeoutSettings.time, is(720))
         assertThat(inputSettings.message, is('Shall we proceed to Promote & Release?'))
+        assertThat(piperStageWrapperExecuted, is(true))
     }
 
     @Test

--- a/vars/piperPipelineStageConfirm.groovy
+++ b/vars/piperPipelineStageConfirm.groovy
@@ -48,38 +48,39 @@ void call(Map parameters = [:]) {
     boolean approval = false
     def userInput
 
-    timeout(
-        unit: 'HOURS',
-        time: config.manualConfirmationTimeout
-    ){
-        if (currentBuild.result == 'UNSTABLE') {
-            def minReasonLength = 10
-            def acknowledgementText = 'I acknowledge that for traceability purposes the approval reason is stored together with my user name / user id'
-            def reasonDescription = "Please provide a reason for overruling the failed steps ${unstableStepNames}, with ${minReasonLength} characters or more:".toString()
-            def acknowledgementDescription = "${acknowledgementText}:".toString()
-            while(!approval) {
-                userInput = input(
-                    message: 'Approve continuation of pipeline, although some steps failed.',
-                    ok: 'Approve',
-                    parameters: [
-                        text(
-                            defaultValue: '',
-                            description: reasonDescription,
-                            name: 'reason'
-                        ),
-                        booleanParam(
-                            defaultValue: false,
-                            description: acknowledgementDescription,
-                            name: 'acknowledgement'
-                        )
-                    ]
-                )
-                approval = validateApproval(userInput.reason, minReasonLength, userInput.acknowledgement, acknowledgementText, unstableStepNames)
+    piperStageWrapper (script: script, stageName: stageName, stageLocking: false) {
+        timeout(
+            unit: 'HOURS',
+            time: config.manualConfirmationTimeout
+        ){
+            if (currentBuild.result == 'UNSTABLE') {
+                def minReasonLength = 10
+                def acknowledgementText = 'I acknowledge that for traceability purposes the approval reason is stored together with my user name / user id'
+                def reasonDescription = "Please provide a reason for overruling the failed steps ${unstableStepNames}, with ${minReasonLength} characters or more:".toString()
+                def acknowledgementDescription = "${acknowledgementText}:".toString()
+                while(!approval) {
+                    userInput = input(
+                        message: 'Approve continuation of pipeline, although some steps failed.',
+                        ok: 'Approve',
+                        parameters: [
+                            text(
+                                defaultValue: '',
+                                description: reasonDescription,
+                                name: 'reason'
+                            ),
+                            booleanParam(
+                                defaultValue: false,
+                                description: acknowledgementDescription,
+                                name: 'acknowledgement'
+                            )
+                        ]
+                    )
+                    approval = validateApproval(userInput.reason, minReasonLength, userInput.acknowledgement, acknowledgementText, unstableStepNames)
+                }
+            } else {
+                input message: config.manualConfirmationMessage
             }
-        } else {
-            input message: config.manualConfirmationMessage
         }
-
     }
 
 }

--- a/vars/piperStageWrapper.groovy
+++ b/vars/piperStageWrapper.groovy
@@ -85,6 +85,9 @@ private void stageLocking(Map config, Closure body) {
             body()
         }
     } else {
+        if(config.ordinal) {
+            milestone config.ordinal
+        }
         body()
     }
 }


### PR DESCRIPTION
This commit will prevent abortion of older builds which are waiting in the Confirm stage,
if a newer build fails in the last stage before the Confirm stage.

Example: If the 'Compliance' stage of the general purpose pipeline (piperPipeline.groovy) fails,
it will abort all former builds which are waiting in the 'Confirm' stage.

The stageLocking nature of piperStageWrapper is disabled for the Confirm stage as we still
want to be able to promote any of the builds waiting for the manual confirmation.

Note: Confirming a build will still abort all older builds waiting at the Confirm stage.

Fixes #2029

# Changes

- [x] Tests
- [ ] Documentation
