### PR TITLE
add access_token alias to all gh secrets

### DIFF
--- a/cmd/fortifyExecuteScan_generated.go
+++ b/cmd/fortifyExecuteScan_generated.go
@@ -291,7 +291,7 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
-						Aliases:   []config.Alias{},
+						Aliases:   []config.Alias{{Name: "access_token"}},
 					},
 					{
 						Name:        "autoCreate",

--- a/cmd/githubCreatePullRequest_generated.go
+++ b/cmd/githubCreatePullRequest_generated.go
@@ -220,7 +220,7 @@ func githubCreatePullRequestMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
-						Aliases:   []config.Alias{{Name: "githubToken"}},
+						Aliases:   []config.Alias{{Name: "githubToken"}, {Name: "access_token"}},
 					},
 					{
 						Name:        "labels",

--- a/cmd/githubPublishRelease_generated.go
+++ b/cmd/githubPublishRelease_generated.go
@@ -257,7 +257,7 @@ func githubPublishReleaseMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
-						Aliases:   []config.Alias{{Name: "githubToken"}},
+						Aliases:   []config.Alias{{Name: "githubToken"}, {Name: "access_token"}},
 					},
 					{
 						Name:        "uploadUrl",

--- a/cmd/githubSetCommitStatus_generated.go
+++ b/cmd/githubSetCommitStatus_generated.go
@@ -218,7 +218,7 @@ func githubSetCommitStatusMetadata() config.StepData {
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: true,
-						Aliases:   []config.Alias{{Name: "githubToken"}},
+						Aliases:   []config.Alias{{Name: "githubToken"}, {Name: "access_token"}},
 					},
 				},
 			},

--- a/cmd/sonarExecuteScan_generated.go
+++ b/cmd/sonarExecuteScan_generated.go
@@ -379,7 +379,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Scope:     []string{"PARAMETERS"},
 						Type:      "string",
 						Mandatory: false,
-						Aliases:   []config.Alias{},
+						Aliases:   []config.Alias{{Name: "access_token"}},
 					},
 					{
 						Name:        "disableInlineComments",

--- a/resources/metadata/fortify.yaml
+++ b/resources/metadata/fortify.yaml
@@ -56,6 +56,8 @@ spec:
           - STEPS
         type: string
         secret: true
+        aliases:
+          - name: access_token
         resourceRef:
           - name: githubTokenCredentialsId
             type: secret

--- a/resources/metadata/githubcreatepr.yaml
+++ b/resources/metadata/githubcreatepr.yaml
@@ -104,6 +104,7 @@ spec:
       - name: token
         aliases:
           - name: githubToken
+          - name: access_token
         description: GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
         scope:
           - GENERAL

--- a/resources/metadata/githubrelease.yaml
+++ b/resources/metadata/githubrelease.yaml
@@ -132,6 +132,7 @@ spec:
       - name: token
         aliases:
           - name: githubToken
+          - name: access_token
         description: "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line"
         scope:
           - GENERAL

--- a/resources/metadata/githubstatus.yaml
+++ b/resources/metadata/githubstatus.yaml
@@ -105,6 +105,7 @@ spec:
       - name: token
         aliases:
           - name: githubToken
+          - name: access_token
         description: GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line.
         scope:
           - GENERAL

--- a/resources/metadata/sonar.yaml
+++ b/resources/metadata/sonar.yaml
@@ -199,6 +199,8 @@ spec:
         scope:
           - PARAMETERS
         secret: true
+        aliases:
+          - name: access_token
         resourceRef:
           - name: githubTokenCredentialsId
             type: secret


### PR DESCRIPTION
# Changes

Add `access_token` alias for all github secrets