### PR TITLE
Avoid CPS serialization issue in setupCPE

### DIFF
--- a/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
+++ b/test/groovy/FioriOnCloudPlatformPipelineTest.groovy
@@ -22,6 +22,7 @@ import org.junit.rules.RuleChain
 
 import com.sap.piper.JenkinsUtils
 import com.sap.piper.Utils
+import com.sap.piper.GitUtils
 
 import util.BasePiperTest
 import util.JenkinsCredentialsRule
@@ -115,12 +116,16 @@ class FioriOnCloudPlatformPipelineTest extends BasePiperTest {
         })
 
         UUID.metaClass.static.randomUUID = { -> 1 }
+
+        GitUtils.metaClass.insideWorkTree = { -> return true }
+        GitUtils.metaClass.getGitCommitIdOrNull = { -> return '0123456789012345678901234567890123456789' }
     }
 
     @After
     public void tearDown() {
         Utils.metaClass = null
         UUID.metaClass = null
+        GitUtils.metaClass = null
     }
 
     @Test

--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -296,6 +296,17 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
     }
 
     @Test
+    void setGitUrlTest() {
+        helper.registerAllowedMethod("fileExists", [String], { String path ->
+            return path.endsWith('.pipeline/config.yml')
+        })
+
+        stepRule.step.setupCommonPipelineEnvironment(script: nullScript, gitUrl: "https://myGit.tdl/myRepo", gitUtils: gitUtilsMock)
+        assertNotNull(nullScript.commonPipelineEnvironment.gitSshUrl)
+        assertNotNull(nullScript.commonPipelineEnvironment.gitHttpsUrl)
+    }
+
+    @Test
     void testSetScmInfoOnCommonPipelineEnvironment() {
         //currently supported formats
         def scmInfoTestList = [

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -109,7 +109,7 @@ void call(Map parameters = [:]) {
     piperStageWrapper (script: script, stageName: stageName, stashContent: [], ordinal: 1, telemetryDisabled: true) {
         def scmInfo = checkout scm
 
-        setupCommonPipelineEnvironment(script: script, customDefaults: parameters.customDefaults, scmInfo: scmInfo,
+        setupCommonPipelineEnvironment(script: script, customDefaults: parameters.customDefaults, gitUrl: scmInfo.GIT_URL,
             configFile: parameters.configFile, customDefaultsFromFiles: parameters.customDefaultsFromFiles)
 
         Map config = ConfigurationHelper.newInstance(this)

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -121,7 +121,7 @@ void call(Map parameters = [:]) {
         }
 
         if (config.gitUrl) {
-            setGitUrlsOnCommonPipelineEnvironment(script, gitUrl)
+            setGitUrlsOnCommonPipelineEnvironment(script, config.gitUrl)
         }
     }
 }


### PR DESCRIPTION
When handing over an instance of SCMInfo we got a
CPS serialization issue. Hence we don't hand over
that instance any more
    
      o git commit id is resolved with exising git tooling
      o git branch is handed over as parameter to setupCPE