### PR TITLE
Enable parallel execution with reused mocks

### DIFF
--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -52,6 +52,7 @@ func newDetectTestUtilsBundle() *detectTestUtilsBundle {
 func TestRunDetect(t *testing.T) {
 	t.Parallel()
 	t.Run("success case", func(t *testing.T) {
+		t.Parallel()
 		utilsMock := newDetectTestUtilsBundle()
 		utilsMock.AddFile("detect.sh", []byte(""))
 		err := runDetect(detectExecuteScanOptions{}, utilsMock)
@@ -66,7 +67,7 @@ func TestRunDetect(t *testing.T) {
 	})
 
 	t.Run("failure case", func(t *testing.T) {
-
+		t.Parallel()
 		utilsMock := newDetectTestUtilsBundle()
 		utilsMock.ShouldFailOnCommand = map[string]error{"./detect.sh --blackduck.url= --blackduck.api.token= --detect.project.name=\\\"\\\" --detect.project.version.name=\\\"\\\" --detect.code.location.name=\\\"\\\"": fmt.Errorf("Test Error")}
 		utilsMock.AddFile("detect.sh", []byte(""))
@@ -76,6 +77,7 @@ func TestRunDetect(t *testing.T) {
 	})
 
 	t.Run("maven parameters", func(t *testing.T) {
+		t.Parallel()
 		utilsMock := newDetectTestUtilsBundle()
 		utilsMock.CurrentDir = "root_folder"
 		utilsMock.AddFile("detect.sh", []byte(""))
@@ -182,7 +184,9 @@ func TestAddDetectArgs(t *testing.T) {
 	}
 
 	for k, v := range testData {
+		v := v
 		t.Run(fmt.Sprintf("run %v", k), func(t *testing.T) {
+			t.Parallel()
 			got, err := addDetectArgs(v.args, v.options, newDetectTestUtilsBundle())
 			assert.NoError(t, err)
 			assert.Equal(t, v.expected, got)

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -20,15 +20,15 @@ type detectTestUtilsBundle struct {
 	*mock.FilesMock
 }
 
-func (c *detectTestUtilsBundle) RunExecutable(e string, p ...string) error {
+func (c *detectTestUtilsBundle) RunExecutable(string, ...string) error {
 	panic("not expected to be called in test")
 }
 
-func (c *detectTestUtilsBundle) SetOptions(options piperhttp.ClientOptions) {
+func (c *detectTestUtilsBundle) SetOptions(piperhttp.ClientOptions) {
 
 }
 
-func (c *detectTestUtilsBundle) DownloadFile(url, filename string, header http.Header, cookies []*http.Cookie) error {
+func (c *detectTestUtilsBundle) DownloadFile(url, filename string, _ http.Header, _ []*http.Cookie) error {
 
 	if c.expectedError != nil {
 		return c.expectedError

--- a/cmd/mavenExecuteIntegration_test.go
+++ b/cmd/mavenExecuteIntegration_test.go
@@ -12,6 +12,7 @@ type mavenExecuteIntegrationTestUtilsBundle struct {
 }
 
 func TestIntegrationTestModuleDoesNotExist(t *testing.T) {
+	t.Parallel()
 	utils := newMavenIntegrationTestsUtilsBundle()
 	config := mavenExecuteIntegrationOptions{}
 
@@ -21,6 +22,7 @@ func TestIntegrationTestModuleDoesNotExist(t *testing.T) {
 }
 
 func TestHappyPathIntegrationTests(t *testing.T) {
+	t.Parallel()
 	utils := newMavenIntegrationTestsUtilsBundle()
 	utils.FilesMock.AddFile("integration-tests/pom.xml", []byte(`<project> </project>`))
 
@@ -49,6 +51,7 @@ func TestHappyPathIntegrationTests(t *testing.T) {
 }
 
 func TestInvalidForkCountParam(t *testing.T) {
+	t.Parallel()
 	// init
 	utils := newMavenIntegrationTestsUtilsBundle()
 	utils.FilesMock.AddFile("integration-tests/pom.xml", []byte(`<project> </project>`))

--- a/cmd/mavenExecuteIntegration_test.go
+++ b/cmd/mavenExecuteIntegration_test.go
@@ -39,7 +39,7 @@ func TestHappyPathIntegrationTests(t *testing.T) {
 
 	expectedParameters1 := []string{
 		"--file",
-		filepath.Join(".", "integration-tests/pom.xml"),
+		filepath.Join(".", "integration-tests", "pom.xml"),
 		"-Dsurefire.rerunFailingTestsCount=2",
 		"-Dsurefire.forkCount=1C",
 		"-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn",

--- a/cmd/mavenExecuteIntegration_test.go
+++ b/cmd/mavenExecuteIntegration_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"
+	"path/filepath"
 	"testing"
 )
 
@@ -38,7 +39,7 @@ func TestHappyPathIntegrationTests(t *testing.T) {
 
 	expectedParameters1 := []string{
 		"--file",
-		"integration-tests/pom.xml",
+		filepath.Join(".", "integration-tests/pom.xml"),
 		"-Dsurefire.rerunFailingTestsCount=2",
 		"-Dsurefire.forkCount=1C",
 		"-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn",
@@ -116,7 +117,9 @@ func TestValidateForkCount(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 			err := validateForkCount(testCase.testValue)
 			if testCase.expectedError == "" {
 				assert.NoError(t, err)


### PR DESCRIPTION
# Changes
Enables parallelization of tests by removing reused mocks and adding parallel command.

Proposal for https://github.com/SAP/jenkins-library/issues/2136.