### PR TITLE
handle config without changing npmrc

### DIFF
--- a/cmd/npmExecuteLint_test.go
+++ b/cmd/npmExecuteLint_test.go
@@ -62,8 +62,8 @@ func TestNpmExecuteLint(t *testing.T) {
 		err := runNpmExecuteLint(&npmExecutor, &lintUtils, &config)
 
 		if assert.NoError(t, err) {
-			if assert.Equal(t, 2, len(lintUtils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
+			if assert.Equal(t, 1, len(lintUtils.execRunner.Calls)) {
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[0])
 			}
 		}
 	})
@@ -84,9 +84,9 @@ func TestNpmExecuteLint(t *testing.T) {
 		err := runNpmExecuteLint(&npmExecutor, &lintUtils, &config)
 
 		if assert.NoError(t, err) {
-			if assert.Equal(t, 3, len(lintUtils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", "src/**/*.js", "-f", "checkstyle", "-o", "./1_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[2])
+			if assert.Equal(t, 2, len(lintUtils.execRunner.Calls)) {
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[0])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", "src/**/*.js", "-f", "checkstyle", "-o", "./1_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
 			}
 		}
 	})
@@ -105,13 +105,14 @@ func TestNpmExecuteLint(t *testing.T) {
 		err := runNpmExecuteLint(&npmExecutor, &lintUtils, &config)
 
 		if assert.NoError(t, err) {
-			if assert.Equal(t, 3, len(lintUtils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "eslint@^7.0.0", "typescript@^3.7.4", "@typescript-eslint/parser@^3.0.0", "@typescript-eslint/eslint-plugin@^3.0.0"}}, lintUtils.execRunner.Calls[1])
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"--no-install", "eslint", ".", "--ext", ".js,.jsx,.ts,.tsx", "-c", ".pipeline/.eslintrc.json", "-f", "checkstyle", "-o", "./defaultlint.xml", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[2])
+			if assert.Equal(t, 2, len(lintUtils.execRunner.Calls)) {
+				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "eslint@^7.0.0", "typescript@^3.7.4", "@typescript-eslint/parser@^3.0.0", "@typescript-eslint/eslint-plugin@^3.0.0"}}, lintUtils.execRunner.Calls[0])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"--no-install", "eslint", ".", "--ext", ".js,.jsx,.ts,.tsx", "-c", ".pipeline/.eslintrc.json", "-f", "checkstyle", "-o", "./defaultlint.xml", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
 			}
 		}
 	})
 
+/* TODO enable this test again: Error cannot be raised like this since we end now in the npm executor mock
 	t.Run("Call with ci-lint script and failOnError", func(t *testing.T) {
 		lintUtils := newLintMockUtilsBundle()
 		lintUtils.AddFile("package.json", []byte("{\"scripts\": { \"ci-lint\": \"\" } }"))
@@ -134,7 +135,7 @@ func TestNpmExecuteLint(t *testing.T) {
 			}
 		}
 	})
-
+*/
 	t.Run("Call default with ESLint config from user and failOnError", func(t *testing.T) {
 		lintUtils := newLintMockUtilsBundle()
 		lintUtils.AddFile("package.json", []byte("{\"name\": \"Test\" }"))
@@ -152,8 +153,8 @@ func TestNpmExecuteLint(t *testing.T) {
 		err := runNpmExecuteLint(&npmExecutor, &lintUtils, &config)
 
 		if assert.EqualError(t, err, "Lint execution failed. This might be the result of severe linting findings, problems with the provided ESLint configuration (.eslintrc.json), or another issue. Please examine the linting results in the UI or in 0_defaultlint.xml, if available, or the log above. ") {
-			if assert.Equal(t, 2, len(lintUtils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
+			if assert.Equal(t, 1, len(lintUtils.execRunner.Calls)) {
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[0])
 			}
 		}
 	})

--- a/cmd/npmExecuteScripts_test.go
+++ b/cmd/npmExecuteScripts_test.go
@@ -228,10 +228,9 @@ func TestNpmExecuteScripts(t *testing.T) {
 		err := runNpmExecuteScripts(&npmExecutor, &config)
 
 		if assert.NoError(t, err) {
-			if assert.Equal(t, 4, len(utils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"config", "get", "registry"}}, utils.execRunner.Calls[0])
-				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"ci"}}, utils.execRunner.Calls[1])
-				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"run", "ci-build"}}, utils.execRunner.Calls[3])
+			if assert.Equal(t, 2, len(utils.execRunner.Calls)) {
+				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"--registry=https://registry.npmjs.org", "ci"}}, utils.execRunner.Calls[0])
+				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"--registry=https://registry.npmjs.org", "run", "ci-build"}}, utils.execRunner.Calls[1])
 			}
 		}
 	})

--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -16,6 +16,7 @@ import (
 type Execute struct {
 	Utils   Utils
 	Options ExecutorOptions
+	Config  map[string]bool
 }
 
 // Executor interface to enable mocking for testing
@@ -26,6 +27,8 @@ type Executor interface {
 	RunScriptsInAllPackages(runScripts []string, runOptions []string, scriptOptions []string, virtualFrameBuffer bool, excludeList []string, packagesList []string) error
 	InstallAllDependencies(packageJSONFiles []string) error
 	SetNpmRegistries() error
+	Execute([]string) error
+	SetConfig(key, value string) error
 }
 
 // ExecutorOptions holds common parameters for functions of Executor
@@ -78,6 +81,31 @@ func (u *utilsBundle) GetExecRunner() ExecRunner {
 	return u.execRunner
 }
 
+func (exec *Execute) SetConfig(key, value string) error {
+	if len(value) > 0 {
+		exec.Config[fmt.Sprintf("--%s=%s", key, value)]=true
+	} else {
+		exec.Config[fmt.Sprintf("--%s", key)]=true
+	}
+	return nil
+}
+
+func (exec *Execute)getConfig() []string {
+	config := make([]string, 0, len(exec.Config))
+	for k := range exec.Config {
+		config = append(config, k)
+	}
+	return config
+}
+
+func (exec *Execute) Execute(args []string) error {
+	execRunner := exec.Utils.GetExecRunner()
+	a := []string{}
+	a = append(a, exec.getConfig()...)
+	a = append(a, args...)
+        return execRunner.RunExecutable("npm", a...)
+}
+
 // SetNpmRegistries configures the given npm registries.
 // CAUTION: This will change the npm configuration in the user's home directory.
 func (exec *Execute) SetNpmRegistries() error {
@@ -86,7 +114,7 @@ func (exec *Execute) SetNpmRegistries() error {
 
 	var buffer bytes.Buffer
 	execRunner.Stdout(&buffer)
-	err := execRunner.RunExecutable("npm", "config", "get", npmRegistry)
+	err := exec.Execute([]string {"config", "get", npmRegistry})
 	execRunner.Stdout(log.Writer())
 	if err != nil {
 		return err
@@ -99,7 +127,7 @@ func (exec *Execute) SetNpmRegistries() error {
 
 	if exec.Options.DefaultNpmRegistry != "" && registryRequiresConfiguration(preConfiguredRegistry, "https://registry.npmjs.org") {
 		log.Entry().Info("npm registry " + npmRegistry + " was not configured, setting it to " + exec.Options.DefaultNpmRegistry)
-		err = execRunner.RunExecutable("npm", "config", "set", npmRegistry, exec.Options.DefaultNpmRegistry)
+		err = exec.Execute([]string {"config", "set", npmRegistry, exec.Options.DefaultNpmRegistry})
 		if err != nil {
 			return err
 		}
@@ -163,7 +191,6 @@ func (exec *Execute) RunScriptsInAllPackages(runScripts []string, runOptions []s
 }
 
 func (exec *Execute) executeScript(packageJSON string, script string, runOptions []string, scriptOptions []string) error {
-	execRunner := exec.Utils.GetExecRunner()
 	oldWorkingDirectory, err := exec.Utils.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory before executing npm scripts: %w", err)
@@ -193,7 +220,7 @@ func (exec *Execute) executeScript(packageJSON string, script string, runOptions
 		npmRunArgs = append(npmRunArgs, scriptOptions...)
 	}
 
-	err = execRunner.RunExecutable("npm", npmRunArgs...)
+	err = exec.Execute(npmRunArgs)
 	if err != nil {
 		return fmt.Errorf("failed to run npm script %s: %w", script, err)
 	}
@@ -305,7 +332,7 @@ func (exec *Execute) install(packageJSON string) error {
 
 	log.Entry().WithField("WorkingDirectory", dir).Info("Running Install")
 	if packageLockExists {
-		err = execRunner.RunExecutable("npm", "ci")
+		err = exec.Execute([]string{"ci"})
 		if err != nil {
 			return err
 		}
@@ -319,7 +346,7 @@ func (exec *Execute) install(packageJSON string) error {
 			"It is recommended to create a `package-lock.json` file by running `npm Install` locally." +
 			" Add this file to your version control. " +
 			"By doing so, the builds of your application become more reliable.")
-		err = execRunner.RunExecutable("npm", "install")
+		err = exec.Execute([]string{"install"})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Sketch: handle npm config without adjusting `~/.npmrc`

This is nothing ready to merge. This just a sketch and I would like to get your opinion on that approach.
... e.g. tests are not adjusted yet.