### PR TITLE
set User-Agent Header

### DIFF
--- a/pkg/abap/build/connector.go
+++ b/pkg/abap/build/connector.go
@@ -119,6 +119,7 @@ func (conn *Connector) InitAAKaaS(aAKaaSEndpoint string, username string, passwo
 	conn.Header = make(map[string][]string)
 	conn.Header["Accept"] = []string{"application/json"}
 	conn.Header["Content-Type"] = []string{"application/json"}
+	conn.Header["User-Agent"] = []string{"Piper-abapAddonAssemblyKit/1.0"}
 
 	cookieJar, _ := cookiejar.New(nil)
 	conn.Client.SetOptions(piperhttp.ClientOptions{


### PR DESCRIPTION
As apps.support.sap.com will work with basic auth only for dedicated User Agents in the future we set one