### PR TITLE
fix(cfDeploy): correct type of default value

### DIFF
--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -233,7 +233,7 @@ spec:
           - STAGES
           - STEPS
           - GENERAL
-        default: "manifest-variables.yml"
+        default: ["manifest-variables.yml"]
         mandatory: false
         aliases:
           - name: cfManifestVariablesFiles


### PR DESCRIPTION
This PR corrects the type of the default for `manifestVariablesFiles` to be `[]string` instead of `string`.

- [ ] ~~regenerate code~~