### PR TITLE
Remove default setting to always pull image

### DIFF
--- a/resources/metadata/mtaBuild.yaml
+++ b/resources/metadata/mtaBuild.yaml
@@ -143,7 +143,6 @@ spec:
           - name: mtarFilePath
   containers:
     - image: devxci/mbtci:1.0.16.1
-      imagePullPolicy: Always
       conditions:
         - conditionRef: strings-equal
           params:


### PR DESCRIPTION
To me this is a smell as this default setting will overwriting setting up dockerExecute in the config.yaml, even though this is closely related to docker, not to this step.
