### PR TITLE
Remove useless space from lockIdentifier

### DIFF
--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -213,7 +213,7 @@ void call(parameters = [:]) {
                     configuration.source
                 )
 
-                lock("$STEP_NAME :${neoCommandHelper.resourceLock()}") {
+                lock("$STEP_NAME:${neoCommandHelper.resourceLock()}") {
                     deploy(script, configuration, neoCommandHelper, configuration.dockerImage, deployMode)
                 }
             }


### PR DESCRIPTION
the space does not contribute to the uniqueness of the lock
identifier. Hence the space should be removed.

