### PR TITLE
Stash also original jar

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -427,7 +427,7 @@ steps:
     timeoutInSeconds: 900
   pipelineStashFilesAfterBuild:
     stashIncludes:
-      buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar'
+      buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original'
       checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html'
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
       sonar: '**/jacoco*.exec, **/sonar-project.properties'


### PR DESCRIPTION
#Changes

To install artifacts later it is required to also have the original jar (created in case of spring repackaging) available in other stages.

- [ ] Tests
- [ ] Documentation
