### PR TITLE
Allow using gitSshKeyCredentialsId for npm install

### DIFF
--- a/test/groovy/SeleniumExecuteTestsTest.groovy
+++ b/test/groovy/SeleniumExecuteTestsTest.groovy
@@ -39,6 +39,7 @@ class SeleniumExecuteTestsTest extends BasePiperTest {
             gitMap = m
         })
         helper.registerAllowedMethod('usernamePassword', [Map], { m -> return m })
+        helper.registerAllowedMethod('sshagent', [List, Closure], { l, c -> c()})
         helper.registerAllowedMethod('withCredentials', [List, Closure], { l, c ->
             l.each {m ->
                 credentials.add(m)
@@ -127,9 +128,9 @@ class SeleniumExecuteTestsTest extends BasePiperTest {
         def expectedEnvVars = ['env1': 'value1', 'env2': 'value2']
         def expectedOptions = '--opt1=val1 --opt2=val2 --opt3'
         def expectedWorkspace = '/path/to/workspace'
-        
+
         nullScript.commonPipelineEnvironment.configuration = [steps:[seleniumExecuteTests:[
-            dockerImage: expectedImage, 
+            dockerImage: expectedImage,
             dockerOptions: expectedOptions,
             dockerEnvVars: expectedEnvVars,
             dockerWorkspace: expectedWorkspace
@@ -148,7 +149,7 @@ class SeleniumExecuteTestsTest extends BasePiperTest {
             assert dockerExecuteRule.dockerParams.dockerEnvVars[key] == value
         }
     }
-    
+
     @Test
     void testExecuteSeleniumCustomBuildTool() {
         stepRule.step.seleniumExecuteTests(

--- a/vars/seleniumExecuteTests.groovy
+++ b/vars/seleniumExecuteTests.groovy
@@ -39,7 +39,8 @@ import groovy.text.GStringTemplateEngine
      */
     'gitBranch',
     /**
-     * Only if `testRepository` is provided: Credentials for a protected testRepository
+     * If `testRepository` is provided: Credentials for a protected testRepository.
+     * Also used for sshagent to allow running npm install with github dependencies.
      * @possibleValues Jenkins credentials id
      */
     'gitSshKeyCredentialsId',
@@ -135,6 +136,10 @@ void call(Map parameters = [:], Closure body) {
                     :utils.unstashAll(config.stashContent)
                 if (config.seleniumHubCredentialsId) {
                     withCredentials([usernamePassword(credentialsId: config.seleniumHubCredentialsId, passwordVariable: 'PIPER_SELENIUM_HUB_PASSWORD', usernameVariable: 'PIPER_SELENIUM_HUB_USER')]) {
+                        body()
+                    }
+                } else if (config.gitSshKeyCredentialsId) {
+                    sshagent([config.gitSshKeyCredentialsId]) {
                         body()
                     }
                 } else {


### PR DESCRIPTION
Support using git ssh key in selenium tests. 
Due to recent changes, right now if we want to use dependencies for npm packages hosted on github, we have to be authenticated during npm install.

# Changes

- [x] Tests
- [x] Documentation
