### PR TITLE
Skip checkout flag

### DIFF
--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -8,6 +8,7 @@ import org.junit.rules.ExpectedException
 import org.junit.rules.RuleChain
 import util.*
 
+import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.hasItems
 import static org.hamcrest.Matchers.hasKey
 import static org.hamcrest.Matchers.is
@@ -226,6 +227,20 @@ class PiperPipelineStageInitTest extends BasePiperTest {
         assertThat(stepParams.setupCommonPipelineEnvironment?.configFile, is('my-config.yml'))
         assertThat(stepParams.setupCommonPipelineEnvironment?.customDefaults, is(['my-custom-defaults.yml']))
         assertThat(stepParams.setupCommonPipelineEnvironment?.customDefaultsFromFiles, is(['my-custom-default-file.yml']))
+    }
+
+    @Test
+    void "Parameter skipCheckout skips the checkout call"() {
+        jsr.step.piperPipelineStageInit(
+            script: nullScript,
+            juStabUtils: utils,
+            buildTool: 'maven',
+            stashSettings: 'com.sap.piper/pipeline/stashSettings.yml',
+            skipCheckout: true
+        )
+
+        assertThat(stepsCalled, hasItems('setupCommonPipelineEnvironment', 'piperInitRunStageConfiguration', 'artifactPrepareVersion', 'pipelineStashFilesBeforeBuild'))
+        assertThat(stepsCalled, not(hasItem('checkout')))
     }
 
 }

--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -236,7 +236,8 @@ class PiperPipelineStageInitTest extends BasePiperTest {
             juStabUtils: utils,
             buildTool: 'maven',
             stashSettings: 'com.sap.piper/pipeline/stashSettings.yml',
-            skipCheckout: true
+            skipCheckout: true,
+            scmInfo: ["dummyScmKey":"dummyScmKey"]
         )
 
         assertThat(stepsCalled, hasItems('setupCommonPipelineEnvironment', 'piperInitRunStageConfiguration', 'artifactPrepareVersion', 'pipelineStashFilesBeforeBuild'))
@@ -253,6 +254,23 @@ class PiperPipelineStageInitTest extends BasePiperTest {
             buildTool: 'maven',
             stashSettings: 'com.sap.piper/pipeline/stashSettings.yml',
             skipCheckout: "false"
+        )
+    }
+
+    @Test
+    void "Try to skip checkout without scmInfo parameter throws error"() {
+        thrown.expectMessage('[piperPipelineStageInit] Need am scmInfo map retrieved from a checkout. ' +
+            'If you want to skip the checkout the scm info needs to be provided by you with parameter scmInfo, ' +
+            'for example as follows:\n' +
+            '  def scmInfo = checkout scm\n' +
+            '  piperPipelineStageInit script:this, skipCheckout: true, scmInfo: scmInfo')
+
+        jsr.step.piperPipelineStageInit(
+            script: nullScript,
+            juStabUtils: utils,
+            buildTool: 'maven',
+            stashSettings: 'com.sap.piper/pipeline/stashSettings.yml',
+            skipCheckout: true
         )
     }
 

--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -243,4 +243,17 @@ class PiperPipelineStageInitTest extends BasePiperTest {
         assertThat(stepsCalled, not(hasItem('checkout')))
     }
 
+    @Test
+    void "Try to skip checkout with parameter skipCheckout not boolean throws error"() {
+        thrown.expectMessage('[piperPipelineStageInit] Parameter skipCheckout has to be of type boolean. Instead got \'java.lang.String\'')
+
+        jsr.step.piperPipelineStageInit(
+            script: nullScript,
+            juStabUtils: utils,
+            buildTool: 'maven',
+            stashSettings: 'com.sap.piper/pipeline/stashSettings.yml',
+            skipCheckout: "false"
+        )
+    }
+
 }

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -116,10 +116,17 @@ void call(Map parameters = [:]) {
     def stageName = StageNameProvider.instance.getStageName(script, parameters, this)
 
     piperStageWrapper (script: script, stageName: stageName, stashContent: [], ordinal: 1, telemetryDisabled: true) {
-        def scmInfo = parameters.scmInfo
         def skipCheckout = parameters.skipCheckout
         if (skipCheckout != null && !(skipCheckout instanceof Boolean)) {
             error "[${STEP_NAME}] Parameter skipCheckout has to be of type boolean. Instead got '${skipCheckout.class.getName()}'"
+        }
+        def scmInfo = parameters.scmInfo
+        if (skipCheckout && !scmInfo) {
+            error "[${STEP_NAME}] Need am scmInfo map retrieved from a checkout. " +
+                "If you want to skip the checkout the scm info needs to be provided by you with parameter scmInfo, " +
+                "for example as follows:\n" +
+                "  def scmInfo = checkout scm\n" +
+                "  piperPipelineStageInit script:this, skipCheckout: true, scmInfo: scmInfo"
         }
         if (!skipCheckout) {
             scmInfo = checkout(parameters.checkoutMap ?: scm)

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -117,7 +117,11 @@ void call(Map parameters = [:]) {
 
     piperStageWrapper (script: script, stageName: stageName, stashContent: [], ordinal: 1, telemetryDisabled: true) {
         def scmInfo = parameters.scmInfo
-        if (!parameters.skipCheckout) {
+        def skipCheckout = parameters.skipCheckout
+        if (skipCheckout != null && !(skipCheckout instanceof Boolean)) {
+            error "[${STEP_NAME}] Parameter skipCheckout has to be of type boolean. Instead got '${skipCheckout.class.getName()}'"
+        }
+        if (!skipCheckout) {
             scmInfo = checkout(parameters.checkoutMap ?: scm)
         }
 

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -70,6 +70,16 @@ import static com.sap.piper.Prerequisites.checkScript
      */
     'checkoutMap',
     /**
+     * The map returned from a Jenkins git checkout. Used to set the git information in the
+     * common pipeline environment.
+     */
+    'scmInfo',
+    /**
+     * Optional skip of checkout if checkout was done before this step already.
+     * @possibleValues `true`, `false`
+     */
+    'skipCheckout',
+    /**
      * Optional path to the pipeline configuration file defining project specific settings.
      */
     'configFile',
@@ -106,7 +116,10 @@ void call(Map parameters = [:]) {
     def stageName = StageNameProvider.instance.getStageName(script, parameters, this)
 
     piperStageWrapper (script: script, stageName: stageName, stashContent: [], ordinal: 1, telemetryDisabled: true) {
-        def scmInfo = checkout(parameters.checkoutMap ?: scm)
+        def scmInfo = parameters.scmInfo
+        if (!parameters.skipCheckout) {
+            scmInfo = checkout(parameters.checkoutMap ?: scm)
+        }
 
         setupCommonPipelineEnvironment(script: script, customDefaults: parameters.customDefaults, scmInfo: scmInfo,
             configFile: parameters.configFile, customDefaultsFromFiles: parameters.customDefaultsFromFiles)
@@ -139,7 +152,7 @@ void call(Map parameters = [:]) {
             ContainerMap.instance.initFromResource(script, config.containerMapResource, buildTool)
         }
 
-        initStashConfiguration(script, config.stashSettings, config.verbose?: false)
+        initStashConfiguration(script, config.stashSettings, config.verbose ?: false)
 
         if (config.verbose) {
             echo "piper-lib-os  configuration: ${script.commonPipelineEnvironment.configuration}"


### PR DESCRIPTION
This change makes it optional for the user to checkout the sources in the piperPipelineStageInit step. For the Cloud CI Service we want to checkout the sources before this step.

# Changes

skipCheckout flag (defaults to false)
scmInfo parameter to pass to setupCommonPipelineEnvironment

- [x] Tests
- [x] Documentation
