### PR TITLE
chore(release): ignore stale issues

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -8,6 +8,7 @@ steps:
       - 'invalid'
       - 'question'
       - 'wontfix'
+      - 'stale'
     owner: 'SAP'
     repository: 'jenkins-library'
     releaseBodyHeader: ''


### PR DESCRIPTION
Shall we ignore issues with the [stale label](https://github.com/SAP/jenkins-library/issues?q=is%3Aopen+is%3Aissue+label%3Astale) in release notes?