### PR TITLE
Adjust comment

### DIFF
--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -14,7 +14,7 @@ import static com.sap.piper.Prerequisites.checkScript
 @Field Set GENERAL_CONFIG_KEYS = [
     /**
      * Defines the build tool used.
-     * @possibleValues `docker`, `kaniko`, `maven`, `mta, ``npm`
+     * @possibleValues `maven`, `mta, ``npm`
      */
     'buildTool',
     /**


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation

Currently supported buildtools with usage of piperPipelineStageInit step are 'mta', 'npm' and 'maven'.
