### PR TITLE
feat: extend getConfig to retrieve metadata by stepName

### DIFF
--- a/cmd/abapAddonAssemblyKitCheckCVs_generated.go
+++ b/cmd/abapAddonAssemblyKitCheckCVs_generated.go
@@ -135,6 +135,9 @@ func abapAddonAssemblyKitCheckCVsMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapAddonAssemblyKitCredentialsId", Description: "Credential stored in Jenkins for the Addon Assembly Kit as a Service (AAKaaS) system", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "abapAddonAssemblyKitEndpoint",
@@ -142,6 +145,7 @@ func abapAddonAssemblyKitCheckCVsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://apps.support.sap.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -150,6 +154,7 @@ func abapAddonAssemblyKitCheckCVsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -158,6 +163,7 @@ func abapAddonAssemblyKitCheckCVsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -166,6 +172,7 @@ func abapAddonAssemblyKitCheckCVsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `addon.yml`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -179,6 +186,7 @@ func abapAddonAssemblyKitCheckCVsMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/abapAddonAssemblyKitCheckPV_generated.go
+++ b/cmd/abapAddonAssemblyKitCheckPV_generated.go
@@ -135,6 +135,9 @@ func abapAddonAssemblyKitCheckPVMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapAddonAssemblyKitCredentialsId", Description: "Credential stored in Jenkins for the Addon Assembly Kit as a Service (AAKaaS) system", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "abapAddonAssemblyKitEndpoint",
@@ -142,6 +145,7 @@ func abapAddonAssemblyKitCheckPVMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://apps.support.sap.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -150,6 +154,7 @@ func abapAddonAssemblyKitCheckPVMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -158,6 +163,7 @@ func abapAddonAssemblyKitCheckPVMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -166,6 +172,7 @@ func abapAddonAssemblyKitCheckPVMetadata() config.StepData {
 						Scope:       []string{},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `addon.yml`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -179,6 +186,7 @@ func abapAddonAssemblyKitCheckPVMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/abapAddonAssemblyKitCreateTargetVector_generated.go
+++ b/cmd/abapAddonAssemblyKitCreateTargetVector_generated.go
@@ -134,6 +134,9 @@ func abapAddonAssemblyKitCreateTargetVectorMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapAddonAssemblyKitCredentialsId", Description: "Credential stored in Jenkins for the Addon Assembly Kit as a Service (AAKaaS) system", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "abapAddonAssemblyKitEndpoint",
@@ -141,6 +144,7 @@ func abapAddonAssemblyKitCreateTargetVectorMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://apps.support.sap.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -149,6 +153,7 @@ func abapAddonAssemblyKitCreateTargetVectorMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -157,6 +162,7 @@ func abapAddonAssemblyKitCreateTargetVectorMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -170,6 +176,7 @@ func abapAddonAssemblyKitCreateTargetVectorMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/abapAddonAssemblyKitPublishTargetVector_generated.go
+++ b/cmd/abapAddonAssemblyKitPublishTargetVector_generated.go
@@ -103,6 +103,9 @@ func abapAddonAssemblyKitPublishTargetVectorMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapAddonAssemblyKitCredentialsId", Description: "Credential stored in Jenkins for the Addon Assembly Kit as a Service (AAKaaS) system", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "abapAddonAssemblyKitEndpoint",
@@ -110,6 +113,7 @@ func abapAddonAssemblyKitPublishTargetVectorMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://apps.support.sap.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -118,6 +122,7 @@ func abapAddonAssemblyKitPublishTargetVectorMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -126,6 +131,7 @@ func abapAddonAssemblyKitPublishTargetVectorMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -134,6 +140,7 @@ func abapAddonAssemblyKitPublishTargetVectorMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_targetVectorScope"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -147,6 +154,7 @@ func abapAddonAssemblyKitPublishTargetVectorMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/abapAddonAssemblyKitRegisterPackages_generated.go
+++ b/cmd/abapAddonAssemblyKitRegisterPackages_generated.go
@@ -135,6 +135,9 @@ func abapAddonAssemblyKitRegisterPackagesMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapAddonAssemblyKitCredentialsId", Description: "Credential stored in Jenkins for the Addon Assembly Kit as a Service (AAKaaS) system", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "abapAddonAssemblyKitEndpoint",
@@ -142,6 +145,7 @@ func abapAddonAssemblyKitRegisterPackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://apps.support.sap.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -150,6 +154,7 @@ func abapAddonAssemblyKitRegisterPackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -158,6 +163,7 @@ func abapAddonAssemblyKitRegisterPackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -171,6 +177,7 @@ func abapAddonAssemblyKitRegisterPackagesMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/abapAddonAssemblyKitReleasePackages_generated.go
+++ b/cmd/abapAddonAssemblyKitReleasePackages_generated.go
@@ -132,6 +132,9 @@ func abapAddonAssemblyKitReleasePackagesMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapAddonAssemblyKitCredentialsId", Description: "Credential stored in Jenkins for the Addon Assembly Kit as a Service (AAKaaS) system", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "abapAddonAssemblyKitEndpoint",
@@ -139,6 +142,7 @@ func abapAddonAssemblyKitReleasePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://apps.support.sap.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -147,6 +151,7 @@ func abapAddonAssemblyKitReleasePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -155,6 +160,7 @@ func abapAddonAssemblyKitReleasePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -168,6 +174,7 @@ func abapAddonAssemblyKitReleasePackagesMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/abapAddonAssemblyKitReserveNextPackages_generated.go
+++ b/cmd/abapAddonAssemblyKitReserveNextPackages_generated.go
@@ -137,6 +137,9 @@ func abapAddonAssemblyKitReserveNextPackagesMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapAddonAssemblyKitCredentialsId", Description: "Credential stored in Jenkins for the Addon Assembly Kit as a Service (AAKaaS) system", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "abapAddonAssemblyKitEndpoint",
@@ -144,6 +147,7 @@ func abapAddonAssemblyKitReserveNextPackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://apps.support.sap.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -152,6 +156,7 @@ func abapAddonAssemblyKitReserveNextPackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -160,6 +165,7 @@ func abapAddonAssemblyKitReserveNextPackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -173,6 +179,7 @@ func abapAddonAssemblyKitReserveNextPackagesMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/abapEnvironmentAssemblePackages_generated.go
+++ b/cmd/abapEnvironmentAssemblePackages_generated.go
@@ -145,6 +145,9 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Platform ABAP Environment system or the Cloud Foundry API", Type: "jenkins", Aliases: []config.Alias{{Name: "cfCredentialsId", Deprecated: false}, {Name: "credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "cfApiEndpoint",
@@ -152,6 +155,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfApiEndpoint"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -160,6 +164,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -168,6 +173,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -176,6 +182,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -184,6 +191,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceKeyName"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceKey"}, {Name: "cloudFoundry/serviceKeyName"}, {Name: "cfServiceKey"}},
 					},
 					{
@@ -192,6 +200,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -200,6 +209,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_username"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -208,6 +218,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_password"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -221,6 +232,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_addonDescriptor"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -229,6 +241,7 @@ func abapEnvironmentAssemblePackagesMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   true,
+						Default:     360,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/abapEnvironmentCheckoutBranch_generated.go
+++ b/cmd/abapEnvironmentCheckoutBranch_generated.go
@@ -117,6 +117,9 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Platform ABAP Environment system or the Cloud Foundry API", Type: "jenkins", Aliases: []config.Alias{{Name: "cfCredentialsId", Deprecated: false}, {Name: "credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -130,6 +133,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -144,6 +148,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -152,6 +157,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_repositoryName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -160,6 +166,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_branchName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -168,6 +175,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -176,6 +184,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_repositories"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -184,6 +193,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfApiEndpoint"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -192,6 +202,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -200,6 +211,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -208,6 +220,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -216,6 +229,7 @@ func abapEnvironmentCheckoutBranchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceKeyName"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceKey"}, {Name: "cloudFoundry/serviceKeyName"}, {Name: "cfServiceKeyName"}},
 					},
 				},

--- a/cmd/abapEnvironmentCloneGitRepo_generated.go
+++ b/cmd/abapEnvironmentCloneGitRepo_generated.go
@@ -117,6 +117,9 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Platform ABAP Environment system or the Cloud Foundry API", Type: "jenkins", Aliases: []config.Alias{{Name: "cfCredentialsId", Deprecated: false}, {Name: "credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -130,6 +133,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -144,6 +148,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -152,6 +157,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_repositories"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -160,6 +166,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_repositoryName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -168,6 +175,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_branchName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -176,6 +184,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -184,6 +193,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfApiEndpoint"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -192,6 +202,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -200,6 +211,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -208,6 +220,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -216,6 +229,7 @@ func abapEnvironmentCloneGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceKeyName"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceKey"}, {Name: "cloudFoundry/serviceKeyName"}, {Name: "cfServiceKey"}},
 					},
 				},

--- a/cmd/abapEnvironmentCreateSystem_generated.go
+++ b/cmd/abapEnvironmentCreateSystem_generated.go
@@ -127,6 +127,9 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "cfCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Cloud Foundry API.", Type: "jenkins", Aliases: []config.Alias{{Name: "cloudFoundry/credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "cfApiEndpoint",
@@ -134,6 +137,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.cf.eu10.hana.ondemand.com`,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -154,6 +158,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -174,6 +179,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -182,6 +188,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -190,6 +197,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -198,6 +206,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfService"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/service"}},
 					},
 					{
@@ -206,6 +215,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServicePlan"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/servicePlan"}},
 					},
 					{
@@ -214,6 +224,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -222,6 +233,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_serviceManifest"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceManifest"}, {Name: "cfServiceManifest"}},
 					},
 					{
@@ -230,6 +242,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_abapSystemAdminEmail"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -238,6 +251,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `Test system created by an automated pipeline`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -246,6 +260,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -254,6 +269,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `H02`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -262,6 +278,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     0,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -270,6 +287,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     0,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -278,6 +296,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_addonDescriptorFileName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -286,6 +305,7 @@ func abapEnvironmentCreateSystemMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/abapEnvironmentPullGitRepo_generated.go
+++ b/cmd/abapEnvironmentPullGitRepo_generated.go
@@ -117,6 +117,9 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Platform ABAP Environment system or the Cloud Foundry API", Type: "jenkins", Aliases: []config.Alias{{Name: "cfCredentialsId", Deprecated: false}, {Name: "credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -130,6 +133,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -144,6 +148,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -152,6 +157,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -160,6 +166,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_repositories"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -168,6 +175,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -176,6 +184,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfApiEndpoint"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -184,6 +193,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -192,6 +202,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -200,6 +211,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -208,6 +220,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceKeyName"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceKey"}, {Name: "cloudFoundry/serviceKeyName"}, {Name: "cfServiceKey"}},
 					},
 					{
@@ -216,6 +229,7 @@ func abapEnvironmentPullGitRepoMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/abapEnvironmentRunATCCheck_generated.go
+++ b/cmd/abapEnvironmentRunATCCheck_generated.go
@@ -118,6 +118,9 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Platform ABAP Environment system or the Cloud Foundry API", Type: "jenkins", Aliases: []config.Alias{{Name: "cfCredentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "atcConfig",
@@ -125,6 +128,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_atcConfig"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -133,6 +137,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfApiEndpoint"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -141,6 +146,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -149,6 +155,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -157,6 +164,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceKeyName"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceKey"}, {Name: "cloudFoundry/serviceKeyName"}, {Name: "cfServiceKey"}},
 					},
 					{
@@ -165,6 +173,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -179,6 +188,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -193,6 +203,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -201,6 +212,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -209,6 +221,7 @@ func abapEnvironmentRunATCCheckMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `ATCResults.xml`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -225,6 +225,10 @@ func artifactPrepareVersionMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "gitHttpsCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing username/password for http access to your git repository.", Type: "jenkins"},
+					{Name: "gitSshKeyCredentialsId", Description: "Jenkins 'SSH Username with private key' credentials ID ssh key for accessing your git repository. You can find details about how to generate an ssh key in the [GitHub documentation](https://docs.github.com/en/enterprise/2.15/user/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent).", Type: "jenkins", Aliases: []config.Alias{{Name: "gitCredentialsId", Deprecated: true}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "buildTool",
@@ -232,6 +236,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_buildTool"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -240,6 +245,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `Project Piper`,
 						Aliases:     []config.Alias{{Name: "gitUserName"}},
 					},
 					{
@@ -248,6 +254,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_customVersionField"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -256,6 +263,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_customVersionSection"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -264,6 +272,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_customVersioningScheme"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -272,6 +281,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_dockerVersionSource"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -280,6 +290,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_filePath"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -288,6 +299,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -296,6 +308,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -304,6 +317,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -324,6 +338,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -332,6 +347,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -340,6 +356,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -348,6 +365,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `build_`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -356,6 +374,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -376,6 +395,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -384,6 +404,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_versioningTemplate"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -392,6 +413,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `cloud`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/checkmarxExecuteScan_generated.go
+++ b/cmd/checkmarxExecuteScan_generated.go
@@ -271,6 +271,9 @@ func checkmarxExecuteScanMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "checkmarxCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing username and password to communicate with the Checkmarx backend.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "avoidDuplicateProjectScans",
@@ -278,6 +281,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -286,6 +290,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go, **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.scala, **/*.ts`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -294,6 +299,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `5`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -302,6 +308,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -310,6 +317,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -318,6 +326,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -326,6 +335,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     3,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -346,6 +356,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -354,6 +365,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_preset"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -362,6 +374,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_projectName"),
 						Aliases:     []config.Alias{{Name: "checkmarxProject"}, {Name: "checkMarxProjectName"}},
 					},
 					{
@@ -370,6 +383,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_pullRequestName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -378,6 +392,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_serverUrl"),
 						Aliases:     []config.Alias{{Name: "checkmarxServerUrl"}},
 					},
 					{
@@ -386,6 +401,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `1`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -394,6 +410,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_teamId"),
 						Aliases:     []config.Alias{{Name: "checkmarxGroupId"}, {Name: "groupId"}},
 					},
 					{
@@ -402,6 +419,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_teamName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -422,6 +440,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -430,6 +449,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -438,6 +458,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -446,6 +467,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     100,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -454,6 +476,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     10,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -462,6 +485,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     100,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -470,6 +494,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `FAILURE`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -478,6 +503,7 @@ func checkmarxExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `percentage`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/cloudFoundryCreateServiceKey_generated.go
+++ b/cmd/cloudFoundryCreateServiceKey_generated.go
@@ -111,6 +111,9 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "cfCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Cloud Foundry API.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "cfApiEndpoint",
@@ -118,6 +121,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfApiEndpoint"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -138,6 +142,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -158,6 +163,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -166,6 +172,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -174,6 +181,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -182,6 +190,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -190,6 +199,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfServiceKeyName"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceKey"}, {Name: "cloudFoundry/serviceKeyName"}, {Name: "cfServiceKey"}},
 					},
 					{
@@ -198,6 +208,7 @@ func cloudFoundryCreateServiceKeyMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceKeyConfig"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceKeyConfig"}},
 					},
 				},

--- a/cmd/cloudFoundryCreateService_generated.go
+++ b/cmd/cloudFoundryCreateService_generated.go
@@ -127,6 +127,9 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "cfCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Cloud Foundry API.", Type: "jenkins", Aliases: []config.Alias{{Name: "cloudFoundry/credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "cfApiEndpoint",
@@ -134,6 +137,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.cf.eu10.hana.ondemand.com`,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -154,6 +158,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -174,6 +179,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -182,6 +188,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -190,6 +197,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -198,6 +206,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfService"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/service"}},
 					},
 					{
@@ -206,6 +215,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServicePlan"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/servicePlan"}},
 					},
 					{
@@ -214,6 +224,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceInstanceName"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstanceName"}},
 					},
 					{
@@ -222,6 +233,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceBroker"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceBroker"}},
 					},
 					{
@@ -230,6 +242,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfCreateServiceConfig"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/createServiceConfig"}},
 					},
 					{
@@ -238,6 +251,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfServiceTags"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceTags"}},
 					},
 					{
@@ -246,6 +260,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `service-manifest.yml`,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceManifest"}, {Name: "cfServiceManifest"}},
 					},
 					{
@@ -254,6 +269,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{{Name: "cloudFoundry/manifestVariables"}, {Name: "cfManifestVariables"}},
 					},
 					{
@@ -262,6 +278,7 @@ func cloudFoundryCreateServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{{Name: "cloudFoundry/manifestVariablesFiles"}, {Name: "cfManifestVariablesFiles"}},
 					},
 				},

--- a/cmd/cloudFoundryCreateSpace_generated.go
+++ b/cmd/cloudFoundryCreateSpace_generated.go
@@ -105,6 +105,9 @@ func cloudFoundryCreateSpaceMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "cfCredentialsId", Description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Foundry API", Type: "jenkins", Aliases: []config.Alias{{Name: "cloudFoundry/credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "cfApiEndpoint",
@@ -112,6 +115,7 @@ func cloudFoundryCreateSpaceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.cf.eu10.hana.ondemand.com`,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -126,6 +130,7 @@ func cloudFoundryCreateSpaceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -140,6 +145,7 @@ func cloudFoundryCreateSpaceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -148,6 +154,7 @@ func cloudFoundryCreateSpaceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -156,6 +163,7 @@ func cloudFoundryCreateSpaceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 				},

--- a/cmd/cloudFoundryDeleteService_generated.go
+++ b/cmd/cloudFoundryDeleteService_generated.go
@@ -108,6 +108,9 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "cfCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Cloud Foundry API.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "cfApiEndpoint",
@@ -115,6 +118,7 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfApiEndpoint"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -135,6 +139,7 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -155,6 +160,7 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -163,6 +169,7 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -171,6 +178,7 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 					{
@@ -179,6 +187,7 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfServiceInstance"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/serviceInstance"}},
 					},
 					{
@@ -187,6 +196,7 @@ func cloudFoundryDeleteServiceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/cfDeleteServiceKeys"}},
 					},
 				},

--- a/cmd/cloudFoundryDeleteSpace_generated.go
+++ b/cmd/cloudFoundryDeleteSpace_generated.go
@@ -105,6 +105,9 @@ func cloudFoundryDeleteSpaceMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "cfCredentialsId", Description: "Jenkins credentials ID containing user and password to authenticate to the Cloud Foundry API", Type: "jenkins", Aliases: []config.Alias{{Name: "cloudFoundry/credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "cfApiEndpoint",
@@ -112,6 +115,7 @@ func cloudFoundryDeleteSpaceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.cf.eu10.hana.ondemand.com`,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -126,6 +130,7 @@ func cloudFoundryDeleteSpaceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -140,6 +145,7 @@ func cloudFoundryDeleteSpaceMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -148,6 +154,7 @@ func cloudFoundryDeleteSpaceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfOrg"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/org"}},
 					},
 					{
@@ -156,6 +163,7 @@ func cloudFoundryDeleteSpaceMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_cfSpace"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/space"}},
 					},
 				},

--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -200,6 +200,10 @@ func cloudFoundryDeployMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "cfCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Cloud Foundry API.", Type: "jenkins", Aliases: []config.Alias{{Name: "cloudFoundry/credentialsId", Deprecated: false}}},
+					{Name: "dockerCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Docker registry.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "apiEndpoint",
@@ -207,6 +211,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.cf.eu10.hana.ondemand.com`,
 						Aliases:     []config.Alias{{Name: "cfApiEndpoint"}, {Name: "cloudFoundry/apiEndpoint"}},
 					},
 					{
@@ -215,6 +220,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_appName"),
 						Aliases:     []config.Alias{{Name: "cfAppName"}, {Name: "cloudFoundry/appName"}},
 					},
 					{
@@ -228,6 +234,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_artifactVersion"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -236,6 +243,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfHome"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -244,6 +252,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfNativeDeployParameters"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -252,6 +261,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_cfPluginHome"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -260,6 +270,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_deployDockerImage"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -268,6 +279,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_deployTool"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -281,6 +293,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_buildTool"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -289,6 +302,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `standard`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -303,6 +317,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_dockerPassword"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -317,6 +332,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_dockerUsername"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -325,6 +341,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -333,6 +350,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_loginParameters"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -341,6 +359,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_manifest"),
 						Aliases:     []config.Alias{{Name: "cfManifest"}, {Name: "cloudFoundry/manifest"}},
 					},
 					{
@@ -349,6 +368,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{{Name: "cfManifestVariables"}, {Name: "cloudFoundry/manifestVariables"}},
 					},
 					{
@@ -357,6 +377,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`manifest-variables.yml`},
 						Aliases:     []config.Alias{{Name: "cfManifestVariablesFiles"}, {Name: "cloudFoundry/manifestVariablesFiles"}},
 					},
 					{
@@ -365,6 +386,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `-f`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -373,6 +395,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_mtaExtensionDescriptor"),
 						Aliases:     []config.Alias{{Name: "cloudFoundry/mtaExtensionDescriptor"}},
 					},
 					{
@@ -386,6 +409,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_mtaPath"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -394,6 +418,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_org"),
 						Aliases:     []config.Alias{{Name: "cfOrg"}, {Name: "cloudFoundry/org"}},
 					},
 					{
@@ -414,6 +439,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -422,6 +448,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `blueGreenCheckScript.sh`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -430,6 +457,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     200,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -438,6 +466,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_space"),
 						Aliases:     []config.Alias{{Name: "cfSpace"}, {Name: "cloudFoundry/space"}},
 					},
 					{
@@ -458,6 +487,7 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/containerSaveImage_generated.go
+++ b/cmd/containerSaveImage_generated.go
@@ -110,6 +110,7 @@ func containerSaveImageMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_containerRegistryUrl"),
 						Aliases:   []config.Alias{{Name: "dockerRegistryUrl"}},
 					},
 					{
@@ -123,6 +124,7 @@ func containerSaveImageMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_containerImage"),
 						Aliases:   []config.Alias{{Name: "dockerImage"}, {Name: "scanImage"}},
 					},
 					{
@@ -131,6 +133,7 @@ func containerSaveImageMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_filePath"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -139,6 +142,7 @@ func containerSaveImageMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -122,6 +122,9 @@ func detectExecuteScanMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "detectTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing the API token used to authenticate with the Synopsis Detect (formerly BlackDuck) Server.", Type: "jenkins", Aliases: []config.Alias{{Name: "apiTokenCredentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "token",
@@ -140,6 +143,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_token"),
 						Aliases:   []config.Alias{{Name: "blackduckToken"}, {Name: "detectToken"}, {Name: "apiToken"}, {Name: "detect/apiToken"}},
 					},
 					{
@@ -148,6 +152,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_codeLocation"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -156,6 +161,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_projectName"),
 						Aliases:     []config.Alias{{Name: "detect/projectName"}},
 					},
 					{
@@ -164,6 +170,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`signature`},
 						Aliases:     []config.Alias{{Name: "detect/scanners"}},
 					},
 					{
@@ -172,6 +179,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`.`},
 						Aliases:     []config.Alias{{Name: "detect/scanPaths"}},
 					},
 					{
@@ -180,6 +188,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`--blackduck.signature.scanner.memory=4096`, `--blackduck.timeout=6000`, `--blackduck.trust.cert=true`, `--detect.report.timeout=4800`, `--logging.level.com.synopsys.integration=DEBUG`, `--detect.maven.excluded.scopes=test`},
 						Aliases:     []config.Alias{{Name: "detect/scanProperties"}},
 					},
 					{
@@ -188,6 +197,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_serverUrl"),
 						Aliases:     []config.Alias{{Name: "detect/serverUrl"}},
 					},
 					{
@@ -196,6 +206,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{{Name: "detect/groups"}},
 					},
 					{
@@ -204,6 +215,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`BLOCKER`},
 						Aliases:     []config.Alias{{Name: "detect/failOn"}},
 					},
 					{
@@ -217,6 +229,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_version"),
 						Aliases:   []config.Alias{{Name: "projectVersion"}, {Name: "detect/projectVersion"}},
 					},
 					{
@@ -225,6 +238,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `major`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -233,6 +247,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -241,6 +256,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -249,6 +265,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -257,6 +274,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/fortifyExecuteScan_generated.go
+++ b/cmd/fortifyExecuteScan_generated.go
@@ -254,6 +254,10 @@ func fortifyExecuteScanMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "fortifyCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to Fortify SSC.", Type: "jenkins"},
+					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "authToken",
@@ -272,6 +276,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_authToken"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -285,6 +290,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_githubToken"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -293,6 +299,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -301,6 +308,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `./`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -309,6 +317,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_pythonRequirementsFile"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -317,6 +326,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -325,6 +335,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `Corporate Security Requirements, Audit All`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -333,6 +344,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `Spot Checks of Each Category`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -341,6 +353,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_pythonRequirementsInstallSuffix"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -349,6 +362,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `python3`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -357,6 +371,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -365,6 +380,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `./pom.xml`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -373,6 +389,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `./setup.py`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -386,6 +403,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_commitId"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -399,6 +417,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_commitMessage"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -407,6 +426,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `https://api.github.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -420,6 +440,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_owner"),
 						Aliases:   []config.Alias{{Name: "githubOrg"}},
 					},
 					{
@@ -433,6 +454,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_repository"),
 						Aliases:   []config.Alias{{Name: "githubRepo"}},
 					},
 					{
@@ -441,6 +463,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `-Xmx4G -Xms512M`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -449,6 +472,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -457,6 +481,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `/transfer/reportDownload.html`,
 						Aliases:     []config.Alias{{Name: "fortifyReportDownloadEndpoint"}},
 					},
 					{
@@ -465,6 +490,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     30,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -473,6 +499,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -481,6 +508,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_translate"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -489,6 +517,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -497,6 +526,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -505,6 +535,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `/api/v1`,
 						Aliases:     []config.Alias{{Name: "fortifyApiEndpoint"}},
 					},
 					{
@@ -513,6 +544,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `PDF`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -521,6 +553,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`./lib`, `.`},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -529,6 +562,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_artifactUrl"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -537,6 +571,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -545,6 +580,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `/upload/resultFileUpload.html`,
 						Aliases:     []config.Alias{{Name: "fortifyFprUploadEndpoint"}},
 					},
 					{
@@ -553,6 +589,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `{{list .GroupID .ArtifactID | join "-" | trimAll "-"}}`,
 						Aliases:     []config.Alias{{Name: "fortifyProjectName"}},
 					},
 					{
@@ -561,6 +598,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -569,6 +607,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_serverUrl"),
 						Aliases:     []config.Alias{{Name: "fortifyServerUrl"}, {Name: "sscUrl"}},
 					},
 					{
@@ -577,6 +616,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     1,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -585,6 +625,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     5,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -593,6 +634,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     1,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -601,6 +643,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `/download/currentStateFprDownload.html`,
 						Aliases:     []config.Alias{{Name: "fortifyFprDownloadEndpoint"}},
 					},
 					{
@@ -609,6 +652,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `major`,
 						Aliases:     []config.Alias{{Name: "defaultVersioningModel"}},
 					},
 					{
@@ -617,6 +661,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `{{.Pip}} install --user .`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -625,6 +670,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     18,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -633,6 +679,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `SAP`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -641,6 +688,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_pullRequestName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -649,6 +697,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `.*Merge pull request #(\\d+) from.*`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -657,6 +706,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `maven`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -665,6 +715,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -673,6 +724,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -681,6 +733,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -689,6 +742,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -697,6 +751,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/gctsCloneRepository_generated.go
+++ b/cmd/gctsCloneRepository_generated.go
@@ -103,6 +103,9 @@ func gctsCloneRepositoryMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing username and password for authentication to the ABAP system on which you want to clone the repository", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -116,6 +119,7 @@ func gctsCloneRepositoryMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -130,6 +134,7 @@ func gctsCloneRepositoryMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -138,6 +143,7 @@ func gctsCloneRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_repository"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -146,6 +152,7 @@ func gctsCloneRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -154,6 +161,7 @@ func gctsCloneRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_client"),
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/gctsCreateRepository_generated.go
+++ b/cmd/gctsCreateRepository_generated.go
@@ -111,6 +111,9 @@ func gctsCreateRepositoryMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing username and password for authentication to the ABAP system on which you want to create the repository", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -124,6 +127,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -138,6 +142,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -146,6 +151,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_repository"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -154,6 +160,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -162,6 +169,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_client"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -170,6 +178,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_remoteRepositoryURL"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -178,6 +187,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_role"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -186,6 +196,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_vSID"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -194,6 +205,7 @@ func gctsCreateRepositoryMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `GIT`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/gctsDeploy_generated.go
+++ b/cmd/gctsDeploy_generated.go
@@ -105,6 +105,9 @@ func gctsDeployMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing username and password for authentication to the ABAP system on which you want to deploy a commit", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -118,6 +121,7 @@ func gctsDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -132,6 +136,7 @@ func gctsDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -140,6 +145,7 @@ func gctsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_repository"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -148,6 +154,7 @@ func gctsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -156,6 +163,7 @@ func gctsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_client"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -164,6 +172,7 @@ func gctsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_commit"),
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/gctsExecuteABAPUnitTests_generated.go
+++ b/cmd/gctsExecuteABAPUnitTests_generated.go
@@ -103,6 +103,9 @@ func gctsExecuteABAPUnitTestsMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing username and password for authentication to the ABAP system on which you want to perform the unit tests", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -116,6 +119,7 @@ func gctsExecuteABAPUnitTestsMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -130,6 +134,7 @@ func gctsExecuteABAPUnitTestsMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -138,6 +143,7 @@ func gctsExecuteABAPUnitTestsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_repository"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -146,6 +152,7 @@ func gctsExecuteABAPUnitTestsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -154,6 +161,7 @@ func gctsExecuteABAPUnitTestsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_client"),
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/gctsRollback_generated.go
+++ b/cmd/gctsRollback_generated.go
@@ -110,6 +110,10 @@ func gctsRollbackMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "abapCredentialsId", Description: "Jenkins credentials ID containing username and password for authentication to the ABAP system on which you want to perform the rollback", Type: "jenkins"},
+					{Name: "githubPersonalAccessTokenId", Description: "GitHub personal access token with at least read permissions for the remote repository", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "username",
@@ -123,6 +127,7 @@ func gctsRollbackMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -137,6 +142,7 @@ func gctsRollbackMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -145,6 +151,7 @@ func gctsRollbackMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_repository"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -153,6 +160,7 @@ func gctsRollbackMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -161,6 +169,7 @@ func gctsRollbackMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_client"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -169,6 +178,7 @@ func gctsRollbackMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_commit"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -182,6 +192,7 @@ func gctsRollbackMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_githubPersonalAccessToken"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -60,6 +60,8 @@ func generateConfig() error {
 		return errors.Wrapf(err, "failed to resolve metadata:")
 	}
 
+	fmt.Println(config.GetJSON(metadata))
+
 	// prepare output resource directories:
 	// this is needed in order to have proper directory permissions in case
 	// resources written inside a container image with a different user
@@ -125,7 +127,7 @@ func addConfigFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&configOptions.parametersJSON, "parametersJSON", os.Getenv("PIPER_parametersJSON"), "Parameters to be considered in JSON format")
 	cmd.Flags().StringVar(&configOptions.stepMetadata, "stepMetadata", "", "Step metadata, passed as path to yaml")
-	cmd.Flags().StringVar(&configOptions.stepName, "stepName", "", "Step name, used to get step metadata if path is not set")
+	cmd.Flags().StringVar(&configOptions.stepName, "stepName", "", "Step name, used to get step metadata if yaml path is not set")
 	cmd.Flags().BoolVar(&configOptions.contextConfig, "contextConfig", false, "Defines if step context configuration should be loaded instead of step config")
 
 }
@@ -194,7 +196,7 @@ func resolveMetadata() (config.StepData, error) {
 				return metadata, errors.Errorf("metadata could not be retrieved by stepName %v", configOptions.stepName)
 			}
 		} else {
-			return metadata, errors.Errorf("either one of stepData or stepName parameter has to be configured")
+			return metadata, errors.Errorf("either one of stepData or stepName parameter has to be passed")
 		}
 	}
 	return metadata, nil

--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -55,26 +55,9 @@ func generateConfig() error {
 	var myConfig config.Config
 	var stepConfig config.StepConfig
 
-	var metadata config.StepData
-	if configOptions.stepMetadata == "" {
-		if configOptions.stepName != "" {
-			metadataMap := GetAllStepMetadata()
-			var ok bool
-			metadata, ok = metadataMap[configOptions.stepMetadata]
-			if !ok {
-				log.Entry().Errorf("metadata could not be retrieved by stepName %v", configOptions.stepName)
-			}
-		}
-	} else {
-		metadataFile, err := configOptions.openFile(configOptions.stepMetadata)
-		if err != nil {
-			return errors.Wrap(err, "metadata: open failed")
-		}
-
-		err = metadata.ReadPipelineStepData(metadataFile)
-		if err != nil {
-			return errors.Wrap(err, "metadata: read failed")
-		}
+	metadata, err := resolveMetadata()
+	if err != nil {
+		return errors.Wrapf(err, "failed to resolve metadata:")
 	}
 
 	// prepare output resource directories:
@@ -142,7 +125,7 @@ func addConfigFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&configOptions.parametersJSON, "parametersJSON", os.Getenv("PIPER_parametersJSON"), "Parameters to be considered in JSON format")
 	cmd.Flags().StringVar(&configOptions.stepMetadata, "stepMetadata", "", "Step metadata, passed as path to yaml")
-	cmd.Flags().StringVar(&configOptions.stepMetadata, "stepName", "", "Step name, used to get step metadata if path is not set")
+	cmd.Flags().StringVar(&configOptions.stepName, "stepName", "", "Step name, used to get step metadata if path is not set")
 	cmd.Flags().BoolVar(&configOptions.contextConfig, "contextConfig", false, "Defines if step context configuration should be loaded instead of step config")
 
 }
@@ -188,4 +171,31 @@ func prepareOutputEnvironment(outputResources []config.StepResources, envRootPat
 			}
 		}
 	}
+}
+
+func resolveMetadata() (config.StepData, error) {
+	var metadata config.StepData
+	if configOptions.stepMetadata != "" {
+		metadataFile, err := configOptions.openFile(configOptions.stepMetadata)
+		if err != nil {
+			return metadata, errors.Wrap(err, "open failed")
+		}
+
+		err = metadata.ReadPipelineStepData(metadataFile)
+		if err != nil {
+			return metadata, errors.Wrap(err, "read failed")
+		}
+	} else {
+		if configOptions.stepName != "" {
+			metadataMap := GetAllStepMetadata()
+			var ok bool
+			metadata, ok = metadataMap[configOptions.stepName]
+			if !ok {
+				return metadata, errors.Errorf("metadata could not be retrieved by stepName %v", configOptions.stepName)
+			}
+		} else {
+			return metadata, errors.Errorf("either one of stepData or stepName parameter has to be configured")
+		}
+	}
+	return metadata, nil
 }

--- a/cmd/githubCheckBranchProtection_generated.go
+++ b/cmd/githubCheckBranchProtection_generated.go
@@ -110,6 +110,9 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "apiUrl",
@@ -117,6 +120,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.github.com`,
 						Aliases:     []config.Alias{{Name: "githubApiUrl"}},
 					},
 					{
@@ -125,6 +129,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `master`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -138,6 +143,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_owner"),
 						Aliases:   []config.Alias{{Name: "githubOrg"}},
 					},
 					{
@@ -151,6 +157,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_repository"),
 						Aliases:   []config.Alias{{Name: "githubRepo"}},
 					},
 					{
@@ -159,6 +166,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -167,6 +175,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -175,6 +184,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     0,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -194,6 +204,7 @@ func githubCheckBranchProtectionMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_token"),
 						Aliases:   []config.Alias{{Name: "githubToken"}, {Name: "access_token"}},
 					},
 				},

--- a/cmd/githubCreatePullRequest_generated.go
+++ b/cmd/githubCreatePullRequest_generated.go
@@ -120,6 +120,9 @@ func githubCreatePullRequestMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "assignees",
@@ -127,6 +130,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -135,6 +139,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_base"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -143,6 +148,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_body"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -151,6 +157,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.github.com`,
 						Aliases:     []config.Alias{{Name: "githubApiUrl"}},
 					},
 					{
@@ -159,6 +166,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_head"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -172,6 +180,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_owner"),
 						Aliases:   []config.Alias{{Name: "githubOrg"}},
 					},
 					{
@@ -185,6 +194,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_repository"),
 						Aliases:   []config.Alias{{Name: "githubRepo"}},
 					},
 					{
@@ -193,6 +203,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://github.com`,
 						Aliases:     []config.Alias{{Name: "githubServerUrl"}},
 					},
 					{
@@ -201,6 +212,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_title"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -214,6 +226,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_token"),
 						Aliases:   []config.Alias{{Name: "githubToken"}},
 					},
 					{
@@ -222,6 +235,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/githubPublishRelease_generated.go
+++ b/cmd/githubPublishRelease_generated.go
@@ -133,6 +133,9 @@ func githubPublishReleaseMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "addClosedIssues",
@@ -140,6 +143,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -148,6 +152,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -156,6 +161,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.github.com`,
 						Aliases:     []config.Alias{{Name: "githubApiUrl"}},
 					},
 					{
@@ -164,6 +170,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_assetPath"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -172,6 +179,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `master`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -180,6 +188,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -188,6 +197,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -201,6 +211,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_owner"),
 						Aliases:   []config.Alias{{Name: "githubOrg"}},
 					},
 					{
@@ -209,6 +220,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -217,6 +229,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_releaseBodyHeader"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -230,6 +243,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_repository"),
 						Aliases:   []config.Alias{{Name: "githubRepo"}},
 					},
 					{
@@ -238,6 +252,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://github.com`,
 						Aliases:     []config.Alias{{Name: "githubServerUrl"}},
 					},
 					{
@@ -251,6 +266,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_token"),
 						Aliases:   []config.Alias{{Name: "githubToken"}},
 					},
 					{
@@ -259,6 +275,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://uploads.github.com`,
 						Aliases:     []config.Alias{{Name: "githubUploadUrl"}},
 					},
 					{
@@ -272,6 +289,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_version"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/githubSetCommitStatus_generated.go
+++ b/cmd/githubSetCommitStatus_generated.go
@@ -121,6 +121,9 @@ func githubSetCommitStatusMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "apiUrl",
@@ -128,6 +131,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://api.github.com`,
 						Aliases:     []config.Alias{{Name: "githubApiUrl"}},
 					},
 					{
@@ -141,6 +145,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_commitId"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -149,6 +154,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_context"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -157,6 +163,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_description"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -170,6 +177,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_owner"),
 						Aliases:   []config.Alias{{Name: "githubOrg"}},
 					},
 					{
@@ -183,6 +191,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_repository"),
 						Aliases:   []config.Alias{{Name: "githubRepo"}},
 					},
 					{
@@ -191,6 +200,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_status"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -199,6 +209,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_targetUrl"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -212,6 +223,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_token"),
 						Aliases:   []config.Alias{{Name: "githubToken"}},
 					},
 				},

--- a/cmd/gitopsUpdateDeployment_generated.go
+++ b/cmd/gitopsUpdateDeployment_generated.go
@@ -128,6 +128,9 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "gitHttpsCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing username/password for http access to your git repository.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "branchName",
@@ -135,6 +138,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `master`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -143,6 +147,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_commitMessage"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -151,6 +156,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `https://github.com`,
 						Aliases:     []config.Alias{{Name: "githubServerUrl"}},
 					},
 					{
@@ -165,6 +171,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -179,6 +186,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -187,6 +195,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_filePath"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -195,6 +204,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_containerName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -208,6 +218,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_containerRegistryUrl"),
 						Aliases:   []config.Alias{{Name: "dockerRegistryUrl"}},
 					},
 					{
@@ -221,6 +232,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_containerImageNameTag"),
 						Aliases:   []config.Alias{{Name: "image"}, {Name: "containerImage"}},
 					},
 					{
@@ -229,6 +241,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_chartPath"),
 						Aliases:     []config.Alias{{Name: "helmChartPath"}},
 					},
 					{
@@ -237,6 +250,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -245,6 +259,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_deploymentName"),
 						Aliases:     []config.Alias{{Name: "helmDeploymentName"}},
 					},
 					{
@@ -253,6 +268,7 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `kubectl`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/hadolintExecute_generated.go
+++ b/cmd/hadolintExecute_generated.go
@@ -101,6 +101,9 @@ func hadolintExecuteMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "configurationCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing username/password for access to your remote configuration file.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "configurationUrl",
@@ -108,6 +111,7 @@ func hadolintExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_configurationUrl"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -122,6 +126,7 @@ func hadolintExecuteMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_configurationUsername"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -136,6 +141,7 @@ func hadolintExecuteMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_configurationPassword"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -144,6 +150,7 @@ func hadolintExecuteMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `./Dockerfile`,
 						Aliases:     []config.Alias{{Name: "dockerfile"}},
 					},
 					{
@@ -152,6 +159,7 @@ func hadolintExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `.hadolint.yaml`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -160,6 +168,7 @@ func hadolintExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `hadolint.xml`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/jsonApplyPatch_generated.go
+++ b/cmd/jsonApplyPatch_generated.go
@@ -103,6 +103,7 @@ func jsonApplyPatchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_input"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -111,6 +112,7 @@ func jsonApplyPatchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_patch"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -119,6 +121,7 @@ func jsonApplyPatchMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_output"),
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -141,6 +141,9 @@ func kanikoExecuteMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "dockerConfigJsonCredentialsId", Description: "Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "buildOptions",
@@ -148,6 +151,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`--skip-tls-verify-pull`},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -156,6 +160,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_containerBuildOptions"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -164,6 +169,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_containerImage"),
 						Aliases:     []config.Alias{{Name: "containerImageNameAndTag"}},
 					},
 					{
@@ -172,6 +178,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_containerImageName"),
 						Aliases:     []config.Alias{{Name: "dockerImageName"}},
 					},
 					{
@@ -185,6 +192,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_containerImageTag"),
 						Aliases:   []config.Alias{{Name: "artifactVersion"}},
 					},
 					{
@@ -193,6 +201,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `rm -f /kaniko/.docker/config.json`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -206,6 +215,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_containerRegistryUrl"),
 						Aliases:   []config.Alias{{Name: "dockerRegistryUrl"}},
 					},
 					{
@@ -214,6 +224,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -233,6 +244,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_dockerConfigJSON"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -241,6 +253,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `Dockerfile`,
 						Aliases:     []config.Alias{{Name: "dockerfile"}},
 					},
 				},

--- a/cmd/karmaExecuteTests_generated.go
+++ b/cmd/karmaExecuteTests_generated.go
@@ -112,6 +112,7 @@ func karmaExecuteTestsMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `npm install --quiet`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -120,6 +121,7 @@ func karmaExecuteTestsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `.`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -128,6 +130,7 @@ func karmaExecuteTestsMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `npm run karma`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -154,6 +154,11 @@ func kubernetesDeployMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "kubeConfigFileCredentialsId", Description: "Jenkins 'Secret file' credentials ID containing kubeconfig file. Details can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).", Type: "jenkins", Aliases: []config.Alias{{Name: "kubeCredentialsId", Deprecated: true}}},
+					{Name: "kubeTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to Kubernetes. This is an alternative way to using a kubeconfig file. Details can be found in the [Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/).", Type: "jenkins", Aliases: []config.Alias{{Name: "k8sTokenCredentialsId", Deprecated: true}}},
+					{Name: "dockerCredentialsId", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "additionalParameters",
@@ -161,6 +166,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{{Name: "helmDeploymentParameters"}},
 					},
 					{
@@ -169,6 +175,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_apiServer"),
 						Aliases:     []config.Alias{{Name: "k8sAPIServer"}},
 					},
 					{
@@ -177,6 +184,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_appTemplate"),
 						Aliases:     []config.Alias{{Name: "k8sAppTemplate"}},
 					},
 					{
@@ -185,6 +193,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_chartPath"),
 						Aliases:     []config.Alias{{Name: "helmChartPath"}},
 					},
 					{
@@ -199,6 +208,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_containerRegistryPassword"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -212,6 +222,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_containerRegistryUrl"),
 						Aliases:   []config.Alias{{Name: "dockerRegistryUrl"}},
 					},
 					{
@@ -226,6 +237,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_containerRegistryUser"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -234,6 +246,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `regsecret`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -242,6 +255,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -250,6 +264,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_deploymentName"),
 						Aliases:     []config.Alias{{Name: "helmDeploymentName"}},
 					},
 					{
@@ -258,6 +273,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `kubectl`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -266,6 +282,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     300,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -274,6 +291,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -287,6 +305,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_image"),
 						Aliases:   []config.Alias{{Name: "deployImage"}},
 					},
 					{
@@ -295,6 +314,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -303,6 +323,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -322,6 +343,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_kubeConfig"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -330,6 +352,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_kubeContext"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -343,6 +366,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_kubeToken"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -351,6 +375,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `default`,
 						Aliases:     []config.Alias{{Name: "helmDeploymentNamespace"}, {Name: "k8sDeploymentNamespace"}},
 					},
 					{
@@ -359,6 +384,7 @@ func kubernetesDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_tillerNamespace"),
 						Aliases:     []config.Alias{{Name: "helmTillerNamespace"}},
 					},
 				},

--- a/cmd/malwareExecuteScan_generated.go
+++ b/cmd/malwareExecuteScan_generated.go
@@ -102,6 +102,9 @@ func malwareExecuteScanMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "malwareScanCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing the technical user/password credential used to communicate with the malwarescanning service.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "host",
@@ -109,6 +112,7 @@ func malwareExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_host"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -123,6 +127,7 @@ func malwareExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -137,6 +142,7 @@ func malwareExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -145,6 +151,7 @@ func malwareExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_file"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -153,6 +160,7 @@ func malwareExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `600`,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/mavenBuild_generated.go
+++ b/cmd/mavenBuild_generated.go
@@ -109,6 +109,7 @@ func mavenBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `pom.xml`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -117,6 +118,7 @@ func mavenBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -125,6 +127,7 @@ func mavenBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -133,6 +136,7 @@ func mavenBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -141,6 +145,7 @@ func mavenBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -149,6 +154,7 @@ func mavenBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -157,6 +163,7 @@ func mavenBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{{Name: "maven/logSuccessfulMavenTransfers"}},
 					},
 				},

--- a/cmd/mavenExecuteIntegration_generated.go
+++ b/cmd/mavenExecuteIntegration_generated.go
@@ -108,6 +108,7 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STEPS", "STAGES"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     1,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -116,6 +117,7 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STEPS", "STAGES"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `1C`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -124,6 +126,7 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -132,6 +135,7 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -140,6 +144,7 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -148,6 +153,7 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -156,6 +162,7 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{{Name: "maven/logSuccessfulMavenTransfers"}},
 					},
 				},

--- a/cmd/mavenExecuteStaticCodeChecks_generated.go
+++ b/cmd/mavenExecuteStaticCodeChecks_generated.go
@@ -126,6 +126,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -134,6 +135,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -142,6 +144,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -150,6 +153,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_spotBugsExcludeFilterFile"),
 						Aliases:     []config.Alias{{Name: "spotBugs/excludeFilterFile"}},
 					},
 					{
@@ -158,6 +162,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_spotBugsIncludeFilterFile"),
 						Aliases:     []config.Alias{{Name: "spotBugs/includeFilterFile"}},
 					},
 					{
@@ -166,6 +171,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     0,
 						Aliases:     []config.Alias{{Name: "spotBugs/maxAllowedViolations"}},
 					},
 					{
@@ -174,6 +180,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     0,
 						Aliases:     []config.Alias{{Name: "pmd/failurePriority"}},
 					},
 					{
@@ -182,6 +189,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     0,
 						Aliases:     []config.Alias{{Name: "pmd/maxAllowedViolations"}},
 					},
 					{
@@ -190,6 +198,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -198,6 +207,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -206,6 +216,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -214,6 +225,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{{Name: "maven/logSuccessfulMavenTransfers"}},
 					},
 					{
@@ -222,6 +234,7 @@ func mavenExecuteStaticCodeChecksMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/mavenExecute_generated.go
+++ b/cmd/mavenExecute_generated.go
@@ -112,6 +112,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_pomPath"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -120,6 +121,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "[]string",
 						Mandatory:   true,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -128,6 +130,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -136,6 +139,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -144,6 +148,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -152,6 +157,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -160,6 +166,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -168,6 +175,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -176,6 +184,7 @@ func mavenExecuteMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{{Name: "maven/logSuccessfulMavenTransfers"}},
 					},
 				},

--- a/cmd/mtaBuild_generated.go
+++ b/cmd/mtaBuild_generated.go
@@ -147,6 +147,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `NEO`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -155,6 +156,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `cloudMbt`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -163,6 +165,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_mtarName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -171,6 +174,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `/opt/sap/mta/lib/mta.jar`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -179,6 +183,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_extensions"),
 						Aliases:     []config.Alias{{Name: "extension"}},
 					},
 					{
@@ -187,6 +192,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `CF`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -195,6 +201,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_applicationName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -203,6 +210,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_defaultNpmRegistry"),
 						Aliases:     []config.Alias{{Name: "npm/defaultNpmRegistry"}},
 					},
 					{
@@ -211,6 +219,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -219,6 +228,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -227,6 +237,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -235,6 +246,7 @@ func mtaBuildMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/nexusUpload_generated.go
+++ b/cmd/nexusUpload_generated.go
@@ -126,6 +126,9 @@ func nexusUploadMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "nexusCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing the technical username/password credential for accessing the nexus endpoint.", Type: "jenkins", Aliases: []config.Alias{{Name: "nexus/credentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "version",
@@ -133,6 +136,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `nexus3`,
 						Aliases:     []config.Alias{{Name: "nexus/version"}},
 					},
 					{
@@ -141,6 +145,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_url"),
 						Aliases:     []config.Alias{{Name: "nexus/url"}},
 					},
 					{
@@ -149,6 +154,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_mavenRepository"),
 						Aliases:     []config.Alias{{Name: "nexus/mavenRepository"}, {Name: "nexus/repository"}},
 					},
 					{
@@ -157,6 +163,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_npmRepository"),
 						Aliases:     []config.Alias{{Name: "nexus/npmRepository"}},
 					},
 					{
@@ -165,6 +172,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_groupId"),
 						Aliases:     []config.Alias{{Name: "nexus/groupId"}},
 					},
 					{
@@ -173,6 +181,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_artifactId"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -181,6 +190,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -189,6 +199,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -203,6 +214,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -217,6 +229,7 @@ func nexusUploadMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 				},

--- a/cmd/npmExecuteLint_generated.go
+++ b/cmd/npmExecuteLint_generated.go
@@ -98,6 +98,7 @@ func npmExecuteLintMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -106,6 +107,7 @@ func npmExecuteLintMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_defaultNpmRegistry"),
 						Aliases:     []config.Alias{{Name: "npm/defaultNpmRegistry"}},
 					},
 				},

--- a/cmd/npmExecuteScripts_generated.go
+++ b/cmd/npmExecuteScripts_generated.go
@@ -107,6 +107,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -115,6 +116,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -123,6 +125,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_defaultNpmRegistry"),
 						Aliases:     []config.Alias{{Name: "npm/defaultNpmRegistry"}},
 					},
 					{
@@ -131,6 +134,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -139,6 +143,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -147,6 +152,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`deployment/**`},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -155,6 +161,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -179,6 +179,10 @@ func protecodeExecuteScanMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "protecodeCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing username and password to authenticate to the Protecode system.", Type: "jenkins"},
+					{Name: "dockerConfigJsonCredentialsId", Description: "Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).", Type: "jenkins", Aliases: []config.Alias{{Name: "dockerCredentialsId", Deprecated: true}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "excludeCVEs",
@@ -186,6 +190,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     ``,
 						Aliases:     []config.Alias{{Name: "protecodeExcludeCVEs"}},
 					},
 					{
@@ -194,6 +199,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{{Name: "protecodeFailOnSevereVulnerabilities"}},
 					},
 					{
@@ -207,6 +213,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_scanImage"),
 						Aliases:   []config.Alias{{Name: "dockerImage"}},
 					},
 					{
@@ -220,6 +227,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_dockerRegistryUrl"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -239,6 +247,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_dockerConfigJSON"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -247,6 +256,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `binary`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -255,6 +265,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_filePath"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -263,6 +274,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -271,6 +283,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `60`,
 						Aliases:     []config.Alias{{Name: "protecodeTimeoutMinutes"}},
 					},
 					{
@@ -279,6 +292,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_serverUrl"),
 						Aliases:     []config.Alias{{Name: "protecodeServerUrl"}},
 					},
 					{
@@ -287,6 +301,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `protecode_report.pdf`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -295,6 +310,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_fetchUrl"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -303,6 +319,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_group"),
 						Aliases:     []config.Alias{{Name: "protecodeGroup"}},
 					},
 					{
@@ -311,6 +328,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -325,6 +343,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{{Name: "user"}},
 					},
 					{
@@ -339,6 +358,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -352,6 +372,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_artifactVersion"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -360,6 +381,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_pullRequestName"),
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/sonarExecuteScan_generated.go
+++ b/cmd/sonarExecuteScan_generated.go
@@ -175,6 +175,10 @@ func sonarExecuteScanMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "sonarTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing the token used to authenticate with the Sonar Server.", Type: "jenkins"},
+					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing the token used to authenticate with the Github Server.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "instance",
@@ -182,6 +186,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `SonarCloud`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -190,6 +195,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_serverUrl"),
 						Aliases:     []config.Alias{{Name: "host"}, {Name: "sonarServerUrl"}},
 					},
 					{
@@ -209,6 +215,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_token"),
 						Aliases:   []config.Alias{{Name: "sonarToken"}},
 					},
 					{
@@ -217,6 +224,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_organization"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -225,6 +233,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -233,6 +242,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.5.0.2216-linux.zip`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -246,6 +256,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_projectVersion"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -254,6 +265,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectKey"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -262,6 +274,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -270,6 +283,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -278,6 +292,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -286,6 +301,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{{Name: "sonarProperties"}},
 					},
 					{
@@ -294,6 +310,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_branchName"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -302,6 +319,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -310,6 +328,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_changeId"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -318,6 +337,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_changeBranch"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -326,6 +346,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_changeTarget"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -334,6 +355,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `GitHub`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -347,6 +369,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_owner"),
 						Aliases:   []config.Alias{{Name: "githubOrg"}},
 					},
 					{
@@ -360,6 +383,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_repository"),
 						Aliases:   []config.Alias{{Name: "githubRepo"}},
 					},
 					{
@@ -373,6 +397,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_githubToken"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -381,6 +406,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -389,6 +415,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -397,6 +424,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `https://api.github.com`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -405,6 +433,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 				},

--- a/cmd/vaultRotateSecretId_generated.go
+++ b/cmd/vaultRotateSecretId_generated.go
@@ -116,6 +116,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `jenkins`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -130,6 +131,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_jenkinsUrl"),
 						Aliases:   []config.Alias{{Name: "url"}},
 					},
 					{
@@ -138,6 +140,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `_`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -152,6 +155,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_jenkinsUsername"),
 						Aliases:   []config.Alias{{Name: "userId"}},
 					},
 					{
@@ -166,6 +170,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_jenkinsToken"),
 						Aliases:   []config.Alias{{Name: "token"}},
 					},
 					{
@@ -174,6 +179,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_vaultAppRoleSecretTokenCredentialsId"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -182,6 +188,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_vaultServerUrl"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -190,6 +197,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_vaultNamespace"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -198,6 +206,7 @@ func vaultRotateSecretIdMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     15,
 						Aliases:     []config.Alias{},
 					},
 				},

--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -214,6 +214,10 @@ func whitesourceExecuteScanMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "userTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing Whitesource user token.", Type: "jenkins", Aliases: []config.Alias{{Name: "whitesourceUserTokenCredentialsId", Deprecated: false}}},
+					{Name: "orgAdminUserTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing Whitesource org admin token.", Type: "jenkins", Aliases: []config.Alias{{Name: "whitesourceOrgAdminUserTokenCredentialsId", Deprecated: false}}},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name: "buildTool",
@@ -226,6 +230,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_buildTool"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -234,6 +239,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_buildDescriptorFile"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -242,6 +248,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `major`,
 						Aliases:     []config.Alias{{Name: "defaultVersioningModel"}},
 					},
 					{
@@ -250,6 +257,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -258,6 +266,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -266,6 +275,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "int",
 						Mandatory:   false,
+						Default:     900,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -274,6 +284,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -282,6 +293,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `./wss-generated-file.config`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -290,6 +302,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `whitesource-reports`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -298,6 +311,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -306,6 +320,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `xlsx`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -314,6 +329,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `15`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -322,6 +338,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -330,6 +347,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `https://saas.whitesourcesoftware.com/api`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -338,6 +356,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{`unit-tests/pom.xml`, `integration-tests/pom.xml`},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -351,6 +370,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_orgToken"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -364,6 +384,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_userToken"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -372,6 +393,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     true,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -380,6 +402,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `wss-unified-agent.jar`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -388,6 +411,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
+						Default:     []string{},
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -396,6 +420,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_productVersion"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -404,6 +429,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_jreDownloadUrl"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -412,6 +438,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_productName"),
 						Aliases:     []config.Alias{{Name: "whitesourceProductName"}},
 					},
 					{
@@ -420,6 +447,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectName"),
 						Aliases:     []config.Alias{{Name: "whitesourceProjectName"}},
 					},
 					{
@@ -428,6 +456,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectToken"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -436,6 +465,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `WhiteSource Security Vulnerability Report`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -444,6 +474,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_installCommand"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -452,6 +483,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_scanType"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -460,6 +492,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `-1`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -468,6 +501,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `**\/src\/main\/**\/*.java **\/*.py **\/*.go **\/*.js **\/*.ts`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -476,6 +510,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `tests/**/*.py **/src/test/**/*.java`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -484,6 +519,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_productToken"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -492,6 +528,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_agentParameters"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -500,6 +537,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_projectSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/projectSettingsFile"}},
 					},
 					{
@@ -508,6 +546,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_globalSettingsFile"),
 						Aliases:     []config.Alias{{Name: "maven/globalSettingsFile"}},
 					},
 					{
@@ -516,6 +555,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_m2Path"),
 						Aliases:     []config.Alias{{Name: "maven/m2Path"}},
 					},
 					{
@@ -524,6 +564,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
+						Default:     false,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -532,6 +573,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_defaultNpmRegistry"),
 						Aliases:     []config.Alias{{Name: "npm/defaultNpmRegistry"}},
 					},
 				},

--- a/cmd/xsDeploy_generated.go
+++ b/cmd/xsDeploy_generated.go
@@ -152,6 +152,9 @@ func xsDeployMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "credentialsId", Description: "Jenkins 'Username with password' credentials ID containing username/password for accessing xs endpoint.", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "deployOpts",
@@ -159,6 +162,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_deployOpts"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -167,6 +171,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `^.*xs bg-deploy -i (.*) -a.*$`,
 						Aliases:     []config.Alias{{Name: "deployIdLogPattern"}},
 					},
 					{
@@ -180,6 +185,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_mtaPath"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -188,6 +194,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     `NONE`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -196,6 +203,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     `DEPLOY`,
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -209,6 +217,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
+						Default:   os.Getenv("PIPER_operationId"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -217,6 +226,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_apiUrl"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -231,6 +241,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_username"),
 						Aliases:   []config.Alias{{Name: "user"}},
 					},
 					{
@@ -245,6 +256,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
+						Default:   os.Getenv("PIPER_password"),
 						Aliases:   []config.Alias{},
 					},
 					{
@@ -253,6 +265,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_org"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -261,6 +274,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_space"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -269,6 +283,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
+						Default:     os.Getenv("PIPER_loginOpts"),
 						Aliases:     []config.Alias{},
 					},
 					{
@@ -277,6 +292,7 @@ func xsDeployMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
+						Default:     os.Getenv("PIPER_xsSessionFile"),
 						Aliases:     []config.Alias{},
 					},
 				},


### PR DESCRIPTION
# Changes

Some groovy steps call piper getConfig to resolve the config before the actual step is called. This requires the step yaml file path to be passed from local file system:
```
./piper getConfig --stepMetadata 'path/to/step.yaml'
```

The proposed change uses the step metadata function and makes the metadata available by only passing the step name to resolve the config:
```
./piper getConfig --stepName <stepName>
```

The step generator had to be extended to generate missing fields of the step yaml files into the go-metadata.


- [ ] Tests
- [ ] Documentation
