### PR TITLE
fix(docs): correct md syntax for headlines

### DIFF
--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -34,7 +34,7 @@ type CustomLibrary struct {
 
 // Replaces the StepName placeholder with the content from the yaml
 func createStepName(stepData *config.StepData) string {
-	return "## " + stepData.Metadata.Name + "\n\n" + stepData.Metadata.Description + "\n"
+	return "# " + stepData.Metadata.Name + "\n\n" + stepData.Metadata.Description + "\n"
 }
 
 // Replaces the Description placeholder with content from the yaml

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -34,7 +34,7 @@ type CustomLibrary struct {
 
 // Replaces the StepName placeholder with the content from the yaml
 func createStepName(stepData *config.StepData) string {
-	return stepData.Metadata.Name + "\n\n" + stepData.Metadata.Description + "\n"
+	return "## " + stepData.Metadata.Name + "\n\n" + stepData.Metadata.Description + "\n"
 }
 
 // Replaces the Description placeholder with content from the yaml

--- a/pkg/documentation/generator/description_test.go
+++ b/pkg/documentation/generator/description_test.go
@@ -18,7 +18,7 @@ func TestCreateStepName(t *testing.T) {
 			input: &config.StepData{
 				Metadata: config.StepMetadata{Name: "teststep", Description: "TestDescription"},
 			},
-			want: "teststep\n\nTestDescription\n",
+			want: "# teststep\n\nTestDescription\n",
 		},
 	}
 	for _, testcase := range tests {

--- a/pkg/documentation/generator/helper.go
+++ b/pkg/documentation/generator/helper.go
@@ -15,9 +15,9 @@ func readAndAdjustTemplate(docFile io.ReadCloser) string {
 	contentStr := string(content)
 
 	//replace old placeholder with new ones
-	contentStr = strings.ReplaceAll(contentStr, "${docGenStepName}", "{{StepName .}}")
-	contentStr = strings.ReplaceAll(contentStr, "${docGenDescription}", "{{Description .}}")
-	contentStr = strings.ReplaceAll(contentStr, "${docGenParameters}", "{{Parameters .}}")
+	contentStr = strings.ReplaceAll(contentStr, "## ${docGenStepName}", "{{StepName .}}")
+	contentStr = strings.ReplaceAll(contentStr, "## ${docGenDescription}", "{{Description .}}")
+	contentStr = strings.ReplaceAll(contentStr, "## ${docGenParameters}", "{{Parameters .}}")
 	contentStr = strings.ReplaceAll(contentStr, "## ${docGenConfiguration}", "")
 	contentStr = strings.ReplaceAll(contentStr, "## ${docJenkinsPluginDependencies}", "")
 

--- a/pkg/documentation/generator/helper.go
+++ b/pkg/documentation/generator/helper.go
@@ -15,7 +15,7 @@ func readAndAdjustTemplate(docFile io.ReadCloser) string {
 	contentStr := string(content)
 
 	//replace old placeholder with new ones
-	contentStr = strings.ReplaceAll(contentStr, "## ${docGenStepName}", "{{StepName .}}")
+	contentStr = strings.ReplaceAll(contentStr, "# ${docGenStepName}", "{{StepName .}}")
 	contentStr = strings.ReplaceAll(contentStr, "## ${docGenDescription}", "{{Description .}}")
 	contentStr = strings.ReplaceAll(contentStr, "## ${docGenParameters}", "{{Parameters .}}")
 	contentStr = strings.ReplaceAll(contentStr, "## ${docGenConfiguration}", "")

--- a/pkg/documentation/generator/parameters.go
+++ b/pkg/documentation/generator/parameters.go
@@ -11,7 +11,7 @@ import (
 // Replaces the Parameters placeholder with the content from the yaml
 func createParametersSection(stepData *config.StepData) string {
 
-	var parameters = "Parameters\n\n"
+	var parameters = "## Parameters\n\n"
 
 	// sort parameters alphabetically with mandatory parameters first
 	sortStepParameters(stepData, true)


### PR DESCRIPTION
Correct header for `Description` and align handling of `md` healing syntax.

<img width="483" alt="Bildschirmfoto 2020-10-14 um 15 26 01" src="https://user-images.githubusercontent.com/26137398/95995304-97544200-0e31-11eb-8e66-68d2d0957c74.png">
