### PR TITLE
don't emit warn message to log in case no verbose flag is available

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -229,7 +229,7 @@ func (c *Config) GetStepConfig(flagValues map[string]interface{}, paramJSON stri
 
 	if verbose, ok := stepConfig.Config["verbose"].(bool); ok && verbose {
 		log.SetVerbose(verbose)
-	} else if !ok {
+	} else if !ok && stepConfig.Config["verbose"] != nil {
 		log.Entry().Warnf("invalid value for parameter verbose: '%v'", stepConfig.Config["verbose"])
 	}
 


### PR DESCRIPTION
It is a normal status that there is no value at all defined for verbose. This means we
are not in verbose mode.

_By the way: cannot assign a suitable reviewer since the committer of the line in question as identified by `git blame` is not known to the project ..._
