### PR TITLE
Bump mta builder default image to 1.0.16.1

### DIFF
--- a/resources/metadata/mtaBuild.yaml
+++ b/resources/metadata/mtaBuild.yaml
@@ -142,7 +142,7 @@ spec:
         params:
           - name: mtarFilePath
   containers:
-    - image: devxci/mbtci:1.0.14.1
+    - image: devxci/mbtci:1.0.16.1
       imagePullPolicy: Always
       conditions:
         - conditionRef: strings-equal


### PR DESCRIPTION
The old image still configures the not used anymore registry npm.sap.com. Update to get rid of that.
