### PR TITLE
cfTrace flag for clound foundry deploy

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -823,7 +823,9 @@ func cfDeploy(
 	var err error
 	var loginPerformed bool
 
-	additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+cfLogFile)
+	if config.CfTrace {
+		additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+cfLogFile)
+	}
 
 	if len(config.CfHome) > 0 {
 		additionalEnvironment = append(additionalEnvironment, "CF_HOME="+config.CfHome)

--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -43,6 +43,7 @@ type cloudFoundryDeployOptions struct {
 	SmokeTestStatusCode      int                    `json:"smokeTestStatusCode,omitempty"`
 	Space                    string                 `json:"space,omitempty"`
 	Username                 string                 `json:"username,omitempty"`
+	CfTrace                  bool                   `json:"cfTrace,omitempty"`
 }
 
 type cloudFoundryDeployInflux struct {
@@ -184,6 +185,7 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().IntVar(&stepConfig.SmokeTestStatusCode, "smokeTestStatusCode", 200, "Expected status code returned by the check.")
 	cmd.Flags().StringVar(&stepConfig.Space, "space", os.Getenv("PIPER_space"), "Cloud Foundry target space")
 	cmd.Flags().StringVar(&stepConfig.Username, "username", os.Getenv("PIPER_username"), "User")
+	cmd.Flags().BoolVar(&stepConfig.CfTrace, "cfTrace", true, "Output the CloudFoundry trace logs.")
 
 	cmd.MarkFlagRequired("apiEndpoint")
 	cmd.MarkFlagRequired("org")
@@ -469,6 +471,14 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Type:      "string",
 						Mandatory: true,
 						Aliases:   []config.Alias{},
+					},
+					{
+						Name:        "cfTrace",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
 					},
 				},
 			},

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -368,6 +368,15 @@ spec:
               - $(vaultPath)/cloudfoundry-$(org)-$(space)
               - $(vaultBasePath)/$(vaultPipelineName)/cloudfoundry-$(org)-$(space)
               - $(vaultBasePath)/GROUP-SECRETS/cloudfoundry-$(org)-$(space)
+      - name: cfTrace
+        type: bool
+        default: true
+        description: "Output the CloudFoundry trace logs."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
   containers:
     - name: cfDeploy
       image: ppiper/cf-cli:6


### PR DESCRIPTION
The `cfTrace` flag has been introduced in groovy for step cfDeploy after creating the step in go. Hence it needs to be provided here now as well. See e9a7590c
