### PR TITLE
tests: expose sonar test secret to workflows

### DIFF
--- a/.github/workflows/integration-tests-pr.yaml
+++ b/.github/workflows/integration-tests-pr.yaml
@@ -85,6 +85,7 @@ jobs:
       - name: test
         env:
           PIPER_INTEGRATION_GITHUB_TOKEN: ${{secrets.PIPER_INTEGRATION_GITHUB_TOKEN}}
+          PIPER_INTEGRATION_SONAR_TOKEN: ${{secrets.PIPER_INTEGRATION_SONAR_TOKEN}}
         run: go test -tags=integration -timeout 20m ./integration/...
       - name: update status
         if: success()

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -64,6 +64,7 @@ jobs:
       - name: test
         env:
           PIPER_INTEGRATION_GITHUB_TOKEN: ${{secrets.PIPER_INTEGRATION_GITHUB_TOKEN}}
+          PIPER_INTEGRATION_SONAR_TOKEN: ${{secrets.PIPER_INTEGRATION_SONAR_TOKEN}}
         run: go test -tags=integration -timeout 20m ./integration/...
       - name: update status
         if: success()


### PR DESCRIPTION
This exposes the `PIPER_INTEGRATION_SONAR_TOKEN` secret needed for #2218 to the integration tests.