### PR TITLE
chore(detect): add error category for policy violations

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -17,7 +17,13 @@ import (
 )
 
 func detectExecuteScan(config detectExecuteScanOptions, telemetryData *telemetry.CustomData) {
-	c := command.Command{}
+	c := command.Command{
+		ErrorCategoryMapping: map[string][]string{
+			log.ErrorCompliance.String(): {
+				"Exiting with code 3 - FAILURE_POLICY_VIOLATION",
+			},
+		},
+	}
 	// reroute command output to logging framework
 	c.Stdout(log.Writer())
 	c.Stderr(log.Writer())

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -20,7 +20,7 @@ func detectExecuteScan(config detectExecuteScanOptions, telemetryData *telemetry
 	c := command.Command{
 		ErrorCategoryMapping: map[string][]string{
 			log.ErrorCompliance.String(): {
-				"Exiting with code 3 - FAILURE_POLICY_VIOLATION",
+				"FAILURE_POLICY_VIOLATION - Detect found policy violations.",
 			},
 		},
 	}


### PR DESCRIPTION
Adds an error category for policy violation issues.

```log
10:03:04  info  detectExecuteScan - 2020-10-06 08:03:04 INFO  [main] --- Overall Status: FAILURE_POLICY_VIOLATION - Detect found policy violations.
10:03:04  info  detectExecuteScan - 2020-10-06 08:03:04 INFO  [main] --- 
10:03:04  info  detectExecuteScan - 2020-10-06 08:03:04 INFO  [main] --- ===============================
10:03:04  info  detectExecuteScan - 2020-10-06 08:03:04 INFO  [main] --- 
10:03:04  info  detectExecuteScan - 2020-10-06 08:03:04 INFO  [main] --- Detect duration: 00h 01m 56s 765ms
10:03:04  error detectExecuteScan - 2020-10-06 08:03:04 ERROR [main] --- Exiting with code 3 - FAILURE_POLICY_VIOLATION
```