### PR TITLE
fix(influx): read simple values from json

### DIFF
--- a/src/com/sap/piper/analytics/InfluxData.groovy
+++ b/src/com/sap/piper/analytics/InfluxData.groovy
@@ -58,7 +58,18 @@ class InfluxData implements Serializable{
                     def value
                     if (name.endsWith(".json")){
                         name = name.replace(".json","")
-                        value = script.readJSON(text: fileContent)
+                        // net.sf.json.JSONSerializer does only handle lists and maps
+                        // http://json-lib.sourceforge.net/apidocs/net/sf/json/package-summary.html
+                        try{
+                            value = script.readJSON(text: fileContent)
+                        }catch(net.sf.json.JSONException e){
+                            // try to wrap the value in an object and read again
+                            if (e.getMessage() == "Invalid JSON String"){
+                                value = script.readJSON(text: "{\"content\": ${fileContent}}").content
+                            }else{
+                                throw e
+                            }
+                        }
                     }else{
                         // handle boolean values
                         if(fileContent == 'true'){


### PR DESCRIPTION
The `net.sf.json.JSONSerializer` reads only `map` and `list` from JSON. 

With this change the Influx handler reads the content again wrapped into an object if an error occurred during reading.

required by #2132