### PR TITLE
Close body also in case of error

### DIFF
--- a/cmd/abapEnvironmentCheckoutBranch.go
+++ b/cmd/abapEnvironmentCheckoutBranch.go
@@ -102,11 +102,13 @@ func triggerCheckout(repositoryName string, branchName string, checkoutConnectio
 
 	// Loging into the ABAP System - getting the x-csrf-token and cookies
 	resp, err := abaputils.GetHTTPResponse("HEAD", checkoutConnectionDetails, nil, client)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		err = abaputils.HandleHTTPError(resp, err, "Authentication on the ABAP system failed", checkoutConnectionDetails)
 		return uriConnectionDetails, err
 	}
-	defer resp.Body.Close()
 
 	// workaround until golang version 1.16 is used
 	time.Sleep(100 * time.Millisecond)
@@ -121,11 +123,13 @@ func triggerCheckout(repositoryName string, branchName string, checkoutConnectio
 
 	// no JSON body needed
 	resp, err = abaputils.GetHTTPResponse("POST", checkoutConnectionDetails, jsonBody, client)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		err = abaputils.HandleHTTPError(resp, err, "Could not trigger checkout of branch "+branchName, uriConnectionDetails)
 		return uriConnectionDetails, err
 	}
-	defer resp.Body.Close()
 	log.Entry().WithField("StatusCode", resp.StatusCode).WithField("repositoryName", repositoryName).WithField("branchName", branchName).Debug("Triggered checkout of branch")
 
 	// Parse Response

--- a/cmd/abapEnvironmentCloneGitRepo.go
+++ b/cmd/abapEnvironmentCloneGitRepo.go
@@ -107,11 +107,13 @@ func triggerClone(repo abaputils.Repository, cloneConnectionDetails abaputils.Co
 
 	// Loging into the ABAP System - getting the x-csrf-token and cookies
 	resp, err := abaputils.GetHTTPResponse("HEAD", cloneConnectionDetails, nil, client)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		err = abaputils.HandleHTTPError(resp, err, "Authentication on the ABAP system failed", cloneConnectionDetails)
 		return uriConnectionDetails, err
 	}
-	defer resp.Body.Close()
 
 	// workaround until golang version 1.16 is used
 	time.Sleep(100 * time.Millisecond)
@@ -129,11 +131,13 @@ func triggerClone(repo abaputils.Repository, cloneConnectionDetails abaputils.Co
 
 	jsonBody := []byte(`{"sc_name":"` + repo.Name + `", "branch_name":"` + repo.Branch + `"` + commitQuery + `}`)
 	resp, err = abaputils.GetHTTPResponse("POST", cloneConnectionDetails, jsonBody, client)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		err = abaputils.HandleHTTPError(resp, err, "Could not clone the Repository / Software Component "+repo.Name+", branch "+repo.Branch+commitString, uriConnectionDetails)
 		return uriConnectionDetails, err
 	}
-	defer resp.Body.Close()
 	log.Entry().WithField("StatusCode", resp.Status).WithField("repositoryName", repo.Name).WithField("branchName", repo.Branch).WithField("commitID", repo.CommitID).Info("Triggered Clone of Repository / Software Component")
 
 	// Parse Response

--- a/cmd/abapEnvironmentPullGitRepo.go
+++ b/cmd/abapEnvironmentPullGitRepo.go
@@ -124,11 +124,13 @@ func triggerPull(repo abaputils.Repository, pullConnectionDetails abaputils.Conn
 
 	// Loging into the ABAP System - getting the x-csrf-token and cookies
 	resp, err := abaputils.GetHTTPResponse("HEAD", pullConnectionDetails, nil, client)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		err = abaputils.HandleHTTPError(resp, err, "Authentication on the ABAP system failed", pullConnectionDetails)
 		return uriConnectionDetails, err
 	}
-	defer resp.Body.Close()
 
 	// workaround until golang version 1.16 is used
 	time.Sleep(100 * time.Millisecond)
@@ -144,11 +146,13 @@ func triggerPull(repo abaputils.Repository, pullConnectionDetails abaputils.Conn
 	commitQuery, commitString := abaputils.GetCommitStrings(repo.CommitID)
 	jsonBody := []byte(`{"sc_name":"` + repo.Name + `"` + commitQuery + `}`)
 	resp, err = abaputils.GetHTTPResponse("POST", pullConnectionDetails, jsonBody, client)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		err = abaputils.HandleHTTPError(resp, err, "Could not pull the Repository / Software Component '"+repo.Name+"'"+commitString, uriConnectionDetails)
 		return uriConnectionDetails, err
 	}
-	defer resp.Body.Close()
 	log.Entry().WithField("StatusCode", resp.Status).WithField("repositoryName", repo.Name).WithField("commitID", repo.CommitID).Debug("Triggered Pull of Repository / Software Component")
 
 	// Parse Response

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -121,6 +121,9 @@ func certificateUpdate(certLinks []string, httpClient piperhttp.Sender, fileUtil
 	}
 	for _, link := range certLinks {
 		response, err := httpClient.SendRequest(http.MethodGet, link, nil, nil, nil)
+		if response != nil && response.Body != nil {
+			defer response.Body.Close()
+		}
 		if err != nil {
 			return errors.Wrap(err, "failed to load certificate from url")
 		}
@@ -129,7 +132,6 @@ func certificateUpdate(certLinks []string, httpClient piperhttp.Sender, fileUtil
 		if err != nil {
 			return errors.Wrap(err, "error reading response")
 		}
-		_ = response.Body.Close()
 		content = append(content, []byte("\n")...)
 		caCerts = append(caCerts, content...)
 	}

--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -48,12 +48,13 @@ func (u *lintUtilsBundle) getExecRunner() command.ExecRunner {
 
 func (u *lintUtilsBundle) getGeneralPurposeConfig(configURL string) {
 	response, err := u.client.SendRequest(http.MethodGet, configURL, nil, nil, nil)
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		log.Entry().Warnf("failed to download general purpose configuration: %v", err)
 		return
 	}
-
-	defer response.Body.Close()
 
 	content, err := ioutil.ReadAll(response.Body)
 	if err != nil {

--- a/pkg/abaputils/manageGitRepositoryUtils.go
+++ b/pkg/abaputils/manageGitRepositoryUtils.go
@@ -21,11 +21,13 @@ func PollEntity(repositoryName string, connectionDetails ConnectionDetailsHTTP, 
 
 	for {
 		var resp, err = GetHTTPResponse("GET", connectionDetails, nil, client)
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
 		if err != nil {
 			err = HandleHTTPError(resp, err, "Could not pull the Repository / Software Component "+repositoryName, connectionDetails)
 			return "", err
 		}
-		defer resp.Body.Close()
 
 		// Parse response
 		var abapResp map[string]*json.RawMessage

--- a/pkg/checkmarx/checkmarx.go
+++ b/pkg/checkmarx/checkmarx.go
@@ -412,12 +412,14 @@ func (sys *SystemInstance) UploadProjectSourceCode(projectID int, zipFile string
 	header.Add("Accept-Encoding", "gzip,deflate")
 	header.Add("Accept", "text/plain")
 	resp, err := sys.client.UploadFile(fmt.Sprintf("%v/cxrestapi/projects/%v/sourceCode/attachments", sys.serverURL, projectID), zipFile, "zippedSource", header, nil)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return errors.Wrap(err, "failed to uploaded zipped sources")
 	}
 
 	data, err := ioutil.ReadAll(resp.Body)
-	defer resp.Body.Close()
 	if err != nil {
 		return errors.Wrap(err, "error reading the response data")
 	}

--- a/pkg/fortify/fortify.go
+++ b/pkg/fortify/fortify.go
@@ -701,11 +701,13 @@ func (sys *SystemInstance) downloadFile(endpoint, method, acceptType, tokenType 
 	} else {
 		response, err = sys.httpClient.SendRequest(method, fmt.Sprintf("%v%v", sys.serverURL, endpoint), strings.NewReader(body.Encode()), header, nil)
 	}
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
 	data, err := ioutil.ReadAll(response.Body)
-	defer response.Body.Close()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading the response data")
 	}

--- a/pkg/http/downloader.go
+++ b/pkg/http/downloader.go
@@ -22,10 +22,12 @@ func (c *Client) DownloadFile(url, filename string, header http.Header, cookies 
 // DownloadRequest ...
 func (c *Client) DownloadRequest(method, url, filename string, header http.Header, cookies []*http.Cookie) error {
 	response, err := c.SendRequest(method, url, nil, header, cookies)
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return errors.Wrapf(err, "HTTP %v request to %v failed with error", method, url)
 	}
-	defer response.Body.Close()
 	parent := filepath.Dir(filename)
 	if len(parent) > 0 {
 		if err = os.MkdirAll(parent, 0775); err != nil {


### PR DESCRIPTION
By moving the defer to close the response body before the error check we ensure that the response body is closed also if an error occurs. Additionally it is checked if there even is a response body to close.

# Changes

- [ ] Tests
- [ ] Documentation
