### PR TITLE
Fix EOF http issue

### DIFF
--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -125,6 +125,7 @@ func GetHTTPResponse(requestType string, connectionDetails ConnectionDetailsHTTP
 	header["x-csrf-token"] = []string{connectionDetails.XCsrfToken}
 
 	req, err := client.SendRequest(requestType, connectionDetails.URL, bytes.NewBuffer(body), header, nil)
+	req.Close = true
 	return req, err
 }
 


### PR DESCRIPTION
# Changes

- [X] Tests

The ABAP steps run occasionally into EOF HTTP errors.
It seems that this issue corresponds to https://stackoverflow.com/questions/17714494/golang-http-request-results-in-eof-errors-when-making-multiple-requests-successi
This PR is the proposed solution