### PR TITLE
Accumulate config validation errors

### DIFF
--- a/resources/com.sap.piper/pipeline/cloudSdkToGppConfigSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkToGppConfigSettings.yml
@@ -1,0 +1,113 @@
+removedOrReplacedConfigKeys:
+  extensionRepository:
+    newConfigKey: "globalExtensionsRepository"
+    general: true
+    customMessage: "To configure a version please use globalExtensionsVersion.
+      You can also configure globalExtensionsRepositoryCredentialsId in case the extension repository is secured.
+      Please note that you can also configure these values as part of your custom defaults / shared configuration."
+  globalSettingsFile:
+    steps: ["mavenExecute"]
+    customMessage: "The SAP Cloud SDK Pipeline uses an own global settings file to inject its download proxy as maven repository mirror.
+      Please only specify the settings via the parameter 'projectSettingsFile'"
+  orgToken:
+    newConfigKey: "credentialsId"
+    stages: ["whitesourceScan"]
+    customMessage: "Store it as a 'Secret Text' in Jenkins and use the 'credentialsId' field instead."
+  archiveDebugLog:
+    postAction: true
+    customMessage: "Please use the step configuration for debugReportArchive instead."
+  tmsUpload:
+    stages: ["productionDeployment"]
+    customMessage: "Since version v39 it is required to configure the step tmsUpload instead.
+      Details can be found in the release notes at https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v39 as well as in the step documentation: https://sap.github.io/jenkins-library/steps/tmsUpload/."
+  sharedConfiguration:
+    newConfigKey: "customDefaults"
+    general: true
+    customMessage: "In addition please move it to the root level of the config file, i.e. before the 'general' section.
+      The value of this key needs to be a list of strings.
+      See also https://sap.github.io/jenkins-library/configuration/#custom-default-configuration for more information.
+      As an example for the necessary change, please consult the release notes of v33 at https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v33"
+  automaticVersioning:
+    general: true
+    customMessage: "Please configure the artifactPrepareVersion step instead.
+      Details can be found in the release notes of v37 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v37"
+  sapNpmRegistry:
+    steps: ["executeNpm", "npmExecuteScripts", "npmExecuteLint", "mtaBuild"]
+    warnInsteadOfError: true
+    customMessage: "The parameter will be ignored during execution.
+      This configuration option was removed in version v41, since the packages of the public SAP NPM Registry were migrated to the default public registry at npmjs.org.
+      Please configure the defaultNpmRegistry parameter instead, in case a custom NPM registry configuration is required."
+  sendNotification:
+    postAction: true
+    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+
+removedOrReplacedSteps:
+  executeMaven:
+    newStepName: "mavenExecute"
+  deployToCfWithCli:
+    newStepName: "cloudFoundryDeploy"
+  deployToNeoWithCli:
+    newStepName: "deployToNeoWithCli"
+  executeFortifyScan:
+    newStepName: "fortifyExecuteScan"
+  artifactSetVersion:
+    newStepName: "artifactPrepareVersion"
+    onlyCheckProjectConfig: true
+    customMessage: "Details can be found in the release notes of v37 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v37"
+  createHdiContainer:
+    customMessage: "The backendIntegrationTests stage has been aligned with project 'Piper' in version v41 and activation of the createHdiContainer step was not migrated.
+      If you still need the functionalities provided by the createHdiContainer step, please open an issue at: https://github.com/SAP/cloud-s4-sdk-pipeline/issues/new?template=pipeline-issue.md
+      Apart from that it is also possible to implement an extension for the backendIntegrationTests stage using the extensibility concept explained in the documentation: https://sap.github.io/jenkins-library/extensibility/
+      For the time being, the step createHdiContainer is still available in the Pipeline and can be called from an extension.
+      The extension must pass all required options to the step via parameters, it cannot be configured in your .pipeline/config.yml."
+  checkGatling:
+    newStepName: "gatlingExecuteTests"
+
+removedOrReplacedStages:
+  integrationTests:
+    newStageName: "integration"
+  backendIntegrationTests:
+    newStageName: "integration"
+  frontendIntegrationTests:
+    newStageName: "integration"
+  staticCodeChecks:
+    customMessage: "Since version v32 it is required to migrate the configuration into your pom.xml file or to the configuration of the new step mavenExecuteStaticCodeChecks.
+      Details can be found in the release notes as well as in the step documentation: https://sap.github.io/jenkins-library/steps/mavenExecuteStaticCodeChecks/."
+  fortifyScan:
+    customMessage: "To configure fortify please use the step configuration for fortifyExecuteScan.
+      Details can be found in the documentation: https://sap.github.io/jenkins-library/steps/fortifyExecuteScan/"
+  lint:
+    customMessage: "Since version v43 it is required to configure the step npmExecuteLint instead.
+      Details can be found in the release notes as well as in the step documentation: https://sap.github.io/jenkins-library/steps/npmExecuteLint/."
+  frontendUnitTests:
+    newStageName: "additionalUnitTests"
+  npmAudit:
+    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+  s4SdkQualityChecks:
+    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+  sonarQubeScan:
+    newStageName: "compliance"
+    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+  checkmarxScan:
+    newStageName: "security"
+    customMessage: "To configure Checkmarx please use the step configuration for checkmarxExecuteScan.
+      Details can be found in the documentation: https://sap.github.io/jenkins-library/steps/checkmarxExecuteScan/"
+  detectScan:
+    newStageName: "security"
+    customMessage: "To configure Synopsys Detect please use the step configuration for detectExecuteScan.
+      Details can be found in the documentation: https://sap.github.io/jenkins-library/steps/detectExecuteScan/"
+  additionalTools:
+    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+
+parameterTypeChanged:
+  appUrls:
+    oldType: "String"
+    newType: "List"
+    stages: ["productionDeployment", "endToEndTests"]
+
+renamedNpmScript:
+  ci-integration-test:
+    newScriptName: "ci-it-backend"
+  ci-test:
+    newScriptName: "ci-frontend-unit-test"
+    warnInsteadOfError: true

--- a/resources/com.sap.piper/pipeline/cloudSdkToGppConfigSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkToGppConfigSettings.yml
@@ -113,7 +113,7 @@ parameterTypeChanged:
   appUrls:
     oldType: "String"
     newType: "List"
-    stages: ["productionDeployment", "endToEndTests"]
+    stages: ["productionDeployment", "endToEndTests", "Release", "Acceptance"]
 
 renamedNpmScript:
   ci-integration-test:

--- a/resources/com.sap.piper/pipeline/cloudSdkToGppConfigSettings.yml
+++ b/resources/com.sap.piper/pipeline/cloudSdkToGppConfigSettings.yml
@@ -5,20 +5,16 @@ removedOrReplacedConfigKeys:
     customMessage: "To configure a version please use globalExtensionsVersion.
       You can also configure globalExtensionsRepositoryCredentialsId in case the extension repository is secured.
       Please note that you can also configure these values as part of your custom defaults / shared configuration."
-  globalSettingsFile:
-    steps: ["mavenExecute"]
-    customMessage: "The SAP Cloud SDK Pipeline uses an own global settings file to inject its download proxy as maven repository mirror.
-      Please only specify the settings via the parameter 'projectSettingsFile'"
   orgToken:
-    newConfigKey: "credentialsId"
-    stages: ["whitesourceScan"]
-    customMessage: "Store it as a 'Secret Text' in Jenkins and use the 'credentialsId' field instead."
+    stages: ["whitesourceScan", "Security"]
+    customMessage: "The credentials ID for the WhiteSource org-token should to be moved to the step configuration of 'whitesourceExecuteScan'.
+      Store it as a 'Secret Text' in Jenkins and supply the ID the 'orgAdminUserTokenCredentialsId' field instead."
   archiveDebugLog:
     postAction: true
     customMessage: "Please use the step configuration for debugReportArchive instead."
   tmsUpload:
-    stages: ["productionDeployment"]
-    customMessage: "Since version v39 it is required to configure the step tmsUpload instead.
+    stages: ["productionDeployment", "Release"]
+    customMessage: "Please configure the step 'tmsUpload' instead.
       Details can be found in the release notes at https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v39 as well as in the step documentation: https://sap.github.io/jenkins-library/steps/tmsUpload/."
   sharedConfiguration:
     newConfigKey: "customDefaults"
@@ -26,10 +22,10 @@ removedOrReplacedConfigKeys:
     customMessage: "In addition please move it to the root level of the config file, i.e. before the 'general' section.
       The value of this key needs to be a list of strings.
       See also https://sap.github.io/jenkins-library/configuration/#custom-default-configuration for more information.
-      As an example for the necessary change, please consult the release notes of v33 at https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v33"
+      As an example for the necessary change, please consult the release notes of v33 of the Cloud SDK Pipeline at https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v33"
   automaticVersioning:
     general: true
-    customMessage: "Please configure the artifactPrepareVersion step instead.
+    customMessage: "Please configure the 'artifactPrepareVersion' step instead.
       Details can be found in the release notes of v37 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v37"
   sapNpmRegistry:
     steps: ["executeNpm", "npmExecuteScripts", "npmExecuteLint", "mtaBuild"]
@@ -39,7 +35,7 @@ removedOrReplacedConfigKeys:
       Please configure the defaultNpmRegistry parameter instead, in case a custom NPM registry configuration is required."
   sendNotification:
     postAction: true
-    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+    customMessage: "Details can be found in the release notes of v43 of the Cloud SDK Pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
 
 removedOrReplacedSteps:
   executeMaven:
@@ -53,51 +49,65 @@ removedOrReplacedSteps:
   artifactSetVersion:
     newStepName: "artifactPrepareVersion"
     onlyCheckProjectConfig: true
-    customMessage: "Details can be found in the release notes of v37 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v37"
+    customMessage: "Details can be found in the release notes of v37 of the Cloud SDK Pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v37"
   createHdiContainer:
-    customMessage: "The backendIntegrationTests stage has been aligned with project 'Piper' in version v41 and activation of the createHdiContainer step was not migrated.
-      If you still need the functionalities provided by the createHdiContainer step, please open an issue at: https://github.com/SAP/cloud-s4-sdk-pipeline/issues/new?template=pipeline-issue.md
-      Apart from that it is also possible to implement an extension for the backendIntegrationTests stage using the extensibility concept explained in the documentation: https://sap.github.io/jenkins-library/extensibility/
-      For the time being, the step createHdiContainer is still available in the Pipeline and can be called from an extension.
-      The extension must pass all required options to the step via parameters, it cannot be configured in your .pipeline/config.yml."
-  checkGatling:
-    newStepName: "gatlingExecuteTests"
+    customMessage: "The createHdiContainer step is no longer available.
+      If you still need the functionalities provided by this step, please open an issue at: https://github.com/SAP/cloud-s4-sdk-pipeline/issues/new?template=pipeline-issue.md
+      Apart from that it is also possible to implement an extension for the stage 'Integration' using the extensibility concept explained in the documentation: https://sap.github.io/jenkins-library/extensibility/"
 
 removedOrReplacedStages:
   integrationTests:
-    newStageName: "integration"
+    newStageName: "Integration"
   backendIntegrationTests:
-    newStageName: "integration"
+    newStageName: "Integration"
   frontendIntegrationTests:
-    newStageName: "integration"
+    newStageName: "Integration"
   staticCodeChecks:
-    customMessage: "Since version v32 it is required to migrate the configuration into your pom.xml file or to the configuration of the new step mavenExecuteStaticCodeChecks.
+    customMessage: "Since version v32 of Cloud SDK Pipeline, it is required to migrate the configuration into your pom.xml file or to the configuration of the new step mavenExecuteStaticCodeChecks.
       Details can be found in the release notes as well as in the step documentation: https://sap.github.io/jenkins-library/steps/mavenExecuteStaticCodeChecks/."
   fortifyScan:
-    customMessage: "To configure fortify please use the step configuration for fortifyExecuteScan.
+    customMessage: "To configure Fortify please use the step configuration for fortifyExecuteScan.
       Details can be found in the documentation: https://sap.github.io/jenkins-library/steps/fortifyExecuteScan/"
   lint:
-    customMessage: "Since version v43 it is required to configure the step npmExecuteLint instead.
+    customMessage: "Since version v43 of Cloud SDK Pipeline, it is required to configure the step npmExecuteLint instead.
       Details can be found in the release notes as well as in the step documentation: https://sap.github.io/jenkins-library/steps/npmExecuteLint/."
   frontendUnitTests:
-    newStageName: "additionalUnitTests"
+    newStageName: "Additional Unit Tests"
   npmAudit:
-    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+    customMessage: "Details can be found in the release notes of v43 of the Cloud SDK Pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
   s4SdkQualityChecks:
-    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+    customMessage: "Details can be found in the release notes of v43 of the Cloud SDK Pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
   sonarQubeScan:
-    newStageName: "compliance"
-    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+    newStageName: "Compliance"
+    customMessage: "Details can be found in the release notes of v43 of the Cloud SDK Pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
   checkmarxScan:
-    newStageName: "security"
+    newStageName: "Security"
     customMessage: "To configure Checkmarx please use the step configuration for checkmarxExecuteScan.
       Details can be found in the documentation: https://sap.github.io/jenkins-library/steps/checkmarxExecuteScan/"
   detectScan:
-    newStageName: "security"
+    newStageName: "Security"
     customMessage: "To configure Synopsys Detect please use the step configuration for detectExecuteScan.
       Details can be found in the documentation: https://sap.github.io/jenkins-library/steps/detectExecuteScan/"
   additionalTools:
-    customMessage: "Details can be found in the release notes of v43 of the pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+    customMessage: "Details can be found in the release notes of v43 of the Cloud SDK Pipeline: https://github.com/SAP/cloud-s4-sdk-pipeline/releases/tag/v43"
+  build:
+    newStageName: "Build"
+  integration:
+    newStageName: "Integration"
+  additionalUnitTests:
+    newStageName: "Additional Unit Tests"
+  endToEndTests:
+    newStageName: "Acceptance"
+  performanceTests:
+    newStageName: "Performance"
+  security:
+    newStageName: "Security"
+  compliance:
+    newStageName: "Compliance"
+  artifactDeployment:
+    customMessage: "The General Purpose Pipeline does not execute the stage 'Artifact Deployment' and there is no alternative stage for the functionality."
+  productionDeployment:
+    newStageName: "Release"
 
 parameterTypeChanged:
   appUrls:

--- a/src/com/sap/piper/LegacyConfigurationCheckUtils.groovy
+++ b/src/com/sap/piper/LegacyConfigurationCheckUtils.groovy
@@ -2,28 +2,39 @@ package com.sap.piper
 
 class LegacyConfigurationCheckUtils{
     static void checkConfiguration(Script script, Map configChanges) {
+        List errors = []
+
         if (configChanges?.removedOrReplacedConfigKeys) {
-            checkForRemovedOrReplacedConfigKeys(script, configChanges.removedOrReplacedConfigKeys)
+            errors.addAll(checkForRemovedOrReplacedConfigKeys(script, configChanges.removedOrReplacedConfigKeys))
         }
 
         if (configChanges?.removedOrReplacedSteps) {
-            checkForRemovedOrReplacedSteps(script, configChanges.removedOrReplacedSteps)
+            errors.addAll(checkForRemovedOrReplacedSteps(script, configChanges.removedOrReplacedSteps))
         }
 
         if (configChanges?.removedOrReplacedStages) {
-            checkForRemovedOrReplacedStages(script, configChanges.removedOrReplacedStages)
+            errors.addAll(checkForRemovedOrReplacedStages(script, configChanges.removedOrReplacedStages))
         }
 
         if (configChanges?.parameterTypeChanged) {
-            checkForParameterTypeChanged(script, configChanges.parameterTypeChanged)
+            errors.addAll(checkForParameterTypeChanged(script, configChanges.parameterTypeChanged))
         }
 
         if (configChanges?.renamedNpmScript) {
-            checkForRenamedNpmScripts(script, configChanges.renamedNpmScript)
+            errors.addAll(checkForRenamedNpmScripts(script, configChanges.renamedNpmScript))
+        }
+
+        if (errors) {
+            script.echo("Your pipeline configuration file contains the following errors:")
+            errors.each {error ->
+                script.echo(error)
+            }
+            script.error("Failing pipeline due to configuration errors")
         }
     }
 
-    static void checkForRemovedOrReplacedConfigKeys(Script script, Map configChanges) {
+    static List checkForRemovedOrReplacedConfigKeys(Script script, Map configChanges) {
+        List errors = []
         configChanges.each {oldConfigKey, changes ->
             List steps = changes?.steps ?: []
             List stages = changes?.stages ?: []
@@ -46,7 +57,7 @@ class LegacyConfigurationCheckUtils{
                     if (warnInsteadOfError) {
                         addPipelineWarning(script, "Deprecated configuration key ${oldConfigKey}", errorMessage)
                     } else {
-                        script.error(errorMessage)
+                        errors.add(errorMessage)
                     }
                 }
             }
@@ -59,7 +70,7 @@ class LegacyConfigurationCheckUtils{
                     if (warnInsteadOfError) {
                         addPipelineWarning(script, "Deprecated configuration key ${oldConfigKey}", errorMessage)
                     } else {
-                        script.error(errorMessage)
+                        errors.add(errorMessage)
                     }
                 }
             }
@@ -72,7 +83,7 @@ class LegacyConfigurationCheckUtils{
                     if (warnInsteadOfError) {
                         addPipelineWarning(script, "Deprecated configuration key ${oldConfigKey}", errorMessage)
                     } else {
-                        script.error(errorMessage)
+                        errors.add(errorMessage)
                     }
                 }
             }
@@ -85,14 +96,16 @@ class LegacyConfigurationCheckUtils{
                     if (warnInsteadOfError) {
                         addPipelineWarning(script, "Deprecated configuration key ${oldConfigKey}", errorMessage)
                     } else {
-                        script.error(errorMessage)
+                        errors.add(errorMessage)
                     }
                 }
             }
         }
+        return errors
     }
 
-    static void checkForRemovedOrReplacedSteps(Script script, Map configChanges) {
+    static List checkForRemovedOrReplacedSteps(Script script, Map configChanges) {
+        List errors = []
         configChanges.each {oldConfigKey, changes ->
             Boolean onlyCheckProjectConfig = changes?.onlyCheckProjectConfig ?: false
             String customMessage = changes?.customMessage ?: ""
@@ -110,13 +123,15 @@ class LegacyConfigurationCheckUtils{
             }
 
             if (config) {
-                script.error("Your pipeline configuration contains configuration for the step ${oldConfigKey}. " +
+                errors.add("Your pipeline configuration contains configuration for the step ${oldConfigKey}. " +
                     "This step has been removed. " + customMessage)
             }
         }
+        return errors
     }
 
-    static void checkForRemovedOrReplacedStages(Script script, Map configChanges) {
+    static List checkForRemovedOrReplacedStages(Script script, Map configChanges) {
+        List errors = []
         configChanges.each {oldConfigKey, changes ->
             String customMessage = changes?.customMessage ?: ""
             String newStageName = changes?.newStageName ?: ""
@@ -126,13 +141,15 @@ class LegacyConfigurationCheckUtils{
             }
 
             if (loadEffectiveStageConfig(script, oldConfigKey)) {
-                script.error("Your pipeline configuration contains configuration for the stage ${oldConfigKey}. " +
+                errors.add("Your pipeline configuration contains configuration for the stage ${oldConfigKey}. " +
                     "This stage has been removed. " + customMessage)
             }
         }
+        return errors
     }
 
-    static void checkForParameterTypeChanged(Script script, Map configChanges) {
+    static List checkForParameterTypeChanged(Script script, Map configChanges) {
+        List errors = []
         configChanges.each { oldConfigKey, changes ->
             String oldType = changes?.oldType ?: ""
             String newType = changes?.newType ?: ""
@@ -144,14 +161,14 @@ class LegacyConfigurationCheckUtils{
             if (oldType != "String") {
                 script.echo ("Your legacy config settings contain an entry for parameterTypeChanged with the key ${oldConfigKey} with the unsupported type ${oldType}. " +
                     "Currently only the type 'String' is supported.")
-                return
+                return errors
             }
 
             for (int i = 0; i < steps.size(); i++) {
                 Map config = loadEffectiveStepConfig(script, steps[i])
                 if (config.containsKey(oldConfigKey)) {
                     if (oldType == "String" && config.get(oldConfigKey) instanceof String) {
-                        script.error("Your pipeline configuration contains the configuration key ${oldConfigKey} for the step ${steps[i]}. " +
+                        errors.add("Your pipeline configuration contains the configuration key ${oldConfigKey} for the step ${steps[i]}. " +
                             "The type of this configuration parameter was changed from ${oldType} to ${newType}. " + customMessage)
                     }
                 }
@@ -161,7 +178,7 @@ class LegacyConfigurationCheckUtils{
                 Map config = loadEffectiveStageConfig(script, stages[i])
                 if (config.containsKey(oldConfigKey)) {
                     if (oldType == "String" && config.get(oldConfigKey) instanceof String) {
-                        script.error("Your pipeline configuration contains the configuration key ${oldConfigKey} for the stage ${stages[i]}. " +
+                        errors.add("Your pipeline configuration contains the configuration key ${oldConfigKey} for the stage ${stages[i]}. " +
                             "The type of this configuration parameter was changed from ${oldType} to ${newType}. " + customMessage)
                     }
                 }
@@ -171,15 +188,17 @@ class LegacyConfigurationCheckUtils{
                 Map config = loadEffectiveGeneralConfig(script)
                 if (config.containsKey(oldConfigKey)) {
                     if (oldType == "String" && config.get(oldConfigKey) instanceof String) {
-                        script.error("Your pipeline configuration contains the configuration key ${oldConfigKey} in the general section. " +
+                        errors.add("Your pipeline configuration contains the configuration key ${oldConfigKey} in the general section. " +
                             "The type of this configuration parameter was changed from ${oldType} to ${newType}. " + customMessage)
                     }
                 }
             }
         }
+        return errors
     }
 
-    static void checkForRenamedNpmScripts(Script script, Map configChanges) {
+    static List checkForRenamedNpmScripts(Script script, Map configChanges) {
+        List errors = []
         configChanges.each { oldScriptName, changes ->
             String newScriptName = changes?.newScriptName ?: ""
             Boolean warnInsteadOfError = changes?.warnInsteadOfError ?: false
@@ -192,10 +211,11 @@ class LegacyConfigurationCheckUtils{
                 if (warnInsteadOfError) {
                     addPipelineWarning(script, "Deprecated npm script ${oldScriptName}", errorMessage)
                 } else {
-                    script.error(errorMessage)
+                    errors.add(errorMessage)
                 }
             }
         }
+        return errors
     }
 
     private static String findPackageWithScript(Script script, String scriptName) {

--- a/src/com/sap/piper/LegacyConfigurationCheckUtils.groovy
+++ b/src/com/sap/piper/LegacyConfigurationCheckUtils.groovy
@@ -31,7 +31,7 @@ class LegacyConfigurationCheckUtils{
             errors.each {error ->
                 script.echo(error)
             }
-            script.error("Failing pipeline due to configuration errors")
+            script.error("Failing pipeline due to configuration errors. Please see log output above.")
         }
     }
 

--- a/src/com/sap/piper/LegacyConfigurationCheckUtils.groovy
+++ b/src/com/sap/piper/LegacyConfigurationCheckUtils.groovy
@@ -25,7 +25,9 @@ class LegacyConfigurationCheckUtils{
         }
 
         if (errors) {
-            script.echo("Your pipeline configuration file contains the following errors:")
+            if (errors.size() > 1) {
+                script.echo("Your pipeline configuration file contains the following errors:")
+            }
             errors.each {error ->
                 script.echo(error)
             }

--- a/test/groovy/com/sap/piper/LegacyConfigurationCheckUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/LegacyConfigurationCheckUtilsTest.groovy
@@ -52,25 +52,24 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
 
     @Test
     void testCheckForRemovedConfigKeys() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key oldConfigKey for the step someStep. " +
-        "This configuration option was removed. test")
         nullScript.commonPipelineEnvironment.configuration = [steps: [someStep: [oldConfigKey: false]]]
         Map configChanges = [oldConfigKey: [steps: ['someStep'], customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key oldConfigKey for the step someStep. " +
+            "This configuration option was removed. test"])
     }
 
     @Test
     void testCheckForReplacedConfigKeys() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key oldConfigKey for the step someStep. " +
-            "This configuration option was removed. Please use the parameter newConfigKey instead. test")
         nullScript.commonPipelineEnvironment.configuration = [steps: [someStep: [oldConfigKey: false]]]
         Map configChanges = [oldConfigKey: [steps: ['someStep'], newConfigKey: "newConfigKey", customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
 
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key oldConfigKey for the step someStep. " +
+            "This configuration option was removed. Please use the parameter newConfigKey instead. test"])
     }
 
     @Test
@@ -81,64 +80,67 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         nullScript.commonPipelineEnvironment.configuration = [steps: [someStep: [oldConfigKey: false]]]
         Map configChanges = [oldConfigKey: [steps: ['someStep'], warnInsteadOfError: true, customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+
         assertEquals(expectedWarning, echoOutput)
+        assertEquals(errors, [])
     }
 
     @Test
     void testCheckForRemovedStageConfigKeys() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key oldConfigKey for the stage someStage. " +
-            "This configuration option was removed. ")
         nullScript.commonPipelineEnvironment.configuration = [stages: [someStage: [oldConfigKey: false]]]
         Map configChanges = [oldConfigKey: [stages: ['someStage']]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key oldConfigKey for the stage someStage. " +
+            "This configuration option was removed. "])
     }
 
     @Test
     void testCheckForRemovedGeneralConfigKeys() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key oldConfigKey in the general section. " +
-            "This configuration option was removed. ")
         nullScript.commonPipelineEnvironment.configuration = [general: [oldConfigKey: false]]
         Map configChanges = [oldConfigKey: [general: true]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key oldConfigKey in the general section. " +
+            "This configuration option was removed. "])
     }
 
     @Test
     void testCheckForRemovedPostActionConfigKeys() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key oldConfigKey in the postActions section. " +
-            "This configuration option was removed. ")
         nullScript.commonPipelineEnvironment.configuration = [postActions: [oldConfigKey: false]]
         Map configChanges = [oldConfigKey: [postAction: true]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedConfigKeys(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key oldConfigKey in the postActions section. " +
+            "This configuration option was removed. "])
     }
 
     @Test
     void testCheckForReplacedStep() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains configuration for the step oldStep. " +
-            "This step has been removed. Please configure the step newStep instead. test")
+        String oldStep = "oldStep"
         nullScript.commonPipelineEnvironment.configuration = [steps: [oldStep: [configKey: false]]]
-        Map configChanges = [oldStep: [newStepName: 'newStep', customMessage: "test"]]
+        Map configChanges = [oldStep: [newStepName: "newStep", customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedSteps(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedSteps(nullScript, configChanges)
 
+        assertEquals(errors, ["Your pipeline configuration contains configuration for the step $oldStep. " +
+            "This step has been removed. Please configure the step newStep instead. test"])
     }
 
     @Test
     void testCheckForRemovedStep() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains configuration for the step oldStep. " +
-            "This step has been removed. test")
+        String oldStep = "oldStep"
         nullScript.commonPipelineEnvironment.configuration = [steps: [oldStep: [configKey: false]]]
         Map configChanges = [oldStep: [customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedSteps(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedSteps(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains configuration for the step $oldStep. " +
+          "This step has been removed. test"])
     }
 
     @Test
@@ -153,64 +155,69 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         nullScript.commonPipelineEnvironment.configuration = [steps: [newStep: [configKey: false]]]
         Map configChanges = [oldStep: [onlyCheckProjectConfig: true]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedSteps(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedSteps(nullScript, configChanges)
+
+        assertEquals(errors, [])
     }
 
     @Test
     void testCheckForReplacedStage() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains configuration for the stage oldStage. " +
-            "This stage has been removed. Please configure the stage newStage instead. test")
+        String oldStage = "oldStage"
         nullScript.commonPipelineEnvironment.configuration = [stages: [oldStage: [configKey: false]]]
         Map configChanges = [oldStage: [newStageName: 'newStage', customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedStages(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedStages(nullScript, configChanges)
 
+        assertEquals(errors, ["Your pipeline configuration contains configuration for the stage $oldStage. " +
+            "This stage has been removed. Please configure the stage newStage instead. test"])
     }
 
     @Test
     void testCheckForRemovedStage() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains configuration for the stage oldStage. " +
-            "This stage has been removed. ")
+        String oldStage = "oldStage"
         nullScript.commonPipelineEnvironment.configuration = [stages: [oldStage: [configKey: false]]]
         Map configChanges = [oldStage: []]
 
-        LegacyConfigurationCheckUtils.checkForRemovedOrReplacedStages(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRemovedOrReplacedStages(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains configuration for the stage $oldStage. " +
+            "This stage has been removed. "])
     }
 
     @Test
     void testCheckForStageParameterTypeChanged() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key configKeyOldType for the stage productionDeployment. " +
-            "The type of this configuration parameter was changed from String to List. test")
+        String stageName = "productionDeployment"
         nullScript.commonPipelineEnvironment.configuration = [stages: [productionDeployment: [configKeyOldType: "string"]]]
         Map configChanges = [configKeyOldType: [oldType: "String", newType: "List", stages: ["productionDeployment", "endToEndTests"], customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForParameterTypeChanged(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForParameterTypeChanged(nullScript, configChanges)
 
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key configKeyOldType for the stage $stageName. " +
+            "The type of this configuration parameter was changed from String to List. test"])
     }
 
     @Test
     void testCheckForStepParameterTypeChanged() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key configKeyOldType for the step testStep. " +
-            "The type of this configuration parameter was changed from String to List. test")
+        String stepName = "testStep"
         nullScript.commonPipelineEnvironment.configuration = [steps: [testStep: [configKeyOldType: "string"]]]
         Map configChanges = [configKeyOldType: [oldType: "String", newType: "List", steps: ["testStep"], customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForParameterTypeChanged(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForParameterTypeChanged(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key configKeyOldType for the step $stepName. " +
+            "The type of this configuration parameter was changed from String to List. test"])
     }
 
     @Test
     void testCheckForGeneralParameterTypeChanged() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key configKeyOldType in the general section. " +
-            "The type of this configuration parameter was changed from String to List. test")
+        String key = "configKeyOldType"
         nullScript.commonPipelineEnvironment.configuration = [general: [configKeyOldType: "string"]]
         Map configChanges = [configKeyOldType: [oldType: "String", newType: "List", general: true, customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForParameterTypeChanged(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForParameterTypeChanged(nullScript, configChanges)
+
+        assertEquals(errors, ["Your pipeline configuration contains the configuration key $key in the general section. " +
+            "The type of this configuration parameter was changed from String to List. test"])
     }
 
     @Test
@@ -221,17 +228,17 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         Map configChanges = [configKeyOldType: [oldType: "Map", newType: "List", steps: ["testStep"], customMessage: "test"]]
 
         LegacyConfigurationCheckUtils.checkForParameterTypeChanged(nullScript, configChanges)
+
         assertEquals(expectedWarning, echoOutput)
     }
 
     @Test
     void testCheckForRenamedNpmScripts() {
-        thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your package.json file package.json contains an npm script using the deprecated name oldNpmScriptName. " +
-            "Please rename the script to newNpmScriptName, since the script oldNpmScriptName will not be executed by the pipeline anymore. test")
         Map configChanges = [oldNpmScriptName: [newScriptName: "newNpmScriptName", customMessage: "test"]]
 
-        LegacyConfigurationCheckUtils.checkForRenamedNpmScripts(nullScript, configChanges)
+        List errors = LegacyConfigurationCheckUtils.checkForRenamedNpmScripts(nullScript, configChanges)
+        assertEquals(errors, ["Your package.json file package.json contains an npm script using the deprecated name oldNpmScriptName. " +
+            "Please rename the script to newNpmScriptName, since the script oldNpmScriptName will not be executed by the pipeline anymore. test"])
     }
 
     @Test
@@ -248,8 +255,7 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
     @Test
     void testCheckConfigurationRemovedOrReplacedConfigKeys() {
         thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key oldConfigKey for the step someStep. " +
-            "This configuration option was removed. test")
+        thrown.expectMessage("Failing pipeline due to configuration errors")
         nullScript.commonPipelineEnvironment.configuration = [steps: [someStep: [oldConfigKey: false]]]
         Map configChanges = [
             removedOrReplacedConfigKeys: [
@@ -261,13 +267,15 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         ]
 
         LegacyConfigurationCheckUtils.checkConfiguration(nullScript, configChanges)
+
+        assertEquals(echoOutput, "Your pipeline configuration contains the configuration key oldConfigKey for the step someStep. " +
+            "This configuration option was removed. test")
     }
 
     @Test
     void testCheckConfigurationRemovedOrReplacedSteps() {
         thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains configuration for the step oldStep. " +
-            "This step has been removed. Please configure the step newStep instead. test")
+        thrown.expectMessage("Failing pipeline due to configuration errors")
         nullScript.commonPipelineEnvironment.configuration = [steps: [oldStep: [configKey: false]]]
         Map configChanges = [
             removedOrReplacedSteps: [
@@ -279,13 +287,15 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         ]
 
         LegacyConfigurationCheckUtils.checkConfiguration(nullScript, configChanges)
+
+        assertEquals(echoOutput, "Your pipeline configuration contains configuration for the step oldStep. " +
+            "This step has been removed. Please configure the step newStep instead. test")
     }
 
     @Test
     void testCheckConfigurationRemovedOrReplacedStages() {
         thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains configuration for the stage oldStage. " +
-            "This stage has been removed. ")
+        thrown.expectMessage("Failing pipeline due to configuration errors")
         nullScript.commonPipelineEnvironment.configuration = [stages: [oldStage: [configKey: false]]]
         Map configChanges = [
             removedOrReplacedStages: [
@@ -294,13 +304,15 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         ]
 
         LegacyConfigurationCheckUtils.checkConfiguration(nullScript, configChanges)
+
+        assertEquals(echoOutput, "Your pipeline configuration contains configuration for the stage oldStage. " +
+            "This stage has been removed. ")
     }
 
     @Test
     void testCheckConfigurationParameterTypeChanged() {
         thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your pipeline configuration contains the configuration key configKeyOldType for the step testStep. " +
-            "The type of this configuration parameter was changed from String to List. test")
+        thrown.expectMessage("Failing pipeline due to configuration errors")
         nullScript.commonPipelineEnvironment.configuration = [steps: [testStep: [configKeyOldType: "string"]]]
         Map configChanges = [
             parameterTypeChanged: [
@@ -313,13 +325,15 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         ]
 
         LegacyConfigurationCheckUtils.checkConfiguration(nullScript, configChanges)
+
+        assertEquals(echoOutput, "Your pipeline configuration contains the configuration key configKeyOldType for the step testStep. " +
+            "The type of this configuration parameter was changed from String to List. test")
     }
 
     @Test
     void testCheckConfigurationRenamedNpmScript() {
         thrown.expect(hudson.AbortException)
-        thrown.expectMessage("Your package.json file package.json contains an npm script using the deprecated name oldNpmScriptName. " +
-            "Please rename the script to newNpmScriptName, since the script oldNpmScriptName will not be executed by the pipeline anymore. test")
+        thrown.expectMessage("Failing pipeline due to configuration errors")
         Map configChanges = [
             renamedNpmScript: [
                 oldNpmScriptName: [
@@ -329,5 +343,36 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
         ]
 
         LegacyConfigurationCheckUtils.checkConfiguration(nullScript, configChanges)
+
+        assertEquals(echoOutput, "Your package.json file package.json contains an npm script using the deprecated name oldNpmScriptName. " +
+            "Please rename the script to newNpmScriptName, since the script oldNpmScriptName will not be executed by the pipeline anymore. test")
+    }
+
+    @Test
+    void testCheckConfigurationMultipleErrors() {
+        thrown.expect(hudson.AbortException)
+        thrown.expectMessage("Failing pipeline due to configuration errors")
+        nullScript.commonPipelineEnvironment.configuration = [steps: [testStep: [configKeyOldType: "string"]]]
+        Map configChanges = [
+            renamedNpmScript: [
+                oldNpmScriptName: [
+                    newScriptName: "newNpmScriptName",
+                    customMessage: "test"]
+            ],
+            parameterTypeChanged: [
+                configKeyOldType: [
+                    oldType: "String",
+                    newType: "List",
+                    steps: ["testStep"],
+                    customMessage: "test"]
+            ]
+        ]
+
+        LegacyConfigurationCheckUtils.checkConfiguration(nullScript, configChanges)
+
+        assertEquals(echoOutput, "Your package.json file package.json contains an npm script using the deprecated name oldNpmScriptName. " +
+            "Please rename the script to newNpmScriptName, since the script oldNpmScriptName will not be executed by the pipeline anymore. test\n" +
+            "Your pipeline configuration contains the configuration key configKeyOldType for the step testStep. " +
+            "The type of this configuration parameter was changed from String to List. test")
     }
 }

--- a/test/groovy/com/sap/piper/LegacyConfigurationCheckUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/LegacyConfigurationCheckUtilsTest.groovy
@@ -268,7 +268,7 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
             ]
         ]
 
-        String exception = "Failing pipeline due to configuration errors"
+        String exception = "Failing pipeline due to configuration errors. Please see log output above."
         String output = "Your pipeline configuration contains the configuration key oldConfigKey for the step someStep. " +
             "This configuration option was removed. test"
 
@@ -289,7 +289,7 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
             ]
         ]
 
-        String exception = "Failing pipeline due to configuration errors"
+        String exception = "Failing pipeline due to configuration errors. Please see log output above."
         String output = "Your pipeline configuration contains configuration for the step oldStep. " +
             "This step has been removed. Please configure the step newStep instead. test"
 
@@ -307,7 +307,7 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
             ]
         ]
 
-        String exception = "Failing pipeline due to configuration errors"
+        String exception = "Failing pipeline due to configuration errors. Please see log output above."
         String output = "Your pipeline configuration contains configuration for the stage oldStage. " +
             "This stage has been removed. "
 
@@ -329,7 +329,7 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
             ]
         ]
 
-        String exception = "Failing pipeline due to configuration errors"
+        String exception = "Failing pipeline due to configuration errors. Please see log output above."
         String output = "Your pipeline configuration contains the configuration key configKeyOldType for the step testStep. " +
             "The type of this configuration parameter was changed from String to List. test"
 
@@ -348,7 +348,7 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
             ]
         ]
 
-        String exception = "Failing pipeline due to configuration errors"
+        String exception = "Failing pipeline due to configuration errors. Please see log output above."
         String output = "Your package.json file package.json contains an npm script using the deprecated name oldNpmScriptName. " +
             "Please rename the script to newNpmScriptName, since the script oldNpmScriptName will not be executed by the pipeline anymore. test"
 
@@ -375,7 +375,7 @@ class LegacyConfigurationCheckUtilsTest extends BasePiperTest {
             ]
         ]
 
-        String exception = "Failing pipeline due to configuration errors"
+        String exception = "Failing pipeline due to configuration errors. Please see log output above."
         String output = "Your pipeline configuration file contains the following errors:\n" +
             "Your pipeline configuration contains the configuration key configKeyOldType for the step testStep. " +
             "The type of this configuration parameter was changed from String to List. test\n" +


### PR DESCRIPTION
# Changes

* Instead of letting the pipeline fail for the first config validation error, accumulate all errors and output them to the log, then fail.
* Beginnings of a resource for validating a config.yml migrated to the GPP. Can be configured in the general section:
```yaml
general:
  legacyConfigSettings: 'com.sap.piper/pipeline/cloudSdkToGppConfigSettings.yml'
```

- [x] Tests
- [ ] Documentation
