### PR TITLE
Fix setupCPE bug

### DIFF
--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -316,6 +316,7 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
             [GIT_URL: 'ssh://git@github.com/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
             [GIT_URL: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com:7777/testOrg/testRepo.git', expectedHttp: 'https://github.com/testOrg/testRepo.git', expectedOrg: 'testOrg', expectedRepo: 'testRepo'],
             [GIT_URL: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/path/to/testOrg/testRepo.git', expectedHttp: 'https://github.com/path/to/testOrg/testRepo.git', expectedOrg: 'path/to/testOrg', expectedRepo: 'testRepo'],
+            [GIT_URL: 'ssh://git@github.com/path/testOrg/testRepo.git', expectedSsh: 'ssh://git@github.com/path/testOrg/testRepo.git', expectedHttp: 'https://github.com/path/testOrg/testRepo.git', expectedOrg: 'path/testOrg', expectedRepo: 'testRepo'],
             [GIT_URL: 'ssh://git@github.com/testRepo.git', expectedSsh: 'ssh://git@github.com/testRepo.git', expectedHttp: 'https://github.com/testRepo.git', expectedOrg: 'N/A', expectedRepo: 'testRepo'],
         ]
 

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -245,6 +245,8 @@ private void setGitUrlsOnCommonPipelineEnvironment(script, String gitUrl) {
     def gitFolder = 'N/A'
     def gitRepo = 'N/A'
     switch (gitPathParts.size()) {
+        case 0:
+            break
         case 1:
             gitRepo = gitPathParts[0]
             break
@@ -252,7 +254,7 @@ private void setGitUrlsOnCommonPipelineEnvironment(script, String gitUrl) {
             gitFolder = gitPathParts[0]
             gitRepo = gitPathParts[1]
             break
-        case { it > 3 }:
+        default:
             gitRepo = gitPathParts[gitPathParts.size()-1]
             gitPathParts.remove(gitPathParts.size()-1)
             gitFolder = gitPathParts.join('/')


### PR DESCRIPTION
Without this change the closure in the switch case will throw an CpsCallableInvocation exception.

Example output with a `gitPath == 3`:
>CpsCallableInvocation{methodName=call, call=com.cloudbees.groovy.cps.impl.CpsClosureDef@47c84984, receiver=org.jenkinsci.plugins.workflow.cps.CpsClosure2@c34320d, arguments=[3]}

# Changes

- [x] Tests


