### PR TITLE
Changes to commonPipelineEnvironment for ABAP

### DIFF
--- a/cmd/abapEnvironmentCloneGitRepo_generated.go
+++ b/cmd/abapEnvironmentCloneGitRepo_generated.go
@@ -144,17 +144,12 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Aliases:   []config.Alias{},
 					},
 					{
-						Name: "repositories",
-						ResourceRef: []config.ResourceReference{
-							{
-								Name:  "commonPipelineEnvironment",
-								Param: "abap/repositories",
-							},
-						},
-						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:      "string",
-						Mandatory: false,
-						Aliases:   []config.Alias{},
+						Name:        "repositories",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
 					},
 					{
 						Name:        "repositoryName",

--- a/resources/metadata/abapEnvironmentCloneGitRepo.yaml
+++ b/resources/metadata/abapEnvironmentCloneGitRepo.yaml
@@ -52,9 +52,6 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        resourceRef:
-          - name: commonPipelineEnvironment
-            param: abap/repositories
       - name: repositoryName
         type: string
         description: Specifies a repository (Software Components) on the SAP Cloud Platform ABAP Environment system

--- a/test/groovy/CommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/CommonPipelineEnvironmentTest.groovy
@@ -63,7 +63,7 @@ class CommonPipelineEnvironmentTest extends BasePiperTest {
         nullScript.commonPipelineEnvironment.originalArtifactVersion = '2.0.0'
         nullScript.commonPipelineEnvironment.setContainerProperty('image', 'myImage')
         nullScript.commonPipelineEnvironment.setValue('custom1', 'customVal1')
-        nullScript.commonPipelineEnvironment.setAbapRepositoryNames('[\"value1\",\"value2\"]')
+        nullScript.commonPipelineEnvironment.setAbapAddonDescriptor('[\"value1\",\"value2\"]')
         nullScript.commonPipelineEnvironment.writeToDisk(nullScript)
 
 
@@ -71,7 +71,7 @@ class CommonPipelineEnvironmentTest extends BasePiperTest {
         assertThat(writeFileRule.files['.pipeline/commonPipelineEnvironment/originalArtifactVersion'], is('2.0.0'))
         assertThat(writeFileRule.files['.pipeline/commonPipelineEnvironment/container/image'], is('myImage'))
         assertThat(writeFileRule.files['.pipeline/commonPipelineEnvironment/custom/custom1'], is('customVal1'))
-        assertThat(writeFileRule.files['.pipeline/commonPipelineEnvironment/abap/repositoryNames'], is('[\"value1\",\"value2\"]'))
+        assertThat(writeFileRule.files['.pipeline/commonPipelineEnvironment/abap/addonDescriptor'], is('[\"value1\",\"value2\"]'))
     }
 
     @Test
@@ -81,7 +81,7 @@ class CommonPipelineEnvironmentTest extends BasePiperTest {
             '.pipeline/commonPipelineEnvironment/artifactVersion',
             '.pipeline/commonPipelineEnvironment/originalArtifactVersion',
             '.pipeline/commonPipelineEnvironment/custom/custom1',
-            '.pipeline/commonPipelineEnvironment/abap/repositoryNames',
+            '.pipeline/commonPipelineEnvironment/abap/addonDescriptor',
         ])
 
         nullScript.metaClass.findFiles {
@@ -97,7 +97,7 @@ class CommonPipelineEnvironmentTest extends BasePiperTest {
             '.pipeline/commonPipelineEnvironment/artifactVersion': '1.0.0',
             '.pipeline/commonPipelineEnvironment/originalArtifactVersion': '2.0.0',
             '.pipeline/commonPipelineEnvironment/custom': 'customVal1',
-            '.pipeline/commonPipelineEnvironment/abap/repositoryNames': '[\"value1\",\"value2\"]',
+            '.pipeline/commonPipelineEnvironment/abap/addonDescriptor': '[\"value1\",\"value2\"]',
         ])
 
         nullScript.commonPipelineEnvironment.readFromDisk(nullScript)
@@ -105,7 +105,7 @@ class CommonPipelineEnvironmentTest extends BasePiperTest {
         assertThat(nullScript.commonPipelineEnvironment.artifactVersion, is('1.0.0'))
         assertThat(nullScript.commonPipelineEnvironment.originalArtifactVersion, is('2.0.0'))
         assertThat(nullScript.commonPipelineEnvironment.valueMap['custom1'], is('customVal1'))
-        assertThat(nullScript.commonPipelineEnvironment.abapRepositoryNames, is("[\"value1\",\"value2\"]"))
+        assertThat(nullScript.commonPipelineEnvironment.abapAddonDescriptor, is("[\"value1\",\"value2\"]"))
     }
 
 }

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -45,7 +45,7 @@ class commonPipelineEnvironment implements Serializable {
 
     String mtarFilePath = ""
 
-    String abapRepositoryNames
+    String abapAddonDescriptor
 
     private Map valueMap = [:]
 
@@ -63,7 +63,7 @@ class commonPipelineEnvironment implements Serializable {
 
         projectName = null
 
-        abapRepositoryNames = null
+        abapAddonDescriptor = null
 
         appContainerProperties = [:]
         artifactVersion = null
@@ -188,7 +188,7 @@ class commonPipelineEnvironment implements Serializable {
         [filename: '.pipeline/commonPipelineEnvironment/git/commitId', property: 'gitCommitId'],
         [filename: '.pipeline/commonPipelineEnvironment/git/commitMessage', property: 'gitCommitMessage'],
         [filename: '.pipeline/commonPipelineEnvironment/mtarFilePath', property: 'mtarFilePath'],
-        [filename: '.pipeline/commonPipelineEnvironment/abap/repositoryNames', property: 'abapRepositoryNames'],
+        [filename: '.pipeline/commonPipelineEnvironment/abap/addonDescriptor', property: 'abapAddonDescriptor'],
     ]
 
     void writeToDisk(script) {


### PR DESCRIPTION
# Changes

- [X] Tests
- [X] Documentation

It was originally planned to pass repositoryNames through this pipeline. repositoryNames is superseded by the more extensive addonDescriptor.

The resourceRef abap/repositories also relates to an earlier design and was never fully implemented. This is not required anymore.
