### PR TITLE
fix(cpe) readToDisk failes with content from writeToDisk

### DIFF
--- a/test/groovy/CommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/CommonPipelineEnvironmentTest.groovy
@@ -108,4 +108,21 @@ class CommonPipelineEnvironmentTest extends BasePiperTest {
         assertThat(nullScript.commonPipelineEnvironment.abapAddonDescriptor, is("[\"value1\",\"value2\"]"))
     }
 
+    @Test
+    void writeAndReadFromDisk() {
+        nullScript.commonPipelineEnvironment.setValue('string', 'testString')
+        nullScript.commonPipelineEnvironment.setValue('boolean', true)
+        nullScript.commonPipelineEnvironment.setValue('integer', 1)
+        nullScript.commonPipelineEnvironment.setValue('list', ['item1', 'item2'])
+        nullScript.commonPipelineEnvironment.setValue('map', [key1: 'val1', key2: 'val2'])
+
+        nullScript.commonPipelineEnvironment.writeToDisk(nullScript)
+        nullScript.commonPipelineEnvironment.readFromDisk(nullScript)
+
+        assertThat(nullScript.commonPipelineEnvironment.getValue('string'), is('testString'))
+        assertThat(nullScript.commonPipelineEnvironment.getValue('boolean'), is(true))
+        assertThat(nullScript.commonPipelineEnvironment.getValue('integer'), is(1))
+        assertThat(nullScript.commonPipelineEnvironment.getValue('list'), is(['item1', 'item2']))
+        assertThat(nullScript.commonPipelineEnvironment.getValue('map'), is([key1: 'val1', key2: 'val2']))
+    }
 }

--- a/test/groovy/CommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/CommonPipelineEnvironmentTest.groovy
@@ -108,21 +108,4 @@ class CommonPipelineEnvironmentTest extends BasePiperTest {
         assertThat(nullScript.commonPipelineEnvironment.abapAddonDescriptor, is("[\"value1\",\"value2\"]"))
     }
 
-    @Test
-    void writeAndReadFromDisk() {
-        nullScript.commonPipelineEnvironment.setValue('string', 'testString')
-        nullScript.commonPipelineEnvironment.setValue('boolean', true)
-        nullScript.commonPipelineEnvironment.setValue('integer', 1)
-        nullScript.commonPipelineEnvironment.setValue('list', ['item1', 'item2'])
-        nullScript.commonPipelineEnvironment.setValue('map', [key1: 'val1', key2: 'val2'])
-
-        nullScript.commonPipelineEnvironment.writeToDisk(nullScript)
-        nullScript.commonPipelineEnvironment.readFromDisk(nullScript)
-
-        assertThat(nullScript.commonPipelineEnvironment.getValue('string'), is('testString'))
-        assertThat(nullScript.commonPipelineEnvironment.getValue('boolean'), is(true))
-        assertThat(nullScript.commonPipelineEnvironment.getValue('integer'), is(1))
-        assertThat(nullScript.commonPipelineEnvironment.getValue('list'), is(['item1', 'item2']))
-        assertThat(nullScript.commonPipelineEnvironment.getValue('map'), is([key1: 'val1', key2: 'val2']))
-    }
 }

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -262,7 +262,7 @@ class commonPipelineEnvironment implements Serializable {
                 return text.toBoolean()
             }
             if (text ==~ /[\d]+/) {
-                return fileContent.toInteger()
+                return text.toInteger()
             }
             if (text.contains('.')) {
                 return text.toFloat()

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -244,7 +244,15 @@ class commonPipelineEnvironment implements Serializable {
             def param = fileName.split('/')[fileName.split('\\/').size()-1]
             if (param.endsWith(".json")){
                 param = param.replace(".json","")
-                containerProperties[param] = script.readJSON(text: fileContent)
+                try {
+                    containerProperties[param] = script.readJSON(text: fileContent)
+                } catch (net.sf.json.JSONException ex) {
+                    // JSON reader cannot handle simple objects like bool, numbers, ...
+                    // as such readJSON cannot read what writeJSON created in such cases
+                    // for now only handle boolean
+                    containerProperties[param] = fileContent.toBoolean()
+                }
+
             }else{
                 containerProperties[param] = fileContent
             }

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -226,7 +226,6 @@ class commonPipelineEnvironment implements Serializable {
             def fileContent = script.readFile(f.getPath())
             def fileName = f.getName()
             def param = fileName.split('/')[fileName.split('\\/').size()-1]
-            echo "reading file '${f.getPath()}' for param '${param}' with content '${fileContent}'"
             if (param.endsWith(".json")){
                 param = param.replace(".json","")
                 if (!fileContent.startsWith('{')) {
@@ -243,7 +242,6 @@ class commonPipelineEnvironment implements Serializable {
             def fileContent = script.readFile(f.getPath())
             def fileName = f.getName()
             def param = fileName.split('/')[fileName.split('\\/').size()-1]
-            echo "reading file '${f.getPath()}' for param '${param}' with content '${fileContent}'"
             if (param.endsWith(".json")){
                 param = param.replace(".json","")
                 containerProperties[param] = script.readJSON(text: fileContent)

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -226,6 +226,7 @@ class commonPipelineEnvironment implements Serializable {
             def fileContent = script.readFile(f.getPath())
             def fileName = f.getName()
             def param = fileName.split('/')[fileName.split('\\/').size()-1]
+            echo "reading file '${f.getPath()}' for param '${param}' with content '${fileContent}'"
             if (param.endsWith(".json")){
                 param = param.replace(".json","")
                 valueMap[param] = script.readJSON(text: fileContent)
@@ -239,6 +240,7 @@ class commonPipelineEnvironment implements Serializable {
             def fileContent = script.readFile(f.getPath())
             def fileName = f.getName()
             def param = fileName.split('/')[fileName.split('\\/').size()-1]
+            echo "reading file '${f.getPath()}' for param '${param}' with content '${fileContent}'"
             if (param.endsWith(".json")){
                 param = param.replace(".json","")
                 containerProperties[param] = script.readJSON(text: fileContent)

--- a/vars/commonPipelineEnvironment.groovy
+++ b/vars/commonPipelineEnvironment.groovy
@@ -229,6 +229,9 @@ class commonPipelineEnvironment implements Serializable {
             echo "reading file '${f.getPath()}' for param '${param}' with content '${fileContent}'"
             if (param.endsWith(".json")){
                 param = param.replace(".json","")
+                if (!fileContent.startsWith('{')) {
+                    fileContent = '{' + fileContent + '}'
+                }
                 valueMap[param] = script.readJSON(text: fileContent)
             }else{
                 valueMap[param] = fileContent


### PR DESCRIPTION
# Changes

fixes error `Error: net.sf.json.JSONException: Invalid JSON String` in following situations
```
        commonPipelineEnvironment.setValue('bool', true)
        commonPipelineEnvironment.setValue('int', 1)
        commonPipelineEnvironment.setValue('float', 1.7)
        commonPipelineEnvironment.setValue('string', 'this is my string')
        
        commonPipelineEnvironment.writeToDisk(this)
        commonPipelineEnvironment.readFromDisk(this)
```

