### PR TITLE
Go Unit Tests fail due to windows/linux file separator mismatch

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strconv"
@@ -436,11 +437,12 @@ func handleSmokeTestScript(smokeTestScript string) ([]string, error) {
 			return []string{}, fmt.Errorf("failed to make smoke-test script executable: %w", err)
 		}
 		pwd, err := fileUtils.Getwd()
+
 		if err != nil {
 			return []string{}, fmt.Errorf("failed to get current working directory for execution of smoke-test script: %w", err)
 		}
 
-		return []string{"--smoke-test", fmt.Sprintf("%s/%s", pwd, smokeTestScript)}, nil
+		return []string{"--smoke-test", fmt.Sprintf("%s", filepath.Join(pwd, smokeTestScript))}, nil
 	}
 	return []string{}, nil
 }

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/yaml"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -1125,7 +1126,7 @@ func TestSmokeTestScriptHandling(t *testing.T) {
 
 			assert.Equal(t, []string{
 				"--smoke-test",
-				"/home/me/mySmokeTestScript.sh",
+				filepath.FromSlash("/home/me/mySmokeTestScript.sh"),
 			}, parts)
 		}
 	})
@@ -1161,7 +1162,7 @@ func TestSmokeTestScriptHandling(t *testing.T) {
 
 			assert.Equal(t, []string{
 				"--smoke-test",
-				"/home/me/blueGreenCheckScript.sh",
+				filepath.FromSlash("/home/me/blueGreenCheckScript.sh"),
 			}, parts)
 		}
 	})

--- a/cmd/mtaBuild_test.go
+++ b/cmd/mtaBuild_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"net/http"
+	"path/filepath"
 	"testing"
 
 	"github.com/SAP/jenkins-library/pkg/mock"
@@ -250,7 +251,7 @@ func TestMarBuild(t *testing.T) {
 			err := runMtaBuild(options, &cpe, utilsMock)
 
 			assert.Nil(t, err)
-			assert.Contains(t, utilsMock.Env, "MAVEN_OPTS=-Dmaven.repo.local=/root_folder/workspace/.pipeline/local_repo")
+			assert.Contains(t, utilsMock.Env, filepath.FromSlash("MAVEN_OPTS=-Dmaven.repo.local=/root_folder/workspace/.pipeline/local_repo"))
 		})
 	})
 

--- a/pkg/mock/fileUtils.go
+++ b/pkg/mock/fileUtils.go
@@ -74,6 +74,7 @@ func (f *FilesMock) init() {
 // current directory of the FilesMock.
 // Relative segments such as "../" are currently NOT supported.
 func (f *FilesMock) toAbsPath(path string) string {
+	path = filepath.FromSlash(path)
 	if path == "." {
 		return f.Separator + f.CurrentDir
 	}
@@ -346,6 +347,7 @@ func (f *FilesMock) Getwd() (string, error) {
 // The directory needs to exist according to the files and directories via AddFile() and AddDirectory().
 // The implementation does not support relative path components such as "..".
 func (f *FilesMock) Chdir(path string) error {
+	path = filepath.FromSlash(path)
 	if path == "." || path == "."+f.Separator {
 		return nil
 	}

--- a/pkg/piperutils/FileUtils.go
+++ b/pkg/piperutils/FileUtils.go
@@ -239,7 +239,7 @@ func ExcludeFiles(files, excludes []string) ([]string, error) {
 	for _, file := range files {
 		includeFile := true
 		for _, exclude := range excludes {
-			matched, err := doublestar.PathMatch(exclude, file)
+			matched, err := doublestar.PathMatch(exclude, filepath.FromSlash(file))
 			if err != nil {
 				return nil, fmt.Errorf("failed to match file %s to pattern %s: %w", file, exclude, err)
 			}

--- a/pkg/piperutils/FileUtils.go
+++ b/pkg/piperutils/FileUtils.go
@@ -238,8 +238,9 @@ func ExcludeFiles(files, excludes []string) ([]string, error) {
 	var filteredFiles []string
 	for _, file := range files {
 		includeFile := true
+		file = filepath.FromSlash(file)
 		for _, exclude := range excludes {
-			matched, err := doublestar.PathMatch(exclude, filepath.FromSlash(file))
+			matched, err := doublestar.PathMatch(exclude, file)
 			if err != nil {
 				return nil, fmt.Errorf("failed to match file %s to pattern %s: %w", file, exclude, err)
 			}

--- a/pkg/sonar/sonar_test.go
+++ b/pkg/sonar/sonar_test.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +26,7 @@ func TestReadTaskReport(t *testing.T) {
 		result, err := ReadTaskReport("./testData/missing")
 		// assert
 		assert.Empty(t, result.ProjectKey)
-		assert.EqualError(t, err, "open testData/missing/.scannerwork/report-task.txt: no such file or directory")
+		assert.Regexp(t, "open testData.missing..scannerwork.report-task.txt: (no such file or directory|The system cannot find the path specified.)", err)
 	})
 
 	t.Run("invalid file", func(t *testing.T) {
@@ -33,6 +34,6 @@ func TestReadTaskReport(t *testing.T) {
 		result, err := ReadTaskReport("./testData/invalid")
 		// assert
 		assert.Empty(t, result.ProjectKey)
-		assert.EqualError(t, err, "decode testData/invalid/.scannerwork/report-task.txt: missing required key projectKey")
+		assert.EqualError(t, err, filepath.FromSlash("decode testData/invalid/.scannerwork/report-task.txt: missing required key projectKey"))
 	})
 }

--- a/pkg/sonar/sonar_test.go
+++ b/pkg/sonar/sonar_test.go
@@ -26,7 +26,9 @@ func TestReadTaskReport(t *testing.T) {
 		result, err := ReadTaskReport("./testData/missing")
 		// assert
 		assert.Empty(t, result.ProjectKey)
-		assert.Regexp(t, "open testData.missing..scannerwork.report-task.txt: (no such file or directory|The system cannot find the path specified.)", err)
+		assert.True(t,
+			(filepath.FromSlash("open testData/missing/.scannerwork/report-task.txt: The system cannot find the path specified.") == err.Error()) ||
+				(filepath.FromSlash("open testData/missing/.scannerwork/report-task.txt: no such file or directory") == err.Error()))
 	})
 
 	t.Run("invalid file", func(t *testing.T) {


### PR DESCRIPTION
See issue #2660.
