### PR TITLE
Fix pullRequestName parameter in fortifyExecuteScan

### DIFF
--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -147,7 +147,7 @@ func runFortifyScan(config fortifyExecuteScanOptions, sys fortify.System, utils 
 
 	if len(config.PullRequestName) > 0 {
 		fortifyProjectVersion = config.PullRequestName
-		projectVersion, err := sys.LookupOrCreateProjectVersionDetailsForPullRequest(project.ID, projectVersion, fortifyProjectVersion)
+		projectVersion, err = sys.LookupOrCreateProjectVersionDetailsForPullRequest(project.ID, projectVersion, fortifyProjectVersion)
 		if err != nil {
 			classifyErrorOnLookup(err)
 			return reports, fmt.Errorf("Failed to lookup / create project version for pull request %v: %w", fortifyProjectVersion, err)


### PR DESCRIPTION
# Changes

This commit fixes the usage of `pullRequestName` parameter in the `fortifyExecuteScan`.

We have to overwrite the existing projectVersion variable instead of creating a new one which only lives in the scope of the if block.
Before the change, we were reusing always the projectVersion deducted from the build descriptor.

- [ ] Tests -> I would love to write tests, but I do not know how. There is no test for the pullRequestName I could extend. Also I still am missing a part in the Contribution Readme that tells me e.g. how to setup a local dev environment and for example run tests locally. Especially the "new" golang part is tricky if you did not work with it before.
- [ ] Documentation -> not needed as the parameter is already documented but not working
