### PR TITLE
artifactPrepareVersion: fix error categorization

### DIFF
--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -340,7 +340,7 @@ func pushChanges(config *artifactPrepareVersionOptions, newVersion string, repos
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "authentication required"):
 			log.SetErrorCategory(log.ErrorConfiguration)
-			case strings.Contains(errText, "knownhosts:"):
+		case strings.Contains(errText, "knownhosts:"):
 			err = errors.Wrap(err, "known_hosts file seems invalid")
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "unable to find any valid known_hosts file"):

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -340,7 +340,7 @@ func pushChanges(config *artifactPrepareVersionOptions, newVersion string, repos
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "authentication required"):
 			log.SetErrorCategory(log.ErrorConfiguration)
-		case strings.Contains(errText, "known_hosts"):
+		case strings.Contains(errText, "knownhosts"):
 			err = errors.Wrap(err, "known_hosts file seems invalid")
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "unable to find any valid known_hosts file"):

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -340,7 +340,7 @@ func pushChanges(config *artifactPrepareVersionOptions, newVersion string, repos
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "authentication required"):
 			log.SetErrorCategory(log.ErrorConfiguration)
-		case strings.Contains(errText, "knownhosts"):
+			case strings.Contains(errText, "knownhosts:"):
 			err = errors.Wrap(err, "known_hosts file seems invalid")
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "unable to find any valid known_hosts file"):

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -340,7 +340,7 @@ func pushChanges(config *artifactPrepareVersionOptions, newVersion string, repos
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "authentication required"):
 			log.SetErrorCategory(log.ErrorConfiguration)
-		case strings.Contains(errText, "knownhosts: illegal base64"):
+		case strings.Contains(errText, "known_hosts"):
 			err = errors.Wrap(err, "known_hosts file seems invalid")
 			log.SetErrorCategory(log.ErrorConfiguration)
 		case strings.Contains(errText, "unable to find any valid known_hosts file"):


### PR DESCRIPTION
# Changes

fixes categorization of errors like

```
artifactPrepareVersion failed - failed to push changes for version '0.0.1-20200920213337': knownhosts: /var/jenkins_home/.ssh/known_hosts:9: illegal base64 data at input byte 8
```
