### PR TITLE
Extend piperPipelineStageSecurity to run detectExecuteScan step

### DIFF
--- a/test/groovy/templates/PiperPipelineStageSecurityTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageSecurityTest.groovy
@@ -51,6 +51,10 @@ class PiperPipelineStageSecurityTest extends BasePiperTest {
             stepsCalled.add('checkmarxExecuteScan')
         })
 
+        helper.registerAllowedMethod('detectExecuteScan', [Map.class], {m ->
+            stepsCalled.add('detectExecuteScan')
+        })
+
         helper.registerAllowedMethod('fortifyExecuteScan', [Map.class], {m ->
             stepsCalled.add('fortifyExecuteScan')
         })
@@ -69,6 +73,9 @@ class PiperPipelineStageSecurityTest extends BasePiperTest {
             juStabUtils: utils,
         )
         assertThat(stepsCalled, not(hasItem('whitesourceExecuteScan')))
+        assertThat(stepsCalled, not(hasItem('checkmarxExecuteScan')))
+        assertThat(stepsCalled, not(hasItem('detectExecuteScan')))
+        assertThat(stepsCalled, not(hasItem('fortifyExecuteScan')))
     }
 
     @Test
@@ -82,6 +89,7 @@ class PiperPipelineStageSecurityTest extends BasePiperTest {
 
         assertThat(stepsCalled, hasItem('whitesourceExecuteScan'))
         assertThat(stepsCalled, not(hasItem('checkmarxExecuteScan')))
+        assertThat(stepsCalled, not(hasItem('detectExecuteScan')))
         assertThat(stepsCalled, not(hasItem('fortifyExecuteScan')))
     }
 
@@ -99,6 +107,26 @@ class PiperPipelineStageSecurityTest extends BasePiperTest {
         )
 
         assertThat(stepsCalled, hasItem('checkmarxExecuteScan'))
+        assertThat(stepsCalled, not(hasItem('detectExecuteScan')))
+        assertThat(stepsCalled, not(hasItem('whitesourceExecuteScan')))
+        assertThat(stepsCalled, not(hasItem('fortifyExecuteScan')))
+    }
+
+    @Test
+    void testSecurityStageDetect() {
+
+        nullScript.commonPipelineEnvironment.configuration = [
+            runStep: [Security: [detectExecuteScan: true]]
+        ]
+
+        jsr.step.piperPipelineStageSecurity(
+            script: nullScript,
+            juStabUtils: utils,
+            detectExecuteScan: true
+        )
+
+        assertThat(stepsCalled, hasItem('detectExecuteScan'))
+        assertThat(stepsCalled, not(hasItem('checkmarxExecuteScan')))
         assertThat(stepsCalled, not(hasItem('whitesourceExecuteScan')))
         assertThat(stepsCalled, not(hasItem('fortifyExecuteScan')))
     }
@@ -117,6 +145,7 @@ class PiperPipelineStageSecurityTest extends BasePiperTest {
         )
 
         assertThat(stepsCalled, hasItem('fortifyExecuteScan'))
+        assertThat(stepsCalled, not(hasItem('detectExecuteScan')))
         assertThat(stepsCalled, not(hasItem('whitesourceExecuteScan')))
         assertThat(stepsCalled, not(hasItem('checkmarxExecuteScan')))
     }

--- a/vars/piperPipelineStageSecurity.groovy
+++ b/vars/piperPipelineStageSecurity.groovy
@@ -41,9 +41,11 @@ void call(Map parameters = [:]) {
         .mixinStageConfig(script.commonPipelineEnvironment, stageName, STEP_CONFIG_KEYS)
         .mixin(parameters, PARAMETER_KEYS)
         .addIfEmpty('checkmarxExecuteScan', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.checkmarxExecuteScan)
+        .addIfEmpty('detectExecuteScan', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.detectExecuteScan)
         .addIfEmpty('fortifyExecuteScan', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.fortifyExecuteScan)
         .addIfEmpty('whitesourceExecuteScan', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.whitesourceExecuteScan)
         .use()
+    
     piperStageWrapper (script: script, stageName: stageName) {
         if (config.checkmarxExecuteScan) {
             securityScanMap['Checkmarx'] = {

--- a/vars/piperPipelineStageSecurity.groovy
+++ b/vars/piperPipelineStageSecurity.groovy
@@ -45,7 +45,7 @@ void call(Map parameters = [:]) {
         .addIfEmpty('fortifyExecuteScan', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.fortifyExecuteScan)
         .addIfEmpty('whitesourceExecuteScan', script.commonPipelineEnvironment.configuration.runStep?.get(stageName)?.whitesourceExecuteScan)
         .use()
-    
+
     piperStageWrapper (script: script, stageName: stageName) {
         if (config.checkmarxExecuteScan) {
             securityScanMap['Checkmarx'] = {

--- a/vars/piperPipelineStageSecurity.groovy
+++ b/vars/piperPipelineStageSecurity.groovy
@@ -13,6 +13,8 @@ import static com.sap.piper.Prerequisites.checkScript
 @Field STAGE_STEP_KEYS = [
     /** Executes a Checkmarx scan */
     'checkmarxExecuteScan',
+    /** Executes Synopsys Detect scans */
+    'detectExecuteScan',
     /** Executes a Fortify scan */
     'fortifyExecuteScan',
     /** Executes a WhiteSource scan */
@@ -49,6 +51,20 @@ void call(Map parameters = [:]) {
                     try{
                         durationMeasure(script: script, measurementName: 'checkmarx_duration') {
                             checkmarxExecuteScan script: script
+                        }
+                    }finally{
+                        deleteDir()
+                    }
+                }
+            }
+        }
+
+        if (config.detectExecuteScan) {
+            securityScanMap['Detect'] = {
+                node(config.nodeLabel) {
+                    try{
+                        durationMeasure(script: script, measurementName: 'detect_duration') {
+                            detectExecuteScan script: script
                         }
                     }finally{
                         deleteDir()


### PR DESCRIPTION
# Changes
This change adds the detectExecuteScan step to the
piperPipelineStageSecurity.

- [x] Tests
- [x] Documentation
