### PR TITLE
Allow npm install in e2e tests

### DIFF
--- a/test/groovy/NpmExecuteEndToEndTestsTest.groovy
+++ b/test/groovy/NpmExecuteEndToEndTestsTest.groovy
@@ -170,7 +170,6 @@ class NpmExecuteEndToEndTestsTest extends BasePiperTest {
         assertFalse(executedInParallel)
         assert npmExecuteScriptsRule.hasParameter('script', nullScript)
         assert npmExecuteScriptsRule.hasParameter('parameters', [dockerOptions: ['--shm-size 512MB']])
-        assert npmExecuteScriptsRule.hasParameter('install', false)
         assert npmExecuteScriptsRule.hasParameter('virtualFrameBuffer', true)
         assert npmExecuteScriptsRule.hasParameter('runScripts', ["ci-e2e"])
         assert npmExecuteScriptsRule.hasParameter('scriptOptions', ["--launchUrl=${appUrl.url}"])
@@ -192,7 +191,6 @@ class NpmExecuteEndToEndTestsTest extends BasePiperTest {
 
         assert npmExecuteScriptsRule.hasParameter('script', nullScript)
         assert npmExecuteScriptsRule.hasParameter('parameters', [dockerOptions: ['--shm-size 512MB']])
-        assert npmExecuteScriptsRule.hasParameter('install', false)
         assert npmExecuteScriptsRule.hasParameter('virtualFrameBuffer', true)
         assert npmExecuteScriptsRule.hasParameter('runScripts', ["ci-e2e"])
         assert npmExecuteScriptsRule.hasParameter('scriptOptions', ["--launchUrl=${appUrl.url}"])
@@ -215,7 +213,6 @@ class NpmExecuteEndToEndTestsTest extends BasePiperTest {
 
         assert npmExecuteScriptsRule.hasParameter('script', nullScript)
         assert npmExecuteScriptsRule.hasParameter('parameters', [dockerOptions: ['--shm-size 512MB']])
-        assert npmExecuteScriptsRule.hasParameter('install', false)
         assert npmExecuteScriptsRule.hasParameter('virtualFrameBuffer', true)
         assert npmExecuteScriptsRule.hasParameter('runScripts', ["ci-e2e"])
         assert npmExecuteScriptsRule.hasParameter('scriptOptions', ["--launchUrl=${appUrl.url}"])
@@ -239,7 +236,6 @@ class NpmExecuteEndToEndTestsTest extends BasePiperTest {
 
         assert npmExecuteScriptsRule.hasParameter('script', nullScript)
         assert npmExecuteScriptsRule.hasParameter('parameters', [dockerOptions: ['--shm-size 512MB']])
-        assert npmExecuteScriptsRule.hasParameter('install', false)
         assert npmExecuteScriptsRule.hasParameter('virtualFrameBuffer', true)
         assert npmExecuteScriptsRule.hasParameter('runScripts', ["ci-e2e"])
         assert npmExecuteScriptsRule.hasParameter('scriptOptions', ["--launchUrl=${appUrl.url}"] + appUrl.parameters)

--- a/vars/npmExecuteEndToEndTests.groovy
+++ b/vars/npmExecuteEndToEndTests.groovy
@@ -120,7 +120,7 @@ void call(Map parameters = [:]) {
                                 error "[${STEP_NAME}] The parameters property is not of type list. Please provide parameters as a list of strings."
                             }
                         }
-                        npmExecuteScripts(script: script, parameters: npmParameters, install: false, virtualFrameBuffer: true, runScripts: [config.runScript], scriptOptions: scriptOptions, buildDescriptorExcludeList: config.buildDescriptorExcludeList)
+                        npmExecuteScripts(script: script, parameters: npmParameters, virtualFrameBuffer: true, runScripts: [config.runScript], scriptOptions: scriptOptions, buildDescriptorExcludeList: config.buildDescriptorExcludeList)
                     }
 
                 } catch (Exception e) {


### PR DESCRIPTION
# Changes

Remove hard-coded `install: false` in `npmExecuteScripts` call to allow the pipeline to configure the step according to how it is right for that pipeline.

- [x] Tests
- [N/A ] Documentation
