### PR TITLE
[CPE] write commonPipelineEnvironment even when it's empty

### DIFF
--- a/test/groovy/CheckmarxExecuteScanTest.groovy
+++ b/test/groovy/CheckmarxExecuteScanTest.groovy
@@ -57,6 +57,8 @@ class CheckmarxExecuteScanTest extends BasePiperTest {
         shellCallRule.setReturnValue('./piper getConfig --contextConfig --stepMetadata \'.pipeline/tmp/metadata/checkmarx.yaml\'', '{"checkmarxCredentialsId": "idOfCxCredential", "verbose": false}')
 
         helper.registerAllowedMethod('findFiles', [Map.class], {return null})
+        helper.registerAllowedMethod("writePipelineEnv", [Map.class], {m -> return })
+        helper.registerAllowedMethod("readPipelineEnv", [Map.class], {m -> return })
     }
 
     @Test

--- a/test/groovy/MavenExecuteIntegrationTest.groovy
+++ b/test/groovy/MavenExecuteIntegrationTest.groovy
@@ -51,6 +51,8 @@ class MavenExecuteIntegrationTest extends BasePiperTest {
         helper.registerAllowedMethod('fileExists', [String], {return true})
         helper.registerAllowedMethod('findFiles', [Map], {return null})
         helper.registerAllowedMethod('testsPublishResults', [Map], {return null})
+        helper.registerAllowedMethod("writePipelineEnv", [Map.class], {m -> return })
+        helper.registerAllowedMethod("readPipelineEnv", [Map.class], {m -> return })
     }
 
     @Test

--- a/test/groovy/NexusUploadTest.groovy
+++ b/test/groovy/NexusUploadTest.groovy
@@ -50,6 +50,8 @@ class NexusUploadTest extends BasePiperTest {
         )
 
         helper.registerAllowedMethod('fileExists', [String.class], {return true})
+        helper.registerAllowedMethod("writePipelineEnv", [Map.class], {m -> return })
+        helper.registerAllowedMethod("readPipelineEnv", [Map.class], {m -> return })
         helper.registerAllowedMethod('findFiles', [Map.class], {return null})
     }
 

--- a/test/groovy/PiperExecuteBinTest.groovy
+++ b/test/groovy/PiperExecuteBinTest.groovy
@@ -53,6 +53,8 @@ class PiperExecuteBinTest extends BasePiperTest {
             return closure()
         })
 
+        helper.registerAllowedMethod("writePipelineEnv", [Map.class], {m -> return })
+        helper.registerAllowedMethod("readPipelineEnv", [Map.class], {m -> return })
         helper.registerAllowedMethod('fileExists', [Map.class], {m ->
             if (m.file == 'noDetailsStep_errorDetails.json') {
                 return false

--- a/vars/writePipelineEnv.groovy
+++ b/vars/writePipelineEnv.groovy
@@ -7,7 +7,7 @@ void call(Map parameters = [:]) {
     final script = checkScript(this, parameters) ?: this
     String piperGoPath = parameters.piperGoPath ?: './piper'
     Map cpe = script.commonPipelineEnvironment.getCPEMap(script)
-    if (!cpe) {
+    if (cpe == null) {
         return
     }
     def jsonMap = groovy.json.JsonOutput.toJson(cpe)


### PR DESCRIPTION
# Changes

* CPE was not written when map was empty. (groovy treats empty maps as falsy 😞 ) 
