### PR TITLE
fix(kaniko): pin kaniko version to v1.3.0-debug (latest working version)

### DIFF
--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -281,7 +281,7 @@ func kanikoExecuteMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "gcr.io/kaniko-project/executor:debug", Options: []config.Option{{Name: "-u", Value: "0"}, {Name: "--entrypoint", Value: "''"}}},
+				{Image: "gcr.io/kaniko-project/executor:v1.3.0-debug", Options: []config.Option{{Name: "-u", Value: "0"}, {Name: "--entrypoint", Value: "''"}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/resources/metadata/kaniko.yaml
+++ b/resources/metadata/kaniko.yaml
@@ -120,7 +120,8 @@ spec:
           - name: container/registryUrl
           - name: container/imageNameTag
   containers:
-    - image: gcr.io/kaniko-project/executor:debug
+    # https://github.com/GoogleContainerTools/kaniko/issues/1586
+    - image: gcr.io/kaniko-project/executor:v1.3.0-debug
       command:
         - /busybox/tail -f /dev/null
       shell: /busybox/sh


### PR DESCRIPTION
# Changes

* pin kaniko container version to v1.3.0-debug (https://github.com/GoogleContainerTools/kaniko/issues/1586)
