### PR TITLE
Adjust url in test case

### DIFF
--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -289,7 +289,7 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
         def scmInfoTestList = [
             [GIT_URL: 'https://github.com/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
             [GIT_URL: 'https://github.com:7777/testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com:7777/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
-            [GIT_URL: 'git@github.com:testOrg/testRepo.git', expectedSsh: 'git@github.com:testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'git://git@github.com/testOrg/testRepo.git', expectedSsh: 'git://git@github.com/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
             [GIT_URL: 'ssh://git@github.com/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
             [GIT_URL: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
             [GIT_URL: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedHttp: 'https://github.com/path/to/testOrg/testRepo.git', expectedOrg: 'path/to/testOrg', expectedRepo: 'testRepo'],

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -210,14 +210,14 @@ private static List copyOrDownloadCustomDefaultsIntoPipelineEnv(script, List cus
 @NonCPS
 /* private */ Map parseUrl(String url) {
 
-    def urlMatcher = url =~ /^((http|https|git|ssh):\/\/)?((.*)@)?([^:\/]+)(:([\d]*))?(\/?(.*))$/
+    def uri = new URI(url)
 
     return [
-        protocol: urlMatcher[0][2],
-        auth: urlMatcher[0][4],
-        host: urlMatcher[0][5],
-        port: urlMatcher[0][7],
-        path: urlMatcher[0][9],
+        protocol: uri.getScheme(),
+        auth: uri.getAuthority(),
+        host: uri.getHost(),
+        port: uri.getPort(),
+        path: uri.getPath().substring(1),
     ]
 }
 


### PR DESCRIPTION
The url in the test case seems to be not a valid URL.

Does anybody know if we need that url as it has been  up to now?

I'm not sure if there are real use cases using the invalid url. Maybe the url gets rewritten by e.g. some `~/.ssh/config` entries so that it is finally a valid  URL.
