### PR TITLE
Add username password docker authentication

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -150,9 +150,9 @@ func certificateUpdate(certLinks []string, httpClient piperhttp.Sender, fileUtil
 	return nil
 }
 
-func generateDockerConfigJSON(username, password, registryUrl string) []byte {
+func generateDockerConfigJSON(username, password, registryURL string) []byte {
 	usernamePassword := fmt.Sprintf("%s:%s", username, password)
 	encodedUsernamePassword := base64.StdEncoding.EncodeToString([]byte(usernamePassword))
-	configJson := fmt.Sprintf(`{"auths":{"%s":{"auth":"%s"}}}`, registryUrl, encodedUsernamePassword)
-	return []byte(configJson)
+	configJSON := fmt.Sprintf(`{"auths":{"%s":{"auth":"%s"}}}`, registryURL, encodedUsernamePassword)
+	return []byte(configJSON)
 }

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -92,21 +92,14 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 		config.BuildOptions = append(config.BuildOptions, dest...)
 	}
 
-	dockerConfig := []byte(`{"auths":{}}`)
-	if len(config.DockerConfigJSON) > 0 {
-		var err error
-		dockerConfig, err = fileUtils.FileRead(config.DockerConfigJSON)
-		if err != nil {
-			return errors.Wrapf(err, "failed to read file '%v'", config.DockerConfigJSON)
-		}
-	} else if len(config.ContainerRegistryUser) > 0 &&
-		len(config.ContainerRegistryPassword) > 0 &&
-		len(config.ContainerRegistryURL) > 0 {
-		dockerConfig = generateDockerConfigJSON(config.ContainerRegistryUser, config.ContainerRegistryPassword, config.ContainerRegistryURL)
-	}
-
-	if err := fileUtils.FileWrite("/kaniko/.docker/config.json", dockerConfig, 0644); err != nil {
-		return errors.Wrap(err, "failed to write file '/kaniko/.docker/config.json'")
+	if _, err := docker.CreateDockerConfigJSON(
+		config.ContainerRegistryURL,
+		config.ContainerRegistryUser,
+		config.ContainerRegistryPassword,
+		config.DockerConfigJSON,
+		"/kaniko/.docker/config.json",
+		fileUtils); err != nil {
+		return err
 	}
 
 	cwd, err := os.Getwd()

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -42,9 +42,11 @@ type AuthEntry struct {
 }
 
 // CreateDockerConfigJSON writes the docker config.json file holding authentication and registry information
-func CreateDockerConfigJSON(registryURL, username, password, configPath string, fileUtils piperutils.FileUtils) (string, error) {
+func CreateDockerConfigJSON(registryURL, username, password, configPath, filePath string, fileUtils piperutils.FileUtils) (string, error) {
 
-	filePath := ".pipeline/dockerConfig.json"
+	if len(filePath) == 0 {
+		filePath = ".pipeline/dockerConfig.json"
+	}
 
 	dockerConfig := map[string]interface{}{}
 	if exists, _ := fileUtils.FileExists(configPath); exists {

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -1,10 +1,29 @@
 package docker
 
 import (
+	"fmt"
+	piperhttp "github.com/SAP/jenkins-library/pkg/http"
+	"github.com/SAP/jenkins-library/pkg/mock"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type stagingServiceUtilsMock struct {
+	*piperhttp.Client
+	*mock.FilesMock
+}
+
+func (s *stagingServiceUtilsMock) GetClient() *piperhttp.Client {
+	return s.Client
+}
+
+func newStagingServiceUtilsMock() *stagingServiceUtilsMock {
+	return &stagingServiceUtilsMock{
+		FilesMock: &mock.FilesMock{},
+		Client:    &piperhttp.Client{},
+	}
+}
 
 func TestGetImageSource(t *testing.T) {
 
@@ -33,4 +52,94 @@ func TestGetImageSource(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, c.want, got)
 	}
+}
+
+func TestCreateDockerConfigJSON(t *testing.T) {
+	t.Parallel()
+	t.Run("success - new file", func(t *testing.T) {
+		utilsMock := newStagingServiceUtilsMock()
+		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", "", utilsMock)
+		assert.NoError(t, err)
+
+		configFileContent, err := utilsMock.FileRead(configFile)
+		assert.NoError(t, err)
+		assert.Contains(t, string(configFileContent), `"auth":"dGVzdFVzZXI6dGVzdFBhc3N3b3Jk"`)
+	})
+
+	t.Run("success - update file", func(t *testing.T) {
+		utilsMock := newStagingServiceUtilsMock()
+		existingConfig := `{
+	"auths": {
+			"existing.registry.url:50000": {
+					"auth": "Base64Auth"
+			}
+	},
+	"HttpHeaders": {
+			"User-Agent": "Docker-Client/18.06.3-ce (linux)"
+	}
+}`
+		existingConfigFilePath := ".docker/config.json"
+		utilsMock.AddFile(existingConfigFilePath, []byte(existingConfig))
+		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+		assert.NoError(t, err)
+
+		configFileContent, err := utilsMock.FileRead(configFile)
+		assert.NoError(t, err)
+		assert.Contains(t, string(configFileContent), `"existing.registry.url:50000"`)
+		assert.Contains(t, string(configFileContent), `"auth":"Base64Auth"`)
+		assert.Contains(t, string(configFileContent), `"https://test.server.url"`)
+		assert.Contains(t, string(configFileContent), `"auth":"dGVzdFVzZXI6dGVzdFBhc3N3b3Jk"`)
+		assert.Contains(t, string(configFileContent), `"User-Agent":"Docker-Client/18.06.3-ce (linux)`)
+	})
+
+	t.Run("success - update file with empty auths", func(t *testing.T) {
+		utilsMock := newStagingServiceUtilsMock()
+		existingConfig := `{
+	"auths": {},
+	"HttpHeaders": {
+		"User-Agent": "Docker-Client/18.06.3-ce (linux)"
+	}
+}`
+		existingConfigFilePath := ".docker/config.json"
+		utilsMock.AddFile(existingConfigFilePath, []byte(existingConfig))
+		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+		assert.NoError(t, err)
+
+		configFileContent, err := utilsMock.FileRead(configFile)
+		assert.NoError(t, err)
+		assert.Contains(t, string(configFileContent), `"auth":"dGVzdFVzZXI6dGVzdFBhc3N3b3Jk"`)
+		assert.Contains(t, string(configFileContent), `"User-Agent":"Docker-Client/18.06.3-ce (linux)`)
+	})
+
+	t.Run("error - config file read", func(t *testing.T) {
+		// FilesMock does not yet provide capability for FileRead errors
+		t.Skip()
+		utilsMock := newStagingServiceUtilsMock()
+		existingConfigFilePath := ".docker/config.json"
+		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+
+		assert.Error(t, err)
+		assert.Contains(t, fmt.Sprint(err), "failed to read file '.docker/config.json'")
+
+	})
+
+	t.Run("error - config file unmarshal", func(t *testing.T) {
+		utilsMock := newStagingServiceUtilsMock()
+		existingConfig := `{`
+		existingConfigFilePath := ".docker/config.json"
+		utilsMock.AddFile(existingConfigFilePath, []byte(existingConfig))
+		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+
+		assert.Error(t, err)
+		assert.Contains(t, fmt.Sprint(err), "failed to unmarshal json file '.docker/config.json'")
+	})
+
+	t.Run("error - config file write", func(t *testing.T) {
+		utilsMock := newStagingServiceUtilsMock()
+		utilsMock.FileWriteError = fmt.Errorf("write error")
+		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", "", utilsMock)
+
+		assert.Error(t, err)
+		assert.Contains(t, fmt.Sprint(err), "failed to write Docker config.json")
+	})
 }

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -58,12 +58,24 @@ func TestCreateDockerConfigJSON(t *testing.T) {
 	t.Parallel()
 	t.Run("success - new file", func(t *testing.T) {
 		utilsMock := newStagingServiceUtilsMock()
-		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", "", utilsMock)
+		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", "", "", utilsMock)
 		assert.NoError(t, err)
 
 		configFileContent, err := utilsMock.FileRead(configFile)
 		assert.NoError(t, err)
 		assert.Contains(t, string(configFileContent), `"auth":"dGVzdFVzZXI6dGVzdFBhc3N3b3Jk"`)
+		assert.Equal(t, configFile, ".pipeline/dockerConfig.json")
+	})
+
+	t.Run("success - write file to other location", func(t *testing.T) {
+		utilsMock := newStagingServiceUtilsMock()
+		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", "", "my/file/path/dockerConfig.json", utilsMock)
+		assert.NoError(t, err)
+
+		configFileContent, err := utilsMock.FileRead(configFile)
+		assert.NoError(t, err)
+		assert.Contains(t, string(configFileContent), `"auth":"dGVzdFVzZXI6dGVzdFBhc3N3b3Jk"`)
+		assert.Equal(t, configFile, "my/file/path/dockerConfig.json")
 	})
 
 	t.Run("success - update file", func(t *testing.T) {
@@ -80,7 +92,7 @@ func TestCreateDockerConfigJSON(t *testing.T) {
 }`
 		existingConfigFilePath := ".docker/config.json"
 		utilsMock.AddFile(existingConfigFilePath, []byte(existingConfig))
-		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, "", utilsMock)
 		assert.NoError(t, err)
 
 		configFileContent, err := utilsMock.FileRead(configFile)
@@ -102,7 +114,7 @@ func TestCreateDockerConfigJSON(t *testing.T) {
 }`
 		existingConfigFilePath := ".docker/config.json"
 		utilsMock.AddFile(existingConfigFilePath, []byte(existingConfig))
-		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+		configFile, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, "", utilsMock)
 		assert.NoError(t, err)
 
 		configFileContent, err := utilsMock.FileRead(configFile)
@@ -116,7 +128,7 @@ func TestCreateDockerConfigJSON(t *testing.T) {
 		t.Skip()
 		utilsMock := newStagingServiceUtilsMock()
 		existingConfigFilePath := ".docker/config.json"
-		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, "", utilsMock)
 
 		assert.Error(t, err)
 		assert.Contains(t, fmt.Sprint(err), "failed to read file '.docker/config.json'")
@@ -128,7 +140,7 @@ func TestCreateDockerConfigJSON(t *testing.T) {
 		existingConfig := `{`
 		existingConfigFilePath := ".docker/config.json"
 		utilsMock.AddFile(existingConfigFilePath, []byte(existingConfig))
-		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, utilsMock)
+		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", existingConfigFilePath, "", utilsMock)
 
 		assert.Error(t, err)
 		assert.Contains(t, fmt.Sprint(err), "failed to unmarshal json file '.docker/config.json'")
@@ -137,7 +149,7 @@ func TestCreateDockerConfigJSON(t *testing.T) {
 	t.Run("error - config file write", func(t *testing.T) {
 		utilsMock := newStagingServiceUtilsMock()
 		utilsMock.FileWriteError = fmt.Errorf("write error")
-		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", "", utilsMock)
+		_, err := CreateDockerConfigJSON("https://test.server.url", "testUser", "testPassword", "", "", utilsMock)
 
 		assert.Error(t, err)
 		assert.Contains(t, fmt.Sprint(err), "failed to write Docker config.json")

--- a/resources/metadata/kaniko.yaml
+++ b/resources/metadata/kaniko.yaml
@@ -8,6 +8,9 @@ spec:
       - name: dockerConfigJsonCredentialsId
         description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).
         type: jenkins
+      - name: dockerCredentialsId
+        description: Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Docker registry.
+        type: jenkins
     params:
       - name: buildOptions
         type: "[]string"
@@ -114,6 +117,30 @@ spec:
           - STAGES
           - STEPS
         default: Dockerfile
+      - name: containerRegistryUser
+        description: Username for container registry access - typically provided by the CI/CD environment.
+        type: string
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        secret: true
+        resourceRef:
+          - name: dockerCredentialsId
+            type: secret
+            param: username
+      - name: containerRegistryPassword
+        description: Password for container registry access - typically provided by the CI/CD environment.
+        type: string
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        secret: true
+        resourceRef:
+          - name: dockerCredentialsId
+            type: secret
+            param: password
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/kaniko.yaml
+++ b/resources/metadata/kaniko.yaml
@@ -9,7 +9,7 @@ spec:
         description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).
         type: jenkins
       - name: dockerCredentialsId
-        description: Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Docker registry.
+        description: Jenkins 'Username and password' credentials ID containing user and password to authenticate to the Docker registry.
         type: jenkins
     params:
       - name: buildOptions

--- a/resources/metadata/kaniko.yaml
+++ b/resources/metadata/kaniko.yaml
@@ -9,7 +9,7 @@ spec:
         description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).
         type: jenkins
       - name: dockerCredentialsId
-        description: Jenkins 'Username and password' credentials ID containing user and password to authenticate to the Docker registry.
+        description: Jenkins 'username and password' credentials ID containing user and password to authenticate to the Docker registry.
         type: jenkins
     params:
       - name: buildOptions


### PR DESCRIPTION
Generate a docker config.json from username, password and registry url. This will streamline this step with `kubernetesDeploy`, [where it is already possible to log in via username, password and registry parameters](https://www.project-piper.io/steps/kubernetesDeploy/#parameters). As we want to use the `kanikoExecute` and `kubernetesDeploy` steps subsequently, it would make sense to only ask for this information once for both steps.

# Changes

- [x] Tests
- [x] Documentation
