### PR TITLE
docs: use correct template library

### DIFF
--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -3,9 +3,9 @@ package generator
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"io"
 	"os"
+	"text/template"
 
 	"github.com/SAP/jenkins-library/pkg/config"
 )


### PR DESCRIPTION
> Go provides two pretty amazing templating libraries - text/template and html/template. How you use these templates is identical, but behind the scenes the html/template package will do some encoding to help prevent code injection. 

Looks like I mixed this up with #2033.

https://github.com/SAP/jenkins-library/blob/4d9d2e78d81f9c1a0317c6a2cecfa127e0e4b927/pkg/generator/helper/docuHelper.go#L10

fixes #2073