### PR TITLE
fix(commonPipelineEnvironment): keep json numbers untouched

### DIFF
--- a/cmd/writePipelineEnv.go
+++ b/cmd/writePipelineEnv.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
@@ -45,7 +46,9 @@ func runWritePipelineEnv() error {
 	}
 
 	commonPipelineEnv := piperenv.CPEMap{}
-	err := json.Unmarshal(inBytes, &commonPipelineEnv)
+	decoder := json.NewDecoder(bytes.NewReader(inBytes))
+	decoder.UseNumber()
+	err := decoder.Decode(&commonPipelineEnv)
 	if err != nil {
 		return err
 	}
@@ -56,11 +59,11 @@ func runWritePipelineEnv() error {
 		return err
 	}
 
-	bytes, err := json.MarshalIndent(commonPipelineEnv, "", "\t")
+	writtenBytes, err := json.MarshalIndent(commonPipelineEnv, "", "\t")
 	if err != nil {
 		return err
 	}
-	_, err = os.Stdout.Write(bytes)
+	_, err = os.Stdout.Write(writtenBytes)
 	if err != nil {
 		return err
 	}

--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -1,6 +1,7 @@
 package piperenv
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/SAP/jenkins-library/pkg/log"
@@ -100,7 +101,9 @@ func readFileContent(fullPath string) (string, interface{}, error) {
 	if strings.HasSuffix(fullPath, ".json") {
 		// value is json encoded
 		var value interface{}
-		err = json.Unmarshal(fileContent, &value)
+		decoder := json.NewDecoder(bytes.NewReader(fileContent))
+		decoder.UseNumber()
+		err = decoder.Decode(&value)
 		if err != nil {
 			return "", nil, err
 		}

--- a/pkg/piperenv/CPEMap_test.go
+++ b/pkg/piperenv/CPEMap_test.go
@@ -110,6 +110,6 @@ func TestNumbersArePassedCorrectly(t *testing.T) {
 func TestCommonPipelineEnvDirNotPresent(t *testing.T) {
 	cpe := CPEMap{}
 	err := cpe.LoadFromDisk("/path/does/not/exist")
-	assert.NoError(t, err)
-	assert.Len(t, cpe, 0)
+	require.NoError(t, err)
+	require.Len(t, cpe, 0)
 }

--- a/pkg/piperenv/CPEMap_test.go
+++ b/pkg/piperenv/CPEMap_test.go
@@ -1,8 +1,9 @@
 package piperenv
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path"
@@ -20,12 +21,12 @@ func Test_writeMapToDisk(t *testing.T) {
 	}
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test-data-*")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
 	})
 	err = testMap.WriteToDisk(tmpDir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	testData := []struct {
 		Path          string
@@ -49,8 +50,8 @@ func Test_writeMapToDisk(t *testing.T) {
 		t.Run(fmt.Sprintf("check path %s", testCase.Path), func(t *testing.T) {
 			tPath := path.Join(tmpDir, testCase.Path)
 			bytes, err := ioutil.ReadFile(tPath)
-			assert.NoError(t, err)
-			assert.Equal(t, testCase.ExpectedValue, string(bytes))
+			require.NoError(t, err)
+			require.Equal(t, testCase.ExpectedValue, string(bytes))
 		})
 	}
 }
@@ -58,31 +59,52 @@ func Test_writeMapToDisk(t *testing.T) {
 func TestCPEMap_LoadFromDisk(t *testing.T) {
 	t.Parallel()
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "test-data-*")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Cleanup(func() {
 		os.RemoveAll(tmpDir)
 	})
 
 	err = ioutil.WriteFile(path.Join(tmpDir, "Foo"), []byte("Bar"), 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(tmpDir, "Hello"), []byte("World"), 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	subPath := path.Join(tmpDir, "Batman")
 	err = os.Mkdir(subPath, 0744)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Bruce"), []byte("Wayne"), 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Test.json"), []byte("54"), 0644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cpe := CPEMap{}
 	err = cpe.LoadFromDisk(tmpDir)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, "Bar", cpe["Foo"])
-	assert.Equal(t, "World", cpe["Hello"])
-	assert.Equal(t, "Wayne", cpe["Batman/Bruce"])
-	assert.Equal(t, float64(54), cpe["Batman/Test"])
+	require.Equal(t, "Bar", cpe["Foo"])
+	require.Equal(t, "World", cpe["Hello"])
+	require.Equal(t, "Wayne", cpe["Batman/Bruce"])
+	require.Equal(t, json.Number("54"), cpe["Batman/Test"])
+}
+
+func TestNumbersArePassedCorrectly(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "test-data-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	const jsonNumber = "5.5000"
+	err = ioutil.WriteFile(path.Join(tmpDir, "test.json"), []byte(jsonNumber), 0644)
+	require.NoError(t, err)
+
+	cpeMap := CPEMap{}
+	err = cpeMap.LoadFromDisk(tmpDir)
+	require.NoError(t, err)
+
+	rawJSON, err := json.Marshal(cpeMap["test"])
+	require.NoError(t, err)
+	require.Equal(t, jsonNumber, string(rawJSON))
 }
 
 func TestCommonPipelineEnvDirNotPresent(t *testing.T) {


### PR DESCRIPTION
# Changes

Whenever go decodes a json field which is of type number and the target type is unknown (`interface{}`) go will automatically choose `float64`. When doing that the numbers are also cleaned (`5.000` becomes `5`).

This behaviour could potentially lead to some errors when groovy code writes float types and go code converts them to int types. 

This behaviour of go can be disabled by calling `UseNumbers` on the `json.Decoder`. By doing this a string representation of the number is kept so that it can be properly encoded again without messing up numbers


## Additional changes

Change `assert` package to `require` in tests to abort the test when something is not working
