### PR TITLE
Hint for parameter useGoStep in markdown

### DIFF
--- a/documentation/docs/steps/cloudFoundryDeploy.md
+++ b/documentation/docs/steps/cloudFoundryDeploy.md
@@ -2,6 +2,13 @@
 
 ## ${docGenDescription}
 
+### Additional hints
+
+* Via parameter `useGoStep` it can be switched between
+the groovy and the go implementation of that step. E.g. in case there are
+issue with the go step it can be swtiched back to the corresponding groovy
+code via `useGoStep:false` in the step configuration.
+
 ## Prerequisites
 
 * Cloud Foundry organization, space and deployment user are available


### PR DESCRIPTION
This PR competes with #2604. Only either this PR or the other one should be merged.

With this PR we introduce a dummy parameter in the markdown for `cloudFoundryDeploy`.  This parameter is pointless basically in go, but when we publish the docu generated via go already that parameter would be omitted in our docu.