### PR TITLE
Remove image pull policy from steps defaults

### DIFF
--- a/resources/metadata/abapEnvironmentAssemblePackages.yaml
+++ b/resources/metadata/abapEnvironmentAssemblePackages.yaml
@@ -126,4 +126,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/abapEnvironmentCheckoutBranch.yaml
+++ b/resources/metadata/abapEnvironmentCheckoutBranch.yaml
@@ -130,4 +130,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/abapEnvironmentCloneGitRepo.yaml
+++ b/resources/metadata/abapEnvironmentCloneGitRepo.yaml
@@ -130,4 +130,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/abapEnvironmentCreateSystem.yaml
+++ b/resources/metadata/abapEnvironmentCreateSystem.yaml
@@ -197,4 +197,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/abapEnvironmentPullGitRepo.yaml
+++ b/resources/metadata/abapEnvironmentPullGitRepo.yaml
@@ -129,4 +129,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/abapEnvironmentRunATCCheck.yaml
+++ b/resources/metadata/abapEnvironmentRunATCCheck.yaml
@@ -131,4 +131,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/cloudFoundryCreateService.yaml
+++ b/resources/metadata/cloudFoundryCreateService.yaml
@@ -197,4 +197,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/cloudFoundryCreateServiceKey.yaml
+++ b/resources/metadata/cloudFoundryCreateServiceKey.yaml
@@ -116,4 +116,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/cloudFoundryCreateSpace.yaml
+++ b/resources/metadata/cloudFoundryCreateSpace.yaml
@@ -81,4 +81,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/cloudFoundryDeleteService.yaml
+++ b/resources/metadata/cloudFoundryDeleteService.yaml
@@ -104,4 +104,3 @@ spec:
     - name: cf
       image: ppiper/cf-cli
       workingDir: "/home/piper"
-      imagePullPolicy: Never

--- a/resources/metadata/cloudFoundryDeleteSpace.yaml
+++ b/resources/metadata/cloudFoundryDeleteSpace.yaml
@@ -81,4 +81,3 @@ spec:
   containers:
     - name: cf
       image: ppiper/cf-cli
-      imagePullPolicy: Never

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -360,7 +360,6 @@ spec:
   containers:
     - name: cfDeploy
       image: ppiper/cf-cli
-      imagePullPolicy: Always
   outputs:
     resources:
       - name: influx

--- a/resources/metadata/mavenBuild.yaml
+++ b/resources/metadata/mavenBuild.yaml
@@ -78,4 +78,3 @@ spec:
   containers:
     - name: mvn
       image: maven:3.6-jdk-8
-      imagePullPolicy: Never

--- a/resources/metadata/mavenExecute.yaml
+++ b/resources/metadata/mavenExecute.yaml
@@ -88,4 +88,3 @@ spec:
   containers:
     - name: mvn
       image: maven:3.6-jdk-8
-      imagePullPolicy: Never

--- a/resources/metadata/mavenExecuteIntegration.yaml
+++ b/resources/metadata/mavenExecuteIntegration.yaml
@@ -90,7 +90,6 @@ spec:
   containers:
     - name: mvn
       image: maven:3.6-jdk-8
-      imagePullPolicy: Never
 
   # This declaration is necessary in order to return any sidecar configuration in the context config.
   sidecars:

--- a/resources/metadata/mavenStaticCodeChecks.yaml
+++ b/resources/metadata/mavenStaticCodeChecks.yaml
@@ -142,4 +142,3 @@ spec:
   containers:
     - name: mvn
       image: maven:3.6-jdk-8
-      imagePullPolicy: Never

--- a/resources/metadata/mtaBuild.yaml
+++ b/resources/metadata/mtaBuild.yaml
@@ -143,7 +143,6 @@ spec:
           - name: mtarFilePath
   containers:
     - image: devxci/mbtci:1.0.16.1
-      imagePullPolicy: Always
       conditions:
         - conditionRef: strings-equal
           params:

--- a/resources/metadata/nexusUpload.yaml
+++ b/resources/metadata/nexusUpload.yaml
@@ -134,4 +134,3 @@ spec:
     # To allow both maven and mta we require an image that contains both tools. If the user configures an image for mavenExecute that also needs to contain both.
     - name: mvn-npm
       image: devxci/mbtci:1.0.4
-      imagePullPolicy: Never

--- a/resources/metadata/npmExecuteLint.yaml
+++ b/resources/metadata/npmExecuteLint.yaml
@@ -32,4 +32,3 @@ spec:
   containers:
     - name: node
       image: node:12-buster
-      imagePullPolicy: Never

--- a/resources/metadata/npmExecuteScripts.yaml
+++ b/resources/metadata/npmExecuteScripts.yaml
@@ -61,4 +61,3 @@ spec:
   containers:
     - name: node
       image: node:12-buster-slim
-      imagePullPolicy: Never

--- a/resources/metadata/versioning.yaml
+++ b/resources/metadata/versioning.yaml
@@ -273,7 +273,6 @@ spec:
           - name: git/commitMessage
   containers:
     - image: maven:3.6-jdk-8
-      imagePullPolicy: Never
       conditions:
         - conditionRef: strings-equal
           params:

--- a/resources/metadata/xsDeploy.yaml
+++ b/resources/metadata/xsDeploy.yaml
@@ -153,4 +153,3 @@ spec:
   containers:
     - name: xs
       image: ppiper/xs-cli
-      imagePullPolicy: Never


### PR DESCRIPTION
Without this change the default setting from dockerExecute and dockerExecuteOnKubernetes are overruled.
With this change the user has to explicitly configure the step if they want this behaviour.
