### PR TITLE
fix(whitesourceExecuteScan) get full list of projects

### DIFF
--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -187,7 +187,7 @@ func addWhitesourceExecuteScanFlags(cmd *cobra.Command, stepConfig *whitesourceE
 	cmd.Flags().StringVar(&stepConfig.ScanImage, "scanImage", os.Getenv("PIPER_scanImage"), "For `buildTool: docker`: Defines the docker image which should be scanned.")
 	cmd.Flags().BoolVar(&stepConfig.ScanImageIncludeLayers, "scanImageIncludeLayers", true, "For `buildTool: docker`: Defines if layers should be included.")
 	cmd.Flags().StringVar(&stepConfig.ScanImageRegistryURL, "scanImageRegistryUrl", os.Getenv("PIPER_scanImageRegistryUrl"), "For `buildTool: docker`: Defines the registry where the scanImage is located.")
-	cmd.Flags().StringVar(&stepConfig.ScanType, "scanType", os.Getenv("PIPER_scanType"), "Type of development stack used to implement the solution. For scan types other than `mta`, `maven`, and `npm`, the WhiteSource Unified Agent is downloaded and used to perform the scan. If the parameter is not provided, it is derived from the parameter `buildTool`, which is usually configured in the general section of the pipeline config file.")
+	cmd.Flags().StringVar(&stepConfig.ScanType, "scanType", os.Getenv("PIPER_scanType"), "**DEPRECATED**: Please set to `ua` in order to prevent usage of deprecated WhiteSource plugins and use Unified Agent instead.")
 	cmd.Flags().BoolVar(&stepConfig.SecurityVulnerabilities, "securityVulnerabilities", true, "Whether security compliance is considered and reported as part of the assessment.")
 	cmd.Flags().StringVar(&stepConfig.ServiceURL, "serviceUrl", `https://saas.whitesourcesoftware.com/api`, "URL to the WhiteSource API endpoint.")
 	cmd.Flags().IntVar(&stepConfig.Timeout, "timeout", 900, "Timeout in seconds until an HTTP call is forcefully terminated.")

--- a/resources/metadata/whitesource.yaml
+++ b/resources/metadata/whitesource.yaml
@@ -315,17 +315,19 @@ spec:
           - STEPS
       - name: scanType
         type: string
-        description: "Type of development stack used to implement the solution.
-          For scan types other than `mta`, `maven`, and `npm`,
-          the WhiteSource Unified Agent is downloaded and used to perform the scan.
-          If the parameter is not provided, it is derived from the parameter `buildTool`,
-          which is usually configured in the general section of the pipeline config file."
+        description: "**DEPRECATED**: Please set to `ua` in order to prevent usage of deprecated WhiteSource plugins and use Unified Agent instead."
+        longDescription: |-
+          WhiteSource deprecated all build-tool specific plugins in 2019.
+          The successor of the individual plugins is the so-called "Unified Agent".
+
+          For now the value `ua` acts as a toogle to not break existing scenarios.
+          We plan to remove this parameter in early Q2/2021.
         scope:
           - GENERAL
           - PARAMETERS
           - STAGES
           - STEPS
-        possibleValues: ["golang", "gradle", "maven", "mta", "npm", "pip", "yarn"]
+        possibleValues: ["ua", "golang", "gradle", "maven", "mta", "npm", "pip", "yarn"]
       - name: securityVulnerabilities
         type: bool
         description: "Whether security compliance is considered and reported as part of the assessment."


### PR DESCRIPTION
# Changes

multi-module projects were handled incorrectly.
For example in the Maven case only the root module was considered for security scanning and not all sub-modules.

This also lead to in incomplete list of scanned projects handed over to subsequent steps.

- [x] Tests
- [x] Documentation
