### PR TITLE
chore(sonar): add error category

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -60,6 +60,7 @@ func sonarExecuteScan(config sonarExecuteScanOptions, _ *telemetry.CustomData, i
 	runner := command.Command{
 		ErrorCategoryMapping: map[string][]string{
 			log.ErrorConfiguration.String(): {
+				"You must define the following mandatory properties for '*': *",
 				"org.sonar.java.AnalysisException: Your project contains .java files, please provide compiled classes with sonar.java.binaries property, or exclude them from the analysis with sonar.exclusions property.",
 				"ERROR: Invalid value for *",
 				"java.lang.IllegalStateException: No files nor directories matching '*'",


### PR DESCRIPTION
Adds error category for `You must define the following mandatory properties for 'Unknown': sonar.projectKey, sonar.sources`.