### PR TITLE
CPI - fix scopes so that shared parameters are available in GENERAL

### DIFF
--- a/cmd/integrationArtifactDeploy_generated.go
+++ b/cmd/integrationArtifactDeploy_generated.go
@@ -171,7 +171,7 @@ func integrationArtifactDeployMetadata() config.StepData {
 					{
 						Name:        "integrationFlowVersion",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
@@ -198,7 +198,7 @@ func integrationArtifactDeployMetadata() config.StepData {
 					{
 						Name:        "oAuthTokenProviderUrl",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactDeploy_generated.go
+++ b/cmd/integrationArtifactDeploy_generated.go
@@ -162,7 +162,7 @@ func integrationArtifactDeployMetadata() config.StepData {
 					{
 						Name:        "integrationFlowId",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactDownload_generated.go
+++ b/cmd/integrationArtifactDownload_generated.go
@@ -172,7 +172,7 @@ func integrationArtifactDownloadMetadata() config.StepData {
 					{
 						Name:        "integrationFlowVersion",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
@@ -190,7 +190,7 @@ func integrationArtifactDownloadMetadata() config.StepData {
 					{
 						Name:        "oAuthTokenProviderUrl",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactDownload_generated.go
+++ b/cmd/integrationArtifactDownload_generated.go
@@ -163,7 +163,7 @@ func integrationArtifactDownloadMetadata() config.StepData {
 					{
 						Name:        "integrationFlowId",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactGetMplStatus_generated.go
+++ b/cmd/integrationArtifactGetMplStatus_generated.go
@@ -191,7 +191,7 @@ func integrationArtifactGetMplStatusMetadata() config.StepData {
 					{
 						Name:        "integrationFlowId",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactGetMplStatus_generated.go
+++ b/cmd/integrationArtifactGetMplStatus_generated.go
@@ -218,7 +218,7 @@ func integrationArtifactGetMplStatusMetadata() config.StepData {
 					{
 						Name:        "oAuthTokenProviderUrl",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactGetServiceEndpoint_generated.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_generated.go
@@ -191,7 +191,7 @@ func integrationArtifactGetServiceEndpointMetadata() config.StepData {
 					{
 						Name:        "integrationFlowId",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactGetServiceEndpoint_generated.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_generated.go
@@ -218,7 +218,7 @@ func integrationArtifactGetServiceEndpointMetadata() config.StepData {
 					{
 						Name:        "oAuthTokenProviderUrl",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactUpdateConfiguration_generated.go
+++ b/cmd/integrationArtifactUpdateConfiguration_generated.go
@@ -177,7 +177,7 @@ func integrationArtifactUpdateConfigurationMetadata() config.StepData {
 					{
 						Name:        "integrationFlowVersion",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
@@ -204,7 +204,7 @@ func integrationArtifactUpdateConfigurationMetadata() config.StepData {
 					{
 						Name:        "oAuthTokenProviderUrl",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactUpdateConfiguration_generated.go
+++ b/cmd/integrationArtifactUpdateConfiguration_generated.go
@@ -168,7 +168,7 @@ func integrationArtifactUpdateConfigurationMetadata() config.StepData {
 					{
 						Name:        "integrationFlowId",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactUpload_generated.go
+++ b/cmd/integrationArtifactUpload_generated.go
@@ -178,7 +178,7 @@ func integrationArtifactUploadMetadata() config.StepData {
 					{
 						Name:        "integrationFlowVersion",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
@@ -214,7 +214,7 @@ func integrationArtifactUploadMetadata() config.StepData {
 					{
 						Name:        "oAuthTokenProviderUrl",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactUpload_generated.go
+++ b/cmd/integrationArtifactUpload_generated.go
@@ -169,7 +169,7 @@ func integrationArtifactUploadMetadata() config.StepData {
 					{
 						Name:        "integrationFlowId",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   true,
 						Aliases:     []config.Alias{},

--- a/resources/metadata/integrationArtifactDeploy.yaml
+++ b/resources/metadata/integrationArtifactDeploy.yaml
@@ -51,6 +51,7 @@ spec:
         description: Specifies the version of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true
@@ -75,6 +76,7 @@ spec:
         description: Specifies the oAuth Provider protocol and host address, including the port. Please provide in the format `<protocol>://<host>:<port>`. Supported protocols are `http` and `https`.
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactDeploy.yaml
+++ b/resources/metadata/integrationArtifactDeploy.yaml
@@ -42,6 +42,7 @@ spec:
         description: Specifies the ID of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactDownload.yaml
+++ b/resources/metadata/integrationArtifactDownload.yaml
@@ -51,6 +51,7 @@ spec:
         description: Specifies the version of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true
@@ -67,6 +68,7 @@ spec:
         description: Specifies the oAuth Provider protocol and host address, including the port. Please provide in the format `<protocol>://<host>:<port>`. Supported protocols are `http` and `https`.
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactDownload.yaml
+++ b/resources/metadata/integrationArtifactDownload.yaml
@@ -42,6 +42,7 @@ spec:
         description: Specifies the ID of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -42,6 +42,7 @@ spec:
         description: Specifies the ID of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -67,6 +67,7 @@ spec:
         description: Specifies the oAuth Provider protocol and host address, including the port. Please provide in the format `<protocol>://<host>:<port>`. Supported protocols are `http` and `https`.
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
+++ b/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
@@ -42,6 +42,7 @@ spec:
         description: Specifies the ID of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
+++ b/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
@@ -67,6 +67,7 @@ spec:
         description: Specifies the oAuth Provider protocol and host address, including the port. Please provide in the format `<protocol>://<host>:<port>`. Supported protocols are `http` and `https`.
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactUpdateConfiguration.yaml
+++ b/resources/metadata/integrationArtifactUpdateConfiguration.yaml
@@ -51,6 +51,7 @@ spec:
         description: Specifies the version of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true
@@ -75,6 +76,7 @@ spec:
         description: Specifies the oAuth Provider protocol and host address, including the port. Please provide in the format `<protocol>://<host>:<port>`. Supported protocols are `http` and `https`.
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactUpdateConfiguration.yaml
+++ b/resources/metadata/integrationArtifactUpdateConfiguration.yaml
@@ -42,6 +42,7 @@ spec:
         description: Specifies the ID of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactUpload.yaml
+++ b/resources/metadata/integrationArtifactUpload.yaml
@@ -42,6 +42,7 @@ spec:
         description: Specifies the ID of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true

--- a/resources/metadata/integrationArtifactUpload.yaml
+++ b/resources/metadata/integrationArtifactUpload.yaml
@@ -51,6 +51,7 @@ spec:
         description: Specifies the version of the Integration Flow artifact
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true
@@ -83,6 +84,7 @@ spec:
         description: Specifies the oAuth Provider protocol and host address, including the port. Please provide in the format `<protocol>://<host>:<port>`. Supported protocols are `http` and `https`.
         scope:
           - PARAMETERS
+          - GENERAL
           - STAGES
           - STEPS
         mandatory: true


### PR DESCRIPTION
# Changes

To not have to define the configuration parameters that are the same between steps over and over again, we allow them to be configured in the general section of the config.yaml

This PR replaces #2811
