### PR TITLE
Move setting git info in cpe from stage init to setupCPE step

### DIFF
--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -15,9 +15,11 @@ import util.JenkinsStepRule
 import util.JenkinsWriteFileRule
 import util.Rules
 
+import static org.hamcrest.Matchers.is
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertNull
+import static org.junit.Assert.assertThat
 
 class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
 
@@ -255,5 +257,52 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
         assertNull(nullScript.commonPipelineEnvironment.buildTool)
     }
 
+    @Test
+    void "Set scmInfo parameter sets commit id"() {
+        helper.registerAllowedMethod("fileExists", [String], { String path ->
+            return path.endsWith('.pipeline/config.yml')
+        })
+
+        def dummyScmInfo = [GIT_COMMIT: 'dummy_git_commit_id', GIT_URL: 'https://github.com/testOrg/testRepo.git']
+
+        stepRule.step.setupCommonPipelineEnvironment(script: nullScript, scmInfo: dummyScmInfo)
+        assertThat(nullScript.commonPipelineEnvironment.gitCommitId, is('dummy_git_commit_id'))
+    }
+
+    @Test
+    void "No scmInfo passed as parameter yields empty git info"() {
+        helper.registerAllowedMethod("fileExists", [String], { String path ->
+            return path.endsWith('.pipeline/config.yml')
+        })
+
+        stepRule.step.setupCommonPipelineEnvironment(script: nullScript)
+        assertNull(nullScript.commonPipelineEnvironment.gitCommitId)
+        assertNull(nullScript.commonPipelineEnvironment.getGitSshUrl())
+        assertNull(nullScript.commonPipelineEnvironment.getGitHttpsUrl())
+        assertNull(nullScript.commonPipelineEnvironment.getGithubOrg())
+        assertNull(nullScript.commonPipelineEnvironment.getGithubRepo())
+    }
+
+    @Test
+    void testSetScmInfoOnCommonPipelineEnvironment() {
+        //currently supported formats
+        def scmInfoTestList = [
+            [GIT_URL: 'https://github.com/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'https://github.com:7777/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com:7777/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'git@github.com:testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedHttp: 'https://github.com/path/to/testOrg/testRepo.git', expectedOrg: 'path/to/testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com/testRepo.git', expectedSsh: 'ssh://git@github.com/testRepo.git', expectedHttp: 'https://github.com/testRepo.git', expectedOrg: 'N/A', expectedRepo: 'testRepo'],
+        ]
+
+        scmInfoTestList.each {scmInfoTest ->
+            stepRule.step.setupCommonPipelineEnvironment.setGitUrlsOnCommonPipelineEnvironment(nullScript, scmInfoTest.GIT_URL)
+            assertThat(nullScript.commonPipelineEnvironment.getGitSshUrl(), is(scmInfoTest.expectedSsh))
+            assertThat(nullScript.commonPipelineEnvironment.getGitHttpsUrl(), is(scmInfoTest.expectedHttp))
+            assertThat(nullScript.commonPipelineEnvironment.getGithubOrg(), is(scmInfoTest.expectedOrg))
+            assertThat(nullScript.commonPipelineEnvironment.getGithubRepo(), is(scmInfoTest.expectedRepo))
+        }
+    }
 }
 

--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -144,28 +144,6 @@ class PiperPipelineStageInitTest extends BasePiperTest {
     }
 
     @Test
-    void testSetScmInfoOnCommonPipelineEnvironment() {
-        //currently supported formats
-        def scmInfoTestList = [
-            [GIT_URL: 'https://github.com/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
-            [GIT_URL: 'https://github.com:7777/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com:7777/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
-            [GIT_URL: 'git@github.com:testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
-            [GIT_URL: 'ssh://git@github.com/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
-            [GIT_URL: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
-            [GIT_URL: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedHttp: 'https://github.com/path/to/testOrg/testRepo.git', expectedOrg: 'path/to/testOrg', expectedRepo: 'testRepo'],
-            [GIT_URL: 'ssh://git@github.com/testRepo.git', expectedSsh: 'ssh://git@github.com/testRepo.git', expectedHttp: 'https://github.com/testRepo.git', expectedOrg: 'N/A', expectedRepo: 'testRepo'],
-        ]
-
-        scmInfoTestList.each {scmInfoTest ->
-            jsr.step.piperPipelineStageInit.setGitUrlsOnCommonPipelineEnvironment(nullScript, scmInfoTest.GIT_URL)
-            assertThat(nullScript.commonPipelineEnvironment.getGitSshUrl(), is(scmInfoTest.expectedSsh))
-            assertThat(nullScript.commonPipelineEnvironment.getGitHttpsUrl(), is(scmInfoTest.expectedHttp))
-            assertThat(nullScript.commonPipelineEnvironment.getGithubOrg(), is(scmInfoTest.expectedOrg))
-            assertThat(nullScript.commonPipelineEnvironment.getGithubRepo(), is(scmInfoTest.expectedRepo))
-        }
-    }
-
-    @Test
     void testPullRequestStageStepActivation() {
 
         nullScript.commonPipelineEnvironment.configuration = [

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -101,7 +101,7 @@ void call(Map parameters = [:]) {
     piperStageWrapper (script: script, stageName: stageName, stashContent: [], ordinal: 1, telemetryDisabled: true) {
         def scmInfo = checkout scm
 
-        setupCommonPipelineEnvironment(script: script, customDefaults: parameters.customDefaults,
+        setupCommonPipelineEnvironment(script: script, customDefaults: parameters.customDefaults, scmInfo: scmInfo,
             configFile: parameters.configFile, customDefaultsFromFiles: parameters.customDefaultsFromFiles)
 
         Map config = ConfigurationHelper.newInstance(this)
@@ -145,9 +145,6 @@ void call(Map parameters = [:]) {
         } else {
             initStashConfiguration(script, config.stashSettings, config.verbose?: false)
         }
-
-        setGitUrlsOnCommonPipelineEnvironment(script, scmInfo.GIT_URL)
-        script.commonPipelineEnvironment.setGitCommitId(scmInfo.GIT_COMMIT)
 
         if (config.verbose) {
             echo "piper-lib-os  configuration: ${script.commonPipelineEnvironment.configuration}"
@@ -221,62 +218,6 @@ private void initStashConfiguration (script, stashSettings, verbose) {
     Map stashConfiguration = readYaml(text: libraryResource(stashSettings))
     if (verbose) echo "Stash config: ${stashConfiguration}"
     script.commonPipelineEnvironment.configuration.stageStashes = stashConfiguration
-}
-
-private void setGitUrlsOnCommonPipelineEnvironment(script, String gitUrl) {
-
-    Map url = parseUrl(gitUrl)
-
-    if (url.protocol in ['http', 'https']) {
-        script.commonPipelineEnvironment.setGitSshUrl("git@${url.host}:${url.path}")
-        script.commonPipelineEnvironment.setGitHttpsUrl(gitUrl)
-    } else if (url.protocol in [ null, 'ssh', 'git']) {
-        script.commonPipelineEnvironment.setGitSshUrl(gitUrl)
-        script.commonPipelineEnvironment.setGitHttpsUrl("https://${url.host}/${url.path}")
-    }
-
-    List gitPathParts = url.path.replaceAll('.git', '').split('/')
-    def gitFolder = 'N/A'
-    def gitRepo = 'N/A'
-    switch (gitPathParts.size()) {
-        case 1:
-            gitRepo = gitPathParts[0]
-            break
-        case 2:
-            gitFolder = gitPathParts[0]
-            gitRepo = gitPathParts[1]
-            break
-        case { it > 3 }:
-            gitRepo = gitPathParts[gitPathParts.size()-1]
-            gitPathParts.remove(gitPathParts.size()-1)
-            gitFolder = gitPathParts.join('/')
-            break
-    }
-    script.commonPipelineEnvironment.setGithubOrg(gitFolder)
-    script.commonPipelineEnvironment.setGithubRepo(gitRepo)
-}
-
-/*
- * Returns the parts of an url.
- * Valid keys for the retured map are:
- *   - protocol
- *   - auth
- *   - host
- *   - port
- *   - path
- */
-@NonCPS
-/* private */ Map parseUrl(String url) {
-
-    def urlMatcher = url =~ /^((http|https|git|ssh):\/\/)?((.*)@)?([^:\/]+)(:([\d]*))?(\/?(.*))$/
-
-    return [
-        protocol: urlMatcher[0][2],
-        auth: urlMatcher[0][4],
-        host: urlMatcher[0][5],
-        port: urlMatcher[0][7],
-        path: urlMatcher[0][9],
-    ]
 }
 
 private void setPullRequestStageStepActivation(script, config, List actions) {

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -38,7 +38,7 @@ import groovy.transform.Field
      * `customDefaults`, but from local or remote files instead of library resources. They are merged with and
      * take precedence over `customDefaults`.*/
     'customDefaultsFromFiles',
-    /** Information object returned from the Jenkins git checkout step to set the git information in the
+    /** The map returned from a Jenkins git checkout. Used to set the git information in the
      * common pipeline environment */
     'scmInfo'
 ]


### PR DESCRIPTION
Everything cpe related should be done in setupCommonPipelineEnvironment.
Thus a new parameter was introduced to accept the scmInfo object
returned by a checkout.

# Changes

- [x] Tests
- [x] Documentation
