### PR TITLE
test: allow usage of httpmock in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
- 	github.com/jarcoal/httpmock v1.0.6
+	github.com/jarcoal/httpmock v1.0.6
 	github.com/magiconair/properties v1.8.4
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
+ 	github.com/jarcoal/httpmock v1.0.6
 	github.com/magiconair/properties v1.8.4
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -536,6 +536,8 @@ github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbk
 github.com/iris-contrib/go.uuid v2.0.0+incompatible/go.mod h1:iz2lgM/1UnEf1kP0L/+fafWORmlnuysV2EMP8MW+qe0=
 github.com/iris-contrib/i18n v0.0.0-20171121225848-987a633949d0/go.mod h1:pMCz62A0xJL6I+umB2YTlFRwWXaDFA0jy+5HzGiJjqI=
 github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrOcOqfqxa4hXw=
+github.com/jarcoal/httpmock v1.0.6 h1:e81vOSexXU3mJuJ4l//geOmKIt+Vkxerk1feQBC8D0g=
+github.com/jarcoal/httpmock v1.0.6/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -54,7 +54,7 @@ func TestDefaultTransport(t *testing.T) {
 		_, err := client.SendRequest("GET", testURL, nil, nil, nil)
 		// assert
 		assert.Error(t, err)
-		assert.Containsf(t, err.Error(), "Get \"%s\": dial tcp [::1]:443: connect: connection refused", testURL)
+		assert.Contains(t, err.Error(), "Get \""+testURL+"\": dial tcp [::1]:443: connect: connection refused")
 		assert.Equal(t, 0, httpmock.GetTotalCallCount(), "unexpected number of requests")
 	})
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -54,7 +54,7 @@ func TestDefaultTransport(t *testing.T) {
 		_, err := client.SendRequest("GET", testURL, nil, nil, nil)
 		// assert
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Get \""+testURL+"\": dial tcp [::1]:443: connect: connection refused")
+		assert.Contains(t, err.Error(), "connect: connection refused")
 		assert.Equal(t, 0, httpmock.GetTotalCallCount(), "unexpected number of requests")
 	})
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestDefaultTransport(t *testing.T) {
 	const testURL string = "https://example.org/api"
-	
+
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder(http.MethodGet, testURL, httpmock.NewStringResponder(200, `OK`))
@@ -37,7 +37,7 @@ func TestDefaultTransport(t *testing.T) {
 	// assert
 	assert.NoError(t, err)
 	assert.Equal(t, 1, httpmock.GetTotalCallCount(), "unexpected number of requests")
-	
+
 	content, err := ioutil.ReadAll(response.Body)
 	defer response.Body.Close()
 	require.NoError(t, err, "unexpected error while reading response body")

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -54,7 +54,7 @@ func TestDefaultTransport(t *testing.T) {
 		_, err := client.SendRequest("GET", testURL, nil, nil, nil)
 		// assert
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Get \"https://localhost/api\": dial tcp [::1]:443: connect: connection refused")
+		assert.Containsf(t, err.Error(), "Get \"%s\": dial tcp [::1]:443: connect: connection refused", testURL)
 		assert.Equal(t, 0, httpmock.GetTotalCallCount(), "unexpected number of requests")
 	})
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -53,9 +53,8 @@ func TestDefaultTransport(t *testing.T) {
 		// test
 		_, err := client.SendRequest("GET", testURL, nil, nil, nil)
 		// assert
-		assert.EqualError(t, err, "HTTP GET request to https://localhost/api failed: "+
-			"Get \"https://localhost/api\": "+
-			"dial tcp [::1]:443: connect: connection refused")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Get \"https://localhost/api\": dial tcp [::1]:443: connect: connection refused")
 		assert.Equal(t, 0, httpmock.GetTotalCallCount(), "unexpected number of requests")
 	})
 }


### PR DESCRIPTION
Allow usage of [`httpmock`](https://github.com/jarcoal/httpmock#usage) by optionally using the `DefaultTransport` object in the http client.

required by #2218