### PR TITLE
Remove handle pipeline step errors from groovy glue code

### DIFF
--- a/vars/malwareExecuteScan.groovy
+++ b/vars/malwareExecuteScan.groovy
@@ -4,8 +4,6 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
 
-    handlePipelineStepErrors (stepName: STEP_NAME, stepParameters: parameters) {
-
         def cred = [
             type: 'usernamePassword',
             id: 'malwareScanCredentialsId',
@@ -13,5 +11,4 @@ void call(Map parameters = [:]) {
         ]
 
         piperExecuteBin parameters, STEP_NAME, "metadata/${STEP_NAME}.yaml", [cred]
-    }
 }


### PR DESCRIPTION
Removing this code will not print the following echo message twice in the logs:

` --- End library step of: malwareExecuteScan ---`

