### PR TITLE
detectExecuteScan: Clean up detect.sh

### DIFF
--- a/cmd/mtaBuild_test.go
+++ b/cmd/mtaBuild_test.go
@@ -9,7 +9,6 @@ import (
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/maven"
 	"github.com/SAP/jenkins-library/pkg/mock"
-	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 )
@@ -267,7 +266,7 @@ func TestMarBuild(t *testing.T) {
 		downloadAndCopySettingsFiles = func(
 			globalSettings string,
 			projectSettings string,
-			fileUtils piperutils.FileUtils,
+			fileUtils maven.FileUtils,
 			httpClient maven.SettingsDownloadUtils) error {
 			projectSettingsFile = projectSettings
 			globalSettingsFile = globalSettings

--- a/pkg/maven/maven.go
+++ b/pkg/maven/maven.go
@@ -43,7 +43,7 @@ type mavenExecRunner interface {
 }
 
 type mavenUtils interface {
-	piperutils.FileUtils
+	FileUtils
 	DownloadFile(url, filename string, header http.Header, cookies []*http.Cookie) error
 }
 

--- a/pkg/maven/settings.go
+++ b/pkg/maven/settings.go
@@ -11,10 +11,12 @@ import (
 
 var getenv = os.Getenv
 
+// SettingsDownloadUtils defines an interface for downloading files.
 type SettingsDownloadUtils interface {
 	DownloadFile(url, filename string, header http.Header, cookies []*http.Cookie) error
 }
 
+// FileUtils defines the external file-related functionality needed by this package.
 type FileUtils interface {
 	FileExists(filename string) (bool, error)
 	Copy(src, dest string) (int64, error)
@@ -22,6 +24,8 @@ type FileUtils interface {
 	Glob(pattern string) (matches []string, err error)
 }
 
+// DownloadAndGetMavenParameters downloads the global or project settings file if the strings contain URLs.
+// It then constructs the arguments that need to be passed to maven in order to point to use these settings files.
 func DownloadAndGetMavenParameters(globalSettingsFile string, projectSettingsFile string, fileUtils FileUtils, httpClient SettingsDownloadUtils) ([]string, error) {
 	mavenArgs := []string{}
 	if len(globalSettingsFile) > 0 {
@@ -48,6 +52,9 @@ func DownloadAndGetMavenParameters(globalSettingsFile string, projectSettingsFil
 	return mavenArgs, nil
 }
 
+// DownloadAndCopySettingsFiles downloads the global or project settings file if the strings contain URLs.
+// It copies the given files to either the locations specified in the environment variables M2_HOME and HOME
+// or the default locations where maven expects them.
 func DownloadAndCopySettingsFiles(globalSettingsFile string, projectSettingsFile string, fileUtils FileUtils, httpClient SettingsDownloadUtils) error {
 	if len(projectSettingsFile) > 0 {
 		destination, err := getProjectSettingsFileDest()


### PR DESCRIPTION
# Changes

Fixes #2237

* Check error from DownloadFile().
* Add deletion of "detect.sh".
* Fix tests. Shows why to avoid `assert.NotNil(t, err)`, since the test was actually getting a different error than what it tested for.
* Avoid using exported `piperutils.FileUtils` interface, at least in code I had to touch. I would have needed to extend this interface for `FileRemove()`, but this would necessitate changes in all unrelated clients of this interface, with no-op functions. That is the reason why interfaces should be declared at the client, not the provider of a struct. See also [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#interfaces).

- [x] Tests
- [ ] Documentation (does not apply)
