### PR TITLE
Fix Cloud SDK Pipeline stash settings for security stage

### DIFF
--- a/resources/com.sap.piper/pipeline/cloudSdkJavaStashSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkJavaStashSettings.yml
@@ -54,6 +54,10 @@ compliance:
   unstash: ['SOURCE', 'M2', 'REPORTS', 'TARGET', 'EXEC_FILES']
   stashes: []
 
+security:
+  unstash: ["SOURCE"]
+  stashes: []
+
 additionalUnitTests:
   unstash: ["SOURCE", "NODE_MODULES", "GENERATED_CAP_FILES"]
   stashes:

--- a/resources/com.sap.piper/pipeline/cloudSdkJavascriptStashSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkJavascriptStashSettings.yml
@@ -51,6 +51,10 @@ compliance:
   unstash: ['SOURCE', 'NODE_MODULES', 'DIST']
   stashes: []
 
+security:
+  unstash: ["SOURCE"]
+  stashes: []
+
 endToEndTests:
   unstash: ["SOURCE", "DEPLOYMENTARTIFACT", "NODE_MODULES", "GENERATED_CAP_FILES"]
   stashes: []

--- a/resources/com.sap.piper/pipeline/cloudSdkMtaStashSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkMtaStashSettings.yml
@@ -54,6 +54,10 @@ compliance:
   unstash: ['SOURCE', 'M2', 'NODE_MODULES', 'REPORTS', 'TARGET']
   stashes: []
 
+security:
+  unstash: ["SOURCE"]
+  stashes: []
+
 additionalUnitTests:
   unstash: ["SOURCE", "NODE_MODULES"]
   stashes:


### PR DESCRIPTION
# Changes

This change fixes the stash settings for the security stage in Cloud
SDK Pipeline. Previously, the SOURCES stash was not unstashed, thus
potentially existing extensions could not be found.

- [ ] Tests
- [ ] Documentation
