### PR TITLE
print version of cf cli

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -838,14 +838,18 @@ func cfDeploy(
 	// TODO set HOME to config.DockerWorkspace
 	command.SetEnv(additionalEnvironment)
 
-	err = _cfLogin(command, cloudfoundry.LoginOptions{
-		CfAPIEndpoint: config.APIEndpoint,
-		CfOrg:         config.Org,
-		CfSpace:       config.Space,
-		Username:      config.Username,
-		Password:      config.Password,
-		CfLoginOpts:   strings.Fields(config.LoginParameters),
-	})
+	err = command.RunExecutable("cf", "version")
+
+	if err == nil {
+		err = _cfLogin(command, cloudfoundry.LoginOptions{
+			CfAPIEndpoint: config.APIEndpoint,
+			CfOrg:         config.Org,
+			CfSpace:       config.Space,
+			Username:      config.Username,
+			Password:      config.Password,
+			CfLoginOpts:   strings.Fields(config.LoginParameters),
+		})
+	}
 
 	if err == nil {
 		loginPerformed = true

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -263,6 +263,7 @@ func TestCfDeployment(t *testing.T) {
 
 				withLoginAndLogout(t, func(t *testing.T) {
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{"push", "-f", "manifest.yml"}},
 					}, s.Calls)
@@ -341,6 +342,7 @@ func TestCfDeployment(t *testing.T) {
 
 			withLoginAndLogout(t, func(t *testing.T) {
 				assert.Equal(t, []mock.ExecCall{
+					{Exec: "cf", Params: []string{"version"}},
 					{Exec: "cf", Params: []string{"plugins"}},
 					{Exec: "cf", Params: []string{"push",
 						"testAppName",
@@ -380,6 +382,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{"push",
 							"testAppName",
@@ -427,6 +430,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"blue-green-deploy",
@@ -469,6 +473,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"push",
@@ -528,6 +533,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"blue-green-deploy",
@@ -609,6 +615,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"push",
@@ -635,7 +642,7 @@ func TestCfDeployment(t *testing.T) {
 
 		s := mock.ExecMockRunner{}
 
-		s.ShouldFailOnCommand = map[string]error{"cf.*": fmt.Errorf("cf deploy failed")}
+		s.ShouldFailOnCommand = map[string]error{"cf.*deploy.*": fmt.Errorf("cf deploy failed")}
 		err := runCloudFoundryDeploy(&config, nil, nil, &s)
 
 		if assert.EqualError(t, err, "cf deploy failed") {
@@ -679,7 +686,10 @@ func TestCfDeployment(t *testing.T) {
 			t.Run("check shell calls", func(t *testing.T) {
 
 				// no calls to the cf client in this case
-				assert.Empty(t, s.Calls)
+				assert.Equal(t,
+					[]mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
+					}, s.Calls)
 				// no logout
 				assert.False(t, logoutCalled)
 			})
@@ -711,6 +721,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"push",
@@ -795,6 +806,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"bg-deploy",
@@ -865,6 +877,7 @@ func TestCfDeployment(t *testing.T) {
 					// Revisit: we don't verify a log message in case of a non existing vars file
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"push",
@@ -945,6 +958,7 @@ func TestCfDeployment(t *testing.T) {
 					// Revisit: we don't verify a log message in case of a non existing vars file
 
 					assert.Equal(t, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{
 							"push",
@@ -995,6 +1009,7 @@ func TestCfDeployment(t *testing.T) {
 				withLoginAndLogout(t, func(t *testing.T) {
 
 					assert.Equal(t, s.Calls, []mock.ExecCall{
+						{Exec: "cf", Params: []string{"version"}},
 						{Exec: "cf", Params: []string{"plugins"}},
 						{Exec: "cf", Params: []string{"deploy", "xyz.mtar", "-f"}}})
 


### PR DESCRIPTION
printing the cf cli version into the log. Knowing which version of the cf cli is used and having that information in the log at the point in time when deployment happens speeds up troubleshooting.