### PR TITLE
Vault: Switch to debug logging for some vault log messages

### DIFF
--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -40,7 +40,7 @@ func getVaultClientFromConfig(config StepConfig, creds VaultCredentials) (vaultC
 	address, addressOk := config.Config["vaultServerUrl"].(string)
 	// if vault isn't used it's not an error
 	if !addressOk || creds.AppRoleID == "" || creds.AppRoleSecretID == "" {
-		log.Entry().Info("Skipping fetching secrets from vault since it is not configured")
+		log.Entry().Debug("Skipping fetching secrets from vault since it is not configured")
 		return nil, nil
 	}
 	namespace := ""
@@ -85,7 +85,7 @@ func resolveVaultReference(ref *ResourceReference, config *StepConfig, client va
 
 		secretValue = lookupPath(client, vaultPath, &param)
 		if secretValue != nil {
-			log.Entry().Infof("Resolved param '%s' with vault path '%s'", param.Name, vaultPath)
+			log.Entry().Debugf("Resolved param '%s' with vault path '%s'", param.Name, vaultPath)
 			if ref.Type == "vaultSecret" {
 				config.Config[param.Name] = *secretValue
 			} else if ref.Type == "vaultSecretFile" {
@@ -133,7 +133,7 @@ func createTemporarySecretFile(namePattern string, content string) (string, erro
 }
 
 func lookupPath(client vaultClient, path string, param *StepParameters) *string {
-	log.Entry().Infof("Trying to resolve vault parameter '%s' at '%s'", param.Name, path)
+	log.Entry().Debugf("Trying to resolve vault parameter '%s' at '%s'", param.Name, path)
 	secret, err := client.GetKvSecret(path)
 	if err != nil {
 		log.Entry().WithError(err).Warnf("Couldn't fetch secret at '%s'", path)


### PR DESCRIPTION
# Changes

In 99% you don't care about the vault log messages. However since they are quite useful for debugging a pipeline they should be visible when debugging is enabled

closes #2255