### PR TITLE
Unstash "source" for npmExecuteScripts

### DIFF
--- a/resources/metadata/npmExecuteScripts.yaml
+++ b/resources/metadata/npmExecuteScripts.yaml
@@ -8,9 +8,7 @@ metadata:
 spec:
   inputs:
     resources:
-      - name: buildDescriptor
-        type: stash
-      - name: tests
+      - name: source
         type: stash
     params:
       - name: install


### PR DESCRIPTION
# Changes

The current stash settings don't include required files for running cucumber tests, thus this PR uses the larger skoped `source` stash.
