### PR TITLE
[CPE] Missing pipeline environment in sonar docker container

### DIFF
--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -3,6 +3,7 @@ package piperenv
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/SAP/jenkins-library/pkg/log"
 	"io/ioutil"
 	"os"
 	"path"
@@ -62,6 +63,7 @@ func (c CPEMap) WriteToDisk(rootDirectory string) error {
 
 func dirToMap(m map[string]interface{}, dirPath, prefix string) error {
 	if stat, err := os.Stat(dirPath); err != nil || !stat.IsDir() {
+		log.Entry().Debugf("stat on %s failed. Path does not exist", dirPath)
 		return nil
 	}
 

--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -62,7 +62,7 @@ func (c CPEMap) WriteToDisk(rootDirectory string) error {
 
 func dirToMap(m map[string]interface{}, dirPath, prefix string) error {
 	if stat, err := os.Stat(dirPath); err != nil || !stat.IsDir() {
-		return fmt.Errorf("stat on '%s' failed. Not a dir?: %w", dirPath, err)
+		return nil
 	}
 
 	items, err := ioutil.ReadDir(dirPath)

--- a/pkg/piperenv/CPEMap_test.go
+++ b/pkg/piperenv/CPEMap_test.go
@@ -84,3 +84,10 @@ func TestCPEMap_LoadFromDisk(t *testing.T) {
 	assert.Equal(t, "Wayne", cpe["Batman/Bruce"])
 	assert.Equal(t, float64(54), cpe["Batman/Test"])
 }
+
+func TestCommonPipelineEnvDirNotPresent(t *testing.T) {
+	cpe := CPEMap{}
+	err := cpe.LoadFromDisk("/path/does/not/exist")
+	assert.NoError(t, err)
+	assert.Len(t, cpe, 0)
+}

--- a/vars/sonarExecuteScan.groovy
+++ b/vars/sonarExecuteScan.groovy
@@ -60,6 +60,7 @@ void call(Map parameters = [:]) {
                 piperExecuteBin.dockerWrapper(script, STEP_NAME, config){
                     if(!fileExists('.git')) utils.unstash('git')
                     piperExecuteBin.handleErrorDetails(STEP_NAME) {
+                        writePipelineEnv(script: script, piperGoPath: piperGoPath)
                         withSonarQubeEnv(stepConfig.instance) {
                             withEnv(environment){
                                 influxWrapper(script){


### PR DESCRIPTION
# Changes

During the execution of the sonarExecuteStep there is no pipeline environment present, since the `writePipelineEnv` call was never executed inside the container.

The new go implementation of reading the common pipeline environment had changed the behaviour of what happens when the `.pipeline/commonPipelineEnvironment` directory is not present to throwing an error. This is now changed back to simply ignoring it. 