### PR TITLE
fix(whitesourceExecuteScan) correctly handle structured projects

### DIFF
--- a/pkg/whitesource/scanReports.go
+++ b/pkg/whitesource/scanReports.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
@@ -49,7 +50,7 @@ func downloadVulnerabilityReport(options ReportOptions, project Project, utils s
 		return nil, err
 	}
 
-	rptFileName := fmt.Sprintf("%s-vulnerability-report.%s", project.Name, options.VulnerabilityReportFormat)
+	rptFileName := fmt.Sprintf("%s-vulnerability-report.%s", strings.ReplaceAll(project.Name, "/", "_"), options.VulnerabilityReportFormat)
 	rptFileName = filepath.Join(options.ReportDirectory, rptFileName)
 	if err := utils.FileWrite(rptFileName, reportBytes, 0644); err != nil {
 		return nil, err
@@ -66,7 +67,7 @@ func downloadRiskReport(options ReportOptions, project Project, utils scanUtils,
 		return nil, err
 	}
 
-	rptFileName := fmt.Sprintf("%s-risk-report.pdf", project.Name)
+	rptFileName := fmt.Sprintf("%s-risk-report.pdf", strings.ReplaceAll(project.Name, "/", "_"))
 	rptFileName = filepath.Join(options.ReportDirectory, rptFileName)
 	if err := utils.FileWrite(rptFileName, reportBytes, 0644); err != nil {
 		return nil, err

--- a/pkg/whitesource/scanReports_test.go
+++ b/pkg/whitesource/scanReports_test.go
@@ -1,11 +1,12 @@
 package whitesource
 
 import (
+	"path/filepath"
+	"testing"
+
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"path/filepath"
-	"testing"
 )
 
 func TestDownloadReports(t *testing.T) {
@@ -31,6 +32,33 @@ func TestDownloadReports(t *testing.T) {
 			assert.Equal(t, []byte("mock-vulnerability-report"), vContent)
 
 			rPath := filepath.Join("report-dir", "mock-project - 1-risk-report.pdf")
+			assert.True(t, utils.HasWrittenFile(rPath))
+			rContent, _ := utils.FileRead(rPath)
+			assert.Equal(t, []byte("mock-risk-report"), rContent)
+		}
+	})
+	t.Run("success - projects with /", func(t *testing.T) {
+		// init
+		options := ReportOptions{
+			ReportDirectory:           "report-dir",
+			VulnerabilityReportFormat: "txt",
+		}
+		utils := &mock.FilesMock{}
+		system := NewSystemMockWithProjectName("2010-05-30 00:15:00 +0100", "@test/mock-project - 1")
+		scan := &Scan{ProductVersion: "1", scannedProjects: map[string]Project{"@test/mock-project - 1": system.Projects[0]}}
+		//scan := &Scan{ProductVersion: "1", scannedProjects: map[string]Project{"mock-product-token": {Name:"@test/mock-project"}}}
+		//_ = scan.AppendScannedProject("@test/mock-project")
+		//_ = scan.UpdateProjects("mock-product-token", system)
+		// test
+		paths, err := scan.DownloadReports(options, utils, system)
+		// assert
+		if assert.NoError(t, err) && assert.Len(t, paths, 2) {
+			vPath := filepath.Join("report-dir", "@test_mock-project - 1-vulnerability-report.txt")
+			assert.True(t, utils.HasWrittenFile(vPath))
+			vContent, _ := utils.FileRead(vPath)
+			assert.Equal(t, []byte("mock-vulnerability-report"), vContent)
+
+			rPath := filepath.Join("report-dir", "@test_mock-project - 1-risk-report.pdf")
 			assert.True(t, utils.HasWrittenFile(rPath))
 			rContent, _ := utils.FileRead(rPath)
 			assert.Equal(t, []byte("mock-risk-report"), rContent)

--- a/pkg/whitesource/sytemMock.go
+++ b/pkg/whitesource/sytemMock.go
@@ -123,9 +123,7 @@ func (m *SystemMock) GetProjectLibraryLocations(projectToken string) ([]Library,
 	return m.Libraries, nil
 }
 
-// NewSystemMock returns a pointer to a new instance of SystemMock.
-func NewSystemMock(lastUpdateDate string) *SystemMock {
-	const projectName = "mock-project - 1"
+func NewSystemMockWithProjectName(lastUpdateDate, projectName string) *SystemMock {
 	mockLibrary := Library{
 		Name:     "mock-library",
 		Filename: "mock-library-file",
@@ -168,4 +166,10 @@ func NewSystemMock(lastUpdateDate string) *SystemMock {
 		RiskReport:          []byte("mock-risk-report"),
 		VulnerabilityReport: []byte("mock-vulnerability-report"),
 	}
+}
+
+// NewSystemMock returns a pointer to a new instance of SystemMock.
+func NewSystemMock(lastUpdateDate string) *SystemMock {
+	const projectName = "mock-project - 1"
+	return NewSystemMockWithProjectName(lastUpdateDate, projectName)
 }

--- a/pkg/whitesource/sytemMock.go
+++ b/pkg/whitesource/sytemMock.go
@@ -123,6 +123,7 @@ func (m *SystemMock) GetProjectLibraryLocations(projectToken string) ([]Library,
 	return m.Libraries, nil
 }
 
+// NewSystemMockWithProjectName returns a pointer to a new instance of SystemMock using a project with a defined name.
 func NewSystemMockWithProjectName(lastUpdateDate, projectName string) *SystemMock {
 	mockLibrary := Library{
 		Name:     "mock-library",


### PR DESCRIPTION
# Changes

report file names of projects which had a structure in the name
like `@test/myProject ` were incorrectly handled

This now prevents that reports are targeted to a sub directory.
Structure is now part of the filename.

- [x] Tests
- ~[ ] Documentation~
