### PR TITLE
[docu] update prerequisites wrt cm client

### DIFF
--- a/documentation/docs/steps/checkChangeInDevelopment.md
+++ b/documentation/docs/steps/checkChangeInDevelopment.md
@@ -4,7 +4,22 @@
 
 ## Prerequisites
 
-* No prerequisites
+* For type SOLMAN
+
+| SOLMAN Version | cm client version |
+|-----------------------------------------|----------------|
+|SAP Solution Manager 7.2 SP6, SP7        | cm_client v1.x |
+|SAP Solution Manager 7.2 SP 8 and higher | cm_client v2.0 |
+
+* For type CTS (without SOLMAN)
+
+| AS ABAP Version       |     Service Pack    |
+|-----------------------|---------------------|
+| 7.50                  |  >= SP12            |
+| 7.51                  |  >= SP07            |
+| 7.52                  |  >= SP03            |
+| 7.53                  |  >= SP01            |
+| 7.54                  |  >= SP01            |
 
 ## ${docGenParameters}
 

--- a/documentation/docs/steps/checkChangeInDevelopment.md
+++ b/documentation/docs/steps/checkChangeInDevelopment.md
@@ -11,6 +11,10 @@
 |SAP Solution Manager 7.2 SP6, SP7        | cm_client v1.x |
 |SAP Solution Manager 7.2 SP 8 and higher | cm_client v2.0 |
 
+CM Client version v2.x is preconfigured. In order to switch to
+version v1.x update `changeManagement/cts/docker/image` with
+`ppiper/cm-client:1.0.0.0`.
+
 * For type CTS (without SOLMAN)
 
 | AS ABAP Version       |     Service Pack    |

--- a/documentation/docs/steps/transportRequestCreate.md
+++ b/documentation/docs/steps/transportRequestCreate.md
@@ -4,7 +4,22 @@
 
 ## Prerequisites
 
-* Solution Manager version `ST720 SP08` or newer.
+* For type SOLMAN
+
+| SOLMAN Version | cm client version |
+|-----------------------------------------|----------------|
+|SAP Solution Manager 7.2 SP6, SP7        | cm_client v1.x |
+|SAP Solution Manager 7.2 SP 8 and higher | cm_client v2.0 |
+
+* For type CTS (without SOLMAN)
+
+| AS ABAP Version       |     Service Pack    |
+|-----------------------|---------------------|
+| 7.50                  |  >= SP12            |
+| 7.51                  |  >= SP07            |
+| 7.52                  |  >= SP03            |
+| 7.53                  |  >= SP01            |
+| 7.54                  |  >= SP01            |
 
 ## ${docGenParameters}
 

--- a/documentation/docs/steps/transportRequestCreate.md
+++ b/documentation/docs/steps/transportRequestCreate.md
@@ -21,6 +21,10 @@
 | 7.53                  |  >= SP01            |
 | 7.54                  |  >= SP01            |
 
+CM Client version v2.x is preconfigured. In order to switch to
+version v1.x update `changeManagement/cts/docker/image` with
+`ppiper/cm-client:1.0.0.0`.
+
 ## ${docGenParameters}
 
 ## ${docGenConfiguration}

--- a/documentation/docs/steps/transportRequestRelease.md
+++ b/documentation/docs/steps/transportRequestRelease.md
@@ -4,7 +4,22 @@
 
 ## Prerequisites
 
-* No prerequisites
+* For type SOLMAN
+
+| SOLMAN Version | cm client version |
+|-----------------------------------------|----------------|
+|SAP Solution Manager 7.2 SP6, SP7        | cm_client v1.x |
+|SAP Solution Manager 7.2 SP 8 and higher | cm_client v2.0 |
+
+* For type CTS (without SOLMAN)
+
+| AS ABAP Version       |     Service Pack    |
+|-----------------------|---------------------|
+| 7.50                  |  >= SP12            |
+| 7.51                  |  >= SP07            |
+| 7.52                  |  >= SP03            |
+| 7.53                  |  >= SP01            |
+| 7.54                  |  >= SP01            |
 
 ## ${docGenParameters}
 

--- a/documentation/docs/steps/transportRequestRelease.md
+++ b/documentation/docs/steps/transportRequestRelease.md
@@ -11,6 +11,10 @@
 |SAP Solution Manager 7.2 SP6, SP7        | cm_client v1.x |
 |SAP Solution Manager 7.2 SP 8 and higher | cm_client v2.0 |
 
+CM Client version v2.x is preconfigured. In order to switch to
+version v1.x update `changeManagement/cts/docker/image` with
+`ppiper/cm-client:1.0.0.0`.
+
 * For type CTS (without SOLMAN)
 
 | AS ABAP Version       |     Service Pack    |

--- a/documentation/docs/steps/transportRequestUploadFile.md
+++ b/documentation/docs/steps/transportRequestUploadFile.md
@@ -4,7 +4,22 @@
 
 ## Prerequisites
 
-* No prerequisites
+* For type SOLMAN
+
+| SOLMAN Version | cm client version |
+|-----------------------------------------|----------------|
+|SAP Solution Manager 7.2 SP6, SP7        | cm_client v1.x |
+|SAP Solution Manager 7.2 SP 8 and higher | cm_client v2.0 |
+
+* For type CTS (without SOLMAN)
+
+| AS ABAP Version       |     Service Pack    |
+|-----------------------|---------------------|
+| 7.50                  |  >= SP12            |
+| 7.51                  |  >= SP07            |
+| 7.52                  |  >= SP03            |
+| 7.53                  |  >= SP01            |
+| 7.54                  |  >= SP01            |
 
 ## ${docGenParameters}
 

--- a/documentation/docs/steps/transportRequestUploadFile.md
+++ b/documentation/docs/steps/transportRequestUploadFile.md
@@ -11,6 +11,10 @@
 |SAP Solution Manager 7.2 SP6, SP7        | cm_client v1.x |
 |SAP Solution Manager 7.2 SP 8 and higher | cm_client v2.0 |
 
+CM Client version v2.x is preconfigured. In order to switch to
+version v1.x update `changeManagement/cts/docker/image` with
+`ppiper/cm-client:1.0.0.0`.
+
 * For type CTS (without SOLMAN)
 
 | AS ABAP Version       |     Service Pack    |


### PR DESCRIPTION
Describes the prerequisites wrt to the backend.

Would be better to have one single page for all transport request related steps, but there is currently no such page.

