### PR TITLE
fix(docs): flag mandatory parameters with default value as non-mandatory

### DIFF
--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -32,17 +32,9 @@ func GenerateStepDocumentation(metadataFiles []string, docuHelperData DocuHelper
 		err = stepData.ReadPipelineStepData(metadataFile)
 		checkError(err)
 
-		for key, parameter := range stepData.Spec.Inputs.Parameters {
-			if parameter.Mandatory {
-				if parameter.Default == nil ||
-					parameter.Default == "" ||
-					parameter.Type == "[]string" && len(parameter.Default.([]string)) == 0 {
-					continue
-				}
-				fmt.Printf("Changing mandatory flag to '%v' for parameter '%s', default value available '%v'.\n", false, parameter.Name, parameter.Default)
-				stepData.Spec.Inputs.Parameters[key].Mandatory = false
-			}
-		}
+		adjustDefaultValues(&stepData)
+
+		adjustMandatoryFlags(&stepData)
 
 		fmt.Print("  Generate documentation.. ")
 		err = generateStepDocumentation(stepData, docuHelperData)
@@ -54,6 +46,46 @@ func GenerateStepDocumentation(metadataFiles []string, docuHelperData DocuHelper
 		}
 	}
 	return nil
+}
+
+func getEmptyForType(parameter config.StepParameters) interface{} {
+	switch parameter.Type {
+	case "bool":
+		return false
+	case "int":
+		return 0
+	case "string":
+		return ""
+	case "[]string":
+		return []string{}
+	default:
+		return nil
+	}
+}
+
+func adjustDefaultValues(stepData *config.StepData) {
+	for key, parameter := range stepData.Spec.Inputs.Parameters {
+		if parameter.Default != nil {
+			continue
+		}
+		typedDefault := getEmptyForType(parameter)
+		fmt.Printf("Changing default value to '%v' for parameter '%s', was '%v'.\n", typedDefault, parameter.Name, parameter.Default)
+		stepData.Spec.Inputs.Parameters[key].Default = typedDefault
+	}
+}
+
+func adjustMandatoryFlags(stepData *config.StepData) {
+	for key, parameter := range stepData.Spec.Inputs.Parameters {
+		if parameter.Mandatory {
+			if parameter.Default == nil ||
+				parameter.Default == "" ||
+				parameter.Type == "[]string" && len(parameter.Default.([]string)) == 0 {
+				continue
+			}
+			fmt.Printf("Changing mandatory flag to '%v' for parameter '%s', default value available '%v'.\n", false, parameter.Name, parameter.Default)
+			stepData.Spec.Inputs.Parameters[key].Mandatory = false
+		}
+	}
 }
 
 // generates the step documentation and replaces the template with the generated documentation

--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -31,6 +31,19 @@ func GenerateStepDocumentation(metadataFiles []string, docuHelperData DocuHelper
 		fmt.Printf("Reading file: %v\n", configFilePath)
 		err = stepData.ReadPipelineStepData(metadataFile)
 		checkError(err)
+
+		for key, parameter := range stepData.Spec.Inputs.Parameters {
+			if parameter.Mandatory {
+				if parameter.Default == nil ||
+					parameter.Default == "" ||
+					parameter.Type == "[]string" && len(parameter.Default.([]string)) == 0 {
+					continue
+				}
+				fmt.Printf("Changing mandatory flag to '%v' for parameter '%s', default value available '%v'.\n", false, parameter.Name, parameter.Default)
+				stepData.Spec.Inputs.Parameters[key].Mandatory = false
+			}
+		}
+
 		fmt.Print("  Generate documentation.. ")
 		err = generateStepDocumentation(stepData, docuHelperData)
 		if err != nil {

--- a/pkg/documentation/generator/main_test.go
+++ b/pkg/documentation/generator/main_test.go
@@ -88,3 +88,78 @@ func TestSetDefaultAndPossisbleValues(t *testing.T) {
 	assert.Equal(t, []interface{}{true, false}, stepData.Spec.Inputs.Parameters[0].PossibleValues)
 
 }
+
+func Test_adjustDefaultValues(t *testing.T) {
+
+	tests := []struct {
+		want  interface{}
+		name  string
+		input *config.StepData
+	}{
+		{want: false, name: "boolean", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "bool", Mandatory: true},
+		}}}}},
+		{want: 0, name: "integer", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "int", Mandatory: true},
+		}}}}},
+		{want: "", name: "string", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "string", Mandatory: true},
+		}}}}},
+		{want: []string{}, name: "string array", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "[]string", Mandatory: true},
+		}}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// test
+			adjustDefaultValues(tt.input)
+			// assert
+			assert.Equal(t, tt.want, tt.input.Spec.Inputs.Parameters[0].Default)
+		})
+	}
+}
+
+func Test_adjustMandatoryFlags(t *testing.T) {
+	tests := []struct {
+		want  bool
+		name  string
+		input *config.StepData
+	}{
+		// TODO: current impl does not met expectations, but behavior is corrected by adjustDefaultValues
+		// {want: false, name: "boolean with default not set", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+		// 	{Name: "param", Type: "bool", Mandatory: true},
+		// }}}}},
+		{want: false, name: "boolean with empty default", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "bool", Mandatory: true, Default: false},
+		}}}}},
+		{want: false, name: "boolean with default", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "bool", Mandatory: true, Default: true},
+		}}}}},
+		{want: true, name: "string with default not set", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "string", Mandatory: true},
+		}}}}},
+		{want: true, name: "string with empty default", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "string", Mandatory: true, Default: ""},
+		}}}}},
+		{want: false, name: "string with default", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "string", Mandatory: true, Default: "Oktober"},
+		}}}}},
+		{want: true, name: "string array with default not set", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "[]string", Mandatory: true},
+		}}}}},
+		{want: true, name: "string array with empty default", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "[]string", Mandatory: true, Default: []string{}},
+		}}}}},
+		{want: false, name: "string array with default", input: &config.StepData{Spec: config.StepSpec{Inputs: config.StepInputs{Parameters: []config.StepParameters{
+			{Name: "param", Type: "[]string", Mandatory: true, Default: []string{"Oktober"}},
+		}}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// test
+			adjustMandatoryFlags(tt.input)
+			// assert
+			assert.Equal(t, tt.want, tt.input.Spec.Inputs.Parameters[0].Mandatory)
+		})
+	}
+}

--- a/pkg/documentation/generator/parameters.go
+++ b/pkg/documentation/generator/parameters.go
@@ -105,7 +105,7 @@ func createParameterDetails(stepData *config.StepData) string {
 
 		details += fmt.Sprintf("| Aliases | %v |\n", aliasList(param.Aliases))
 		details += fmt.Sprintf("| Type | `%v` |\n", param.Type)
-		details += fmt.Sprintf("| Mandatory | %v |\n", ifThenElse(param.Mandatory && param.Default == nil, "**yes**", "no"))
+		details += fmt.Sprintf("| Mandatory | %v |\n", ifThenElse(param.Mandatory, "**yes**", "no"))
 		details += fmt.Sprintf("| Default | %v |\n", formatDefault(param, stepParameterNames))
 		if param.PossibleValues != nil {
 			details += fmt.Sprintf("| Possible values | %v |\n", possibleValueList(param.PossibleValues))


### PR DESCRIPTION
This PR makes the docs generator flag parameters that come with a default as optional. This also corrects the default values depending on their type to be not `nil`.