### PR TITLE
Catch runtime error in ATC step

### DIFF
--- a/cmd/abapEnvironmentRunATCCheck.go
+++ b/cmd/abapEnvironmentRunATCCheck.go
@@ -105,8 +105,10 @@ func triggerATCrun(config abapEnvironmentRunATCCheckOptions, details abaputils.C
 	filelocation, err := filepath.Glob(config.AtcConfig)
 	//Parse YAML ATC run configuration as body for ATC run trigger
 	if err == nil {
-		filename, _ := filepath.Abs(filelocation[0])
-		atcConfigyamlFile, err = ioutil.ReadFile(filename)
+		filename, err := filepath.Abs(filelocation[0])
+		if err == nil {
+			atcConfigyamlFile, err = ioutil.ReadFile(filename)
+		}
 	}
 	var ATCConfig ATCconfig
 	if err == nil {


### PR DESCRIPTION
# Changes
This PR catches the error mentioned in #2337. Unit tests will be handled in a separate Pull Request
Since there is no try and catch in Golang this seems like the best option to me
