### PR TITLE
fix: make unstash work for parallel executions

### DIFF
--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -92,7 +92,7 @@ def unstash(name, msg = "Unstash failed:") {
 def unstashAll(stashContent) {
     def unstashedContent = []
     if (stashContent) {
-        for (i = 0; i < stashContent.size(); i++) {
+        for (int i = 0; i < stashContent.size(); i++) {
             if (stashContent[i]) {
                 unstashedContent += unstash(stashContent[i])
             }


### PR DESCRIPTION
without 'int' in a 'for (i = 0; ...)' loop 'i' is
a global variable and the value gets inside some parallel
execution randomly incremented from the parallel threads.

Defining it with the keyword 'int' makes it a method local
variable which does not change its value 'randomly'.

# Changes

- [ ] Tests
- [ ] Documentation
