### PR TITLE
mask secret also when they are url encoded

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -3,6 +3,7 @@ package log
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -110,8 +111,13 @@ func RegisterHook(hook logrus.Hook) {
 	logrus.AddHook(hook)
 }
 
+// RegisterSecret registers a value which should be masked in every log message
 func RegisterSecret(secret string) {
 	if len(secret) > 0 {
 		secrets = append(secrets, secret)
+		encoded := url.QueryEscape(secret)
+		if secret != encoded {
+			secrets = append(secrets, encoded)
+		}
 	}
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -2,8 +2,10 @@ package log
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
+	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSecrets(t *testing.T) {
@@ -22,6 +24,24 @@ func TestSecrets(t *testing.T) {
 		RegisterSecret(secret)
 		Entry().Infof("My secret is %s.", secret)
 		assert.NotContains(t, buffer.String(), secret)
+	})
+
+	t.Run("should log url encoded", func(t *testing.T) {
+		secret := "secret-token!0"
+		encodedSecret := url.QueryEscape(secret)
+
+		outWriter := Entry().Logger.Out
+		var buffer bytes.Buffer
+		Entry().Logger.SetOutput(&buffer)
+		defer func() { Entry().Logger.SetOutput(outWriter) }()
+
+		Entry().Infof("My secret is %s.", secret)
+		assert.Contains(t, buffer.String(), secret)
+
+		buffer.Reset()
+		RegisterSecret(secret)
+		Entry().Infof("My secret is %s.", encodedSecret)
+		assert.NotContains(t, buffer.String(), encodedSecret)
 	})
 }
 


### PR DESCRIPTION
## Problem

Although secrets are masked when they appear in the log output there are certain scenarios where they can appear inside a url where they are properly encoded so that they are human readable but not recognised as the registered secret.

# Changes

Now when a secret is registered we also check wether it looks different when it's url encoded (i.e if it contains special characters) if so we will also mask the url encoded values in the log

 
- [x] Tests
- [ ] Documentation
