### PR TITLE
Add new stable repo for helm

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -73,7 +73,7 @@ func runHelmDeploy(config kubernetesDeployOptions, command command.ExecRunner, s
 	command.Stdout(stdout)
 
 	if config.DeployTool == "helm" {
-		initParams := []string{"init", "--client-only"}
+		initParams := []string{"init", "--stable-repo-url=https://charts.helm.sh/stable", "--client-only"}
 		if err := command.RunExecutable("helm", initParams...); err != nil {
 			log.Entry().WithError(err).Fatal("Helm init call failed")
 		}

--- a/cmd/kubernetesDeploy_test.go
+++ b/cmd/kubernetesDeploy_test.go
@@ -46,7 +46,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		runKubernetesDeploy(opts, &e, &stdout)
 
 		assert.Equal(t, "helm", e.Calls[0].Exec, "Wrong init command")
-		assert.Equal(t, []string{"init", "--client-only"}, e.Calls[0].Params, "Wrong init parameters")
+		assert.Equal(t, []string{"init", "--stable-repo-url=https://charts.helm.sh/stable", "--client-only"}, e.Calls[0].Params, "Wrong init parameters")
 
 		assert.Equal(t, "kubectl", e.Calls[1].Exec, "Wrong secret creation command")
 		assert.Equal(t, []string{"--insecure-skip-tls-verify=true", "create", "secret", "docker-registry", "testSecret", "--docker-server=my.registry:55555", "--docker-username=registryUser", "--docker-password=********", "--dry-run=true", "--output=json"}, e.Calls[1].Params, "Wrong secret creation parameters")
@@ -105,7 +105,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		runKubernetesDeploy(opts, &e, &stdout)
 
 		assert.Equal(t, "helm", e.Calls[0].Exec, "Wrong init command")
-		assert.Equal(t, []string{"init", "--client-only"}, e.Calls[0].Params, "Wrong init parameters")
+		assert.Equal(t, []string{"init", "--stable-repo-url=https://charts.helm.sh/stable", "--client-only"}, e.Calls[0].Params, "Wrong init parameters")
 
 		assert.Equal(t, "kubectl", e.Calls[1].Exec, "Wrong secret creation command")
 		assert.Equal(t, []string{"--insecure-skip-tls-verify=true", "create", "secret", "docker-registry", "testSecret", "--docker-server=my.registry:55555", "--docker-username=registryUser", "--docker-password=********", "--dry-run=true", "--output=json"}, e.Calls[1].Params, "Wrong secret creation parameters")


### PR DESCRIPTION
# Changes

Solves #2491
 By default kubernetsDeploy adds  stable repo from https://kubernetes-charts.storage.googleapis.com.
Stable repo of helm has been moved from https://kubernetes-charts.storage.googleapis.com to https://charts.helm.sh/stable.

- [x ] Tests

