### PR TITLE
WhiteSource: Remove performance-tests from default maven excludes

### DIFF
--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -487,7 +487,6 @@ func generateMavenWhitesourceFlags(config *ScanOptions, utils whitesourceUtils) 
 		excludes = []string{
 			filepath.Join("unit-tests", "pom.xml"),
 			filepath.Join("integration-tests", "pom.xml"),
-			filepath.Join("performance-tests", "pom.xml"),
 		}
 	}
 	// From the documentation, these are file paths to a module's pom.xml.

--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -628,7 +628,7 @@ func executeNpmScanForModule(modulePath string, config *ScanOptions, scan *white
 	}
 	defer func() { _ = utils.FileRemove(whiteSourceConfig) }()
 
-	projectName, err := getNpmProjectName(modulePath, utils)
+	projectName, err := getNpmProjectName(dir, utils)
 	if err != nil {
 		return err
 	}

--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -483,12 +483,7 @@ func generateMavenWhitesourceDefines(config *ScanOptions) []string {
 
 func generateMavenWhitesourceFlags(config *ScanOptions, utils whitesourceUtils) (flags []string, excludes []string) {
 	excludes = config.BuildDescriptorExcludeList
-	if len(excludes) == 0 {
-		excludes = []string{
-			filepath.Join("unit-tests", "pom.xml"),
-			filepath.Join("integration-tests", "pom.xml"),
-		}
-	}
+
 	// From the documentation, these are file paths to a module's pom.xml.
 	// For MTA projects, we want to support mixing paths to package.json files and pom.xml files.
 	for _, exclude := range excludes {

--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -139,7 +139,7 @@ func addWhitesourceExecuteScanFlags(cmd *cobra.Command, stepConfig *whitesourceE
 	cmd.Flags().StringVar(&stepConfig.ParallelLimit, "parallelLimit", `15`, "Limit of parallel jobs being run at once in case of `scanType: 'mta'` based scenarios, defaults to `15`.")
 	cmd.Flags().BoolVar(&stepConfig.Reporting, "reporting", true, "Whether assessment is being done at all, defaults to `true`")
 	cmd.Flags().StringVar(&stepConfig.ServiceURL, "serviceUrl", `https://saas.whitesourcesoftware.com/api`, "URL to the WhiteSource server API used for communication.")
-	cmd.Flags().StringSliceVar(&stepConfig.BuildDescriptorExcludeList, "buildDescriptorExcludeList", []string{}, "List of build descriptors and therefore modules to exclude from the scan and assessment activities.")
+	cmd.Flags().StringSliceVar(&stepConfig.BuildDescriptorExcludeList, "buildDescriptorExcludeList", []string{`unit-tests/pom.xml`, `integration-tests/pom.xml`}, "List of build descriptors and therefore modules to exclude from the scan and assessment activities.")
 	cmd.Flags().StringVar(&stepConfig.OrgToken, "orgToken", os.Getenv("PIPER_orgToken"), "WhiteSource token identifying your organization.")
 	cmd.Flags().StringVar(&stepConfig.UserToken, "userToken", os.Getenv("PIPER_userToken"), "WhiteSource token identifying the user executing the scan")
 	cmd.Flags().BoolVar(&stepConfig.LicensingVulnerabilities, "licensingVulnerabilities", true, "Whether license compliance is considered and reported as part of the assessment.")

--- a/cmd/whitesourceExecuteScan_test.go
+++ b/cmd/whitesourceExecuteScan_test.go
@@ -419,7 +419,7 @@ func TestExecuteScanNPM(t *testing.T) {
 		// test
 		err := executeScan(&config, scan, utilsMock)
 		// assert
-		assert.EqualError(t, err, "failed to scan NPM module 'package.json': the file 'package.json/package.json' must configure a name")
+		assert.EqualError(t, err, "failed to scan NPM module 'package.json': the file '"+filepath.Join("package.json", "package.json")+"' must configure a name")
 	})
 	t.Run("npm ls fails", func(t *testing.T) {
 		// init

--- a/cmd/whitesourceExecuteScan_test.go
+++ b/cmd/whitesourceExecuteScan_test.go
@@ -419,7 +419,7 @@ func TestExecuteScanNPM(t *testing.T) {
 		// test
 		err := executeScan(&config, scan, utilsMock)
 		// assert
-		assert.EqualError(t, err, "failed to scan NPM module 'package.json': the file '"+filepath.Join("package.json", "package.json")+"' must configure a name")
+		assert.EqualError(t, err, "failed to scan NPM module 'package.json': the file 'package.json' must configure a name")
 	})
 	t.Run("npm ls fails", func(t *testing.T) {
 		// init

--- a/resources/metadata/whitesource.yaml
+++ b/resources/metadata/whitesource.yaml
@@ -159,6 +159,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+        default: ["unit-tests/pom.xml","integration-tests/pom.xml"]
       - name: orgToken
         type: string
         description: "WhiteSource token identifying your organization."


### PR DESCRIPTION
# Changes

This change fixes an issue with the default maven excludes where the step would fail when performance tests are present in the project, but are not a module in the root pom. In addition, it provides a small fix of an assertion on a file path to also work on Windows.

- [x] Tests
- [ ] Documentation
