### PR TITLE
Remove obsolete parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/motemen/go-nuts v0.0.0-20200601065735-3df31f16cb2f
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
-	github.com/piper-validation/fortify-client-go v0.0.0-20200206215926-532b5b150d22
+	github.com/piper-validation/fortify-client-go v0.0.0-20210114140201-1261216783c6
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/smartystreets/assertions v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -700,8 +700,8 @@ github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUM
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/piper-validation/fortify-client-go v0.0.0-20200206215926-532b5b150d22 h1:xSbcGENeXvuG+tu4suCmsr+Vm+p3peYNgJDDxUBeJa8=
-github.com/piper-validation/fortify-client-go v0.0.0-20200206215926-532b5b150d22/go.mod h1:EZkdCgngw/tInYdidqDQlRIXvyM1fSbqn/vx83YNCcw=
+github.com/piper-validation/fortify-client-go v0.0.0-20210114140201-1261216783c6 h1:OjKQAKjXxa9qV9ZB/fhUEUhfo0H3RSBMg7uE1c9Func=
+github.com/piper-validation/fortify-client-go v0.0.0-20210114140201-1261216783c6/go.mod h1:EZkdCgngw/tInYdidqDQlRIXvyM1fSbqn/vx83YNCcw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/fortify/fortify.go
+++ b/pkg/fortify/fortify.go
@@ -343,7 +343,6 @@ func (sys *SystemInstance) ProjectVersionCopyFromPartial(sourceID, targetID int6
 		PreviousProjectVersionID:    &sourceID,
 		CopyAnalysisProcessingRules: &enable,
 		CopyBugTrackerConfiguration: &enable,
-		CopyCurrentStateFpr:         &enable,
 		CopyCustomTags:              &enable,
 	}
 	params := &project_version_controller.CopyProjectVersionParams{Resource: &settings}
@@ -357,11 +356,9 @@ func (sys *SystemInstance) ProjectVersionCopyFromPartial(sourceID, targetID int6
 
 // ProjectVersionCopyCurrentState copies the project version state of sourceID into the new project version addressed by targetID
 func (sys *SystemInstance) ProjectVersionCopyCurrentState(sourceID, targetID int64) error {
-	enable := true
 	settings := models.ProjectVersionCopyCurrentStateRequest{
 		ProjectVersionID:         &targetID,
 		PreviousProjectVersionID: &sourceID,
-		CopyCurrentStateFpr:      &enable,
 	}
 	params := &project_version_controller.CopyCurrentStateForProjectVersionParams{Resource: &settings}
 	params.WithTimeout(sys.timeout)

--- a/pkg/fortify/fortify_test.go
+++ b/pkg/fortify/fortify_test.go
@@ -3,12 +3,12 @@ package fortify
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 	"time"
-	"net/http"
-	"net/http/httptest"
 
 	"github.com/go-openapi/strfmt"
 	ff "github.com/piper-validation/fortify-client-go/fortify"

--- a/pkg/fortify/fortify_test.go
+++ b/pkg/fortify/fortify_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
 	"net/http"
 	"net/http/httptest"
 

--- a/pkg/fortify/fortify_test.go
+++ b/pkg/fortify/fortify_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"net/http"
+	"net/http/httptest"
+
 	"github.com/go-openapi/strfmt"
 	ff "github.com/piper-validation/fortify-client-go/fortify"
 	"github.com/piper-validation/fortify-client-go/models"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
 
 	piperHttp "github.com/SAP/jenkins-library/pkg/http"
 )
@@ -434,7 +435,7 @@ func TestProjectVersionCopyFromPartial(t *testing.T) {
 	defer server.Close()
 
 	t.Run("test success", func(t *testing.T) {
-		expected := `{"copyAnalysisProcessingRules":true,"copyBugTrackerConfiguration":true,"copyCurrentStateFpr":true,"copyCustomTags":true,"previousProjectVersionId":10172,"projectVersionId":10173}
+		expected := `{"copyAnalysisProcessingRules":true,"copyBugTrackerConfiguration":true,"copyCustomTags":true,"previousProjectVersionId":10172,"projectVersionId":10173}
 `
 		err := sys.ProjectVersionCopyFromPartial(10172, 10173)
 		assert.NoError(t, err, "ProjectVersionCopyFromPartial call not successful")
@@ -473,7 +474,7 @@ func TestProjectVersionCopyCurrentState(t *testing.T) {
 	defer server.Close()
 
 	t.Run("test success", func(t *testing.T) {
-		expected := `{"copyCurrentStateFpr":true,"previousProjectVersionId":10172,"projectVersionId":10173}
+		expected := `{"previousProjectVersionId":10172,"projectVersionId":10173}
 `
 		err := sys.ProjectVersionCopyCurrentState(10172, 10173)
 		assert.NoError(t, err, "ProjectVersionCopyCurrentState call not successful")


### PR DESCRIPTION
# Changes

- [x] Tests
- [ ] ~Documentation~

With latest Fortify SSC update a parameter was removed from two API calls, therefore we need to adapt our usage.
