### PR TITLE
fix pull via sha256

### DIFF
--- a/cmd/abapAddonAssemblyKitCheckPV.go
+++ b/cmd/abapAddonAssemblyKitCheckPV.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"net/url"
 
 	abapbuild "github.com/SAP/jenkins-library/pkg/abap/build"
 	"github.com/SAP/jenkins-library/pkg/abaputils"
@@ -78,8 +79,8 @@ func (p *productVersion) transferVersionFields(initialAddonDescriptor *abaputils
 }
 
 func (p *productVersion) validateAndResolveVersionFields() error {
-	log.Entry().Infof("Validate product %s version '%s' and resolve version", p.Name, p.VersionYAML)
-	appendum := "/odata/aas_ocs_package/ValidateProductVersion?Name='" + p.Name + "'&Version='" + p.VersionYAML + "'"
+	log.Entry().Infof("Validate product '%s' version '%s' and resolve version", p.Name, p.VersionYAML)
+	appendum := "/odata/aas_ocs_package/ValidateProductVersion?Name='" + url.QueryEscape(p.Name) + "'&Version='" + url.QueryEscape(p.VersionYAML) + "'"
 	body, err := p.Connector.Get(appendum)
 	if err != nil {
 		return err

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -336,5 +336,12 @@ func getTarName(config *protecodeExecuteScanOptions) string {
 	}
 	// replace unwanted chars
 	fileName = strings.ReplaceAll(fileName, "/", "_")
+	log.Entry().Infof("Filename : %s", fileName)
+	input := "@sha256"
+	if strings.Contains(fileName, input) { 
+		fileName = strings.ReplaceAll(fileName, ":",    "_")
+		fileName = strings.ReplaceAll(fileName, "@sha256", "")
+		log.Entry().Infof("Image Pulled via sha: %s", fileName)
+    }
 	return fileName + ".tar"
 }

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -336,12 +336,10 @@ func getTarName(config *protecodeExecuteScanOptions) string {
 	}
 	// replace unwanted chars
 	fileName = strings.ReplaceAll(fileName, "/", "_")
-	log.Entry().Infof("Filename : %s", fileName)
-	input := "@sha256"
-	if strings.Contains(fileName, input) { 
-		fileName = strings.ReplaceAll(fileName, ":",    "_")
-		fileName = strings.ReplaceAll(fileName, "@sha256", "")
-		log.Entry().Infof("Image Pulled via sha: %s", fileName)
-    }
+	sha256 := "@sha256"
+	if strings.Contains(fileName, sha256) {
+		fileName = strings.ReplaceAll(fileName, ":", "_")
+		fileName = strings.ReplaceAll(fileName, sha256, "")
+	}
 	return fileName + ".tar"
 }

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -336,10 +336,7 @@ func getTarName(config *protecodeExecuteScanOptions) string {
 	}
 	// replace unwanted chars
 	fileName = strings.ReplaceAll(fileName, "/", "_")
-	sha256 := "@sha256"
-	if strings.Contains(fileName, sha256) {
-		fileName = strings.ReplaceAll(fileName, ":", "_")
-		fileName = strings.ReplaceAll(fileName, sha256, "")
-	}
+	sha256 := "@sha256:"
+	fileName = strings.Replace(fileName, sha256, "_", 1)
 	return fileName + ".tar"
 }

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -409,7 +409,13 @@ func TestGetTarName(t *testing.T) {
 			"",
 			"ppiper_cf-cli_c25dbacb9ab6e912afe0fe926d8f9d949c60adfe55d16778bde5941e6c37be11.tar",
 		},
+		"with sha+version ": {
+			"ppiper/cf-cli@sha256:c25dbacb9ab6e912afe0fe926d8f9d949c60adfe55d16778bde5941e6c37be11",
+			"verZion",
+			"ppiper_cf-cli_c25dbacb9ab6e912afe0fe926d8f9d949c60adfe55d16778bde5941e6c37be11_verZion.tar",
+		},
 	}
+
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, c.expect, getTarName(&protecodeExecuteScanOptions{ScanImage: c.image, ArtifactVersion: c.version}))

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -404,8 +404,12 @@ func TestGetTarName(t *testing.T) {
 			"",
 			"abc.tar",
 		},
+		"with sha ": {
+			"ppiper/cf-cli@sha256:c25dbacb9ab6e912afe0fe926d8f9d949c60adfe55d16778bde5941e6c37be11",
+			"",
+			"ppiper_cf-cli_c25dbacb9ab6e912afe0fe926d8f9d949c60adfe55d16778bde5941e6c37be11.tar",
+		},
 	}
-
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, c.expect, getTarName(&protecodeExecuteScanOptions{ScanImage: c.image, ArtifactVersion: c.version}))

--- a/documentation/docs/scenarios/abapEnvironmentAddons.md
+++ b/documentation/docs/scenarios/abapEnvironmentAddons.md
@@ -14,11 +14,11 @@ Of course, this tackles only the upstream part of the SaaS solution lifecycle. O
 
 ## The Add-on Product
 
-The installation and maintenance of ABAP software is done / controlled via software product versions. A **software product version** is a „bundle" of software component versions made available at the same time for implementing a well-defined scope of functionality. It is the technical / delivery view on a software portfolio.
+The installation and maintenance of ABAP software is done / controlled via add-on product versions. An **add-on product version** is a „bundle" of software component versions made available at the same time for implementing a well-defined scope of functionality. It is the technical / delivery view on a software portfolio.
 
-### Software Product Version
+### Add-on Product Version
 
-A software product version is defined by a name and a version string. The name of a software product is a string with a maximum of 30 characters and consists of the [namespace](https://launchpad.support.sap.com/#/notes/84282) and a freely chooseble part - `/NAMESPC/PRODUCT1`. The version string consists of three numbers separated by a dot - `1.2.0`. The numbers in the version string have a hierarchic relationship:
+An add-on product version is defined by a name and a version string. The name of an add-on product is a string with a maximum of 30 characters and consists of the [namespace](https://launchpad.support.sap.com/#/notes/84282) and a freely chooseble part - `/NAMESPC/PRODUCT1`. The version string consists of three numbers separated by a dot - `1.2.0`. The numbers in the version string have a hierarchic relationship:
 
 - The first number denotes the release. Release deliveries contain the complete scope of functionality. It is possible to change the software component version bundle in a new release.
 - The second number denotes the Support Package Stack level. A Support Package stack consists of Support Package deliveries of the contained software component versions. It is not possible to change the software component version bundle in such a delivery.
@@ -30,7 +30,7 @@ A software product version is defined by a name and a version string. The name o
 
 ### Software Component Version
 
-A **software component version** is a technically distinguishable unit of software and is installed and patched as a whole. It consists of ABAP development packages and contained objects. Software component versions are delivered via delivery packages. But software component versions are not individual shipment entities. They can only be delivered to customers as part of a [software product version](#software-product-version).
+A **software component version** is a technically distinguishable unit of software and is installed and patched as a whole. It consists of ABAP development packages and contained objects. Software component versions are delivered via delivery packages. But software component versions are not individual shipment entities. They can only be delivered to customers as part of an [add-on product version](#add-on-product-version).
 A software component version is defined by a name and a version string. The name of a software component is string with a maximum of characters and consists of the [namespace](https://launchpad.support.sap.com/#/notes/84282) and a freely chooseble part - /NAMESPC/COMPONENT1. The version consists of three numbers separated by a dot - 1.2.0. The numbers in the version string have a hierarchic relationship:
 
 - The first number denotes the release. Release deliveries contains the whole software component and deliver new and enhancements of existing functionalities. They are delivered with delivery packages of type [“Installation Package”](https://help.sap.com/viewer/9043aa5d2f834ad385e1cdfdadc06b6f/5.0.4.7/en-US/6082f55473568c77e10000000a174cb4.html).
@@ -41,7 +41,7 @@ A software component version is defined by a name and a version string. The name
 
 ### Target Vector
 
-As explained above, the shipment of a software takes place via software product versions. The delivered content of a software product version is defined in a target vector, which is used by the deployment tools. The target vector is derived from the addon.yml (more on that below) and contains the following information:
+As explained above, the shipment of a software takes place via add-on product versions. The delivered content of an add-on product version is defined in a target vector, which is used by the deployment tools. The target vector is derived from the addon.yml (more on that below) and contains the following information:
 
 - Product name
 - Product release
@@ -53,7 +53,7 @@ As explained above, the shipment of a software takes place via software product 
 
 ## Building the Add-on Product
 
-The build process of a software product is orchestrated by a Jenkins Pipeline, the “ABAP Environment Pipeline” provided in this project. To run this pipeline, it only needs to be configured – which will be explained in the sections “Prerequisites” and “Configuration”.
+The build process of an add-on product is orchestrated by a Jenkins Pipeline, the “ABAP Environment Pipeline” provided in this project. To run this pipeline, it only needs to be configured – which will be explained in the sections “Prerequisites” and “Configuration”.
 
 ![ABAP Environment Pipeline Build](../images/abapEnvironmentBuildPipeline.png)
 
@@ -72,7 +72,7 @@ The assembly system should be of [service type abap](https://help.sap.com/viewer
 
 #### Add-on Assembly Kit as a Service (=AAKaaS)
 
-The Add-on Assembly Kit as a Service is responsible for registering and publishing the software product. It is accessible via APIs with an S-User.
+The Add-on Assembly Kit as a Service is responsible for registering and publishing the add-on product. It is accessible via APIs with an S-User.
 
 ### Deployment Tools
 
@@ -138,7 +138,7 @@ A configuration file `.pipeline/config.yml` is used to provide all required valu
 
 #### Add-on descriptor file
 
-The build process is controlled by an add-on descriptor file called `addon.yml`. This file must be created manually and must be stored in the GIT repository of the pipeline. It must contain information about the to-be-delivered [software product version](#software-product-version) and the contained [software component versions](#software-component-version). Below, you see an example:
+The build process is controlled by an add-on descriptor file called `addon.yml`. This file must be created manually and must be stored in the GIT repository of the pipeline. It must contain information about the to-be-delivered [add-on product version](#add-on-product-version) and the contained [software component versions](#software-component-version). Below, you see an example:
 
 ```YAML
 ---

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -169,7 +169,7 @@ func (c *Client) Upload(data UploadRequestData) (*http.Response, error) {
 		return response, errors.Wrapf(err, "HTTP %v request to %v failed with error", data.Method, data.URL)
 	}
 
-	return c.handleResponse(response)
+	return c.handleResponse(response, data.URL)
 }
 
 // SendRequest sends an http request with a defined method
@@ -186,7 +186,7 @@ func (c *Client) SendRequest(method, url string, body io.Reader, header http.Hea
 		return response, errors.Wrapf(err, "error calling %v", url)
 	}
 
-	return c.handleResponse(response)
+	return c.handleResponse(response, url)
 }
 
 // SetOptions sets options used for the http client
@@ -349,7 +349,7 @@ func (c *Client) createRequest(method, url string, body io.Reader, header *http.
 	return request, nil
 }
 
-func (c *Client) handleResponse(response *http.Response) (*http.Response, error) {
+func (c *Client) handleResponse(response *http.Response, url string) (*http.Response, error) {
 	// 2xx codes do not create an error
 	if response.StatusCode >= 200 && response.StatusCode < 300 {
 		return response, nil
@@ -361,7 +361,7 @@ func (c *Client) handleResponse(response *http.Response) (*http.Response, error)
 	case http.StatusForbidden:
 		c.logger.WithField("HTTP Error", "403 (Forbidden)").Error("Permission issue, please check your user permissions!")
 	case http.StatusNotFound:
-		c.logger.WithField("HTTP Error", "404 (Not Found)").Error("Requested resource could not be found")
+		c.logger.WithField("HTTP Error", "404 (Not Found)").Errorf("Requested resource ('%s') could not be found", url)
 	case http.StatusInternalServerError:
 		c.logger.WithField("HTTP Error", "500 (Internal Server Error)").Error("Unknown error occurred.")
 	}


### PR DESCRIPTION
# Changes
Current state of protecodeExecuteScan step within the piper library doesn't support the scan/upload of dockerImage if image is pulled via sha256 Digest. For example, if the user wants to scan below dockerImage and upload the scan result to Black Duck Binary Analysis :
jenkins_jnlp-slave**@sha256:**3073bbe8afbe63652b2903d308ba405b16290d81a08688b75a51a6e0f1b4087
This is bound to fail. 
Request you to merge the changes so the images can be pulled via sha digest.


- [x] Tests
- [ ] Documentation
