### PR TITLE
Cloud SDK: Update stash settings, stage defaults and containers map for a single call of integration stage

### DIFF
--- a/documentation/docs/pipelines/cloud-sdk/configuration.md
+++ b/documentation/docs/pipelines/cloud-sdk/configuration.md
@@ -58,6 +58,10 @@ To configure static code checks, please configure the step `mavenExecuteStaticCo
 
 ### backendIntegrationTests
 
+The `backendIntegrationTests` stage has been integrated into the project "Piper" stage `Integration`.
+Thus, it is required to update the stage name in the stages section of your configuration to `integration`.
+The configuration parameters available for the stage remain the same.
+
 | Property | Mandatory | Default Value | Description |
 | --- | --- | --- | --- |
 | `retry` | | `1` | The number of times that integration tests will retry before aborting the build. **Note:** This will consume more time for the jenkins build. |
@@ -67,7 +71,7 @@ To configure static code checks, please configure the step `mavenExecuteStaticCo
 Example:
 
 ```yaml
-backendIntegrationTests:
+integration:
   retry: 2
   credentials:
     - alias: 'ERP'
@@ -91,7 +95,7 @@ To use this optional feature the following configuration values have to be provi
 Example:
 
 ```yaml
-backendIntegrationTests:
+integration:
   retry: 2
   credentials:
     - alias: 'ERP'
@@ -106,6 +110,10 @@ backendIntegrationTests:
 ```
 
 ### frontendIntegrationTests
+
+The `frontendIntegrationTests` stage has been integrated into the project "Piper" stage `Integration`.
+Thus, it is required to update the stage name in the stages section of your configuration to `integration`.
+The configuration parameters available for the stage remain the same.
 
 | Property | Mandatory | Default Value | Description |
 | --- | --- | --- | --- |

--- a/resources/com.sap.piper/pipeline/cloudSdkContainersMap.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkContainersMap.yml
@@ -24,11 +24,10 @@ containerMaps:
     - mtaBuild
     - mavenExecuteStaticCodeChecks
     - npmExecuteLint
-  backendIntegrationTests:
+  integration:
     - mavenExecute
     - executeNpm
     - createHdiContainer
-  frontendIntegrationTests:
     - npmExecuteScripts
   additionalUnitTests:
     - npmExecuteScripts

--- a/resources/com.sap.piper/pipeline/cloudSdkJavaStashSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkJavaStashSettings.yml
@@ -33,8 +33,8 @@ build:
       merge: true
       includes: "s4hana_pipeline/reports/**, **/target/site/**/jacoco.xml"
 
-backendIntegrationTests:
-  unstash: ["SOURCE", "M2", "TARGET", "GENERATED_CAP_FILES"]
+integration:
+  unstash: ["SOURCE", "M2", "TARGET", "NODE_MODULES", "GENERATED_CAP_FILES"]
   stashes:
     - name: "REPORTS"
       merge: true
@@ -42,13 +42,6 @@ backendIntegrationTests:
     - name: "EXEC_FILES"
       merge: true
       includes: "**/target/**/*.exec"
-
-frontendIntegrationTests:
-  unstash: ["SOURCE", "NODE_MODULES", "GENERATED_CAP_FILES"]
-  stashes:
-    - name: "REPORTS"
-      merge: true
-      includes: "s4hana_pipeline/reports/**, **/target/site/**/jacoco.xml"
 
 compliance:
   unstash: ['SOURCE', 'M2', 'REPORTS', 'TARGET', 'EXEC_FILES']

--- a/resources/com.sap.piper/pipeline/cloudSdkJavascriptStashSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkJavascriptStashSettings.yml
@@ -33,14 +33,7 @@ additionalUnitTests:
       merge: true
       includes: "s4hana_pipeline/reports/**"
 
-backendIntegrationTests:
-  unstash: ["SOURCE", "DIST", "NODE_MODULES", "GENERATED_CAP_FILES"]
-  stashes:
-    - name: "REPORTS"
-      merge: true
-      includes: "s4hana_pipeline/reports/**"
-
-frontendIntegrationTests:
+integration:
   unstash: ["SOURCE", "DIST", "NODE_MODULES", "GENERATED_CAP_FILES"]
   stashes:
     - name: "REPORTS"

--- a/resources/com.sap.piper/pipeline/cloudSdkLegacyConfigSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkLegacyConfigSettings.yml
@@ -62,6 +62,8 @@ removedOrReplacedSteps:
       The extension must pass all required options to the step via parameters, it cannot be configured in your .pipeline/config.yml."
 
 removedOrReplacedStages:
+  integrationTests:
+    newStageName: "integration"
   backendIntegrationTests:
     newStageName: "integration"
   frontendIntegrationTests:

--- a/resources/com.sap.piper/pipeline/cloudSdkLegacyConfigSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkLegacyConfigSettings.yml
@@ -63,11 +63,7 @@ removedOrReplacedSteps:
 
 removedOrReplacedStages:
   integrationTests:
-    newStageName: "integration"
-  backendIntegrationTests:
-    newStageName: "integration"
-  frontendIntegrationTests:
-    newStageName: "integration"
+    newStageName: "backendIntegrationTests"
   staticCodeChecks:
     customMessage: "Since version v32 it is required to migrate the configuration into your pom.xml file or to the configuration of the new step mavenExecuteStaticCodeChecks.
       Details can be found in the release notes as well as in the step documentation: https://sap.github.io/jenkins-library/steps/mavenExecuteStaticCodeChecks/."

--- a/resources/com.sap.piper/pipeline/cloudSdkLegacyConfigSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkLegacyConfigSettings.yml
@@ -62,8 +62,10 @@ removedOrReplacedSteps:
       The extension must pass all required options to the step via parameters, it cannot be configured in your .pipeline/config.yml."
 
 removedOrReplacedStages:
-  integrationTests:
-    newStageName: "backendIntegrationTests"
+  backendIntegrationTests:
+    newStageName: "integration"
+  frontendIntegrationTests:
+    newStageName: "integration"
   staticCodeChecks:
     customMessage: "Since version v32 it is required to migrate the configuration into your pom.xml file or to the configuration of the new step mavenExecuteStaticCodeChecks.
       Details can be found in the release notes as well as in the step documentation: https://sap.github.io/jenkins-library/steps/mavenExecuteStaticCodeChecks/."

--- a/resources/com.sap.piper/pipeline/cloudSdkMtaStashSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkMtaStashSettings.yml
@@ -33,7 +33,7 @@ build:
       merge: true
       includes: "s4hana_pipeline/reports/**, **/target/site/**/jacoco.xml"
 
-backendIntegrationTests:
+integration:
   unstash: ["SOURCE", "M2", "TARGET", "NODE_MODULES", "GENERATED_CAP_FILES"]
   stashes:
     - name: "REPORTS"
@@ -42,13 +42,6 @@ backendIntegrationTests:
     - name: "EXEC_FILES"
       merge: true
       includes: "**/target/**/*.exec"
-
-frontendIntegrationTests:
-  unstash: ["SOURCE", "NODE_MODULES", "GENERATED_CAP_FILES"]
-  stashes:
-    - name: "REPORTS"
-      merge: true
-      includes: "s4hana_pipeline/reports/**, **/target/site/**/jacoco.xml"
 
 compliance:
   unstash: ['SOURCE', 'M2', 'NODE_MODULES', 'REPORTS', 'TARGET']

--- a/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkStageDefaults.yml
@@ -9,11 +9,12 @@ stages:
           - '**/*.jsx'
           - '**/*.ts'
           - '**/*.tsx'
-  backendIntegrationTests:
+  integration:
     stepConditions:
       npmExecuteScripts:
         npmScripts:
           - 'ci-it-backend'
+          - 'ci-it-frontend'
       mavenExecuteIntegration:
         filePattern: 'integration-tests/pom.xml'
   compliance:
@@ -24,11 +25,6 @@ stages:
           - 'sonarTokenCredentialsId'
           - 'projectKey'
           - 'instance'
-  frontendIntegrationTests:
-    stepConditions:
-      npmExecuteScripts:
-        npmScripts:
-          - 'ci-it-frontend'
   additionalUnitTests:
     stepConditions:
       npmExecuteScripts:


### PR DESCRIPTION
This change updates the stash settings, stage defaults and the containers map to
allow a single call of `piperPipelineStageIntegration` in SAP Cloud SDK Pipeline.

# Changes

- [ ] Tests
- [x] Documentation
