### PR TITLE
WhiteSource: Pass correct module path to npm.InstallAllDependencies()

### DIFF
--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -639,7 +639,7 @@ func executeNpmScanForModule(modulePath string, config *ScanOptions, scan *white
 		return err
 	}
 
-	if err := reinstallNodeModulesIfLsFails(modulePath, config, utils); err != nil {
+	if err := reinstallNodeModulesIfLsFails(config, utils); err != nil {
 		return err
 	}
 
@@ -681,7 +681,7 @@ func getNpmProjectName(modulePath string, utils whitesourceUtils) (string, error
 // This hack/work-around that should be removed once scanning it consistently performed using the Unified Agent.
 // A possible reason for encountering "npm ls" errors in the first place is that a different node version
 // is used for whitesourceExecuteScan due to a different docker image being used compared to the build stage.
-func reinstallNodeModulesIfLsFails(modulePath string, config *ScanOptions, utils whitesourceUtils) error {
+func reinstallNodeModulesIfLsFails(config *ScanOptions, utils whitesourceUtils) error {
 	// No need to have output from "npm ls" in the log
 	utils.Stdout(ioutil.Discard)
 	defer utils.Stdout(log.Writer())
@@ -706,7 +706,8 @@ func reinstallNodeModulesIfLsFails(modulePath string, config *ScanOptions, utils
 			return fmt.Errorf("failed to remove package-lock.json: %w", err)
 		}
 	}
-	return utils.InstallAllNPMDependencies(config, []string{modulePath})
+	// Passing only "package.json", because we are already inside the module's directory.
+	return utils.InstallAllNPMDependencies(config, []string{"package.json"})
 }
 
 // executeYarnScan generates a configuration file whitesource.config.json with appropriate values from config,


### PR DESCRIPTION
# Changes

Pass correct module path to npm.InstallAllDependencies(). We are already in the module's directory.

- [x] Tests
- [ ] Documentation
