### PR TITLE
(kubernetesDeploy) allow to keep a failed deployment 

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -160,7 +160,11 @@ func runHelmDeploy(config kubernetesDeployOptions, command command.ExecRunner, s
 	}
 
 	if config.DeployTool == "helm3" {
-		upgradeParams = append(upgradeParams, "--atomic", "--timeout", fmt.Sprintf("%vs", config.HelmDeployWaitSeconds))
+		upgradeParams = append(upgradeParams, "--wait", "--timeout", fmt.Sprintf("%vs", config.HelmDeployWaitSeconds))
+	}
+
+	if !config.KeepFailedDeployments {
+		upgradeParams = append(upgradeParams, "--atomic")
 	}
 
 	if len(config.KubeContext) > 0 {

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -29,6 +29,7 @@ type kubernetesDeployOptions struct {
 	HelmValues                 []string `json:"helmValues,omitempty"`
 	Image                      string   `json:"image,omitempty"`
 	IngressHosts               []string `json:"ingressHosts,omitempty"`
+	KeepFailedDeployments      bool     `json:"keepFailedDeployments,omitempty"`
 	KubeConfig                 string   `json:"kubeConfig,omitempty"`
 	KubeContext                string   `json:"kubeContext,omitempty"`
 	KubeToken                  string   `json:"kubeToken,omitempty"`
@@ -129,6 +130,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringSliceVar(&stepConfig.HelmValues, "helmValues", []string{}, "List of helm values as YAML file reference or URL (as per helm parameter description for `-f` / `--values`)")
 	cmd.Flags().StringVar(&stepConfig.Image, "image", os.Getenv("PIPER_image"), "Full name of the image to be deployed.")
 	cmd.Flags().StringSliceVar(&stepConfig.IngressHosts, "ingressHosts", []string{}, "(Deprecated) List of ingress hosts to be exposed via helm deployment.")
+	cmd.Flags().BoolVar(&stepConfig.KeepFailedDeployments, "keepFailedDeployments", true, "Defines whether a failed deployment will be purged")
 	cmd.Flags().StringVar(&stepConfig.KubeConfig, "kubeConfig", os.Getenv("PIPER_kubeConfig"), "Defines the path to the \"kubeconfig\" file.")
 	cmd.Flags().StringVar(&stepConfig.KubeContext, "kubeContext", os.Getenv("PIPER_kubeContext"), "Defines the context to use from the \"kubeconfig\" file.")
 	cmd.Flags().StringVar(&stepConfig.KubeToken, "kubeToken", os.Getenv("PIPER_kubeToken"), "Contains the id_token used by kubectl for authentication. Consider using kubeConfig parameter instead.")
@@ -291,6 +293,14 @@ func kubernetesDeployMetadata() config.StepData {
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+					},
+					{
+						Name:        "keepFailedDeployments",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 					},

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -130,7 +130,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringSliceVar(&stepConfig.HelmValues, "helmValues", []string{}, "List of helm values as YAML file reference or URL (as per helm parameter description for `-f` / `--values`)")
 	cmd.Flags().StringVar(&stepConfig.Image, "image", os.Getenv("PIPER_image"), "Full name of the image to be deployed.")
 	cmd.Flags().StringSliceVar(&stepConfig.IngressHosts, "ingressHosts", []string{}, "(Deprecated) List of ingress hosts to be exposed via helm deployment.")
-	cmd.Flags().BoolVar(&stepConfig.KeepFailedDeployments, "keepFailedDeployments", true, "Defines whether a failed deployment will be purged")
+	cmd.Flags().BoolVar(&stepConfig.KeepFailedDeployments, "keepFailedDeployments", false, "Defines whether a failed deployment will be purged")
 	cmd.Flags().StringVar(&stepConfig.KubeConfig, "kubeConfig", os.Getenv("PIPER_kubeConfig"), "Defines the path to the \"kubeconfig\" file.")
 	cmd.Flags().StringVar(&stepConfig.KubeContext, "kubeContext", os.Getenv("PIPER_kubeContext"), "Defines the context to use from the \"kubeconfig\" file.")
 	cmd.Flags().StringVar(&stepConfig.KubeToken, "kubeToken", os.Getenv("PIPER_kubeToken"), "Contains the id_token used by kubectl for authentication. Consider using kubeConfig parameter instead.")

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -213,6 +213,15 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: keepFailedDeployments
+        type: bool
+        description: Defines whether a failed deployment will be purged
+        default: true
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: kubeConfig
         type: string
         description: Defines the path to the \"kubeconfig\" file.

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -216,7 +216,7 @@ spec:
       - name: keepFailedDeployments
         type: bool
         description: Defines whether a failed deployment will be purged
-        default: true
+        default: false
         scope:
           - GENERAL
           - PARAMETERS


### PR DESCRIPTION
# Changes

At the moment failed deployments will be deleted immediately which limits the debugging options. It should be possible to keep a failed deployment to be able to debug the error

Add `keepFailedDeployments` parameter to enable debugging when using helm 

**Important Note**
This PR enables the --atomic parameter for helm2 deployments. At the moment it is just enabled for helm3 deployments
