### PR TITLE
dockerExecuteOnKubernetes: Add capability for volume mounts

### DIFF
--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -806,13 +806,9 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
             containerName: 'mycontainer',
             dockerImage: 'maven:3.5-jdk-8-alpine',
             containerMountPath: '/opt',
-            sidecarImage: 'maven:latest',
-            sidecarName: 'mysidecar',
-            sidecarMountPath: '/tmp',
         ) { bodyExecuted = true }
 
         def containerSpec = podSpec.spec.containers.find{it.image == "maven:3.5-jdk-8-alpine"}
-        def sidecarContainerSpec = podSpec.spec.containers.find{it.image == "maven:latest"}
         assertTrue(bodyExecuted)
         assertEquals("myvolume", podSpec.spec.volumes[0].name)
         assertEquals(
@@ -820,11 +816,6 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
                 "name"     : "myvolume",
                 "mountPath": "/opt"
             ]], containerSpec.volumeMounts)
-        assertEquals(
-            [[
-                "name"     : "myvolume",
-                "mountPath": "/tmp"
-            ]], sidecarContainerSpec.volumeMounts)
     }
 
     private container(options, body) {

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -802,7 +802,6 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
         stepRule.step.dockerExecuteOnKubernetes(
             script: nullScript,
             juStabUtils: utils,
-            volumeName : 'myvolume',
             containerName: 'mycontainer',
             dockerImage: 'maven:3.5-jdk-8-alpine',
             containerMountPath: '/opt',
@@ -810,10 +809,10 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
 
         def containerSpec = podSpec.spec.containers.find{it.image == "maven:3.5-jdk-8-alpine"}
         assertTrue(bodyExecuted)
-        assertEquals("myvolume", podSpec.spec.volumes[0].name)
+        assertEquals("volume", podSpec.spec.volumes[0].name)
         assertEquals(
             [[
-                "name"     : "myvolume",
+                "name"     : "volume",
                 "mountPath": "/opt"
             ]], containerSpec.volumeMounts)
     }

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -809,7 +809,11 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
 
         def containerSpec = podSpec.spec.containers.find{it.image == "maven:3.5-jdk-8-alpine"}
         assertTrue(bodyExecuted)
-        assertEquals("volume", podSpec.spec.volumes[0].name)
+        assertEquals(
+            [[
+                 "name"    : "volume",
+                 "emptyDir": [:]
+             ]], podSpec.spec.volumes)
         assertEquals(
             [[
                 "name"     : "volume",

--- a/test/groovy/DockerExecuteOnKubernetesTest.groovy
+++ b/test/groovy/DockerExecuteOnKubernetesTest.groovy
@@ -401,7 +401,7 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
             sidecarName: 'mysidecar') {
                 bodyExecuted = true
             }
-            
+
         assertEquals(requests: [memory: '10Gi',cpu: '5.00'],limits: [memory: '20Gi',cpu: '10'], resources.mysidecar)
         assertEquals(requests: [memory: '3Gi',cpu: '0.33'],limits: [memory: '6Gi',cpu: '3'], resources.jnlp)
         assertEquals(requests: [memory: '2Gi',cpu: '0.75'],limits: [memory: '4Gi',cpu: '2'], resources.mavenexecute)
@@ -797,6 +797,35 @@ class DockerExecuteOnKubernetesTest extends BasePiperTest {
             hasEntry('excludes', 'container/exclude.test'))))
     }
 
+    @Test
+    void testDockerExecuteWithVolumeProperties() {
+        stepRule.step.dockerExecuteOnKubernetes(
+            script: nullScript,
+            juStabUtils: utils,
+            volumeName : 'myvolume',
+            containerName: 'mycontainer',
+            dockerImage: 'maven:3.5-jdk-8-alpine',
+            containerMountPath: '/opt',
+            sidecarImage: 'maven:latest',
+            sidecarName: 'mysidecar',
+            sidecarMountPath: '/tmp',
+        ) { bodyExecuted = true }
+
+        def containerSpec = podSpec.spec.containers.find{it.image == "maven:3.5-jdk-8-alpine"}
+        def sidecarContainerSpec = podSpec.spec.containers.find{it.image == "maven:latest"}
+        assertTrue(bodyExecuted)
+        assertEquals("myvolume", podSpec.spec.volumes[0].name)
+        assertEquals(
+            [[
+                "name"     : "myvolume",
+                "mountPath": "/opt"
+            ]], containerSpec.volumeMounts)
+        assertEquals(
+            [[
+                "name"     : "myvolume",
+                "mountPath": "/tmp"
+            ]], sidecarContainerSpec.volumeMounts)
+    }
 
     private container(options, body) {
         containerName = options.name

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -339,19 +339,13 @@ private String generatePodSpec(Map config) {
     podSpec.spec.securityContext = getSecurityContext(config)
 
     if (config.containerMountPath) {
-        def uniquePlaceholder = UUID.randomUUID().toString()
         podSpec.spec.volumes = [[
                                     name    : "volume",
-                                    emptyDir: uniquePlaceholder
+                                    emptyDir: [:]
                                 ]]
-
-        def specYaml = new JsonUtils().groovyObjectToPrettyJsonString(podSpec)
-        specYaml = specYaml.replaceFirst("\"${uniquePlaceholder}\"", "{}")
-
-        return specYaml
-    } else {
-        return new JsonUtils().groovyObjectToPrettyJsonString(podSpec)
     }
+
+    return new JsonUtils().groovyObjectToPrettyJsonString(podSpec)
 }
 
 

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -191,7 +191,6 @@ import hudson.AbortException
      * to the step call takes precedence.
      */
     'resources',
-    'volumeName',
     'containerMountPath',
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.minus([
@@ -334,10 +333,10 @@ private String generatePodSpec(Map config) {
     podSpec.spec.containers = getContainerList(config)
     podSpec.spec.securityContext = getSecurityContext(config)
 
-    if (config.volumeName) {
+    if (config.containerMountPath) {
         def uniquePlaceholder = UUID.randomUUID().toString()
         podSpec.spec.volumes = [[
-                                    name    : config.volumeName,
+                                    name    : "volume",
                                     emptyDir: uniquePlaceholder
                                 ]]
 
@@ -448,7 +447,7 @@ private List getContainerList(config) {
             env            : getContainerEnvs(config, imageName, config.dockerEnvVars, config.dockerWorkspace)
         ]
         if (config.containerMountPath) {
-            containerSpec.volumeMounts = [[name: config.volumeName, mountPath: config.containerMountPath]]
+            containerSpec.volumeMounts = [[name: "volume", mountPath: config.containerMountPath]]
         }
 
         def configuredCommand = config.containerCommands?.get(imageName)

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -191,6 +191,9 @@ import hudson.AbortException
      * to the step call takes precedence.
      */
     'resources',
+    'volumeName',
+    'sidecarMountPath',
+    'containerMountPath',
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.minus([
     'stashIncludes',
@@ -329,6 +332,10 @@ private String generatePodSpec(Map config) {
         spec      : [:]
     ]
     podSpec.spec += getAdditionalPodProperties(config)
+    podSpec.spec.volumes = [[
+                                name    : config.volumeName,
+                                emptyDir: {}
+                            ]]
     podSpec.spec.containers = getContainerList(config)
     podSpec.spec.securityContext = getSecurityContext(config)
 
@@ -429,6 +436,7 @@ private List getContainerList(config) {
         def containerSpec = [
             name           : containerName.toLowerCase(),
             image          : imageName,
+            volumeMounts   : [[name: config.volumeName, mountPath: config.containerMountPath]],
             imagePullPolicy: pullImage ? "Always" : "IfNotPresent",
             env            : getContainerEnvs(config, imageName, config.dockerEnvVars, config.dockerWorkspace)
         ]
@@ -476,6 +484,7 @@ private List getContainerList(config) {
         def containerSpec = [
             name           : sideCarContainerName,
             image          : config.sidecarImage,
+            volumeMounts   : [[name: config.volumeName, mountPath: config.sidecarMountPath]],
             imagePullPolicy: config.sidecarPullImage ? "Always" : "IfNotPresent",
             env            : getContainerEnvs(config, config.sidecarImage, config.sidecarEnvVars, config.sidecarWorkspace),
             command        : []

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -320,7 +320,6 @@ void executeOnPod(Map config, utils, Closure body, Script script) {
 }
 
 private String generatePodSpec(Map config) {
-    def containers = getContainerList(config)
     def podSpec = [
         apiVersion: "v1",
         kind      : "Pod",

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -332,10 +332,12 @@ private String generatePodSpec(Map config) {
         spec      : [:]
     ]
     podSpec.spec += getAdditionalPodProperties(config)
-    podSpec.spec.volumes = [[
-                                name    : config.volumeName,
-                                emptyDir: {}
-                            ]]
+    if (config.volumeName) {
+        podSpec.spec.volumes = [[
+                                    name    : config.volumeName,
+                                    emptyDir: {}
+                                ]]
+    }
     podSpec.spec.containers = getContainerList(config)
     podSpec.spec.securityContext = getSecurityContext(config)
 
@@ -436,10 +438,12 @@ private List getContainerList(config) {
         def containerSpec = [
             name           : containerName.toLowerCase(),
             image          : imageName,
-            volumeMounts   : [[name: config.volumeName, mountPath: config.containerMountPath]],
             imagePullPolicy: pullImage ? "Always" : "IfNotPresent",
             env            : getContainerEnvs(config, imageName, config.dockerEnvVars, config.dockerWorkspace)
         ]
+        if (config.containerMountPath) {
+            containerSpec.volumeMounts = [[name: config.volumeName, mountPath: config.containerMountPath]]
+        }
 
         def configuredCommand = config.containerCommands?.get(imageName)
         def shell = config.containerShell ?: '/bin/sh'
@@ -484,11 +488,13 @@ private List getContainerList(config) {
         def containerSpec = [
             name           : sideCarContainerName,
             image          : config.sidecarImage,
-            volumeMounts   : [[name: config.volumeName, mountPath: config.sidecarMountPath]],
             imagePullPolicy: config.sidecarPullImage ? "Always" : "IfNotPresent",
             env            : getContainerEnvs(config, config.sidecarImage, config.sidecarEnvVars, config.sidecarWorkspace),
             command        : []
         ]
+        if (config.sidecarMountPath) {
+            containerSpec.volumeMounts = [[name: config.volumeName, mountPath: config.sidecarMountPath]]
+        }
 
         def resources = getResources(sideCarContainerName, config)
         if(resources) {

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -332,16 +332,23 @@ private String generatePodSpec(Map config) {
         spec      : [:]
     ]
     podSpec.spec += getAdditionalPodProperties(config)
-    if (config.volumeName) {
-        podSpec.spec.volumes = [[
-                                    name    : config.volumeName,
-                                    emptyDir: {}
-                                ]]
-    }
     podSpec.spec.containers = getContainerList(config)
     podSpec.spec.securityContext = getSecurityContext(config)
 
-    return new JsonUtils().groovyObjectToPrettyJsonString(podSpec)
+    if (config.volumeName) {
+        def uniquePlaceholder = UUID.randomUUID().toString()
+        podSpec.spec.volumes = [[
+                                    name    : config.volumeName,
+                                    emptyDir: uniquePlaceholder
+                                ]]
+
+        def specYaml = new JsonUtils().groovyObjectToPrettyJsonString(podSpec)
+        specYaml = specYaml.replaceFirst("\"${uniquePlaceholder}\"", "{}")
+
+        return specYaml
+    } else {
+        return new JsonUtils().groovyObjectToPrettyJsonString(podSpec)
+    }
 }
 
 

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -192,9 +192,10 @@ import hudson.AbortException
      */
     'resources',
     /**
-     * The path to which a volume should be mounted to. This will create an emptyDir volume
-     * with name 'volume'. This volume will be available at the same mount path in each container
-     * of the provided containerMap.
+     * The path to which a volume should be mounted to. This volume will be available at the same
+     * mount path in each container of the provided containerMap. The volume is of type emptyDir
+     * and has the name 'volume'. With the additionalPodProperties parameter one can for example
+     * use this volume in an initContainer.
      */
     'containerMountPath',
 ])

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -192,7 +192,7 @@ import hudson.AbortException
      */
     'resources',
     /**
-     * The path to which a volume should e mounted to. This will create an emptyDir volume
+     * The path to which a volume should be mounted to. This will create an emptyDir volume
      * with name 'volume'. This volume will be available at the same mount path in each container
      * of the provided containerMap.
      */

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -191,6 +191,11 @@ import hudson.AbortException
      * to the step call takes precedence.
      */
     'resources',
+    /**
+     * The path to which a volume should e mounted to. This will create an emptyDir volume
+     * with name 'volume'. This volume will be available at the same mount path in each container
+     * of the provided containerMap.
+     */
     'containerMountPath',
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.minus([

--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -192,7 +192,6 @@ import hudson.AbortException
      */
     'resources',
     'volumeName',
-    'sidecarMountPath',
     'containerMountPath',
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS.minus([
@@ -499,9 +498,6 @@ private List getContainerList(config) {
             env            : getContainerEnvs(config, config.sidecarImage, config.sidecarEnvVars, config.sidecarWorkspace),
             command        : []
         ]
-        if (config.sidecarMountPath) {
-            containerSpec.volumeMounts = [[name: config.volumeName, mountPath: config.sidecarMountPath]]
-        }
 
         def resources = getResources(sideCarContainerName, config)
         if(resources) {


### PR DESCRIPTION
# Changes

This will add a parameter `containerMountPath` which can be used to mount a volume available at this path in each container defined in the `containerMap`. We use it together with `additionalPodProperties` to combine it with an initContainer.

- [x] Tests
- [x] Documentation
