### PR TITLE
Unstash sources in integration tests

### DIFF
--- a/resources/com.sap.piper/pipeline/stashSettings.yml
+++ b/resources/com.sap.piper/pipeline/stashSettings.yml
@@ -15,6 +15,12 @@ Build:
   - source
   stashes: []
 
+Integration:
+  unstash:
+  - source
+  - buildResult
+  stashes: []
+
 Acceptance:
   unstash:
   - buildResult

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -48,7 +48,6 @@ void call(Map parameters = [:]) {
 
         boolean publishResults = false
         try {
-            utils.unstashAll(['source', 'buildResult'])
             writeTemporaryCredentials(script: script) {
                 if (config.npmExecuteScripts) {
                     publishResults = true

--- a/vars/piperPipelineStageIntegration.groovy
+++ b/vars/piperPipelineStageIntegration.groovy
@@ -48,6 +48,7 @@ void call(Map parameters = [:]) {
 
         boolean publishResults = false
         try {
+            utils.unstashAll(['source', 'buildResult'])
             writeTemporaryCredentials(script: script) {
                 if (config.npmExecuteScripts) {
                     publishResults = true


### PR DESCRIPTION
# Changes

The integration tests always require sources and build results to be unstashed, so we unstash them as part of the stage.
