### PR TITLE
Forward config-related params to setupCommonPipelineEnvironment

### DIFF
--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -29,6 +29,7 @@ class PiperPipelineStageInitTest extends BasePiperTest {
         .around(jsr)
 
     private List stepsCalled = []
+    private Map  stepParams = [:]
 
     @Before
     void init() {
@@ -60,6 +61,7 @@ class PiperPipelineStageInitTest extends BasePiperTest {
 
         helper.registerAllowedMethod('setupCommonPipelineEnvironment', [Map.class], { m ->
             stepsCalled.add('setupCommonPipelineEnvironment')
+            stepParams['setupCommonPipelineEnvironment'] = m
         })
 
         helper.registerAllowedMethod('piperInitRunStageConfiguration', [Map.class], { m ->
@@ -233,6 +235,18 @@ class PiperPipelineStageInitTest extends BasePiperTest {
             'artifactSetVersion',
             'pipelineStashFilesBeforeBuild'
         ))
+    }
+
+    @Test
+    void testInitForwardConfigParams() {
+        jsr.step.piperPipelineStageInit(script: nullScript, juStabUtils: utils, configFile: 'my-config.yml',
+            customDefaults: ['my-custom-defaults.yml'], customDefaultsFromFiles: ['my-custom-default-file.yml'],
+            buildTool: 'maven')
+
+        assertThat(stepsCalled, hasItems('setupCommonPipelineEnvironment'))
+        assertThat(stepParams.setupCommonPipelineEnvironment?.configFile, is('my-config.yml'))
+        assertThat(stepParams.setupCommonPipelineEnvironment?.customDefaults, is(['my-custom-defaults.yml']))
+        assertThat(stepParams.setupCommonPipelineEnvironment?.customDefaultsFromFiles, is(['my-custom-default-file.yml']))
     }
 
     @Test

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -62,6 +62,23 @@ import static com.sap.piper.Prerequisites.checkScript
      * Enables the use of technical stage names.
      */
     'useTechnicalStageNames',
+    /**
+     * Optional path to the pipeline configuration file defining project specific settings.
+     */
+    'configFile',
+    /**
+     * Optional list of file names which will be extracted from library resources and which serve as source for
+     * default values for the pipeline configuration. These are merged with and override built-in defaults, with
+     * a parameter supplied by the last resource file taking precedence over the same parameter supplied in an
+     * earlier resource file or built-in default.
+     */
+    'customDefaults',
+    /**
+     * Optional list of file paths or URLs which must point to YAML content. These work exactly like
+     * `customDefaults`, but from local or remote files instead of library resources. They are merged with and
+     * take precedence over `customDefaults`.
+     */
+    'customDefaultsFromFiles'
 ])
 
 /**
@@ -84,7 +101,8 @@ void call(Map parameters = [:]) {
     piperStageWrapper (script: script, stageName: stageName, stashContent: [], ordinal: 1, telemetryDisabled: true) {
         def scmInfo = checkout scm
 
-        setupCommonPipelineEnvironment script: script, customDefaults: parameters.customDefaults
+        setupCommonPipelineEnvironment(script: script, customDefaults: parameters.customDefaults,
+            configFile: parameters.configFile, customDefaultsFromFiles: parameters.customDefaultsFromFiles)
 
         Map config = ConfigurationHelper.newInstance(this)
             .loadStepDefaults()


### PR DESCRIPTION
# Changes

Allow calling the `piperPipelineStageInit` with the parameters `configFile` and `customDefaultsFromFiles` in addition to the already forwarded `customDefaults`.

Still only `customDefaults` can be parameter to `piperPipeline`, I've not modified the GP pipeline itself. The Init stage is however called from the Cloud SDK Pipeline, and the change is useful there.

- [x] Tests
- [x] Documentation
