### PR TITLE
Issue #2103 new project never called

### DIFF
--- a/cmd/checkmarxExecuteScan.go
+++ b/cmd/checkmarxExecuteScan.go
@@ -93,7 +93,8 @@ func loadExistingProject(sys checkmarx.System, initialProjectName, pullRequestNa
 		if err != nil || len(projects) == 0 {
 			projects, err = sys.GetProjectsByNameAndTeam(initialProjectName, teamID)
 			if err != nil || len(projects) == 0 {
-				return project, projectName, errors.Wrap(err, "no projects found")
+				log.Entry().Infof("no projects found")
+				return project, projectName, nil
 			}
 			branchProject, err := sys.GetProjectByID(sys.CreateBranch(projects[0].ID, projectName))
 			if err != nil {
@@ -107,7 +108,8 @@ func loadExistingProject(sys checkmarx.System, initialProjectName, pullRequestNa
 	} else {
 		projects, err := sys.GetProjectsByNameAndTeam(projectName, teamID)
 		if err != nil || len(projects) == 0 {
-			return project, projectName, errors.Wrap(err, "no projects found")
+			log.Entry().Infof("no projects found")
+			return project, projectName, nil
 		}
 		project = projects[0]
 		log.Entry().Debugf("Loaded project with name %v", project.Name)

--- a/cmd/checkmarxExecuteScan_test.go
+++ b/cmd/checkmarxExecuteScan_test.go
@@ -321,6 +321,22 @@ func TestRunScan(t *testing.T) {
 	assert.Equal(t, true, sys.scanProjectCalled, "ScanProject was not invoked")
 }
 
+func TestRunScanCreateNewProject(t *testing.T) {
+	sys := &systemMock{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`), createProject: true}
+	options := checkmarxExecuteScanOptions{ProjectName: "TestExisting", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "10048", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
+	workspace, err := ioutil.TempDir("", "workspace1")
+	if err != nil {
+		t.Fatal("Failed to create temporary workspace directory")
+	}
+	// clean up tmp dir
+	defer os.RemoveAll(workspace)
+
+	influx := checkmarxExecuteScanInflux{}
+
+	err = runScan(options, sys, workspace, &influx)
+	assert.NoError(t, err, "error occured but none expected")
+}
+
 func TestVerifyOnly(t *testing.T) {
 	sys := &systemMockForExistingProject{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`)}
 	options := checkmarxExecuteScanOptions{VerifyOnly: true, ProjectName: "TestExisting", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "10048", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}


### PR DESCRIPTION
# Changes
https://github.com/SAP/jenkins-library/issues/2103
Handles "No Project found" as log and returns no error to process project creation.

- [ x ] Tests
- [ ? ] Documentation
