### PR TITLE
meaningful error when dockerRegistryUrl is invalid

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -55,7 +55,10 @@ func (c *Client) GetImageSource() (string, error) {
 	if len(c.registryURL) > 0 && len(c.localPath) <= 0 {
 		registry := c.registryURL
 
-		url, _ := url.Parse(c.registryURL)
+		url, err := url.Parse(c.registryURL)
+		if err != nil {
+			return "", fmt.Errorf("invalid registry url: %w", err)
+		}
 		//remove protocoll from registryURL to get registry
 		if len(url.Scheme) > 0 {
 			registry = strings.Replace(c.registryURL, fmt.Sprintf("%v://", url.Scheme), "", 1)

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -33,4 +33,10 @@ func TestGetImageSource(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, c.want, got)
 	}
+
+	// negative case
+	options := ClientOptions{ImageName: "abc", RegistryURL: " http: //aa.bb"}
+	client.SetOptions(options)
+	_, err := client.GetImageSource()
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Current if the parameter `dockerRegistryUrl` (e.g. in `protecodeExecuteScan`) contains an invalid URL the whole step crashes violently with a non-informative segmentation violation error:
```
...
info  protecodeExecuteScan - Docker credentials configuration: NONE
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xd11935]

goroutine 1 [running]:
github.com/SAP/jenkins-library/pkg/docker.(*Client).GetImageSource(0xc000599a80, 0x15, 0x258, 0x1ba4ae0, 0xc00030d8c0)
	/home/runner/work/jenkins-library/jenkins-library/pkg/docker/docker.go:60 +0x2f5
github.com/SAP/jenkins-library/cmd.getDockerImage(0x1bbbc40, 0xc000599a80, 0xc00056b978, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/runner/work/jenkins-library/jenkins-library/cmd/protecodeExecuteScan.go:104 +0x1b4
...
```

- [X] Tests
- [ ] Documentation
