### PR TITLE
docs: make used library and binary name in samples exchangeable

### DIFF
--- a/pkg/documentation/generator.go
+++ b/pkg/documentation/generator.go
@@ -9,21 +9,31 @@ import (
 
 	generator "github.com/SAP/jenkins-library/pkg/documentation/generator"
 	"github.com/SAP/jenkins-library/pkg/generator/helper"
+	"github.com/ghodss/yaml"
 )
 
 func main() {
 	var metadataPath string
 	var docTemplatePath string
+	var customLibraryStepFile string
 
 	flag.StringVar(&metadataPath, "metadataDir", "./resources/metadata", "The directory containing the step metadata. Default points to \\'resources/metadata\\'.")
 	flag.StringVar(&docTemplatePath, "docuDir", "./documentation/docs/steps/", "The directory containing the docu stubs. Default points to \\'documentation/docs/steps/\\'.")
-	flag.StringVar(&generator.LibraryName, "libraryName", generator.LibraryName, "")
-	flag.StringVar(&generator.BinaryName, "binaryName", generator.BinaryName, "")
+	flag.StringVar(&customLibraryStepFile, "customLibraryStepFile", "", "")
 
 	flag.Parse()
 
 	fmt.Println("using Metadata Directory:", metadataPath)
 	fmt.Println("using Documentation Directory:", docTemplatePath)
+
+	if len(customLibraryStepFile) > 0 {
+		fmt.Println("Reading custom library step mapping..")
+		content, err := ioutil.ReadFile(customLibraryStepFile)
+		checkError(err)
+		err = yaml.Unmarshal(content, &generator.CustomLibrarySteps)
+		checkError(err)
+		fmt.Println(generator.CustomLibrarySteps)
+	}
 
 	metadataFiles, err := helper.MetadataFiles(metadataPath)
 	checkError(err)

--- a/pkg/documentation/generator.go
+++ b/pkg/documentation/generator.go
@@ -17,6 +17,9 @@ func main() {
 
 	flag.StringVar(&metadataPath, "metadataDir", "./resources/metadata", "The directory containing the step metadata. Default points to \\'resources/metadata\\'.")
 	flag.StringVar(&docTemplatePath, "docuDir", "./documentation/docs/steps/", "The directory containing the docu stubs. Default points to \\'documentation/docs/steps/\\'.")
+	flag.StringVar(&generator.LibraryName, "libraryName", generator.LibraryName, "")
+	flag.StringVar(&generator.BinaryName, "binaryName", generator.BinaryName, "")
+
 	flag.Parse()
 
 	fmt.Println("using Metadata Directory:", metadataPath)

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -6,6 +6,12 @@ import (
 	"github.com/SAP/jenkins-library/pkg/config"
 )
 
+// BinaryName is the name of the local binary that is used for sample generation.
+var BinaryName string = "piper"
+
+// LibraryName is the id of the library in the Jenkins that is used for sample generation.
+var LibraryName string = "piper-lib-os"
+
 // Replaces the StepName placeholder with the content from the yaml
 func createStepName(stepData *config.StepData) string {
 	return stepData.Metadata.Name + "\n\n" + stepData.Metadata.Description + "\n"

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -6,6 +6,15 @@ import (
 	"github.com/SAP/jenkins-library/pkg/config"
 )
 
+const configRecommendation = "We recommend to define values of [step parameters](#parameters) via [config.yml file](../configuration.md). In this case, calling the step is reduced to one simple line.<br />Calling the step can be done either via the Jenkins library step or on the [command line](../cli/index.md)."
+
+const (
+	headlineDescription     = "## Description\n\n"
+	headlineUsage           = "## Usage\n\n"
+	headlineJenkinsPipeline = "### Jenkins Pipeline\n\n"
+	headlineCommandLine     = "### Command Line\n\n"
+)
+
 // BinaryName is the name of the local binary that is used for sample generation.
 var BinaryName string = "piper"
 
@@ -21,13 +30,13 @@ func createStepName(stepData *config.StepData) string {
 func createDescriptionSection(stepData *config.StepData) string {
 	description := ""
 
-	description += "Description\n\n" + stepData.Metadata.LongDescription + "\n\n"
+	description += headlineDescription + stepData.Metadata.LongDescription + "\n\n"
 
-	description += "## Usage\n\n"
-	description += "We recommend to define values of [step parameters](#parameters) via [config.yml file](../configuration.md). In this case, calling the step is reduced to one simple line.<br />Calling the step can be done either via the Jenkins library step or on the [command line](../cli/index.md).\n\n"
-	description += "### Jenkins pipelines\n\n"
-	description += fmt.Sprintf("```library('%s')\n\ngroovy\n%v script: this\n```\n", LibraryName, stepData.Metadata.Name)
-	description += "### Command line\n\n"
+	description += headlineUsage
+	description += configRecommendation + "\n\n"
+	description += headlineJenkinsPipeline
+	description += fmt.Sprintf("```groovy\nlibrary('%s')\n\n%v script: this\n```\n\n", LibraryName, stepData.Metadata.Name)
+	description += headlineCommandLine
 	description += fmt.Sprintf("```sh\n%s %v\n```\n\n", BinaryName, stepData.Metadata.Name)
 	description += stepOutputs(stepData)
 	return description

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -21,8 +21,10 @@ var defaultBinaryName string = "piper"
 // defaultLibraryName is the id of the library in the Jenkins that is used for sample generation.
 var defaultLibraryName string = "piper-lib-os"
 
+// CustomLibrarySteps holds a list of libraries with it's custom steps.
 var CustomLibrarySteps = []CustomLibrary{}
 
+// CustomLibrary represents a custom library with it's custom step names, binary name and library name.
 type CustomLibrary struct {
 	Name        string   `yaml: "name,omitempty"`
 	BinaryName  string   `yaml: "binaryName,omitempty"`

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -19,10 +19,10 @@ func createDescriptionSection(stepData *config.StepData) string {
 
 	description += "## Usage\n\n"
 	description += "We recommend to define values of [step parameters](#parameters) via [config.yml file](../configuration.md). In this case, calling the step is reduced to one simple line.<br />Calling the step can be done either via the Jenkins library step or on the [command line](../cli/index.md).\n\n"
-	description += "### Jenkins pipelines\n\n```groovy\n"
-	description += fmt.Sprintf("%v script: this\n```\n", stepData.Metadata.Name)
-	description += "### Command line\n\n```\n"
-	description += fmt.Sprintf("piper %v\n```\n\n", stepData.Metadata.Name)
+	description += "### Jenkins pipelines\n\n"
+	description += fmt.Sprintf("```groovy\n%v script: this\n```\n", stepData.Metadata.Name)
+	description += "### Command line\n\n"
+	description += fmt.Sprintf("```sh\npiper %v\n```\n\n", stepData.Metadata.Name)
 	description += stepOutputs(stepData)
 	return description
 }

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -26,9 +26,9 @@ func createDescriptionSection(stepData *config.StepData) string {
 	description += "## Usage\n\n"
 	description += "We recommend to define values of [step parameters](#parameters) via [config.yml file](../configuration.md). In this case, calling the step is reduced to one simple line.<br />Calling the step can be done either via the Jenkins library step or on the [command line](../cli/index.md).\n\n"
 	description += "### Jenkins pipelines\n\n"
-	description += fmt.Sprintf("```groovy\n%v script: this\n```\n", stepData.Metadata.Name)
+	description += fmt.Sprintf("```library('%s')\n\ngroovy\n%v script: this\n```\n", LibraryName, stepData.Metadata.Name)
 	description += "### Command line\n\n"
-	description += fmt.Sprintf("```sh\npiper %v\n```\n\n", stepData.Metadata.Name)
+	description += fmt.Sprintf("```sh\n%s %v\n```\n\n", BinaryName, stepData.Metadata.Name)
 	description += stepOutputs(stepData)
 	return description
 }

--- a/pkg/documentation/generator/description_test.go
+++ b/pkg/documentation/generator/description_test.go
@@ -1,0 +1,53 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/SAP/jenkins-library/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateStepName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *config.StepData
+		want  string
+	}{
+		{
+			name: "simple step name section",
+			input: &config.StepData{
+				Metadata: config.StepMetadata{Name: "teststep", Description: "TestDescription"},
+			},
+			want: "teststep\n\nTestDescription\n",
+		},
+	}
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			assert.Equal(t, testcase.want, createStepName(testcase.input))
+		})
+	}
+}
+
+func TestCreateDescriptionSection(t *testing.T) {
+	tests := []struct {
+		name  string
+		input *config.StepData
+		want  string
+	}{
+		{
+			name: "simple step description section",
+			input: &config.StepData{
+				Metadata: config.StepMetadata{Name: "teststep", LongDescription: "TestDescription"},
+			},
+			want: headlineDescription + "TestDescription" + "\n\n" +
+				headlineUsage + configRecommendation + "\n\n" +
+				headlineJenkinsPipeline + "```groovy\nlibrary('piper-lib-os')\n\nteststep script: this\n```" + "\n\n" +
+				headlineCommandLine + "```sh\npiper teststep\n```" + "\n\n",
+		},
+	}
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			assert.Equal(t, testcase.want, createDescriptionSection(testcase.input))
+		})
+	}
+}

--- a/pkg/documentation/generator/description_test.go
+++ b/pkg/documentation/generator/description_test.go
@@ -29,6 +29,13 @@ func TestCreateStepName(t *testing.T) {
 }
 
 func TestCreateDescriptionSection(t *testing.T) {
+	CustomLibrarySteps = []CustomLibrary{{
+		Name:        "TestLibrary",
+		BinaryName:  "myBinary",
+		LibraryName: "myLibrary",
+		Steps:       []string{"myCustomStep"},
+	}}
+
 	tests := []struct {
 		name  string
 		input *config.StepData
@@ -43,6 +50,16 @@ func TestCreateDescriptionSection(t *testing.T) {
 				headlineUsage + configRecommendation + "\n\n" +
 				headlineJenkinsPipeline + "```groovy\nlibrary('piper-lib-os')\n\nteststep script: this\n```" + "\n\n" +
 				headlineCommandLine + "```sh\npiper teststep\n```" + "\n\n",
+		},
+		{
+			name: "custom step description section",
+			input: &config.StepData{
+				Metadata: config.StepMetadata{Name: "myCustomStep", LongDescription: "TestDescription"},
+			},
+			want: headlineDescription + "TestDescription" + "\n\n" +
+				headlineUsage + configRecommendation + "\n\n" +
+				headlineJenkinsPipeline + "```groovy\nlibrary('myLibrary')\n\nmyCustomStep script: this\n```" + "\n\n" +
+				headlineCommandLine + "```sh\nmyBinary myCustomStep\n```" + "\n\n",
 		},
 	}
 	for _, testcase := range tests {


### PR DESCRIPTION
This PR provides the ability to run the docs generator with `--customLibraryStepFile` parameter to provide a list of custom steps. In the docs sample section for these steps a custom library name and binary name will be used.

Also add the `library('...')` tag that needs to be used to call the step.

<img width="778" alt="Bildschirmfoto 2020-09-29 um 15 02 56" src="https://user-images.githubusercontent.com/26137398/94561889-ee202000-0264-11eb-817f-5b05d5debc41.png">
<img width="394" alt="Bildschirmfoto 2020-09-29 um 15 03 55" src="https://user-images.githubusercontent.com/26137398/94561973-055f0d80-0265-11eb-8af8-e3783904e643.png">

The `customLibraryStepFile` parameter required a file in the following format:

```yaml
- name: anyName
  binaryName: myBinary
  libraryName: my-custom-library-name
  steps:
    - myCustomStep
    - ...
```