### PR TITLE
Fix docu

### DIFF
--- a/resources/metadata/mavenStaticCodeChecks.yaml
+++ b/resources/metadata/mavenStaticCodeChecks.yaml
@@ -68,7 +68,7 @@ spec:
         aliases:
           - name: spotBugs/maxAllowedViolations
       - name: pmdFailurePriority
-        description: What priority level to fail the build on. PMD violations are assigned a priority from 1 (most severe) to 5 (least severe) according the the rule's priority. Violations at or less than this priority level are considered failures and will fail the build if failOnViolation=true and the count exceeds maxAllowedViolations. The other violations will be regarded as warnings and will be displayed in the build output if verbose=true. Setting a value of 5 will treat all violations as failures, which may cause the build to fail. Setting a value of 1 will treat all violations as warnings. Only values from 1 to 5 are valid.
+        description: What priority level to fail the build on. PMD violations are assigned a priority from 1 (most severe) to 5 (least severe) according to the rule's priority. Violations at or less than this priority level are considered failures and will fail the build if failOnViolation=true and the count exceeds maxAllowedViolations. The other violations will be regarded as warnings and will be displayed in the build output if verbose=true. Setting a value of 5 will treat all violations as failures, which may cause the build to fail. Setting a value of 1 will treat all violations as warnings. Only values from 1 to 5 are valid.
         type: int
         scope:
           - PARAMETERS


### PR DESCRIPTION
~~It sounds bit confusing that most severe violation is considered as value "1" and least severe violation is considered "5". In that case, the pipeline should fail if the value is set to "1" but not "5" ?~~
