### PR TITLE
Tell us what was changed.

### DIFF
--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -72,7 +72,7 @@ jobs:
     - name: generate
       run: go run pkg/generator/step-metadata.go
     - name: verify
-      run: git diff --name-only --exit-code
+      run: git diff --exit-code
   dependencies:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
With the current approach we get a failure when the generated
content triggers a change. But we cannot see what was changed.

With this commit we can see the diff. In case there is not diff
we will not see anything, so there is in that case no real change
in the behaviour. But in case there is a change we will see that
change.

Without that we have to reproduce locally, which means additional
efforts.

