### PR TITLE
use go layer for cf-deploy by default

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -195,6 +195,7 @@ steps:
           unstable: false
     archive: false
   cloudFoundryDeploy:
+    useGoStep: true
     cloudFoundry:
       apiEndpoint: 'https://api.cf.eu10.hana.ondemand.com'
     apiParameters: ''


### PR DESCRIPTION
❗ Should be merged only after prior announcement and together with other cleanup steps by end of March.

Integration test [scs|cap] performs the deployment via piper-go:

```
2021-02-11T09:12:59.6361664Z 14082 [scs|cap] [Pipeline] {
2021-02-11T09:12:59.6362091Z 14083 [scs|cap] [Pipeline] sh
2021-02-11T09:12:59.6362611Z 14084 [scs|cap] + ./piper cloudFoundryDeploy
2021-02-11T09:12:59.6363602Z 14085 [scs|cap] info  cloudFoundryDeploy - Using stageName 'Deploy' from env variable 'STAGE_NAME'
2021-02-11T09:12:59.6364683Z 14086 [scs|cap] info  cloudFoundryDeploy - Project config: '.pipeline/config.yml'
2021-02-11T09:12:59.6366543Z 14087 [scs|cap] info  cloudFoundryDeploy - General parameters: deployTool='mtaDeployPlugin', deployType='standard', cfApiEndpoint='https://api.cf.eu10.hana.ondemand.com', cfOrg='piper', cfSpace='val-it-1613034600282'
2021-02-11T09:12:59.6368685Z 14088 [scs|cap] info  cloudFoundryDeploy - Using additional environment variables: [CF_TRACE=cf.log]
2021-02-11T09:12:59.6369879Z 14089 [scs|cap] info  cloudFoundryDeploy - running command: cf version
2021-02-11T09:12:59.6371268Z 14090 [scs|cap] info  cloudFoundryDeploy - cf version 6.53.0+8e2b70a4a.2020-10-01
```
