### PR TITLE
Fix stage stashes for potential use of neoDeploy

### DIFF
--- a/resources/com.sap.piper/pipeline/stashSettings.yml
+++ b/resources/com.sap.piper/pipeline/stashSettings.yml
@@ -1,30 +1,31 @@
 Init:
   unstash: []
   stashes:
-  - name: "source"
-    includes: "**/*"
-    excludes: ".pipeline/**"
+    - name: "source"
+      includes: "**/*"
+      excludes: ".pipeline/**"
 
 'Pull-Request Voting':
   unstash:
-  - source
+    - source
   stashes: []
 
 Build:
   unstash:
-  - source
+    - source
   stashes: []
 
 Integration:
   unstash:
-  - source
-  - buildResult
+    - source
+    - buildResult
   stashes: []
 
 Acceptance:
   unstash:
-  - buildResult
-  - deployDescriptor
+    - buildDescriptor
+    - buildResult
+    - deployDescriptor
   stashes: []
 
 Performance:
@@ -35,6 +36,7 @@ Performance:
 
 Release:
   unstash:
-  - buildResult
-  - deployDescriptor
+    - buildDescriptor
+    - buildResult
+    - deployDescriptor
   stashes: []


### PR DESCRIPTION
# Changes

When specifying `mavenDeploymentModule` for the step `neoDeploy`, it needs the pom.xml file(s).

- [ ] Tests
- [ ] Documentation
