### PR TITLE
feat(sonar): create report for issue count 

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -222,9 +222,13 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 		return err
 	}
 	log.Entry().Debugf("Influx values: %v", influx.sonarqube_data.fields)
-	SonarUtils.WriteReport(SonarUtils.ReportData{
-		ServerURL:  taskReport.ServerURL,
-		ProjectKey: taskReport.ProjectKey,
+	err = SonarUtils.WriteReport(SonarUtils.ReportData{
+		ServerURL:    taskReport.ServerURL,
+		ProjectKey:   taskReport.ProjectKey,
+		TaskID:       taskReport.TaskID,
+		ChangeID:     config.ChangeID,
+		BranchName:   config.BranchName,
+		Organization: config.Organization,
 		NumberOfIssues: SonarUtils.Issues{
 			Blocker:  influx.sonarqube_data.fields.blocker_issues,
 			Critical: influx.sonarqube_data.fields.critical_issues,
@@ -232,7 +236,10 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 			Minor:    influx.sonarqube_data.fields.minor_issues,
 			Info:     influx.sonarqube_data.fields.info_issues,
 		},
-	}, sonar.workingDir, "sonarScanReport.json", ioutil.WriteFile)
+	}, sonar.workingDir, ioutil.WriteFile)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -222,6 +222,17 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 		return err
 	}
 	log.Entry().Debugf("Influx values: %v", influx.sonarqube_data.fields)
+	SonarUtils.WriteReport(SonarUtils.ReportData{
+		ServerURL:  taskReport.ServerURL,
+		ProjectKey: taskReport.ProjectKey,
+		NumberOfIssues: SonarUtils.Issues{
+			Blocker:  influx.sonarqube_data.fields.blocker_issues,
+			Critical: influx.sonarqube_data.fields.critical_issues,
+			Major:    influx.sonarqube_data.fields.major_issues,
+			Minor:    influx.sonarqube_data.fields.minor_issues,
+			Info:     influx.sonarqube_data.fields.info_issues,
+		},
+	}, sonar.workingDir, "sonarScanReport.json", ioutil.WriteFile)
 	return nil
 }
 

--- a/pkg/sonar/report.go
+++ b/pkg/sonar/report.go
@@ -6,10 +6,16 @@ import (
 	"path/filepath"
 )
 
+const reportFileName = "sonarscan.json"
+
 //ReportData is representing the data of the step report JSON
 type ReportData struct {
 	ServerURL      string `json:"serverUrl"`
 	ProjectKey     string `json:"projectKey"`
+	TaskID         string `json:"taskId"`
+	ChangeID       string `json:"changeID,omitempty"`
+	BranchName     string `json:"branchName,omitempty"`
+	Organization   string `json:"organization,omitempty"`
 	NumberOfIssues Issues `json:"numberOfIssues"`
 }
 
@@ -23,7 +29,7 @@ type Issues struct {
 }
 
 // WriteReport ...
-func WriteReport(data ReportData, reportPath string, reportFileName string, writeToFile func(f string, d []byte, p os.FileMode) error) error {
+func WriteReport(data ReportData, reportPath string, writeToFile func(f string, d []byte, p os.FileMode) error) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/pkg/sonar/report.go
+++ b/pkg/sonar/report.go
@@ -1,0 +1,32 @@
+package sonar
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+//ReportData is representing the data of the step report JSON
+type ReportData struct {
+	ServerURL      string `json:"serverUrl"`
+	ProjectKey     string `json:"projectKey"`
+	NumberOfIssues Issues `json:"numberOfIssues"`
+}
+
+// Issues ...
+type Issues struct {
+	Blocker  int `json:"blocker"`
+	Critical int `json:"critical"`
+	Major    int `json:"major"`
+	Minor    int `json:"minor"`
+	Info     int `json:"info"`
+}
+
+// WriteReport ...
+func WriteReport(data ReportData, reportPath string, reportFileName string, writeToFile func(f string, d []byte, p os.FileMode) error) error {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return writeToFile(filepath.Join(reportPath, reportFileName), jsonData, 0644)
+}

--- a/pkg/sonar/report_test.go
+++ b/pkg/sonar/report_test.go
@@ -1,0 +1,40 @@
+package sonar
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var fileContent string
+var fileName string
+
+func writeToFileMock(f string, d []byte, p os.FileMode) error {
+	fileContent = string(d)
+	fileName = f
+	return nil
+}
+
+func TestWriteReport(t *testing.T) {
+	// init
+	const expected = `{"serverUrl":"https://sonarcloud.io","projectKey":"Piper-Validation/Golang","taskId":"mock.Anything","numberOfIssues":{"blocker":0,"critical":1,"major":2,"minor":3,"info":4}}`
+	testData := ReportData{
+		ServerURL:  "https://sonarcloud.io",
+		ProjectKey: "Piper-Validation/Golang",
+		TaskID:     mock.Anything,
+		NumberOfIssues: Issues{
+			Critical: 1,
+			Major:    2,
+			Minor:    3,
+			Info:     4,
+		},
+	}
+	// test
+	err := WriteReport(testData, "", writeToFileMock)
+	// assert
+	assert.NoError(t, err)
+	assert.Equal(t, expected, fileContent)
+	assert.Equal(t, reportFileName, fileName)
+}

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -68,6 +68,7 @@ void call(Map parameters = [:]) {
                                 influxWrapper(script){
                                     piperExecuteBin.credentialWrapper(config, credentialInfo){
                                         sh "${piperGoPath} ${STEP_NAME}${customDefaultConfig}${customConfigArg}"
+                                        archiveArtifacts artifacts: "sonarScanReport.json"
                                     }
                                     jenkinsUtils.handleStepResults(STEP_NAME, false, false)
                                     script.commonPipelineEnvironment.readFromDisk(script)

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -68,7 +68,7 @@ void call(Map parameters = [:]) {
                                 influxWrapper(script){
                                     piperExecuteBin.credentialWrapper(config, credentialInfo){
                                         sh "${piperGoPath} ${STEP_NAME}${customDefaultConfig}${customConfigArg}"
-                                        archiveArtifacts artifacts: "sonarScanReport.json"
+                                        archiveArtifacts artifacts: "sonarscan.json", allowEmptyArchive: true
                                     }
                                     jenkinsUtils.handleStepResults(STEP_NAME, false, false)
                                     script.commonPipelineEnvironment.readFromDisk(script)


### PR DESCRIPTION
With this change the `sonarExecuteScan` step creates a report `sonarscan.json` which contains:
- sonar server url
- project key
- task id
- number of issues by severity