### PR TITLE
Conditions for npmExecuteScripts in Additional Unit Tests

### DIFF
--- a/resources/com.sap.piper/pipeline/stageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/stageDefaults.yml
@@ -23,6 +23,9 @@ stages:
         filePattern: '**/*.bats'
       karmaExecuteTests:
         filePattern: '**/karma.conf.js'
+      npmExecuteScripts:
+        npmScripts:
+          - 'ci-frontend-unit-test'
   Integration: {}
   Acceptance:
     stepConditions:

--- a/resources/com.sap.piper/pipeline/stageDefaults.yml
+++ b/resources/com.sap.piper/pipeline/stageDefaults.yml
@@ -24,8 +24,8 @@ stages:
       karmaExecuteTests:
         filePattern: '**/karma.conf.js'
       npmExecuteScripts:
-        npmScripts:
-          - 'ci-frontend-unit-test'
+        configKeys:
+          - 'runScripts'
   Integration: {}
   Acceptance:
     stepConditions:


### PR DESCRIPTION
# Changes

Add stage run configuration to autodetect the presence of "ci-frontend-unit-test" script(s) and enable the step "npmExecuteScripts" in the stage "Additional Unit Tests" automatically.

- [ ] Tests (does not apply)
- [ ] Documentation (already documented for stage)
