### PR TITLE
fix: piper never writes with correct file permissions since umask is never considered

### DIFF
--- a/cmd/init_unix.go
+++ b/cmd/init_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package cmd
+
+import "syscall"
+
+func init() {
+	// unset umask otherwise permissions on file or directory
+	// creation are altered in unpredictable ways.
+	syscall.Umask(0)
+}


### PR DESCRIPTION
## What is the problem
Unix systems use [umasks](https://en.wikipedia.org/wiki/Umask) to control permissions on newly created files or directories.
As a default  umask `022` is often picked.  Which means that the permission `777` will result in `755` after the umask was applied or
`766` will result in `744`. Or in words the `write` permission will be removed for `groups` and `others`.

Piper tries to write files and create directories with very broad permissions at several places ([writing outputs](https://github.com/SAP/jenkins-library/blob/8883a5148c0801d854d93a0f9b12ec1c7858151b/pkg/piperenv/environment.go#L59-L65)) in the past the permissions specified in the code were never the permissions that ended up on the filesystem on unix systems since the umask was applied first.

Most of the time this was not a problem because piper is executed as the owner of the files, however things get pretty messed up when people start to run stuff in docker with different user IDs, restoring stashes, with previously created folders that have no write permissions because of the umask... then is when 💩  hits the fan.

## Changes

On unix systems we reset the umask to 0. Permissions don't get altered anymore. And everything works fine. 

