### PR TITLE
whitesource: use only Unified Agent for scanning

### DIFF
--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -388,7 +388,7 @@ func validateProductVersion(version string) string {
 func wsScanOptions(config *ScanOptions) *ws.ScanOptions {
 	return &ws.ScanOptions{
 		BuildTool:                  config.BuildTool,
-		ScanType:                   config.ScanType,
+		ScanType:                   "", // no longer provided via config
 		OrgToken:                   config.OrgToken,
 		UserToken:                  config.UserToken,
 		ProductName:                config.ProductName,
@@ -415,41 +415,15 @@ func wsScanOptions(config *ScanOptions) *ws.ScanOptions {
 	}
 }
 
-// executeScan executes different types of scans depending on the scanType parameter.
-// The default is to download the Unified Agent and use it to perform the scan.
+// Unified Agent is the only supported option by WhiteSource going forward:
+// The Unified Agent will be used to perform the scan.
 func executeScan(config *ScanOptions, scan *ws.Scan, utils whitesourceUtils) error {
-	if config.ScanType == "" {
-		config.ScanType = config.BuildTool
-	}
 
 	options := wsScanOptions(config)
 
-	switch config.ScanType {
-	case "mta":
-		// Execute scan for maven and all npm modules
-		if err := scan.ExecuteMTAScan(options, utils); err != nil {
-			return err
-		}
-	case "maven":
-		// Execute scan with maven plugin goal
-		if err := scan.ExecuteMavenScan(options, utils); err != nil {
-			return err
-		}
-	case "npm":
-		// Execute scan with in each npm module using npm.Executor
-		if err := scan.ExecuteNpmScan(options, utils); err != nil {
-			return err
-		}
-	case "yarn":
-		// Execute scan with whitesource yarn plugin
-		if err := scan.ExecuteYarnScan(options, utils); err != nil {
-			return err
-		}
-	default:
-		// Execute scan with Unified Agent jar file
-		if err := scan.ExecuteUAScan(options, utils); err != nil {
-			return err
-		}
+	// Execute scan with Unified Agent jar file
+	if err := scan.ExecuteUAScan(options, utils); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -35,7 +35,6 @@ type whitesourceExecuteScanOptions struct {
 	JreDownloadURL                       string   `json:"jreDownloadUrl,omitempty"`
 	LicensingVulnerabilities             bool     `json:"licensingVulnerabilities,omitempty"`
 	OrgToken                             string   `json:"orgToken,omitempty"`
-	ParallelLimit                        string   `json:"parallelLimit,omitempty"`
 	ProductName                          string   `json:"productName,omitempty"`
 	ProductToken                         string   `json:"productToken,omitempty"`
 	Version                              string   `json:"version,omitempty"`
@@ -45,7 +44,6 @@ type whitesourceExecuteScanOptions struct {
 	ScanImage                            string   `json:"scanImage,omitempty"`
 	ScanImageIncludeLayers               bool     `json:"scanImageIncludeLayers,omitempty"`
 	ScanImageRegistryURL                 string   `json:"scanImageRegistryUrl,omitempty"`
-	ScanType                             string   `json:"scanType,omitempty"`
 	SecurityVulnerabilities              bool     `json:"securityVulnerabilities,omitempty"`
 	ServiceURL                           string   `json:"serviceUrl,omitempty"`
 	Timeout                              int      `json:"timeout,omitempty"`
@@ -226,7 +224,6 @@ func addWhitesourceExecuteScanFlags(cmd *cobra.Command, stepConfig *whitesourceE
 	cmd.Flags().StringVar(&stepConfig.JreDownloadURL, "jreDownloadUrl", `https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jre-11.0.2_linux-x64_bin.tar.gz`, "URL used for downloading the Java Runtime Environment (JRE) required to run the WhiteSource Unified Agent.")
 	cmd.Flags().BoolVar(&stepConfig.LicensingVulnerabilities, "licensingVulnerabilities", true, "[NOT IMPLEMENTED] Whether license compliance is considered and reported as part of the assessment.")
 	cmd.Flags().StringVar(&stepConfig.OrgToken, "orgToken", os.Getenv("PIPER_orgToken"), "WhiteSource token identifying your organization.")
-	cmd.Flags().StringVar(&stepConfig.ParallelLimit, "parallelLimit", `15`, "[NOT IMPLEMENTED] Limit of parallel jobs being run at once in case of `scanType: 'mta'` based scenarios, defaults to `15`.")
 	cmd.Flags().StringVar(&stepConfig.ProductName, "productName", os.Getenv("PIPER_productName"), "Name of the WhiteSource product used for results aggregation. This parameter is mandatory if the parameter `createProductFromPipeline` is set to `true` and the WhiteSource product does not yet exist. It is also mandatory if the parameter `productToken` is not provided.")
 	cmd.Flags().StringVar(&stepConfig.ProductToken, "productToken", os.Getenv("PIPER_productToken"), "Token of the WhiteSource product to be created and used for results aggregation, usually determined automatically. Can optionally be provided as an alternative to `productName`.")
 	cmd.Flags().StringVar(&stepConfig.Version, "version", os.Getenv("PIPER_version"), "Version of the WhiteSource product to be created and used for results aggregation.")
@@ -236,7 +233,6 @@ func addWhitesourceExecuteScanFlags(cmd *cobra.Command, stepConfig *whitesourceE
 	cmd.Flags().StringVar(&stepConfig.ScanImage, "scanImage", os.Getenv("PIPER_scanImage"), "For `buildTool: docker`: Defines the docker image which should be scanned.")
 	cmd.Flags().BoolVar(&stepConfig.ScanImageIncludeLayers, "scanImageIncludeLayers", true, "For `buildTool: docker`: Defines if layers should be included.")
 	cmd.Flags().StringVar(&stepConfig.ScanImageRegistryURL, "scanImageRegistryUrl", os.Getenv("PIPER_scanImageRegistryUrl"), "For `buildTool: docker`: Defines the registry where the scanImage is located.")
-	cmd.Flags().StringVar(&stepConfig.ScanType, "scanType", os.Getenv("PIPER_scanType"), "**DEPRECATED**: Please set to `ua` in order to prevent usage of deprecated WhiteSource plugins and use Unified Agent instead.")
 	cmd.Flags().BoolVar(&stepConfig.SecurityVulnerabilities, "securityVulnerabilities", true, "Whether security compliance is considered and reported as part of the assessment.")
 	cmd.Flags().StringVar(&stepConfig.ServiceURL, "serviceUrl", `https://saas.whitesourcesoftware.com/api`, "URL to the WhiteSource API endpoint.")
 	cmd.Flags().IntVar(&stepConfig.Timeout, "timeout", 900, "Timeout in seconds until an HTTP call is forcefully terminated.")
@@ -434,14 +430,6 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Aliases:   []config.Alias{{Name: "whitesourceOrgToken"}, {Name: "whitesource/orgToken"}},
 					},
 					{
-						Name:        "parallelLimit",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-					},
-					{
 						Name:        "productName",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
@@ -514,14 +502,6 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Name:        "scanImageRegistryUrl",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-					},
-					{
-						Name:        "scanType",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -637,11 +617,11 @@ func whitesourceExecuteScanMetadata() config.StepData {
 			},
 			Containers: []config.Container{
 				{Image: "buildpack-deps:stretch-curl", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "dub"}, {Name: "buildTool", Value: "docker"}}}}},
-				{Image: "devxci/mbtci:1.0.14", WorkingDir: "/home/mta", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "mta"}}}, {ConditionRef: "strings-equal", Params: []config.Param{{Name: "scanType", Value: "mta"}}}}},
+				{Image: "devxci/mbtci:1.0.14", WorkingDir: "/home/mta", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "mta"}}}}},
 				{Image: "golang:1", WorkingDir: "/go", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "golang"}}}}},
 				{Image: "hseeberger/scala-sbt:8u181_2.12.8_1.2.8", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "sbt"}}}}},
-				{Image: "maven:3.5-jdk-8", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}}}, {ConditionRef: "strings-equal", Params: []config.Param{{Name: "scanType", Value: "maven"}}}}},
-				{Image: "node:lts-stretch", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "npm"}}}, {ConditionRef: "strings-equal", Params: []config.Param{{Name: "scanType", Value: "npm"}}}}},
+				{Image: "maven:3.5-jdk-8", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}}}}},
+				{Image: "node:lts-stretch", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "npm"}}}}},
 				{Image: "python:3.6-stretch", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "pip"}}}}},
 			},
 			Outputs: config.StepOutputs{

--- a/cmd/whitesourceExecuteScan_test.go
+++ b/cmd/whitesourceExecuteScan_test.go
@@ -66,7 +66,6 @@ func TestRunWhitesourceExecuteScan(t *testing.T) {
 	t.Run("fails for invalid configured project token", func(t *testing.T) {
 		// init
 		config := ScanOptions{
-			ScanType:            "unified-agent",
 			BuildDescriptorFile: "my-mta.yml",
 			VersioningModel:     "major",
 			ProductName:         "mock-product",
@@ -98,7 +97,6 @@ func TestRunWhitesourceExecuteScan(t *testing.T) {
 			AgentFileName:             "ua.jar",
 			ProductName:               "mock-product",
 			ProjectToken:              "mock-project-token",
-			ScanType:                  "unified-agent",
 		}
 		utilsMock := newWhitesourceUtilsMock()
 		utilsMock.AddFile("wss-generated-file.config", []byte("key=value"))

--- a/resources/metadata/whitesource.yaml
+++ b/resources/metadata/whitesource.yaml
@@ -203,15 +203,6 @@ spec:
         resourceRef:
           - name: orgAdminUserTokenCredentialsId
             type: secret
-      - name: parallelLimit
-        type: string
-        description: '[NOT IMPLEMENTED] Limit of parallel jobs being run at once in case of `scanType:
-          ''mta''` based scenarios, defaults to `15`.'
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        default: 15
       - name: productName
         aliases:
           - name: whitesourceProductName
@@ -313,21 +304,6 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-      - name: scanType
-        type: string
-        description: "**DEPRECATED**: Please set to `ua` in order to prevent usage of deprecated WhiteSource plugins and use Unified Agent instead."
-        longDescription: |-
-          WhiteSource deprecated all build-tool specific plugins in 2019.
-          The successor of the individual plugins is the so-called "Unified Agent".
-
-          For now the value `ua` acts as a toogle to not break existing scenarios.
-          We plan to remove this parameter in early Q2/2021.
-        scope:
-          - GENERAL
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        possibleValues: ["ua", "golang", "gradle", "maven", "mta", "npm", "pip", "yarn"]
       - name: securityVulnerabilities
         type: bool
         description: "Whether security compliance is considered and reported as part of the assessment."
@@ -507,10 +483,6 @@ spec:
           params:
             - name: buildTool
               value: mta
-        - conditionRef: strings-equal
-          params:
-            - name: scanType
-              value: mta
     - image: golang:1
       workingDir: /go
       env: []
@@ -535,10 +507,6 @@ spec:
           params:
             - name: buildTool
               value: maven
-        - conditionRef: strings-equal
-          params:
-            - name: scanType
-              value: maven
     - image: node:lts-stretch
       workingDir: /home/node
       env: []
@@ -546,10 +514,6 @@ spec:
         - conditionRef: strings-equal
           params:
             - name: buildTool
-              value: npm
-        - conditionRef: strings-equal
-          params:
-            - name: scanType
               value: npm
     - image: python:3.6-stretch
       workingDir: /tmp


### PR DESCRIPTION
# Changes

don't use native build-tool specific plugins any longer.
They have been deprecated by WhiteSource mid 2019 already.

- [x] Tests
- [x] Documentation
