### PR TITLE
transport request: consider old label default

### DIFF
--- a/pkg/transportrequest/gitutils.go
+++ b/pkg/transportrequest/gitutils.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 )
 
 var logRange = gitUtils.LogRange
@@ -75,7 +76,7 @@ func findIDInRange(label, from, to string, trGitUtils iTransportRequestGitUtils)
 // a separate line in the commit message body.
 // In case several labels are found they are returned in ascending order.
 func FindLabelsInCommits(commits object.CommitIter, label string) ([]string, error) {
-	labelRegex, err := regexp.Compile(fmt.Sprintf(`(?m)^\s*%s\s*:\s*(\S*)\s*$`, label))
+	labelRegex, err := regexp.Compile(finishLabel(label))
 	if err != nil {
 		return []string{}, fmt.Errorf("Cannot extract label: %w", err)
 	}
@@ -96,4 +97,13 @@ func FindLabelsInCommits(commits object.CommitIter, label string) ([]string, err
 	labels := piperutils.UniqueStrings(ids)
 	sort.Strings(labels)
 	return labels, nil
+}
+
+func finishLabel(label string) string {
+	// contains prefix, like the old default
+	if strings.ContainsAny(label, ":=") {
+		return fmt.Sprintf(`(?m)^\s*%s\s*(\S*)\s*$`, label)
+	}
+	// contains key only, like the new default
+	return fmt.Sprintf(`(?m)^\s*%s\s*:\s*(\S*)\s*$`, label)
 }

--- a/pkg/transportrequest/gitutils_test.go
+++ b/pkg/transportrequest/gitutils_test.go
@@ -198,7 +198,32 @@ func TestRetrieveLabelStraightForward(t *testing.T) {
 				}
 			}
 		})
+		t.Run("default label with default reg ex", func(t *testing.T) {
+			commitIter := &commitIteratorMock{
+				commits: []object.Commit{
+					object.Commit{
+						Hash:    plumbing.NewHash("3434343434343434343434343434343434343434"),
+						Message: "TransportRequest: 12345678",
+					},
+				},
+			}
+			labels, err := FindLabelsInCommits(commitIter, "TransportRequest\\s?:")
+			if assert.NoError(t, err) {
+				assert.Equal(t, "12345678", labels[0])
+			}
+		})
 	})
+}
+
+func TestFinishLabel(t *testing.T) {
+	t.Parallel()
+	t.Run("default label old", func(t *testing.T) {
+		assert.Equal(t, `(?m)^\s*TransportRequest\s?:\s*(\S*)\s*$`, finishLabel("TransportRequest\\s?:"))
+	})
+	t.Run("default label new", func(t *testing.T) {
+		assert.Equal(t, `(?m)^\s*TransportRequest\s*:\s*(\S*)\s*$`, finishLabel("TransportRequest"))
+	})
+
 }
 
 func TestFindIDInRange(t *testing.T) {


### PR DESCRIPTION
# Changes
for compatibility the transport request/changedocument label needs to be adusted.

- [x] Tests
- [ ] Documentation
