### PR TITLE
remove duplicate function from interface

### DIFF
--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"path"
 	"strings"

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -85,8 +85,6 @@ type mtaBuildUtils interface {
 	FileRead(path string) ([]byte, error)
 	FileWrite(path string, content []byte, perm os.FileMode) error
 
-	DownloadFile(url, filename string, header http.Header, cookies []*http.Cookie) error
-
 	DownloadAndCopySettingsFiles(globalSettingsFile string, projectSettingsFile string) error
 
 	SetNpmRegistries(defaultNpmRegistry string) error


### PR DESCRIPTION
`DownloadFile` is already defined in [`maven.Utils`](https://github.com/SAP/jenkins-library/blob/bc38af7c919c1fc8df70f71de26f481292944b03/pkg/maven/maven.go#L46). This is marked as error during local build: 

```log
# github.com/SAP/jenkins-library/cmd [github.com/SAP/jenkins-library/cmd.test]
/***/jenkins-library/cmd/mtaBuild.go:88: duplicate method DownloadFile
note: module requires Go 1.15
FAIL	github.com/SAP/jenkins-library/cmd [build failed]
FAIL
```