### PR TITLE
use go step as additional dummy parameter

### DIFF
--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -43,6 +43,7 @@ type cloudFoundryDeployOptions struct {
 	SmokeTestStatusCode      int                    `json:"smokeTestStatusCode,omitempty"`
 	Space                    string                 `json:"space,omitempty"`
 	Username                 string                 `json:"username,omitempty"`
+	UseGoStep                bool                   `json:"useGoStep,omitempty"`
 }
 
 type cloudFoundryDeployInflux struct {
@@ -184,6 +185,7 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().IntVar(&stepConfig.SmokeTestStatusCode, "smokeTestStatusCode", 200, "Expected status code returned by the check.")
 	cmd.Flags().StringVar(&stepConfig.Space, "space", os.Getenv("PIPER_space"), "Cloud Foundry target space")
 	cmd.Flags().StringVar(&stepConfig.Username, "username", os.Getenv("PIPER_username"), "User")
+	cmd.Flags().BoolVar(&stepConfig.UseGoStep, "useGoStep", false, "When set to false the the groovy fallback for cloudFoundryDeploy will be used. Otherwise the corresponding go coding will be used.")
 
 	cmd.MarkFlagRequired("apiEndpoint")
 	cmd.MarkFlagRequired("org")
@@ -469,6 +471,14 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Type:      "string",
 						Mandatory: true,
 						Aliases:   []config.Alias{},
+					},
+					{
+						Name:        "useGoStep",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
 					},
 				},
 			},

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -368,6 +368,14 @@ spec:
               - $(vaultPath)/cloudfoundry-$(org)-$(space)
               - $(vaultBasePath)/$(vaultPipelineName)/cloudfoundry-$(org)-$(space)
               - $(vaultBasePath)/GROUP-SECRETS/cloudfoundry-$(org)-$(space)
+      - name: useGoStep
+        type: bool
+        description: "When set to false the the groovy fallback for cloudFoundryDeploy will be used. Otherwise the corresponding go coding will be used."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
   containers:
     - name: cfDeploy
       image: ppiper/cf-cli:6


### PR DESCRIPTION
This PR competes with #2603. Only either this PR or the other one should be merged.

With this PR we introduce a dummy parameter in the GO layer for `useGoStep`. This parameter is pointless basically in go, but when we publish the docu generated via go already that parameter would be omitted in our docu.
