### PR TITLE
(feat) adds error logging output for downloading reports from WhiteSource

### DIFF
--- a/pkg/whitesource/scanReports.go
+++ b/pkg/whitesource/scanReports.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/pkg/errors"
 )
 
 // ReportOptions defines options for downloading reports after scanning.
@@ -47,13 +48,13 @@ func (s *Scan) DownloadReports(options ReportOptions, utils scanUtils, sys white
 func downloadVulnerabilityReport(options ReportOptions, project Project, utils scanUtils, sys whitesource) (*piperutils.Path, error) {
 	reportBytes, err := sys.GetProjectVulnerabilityReport(project.Token, options.VulnerabilityReportFormat)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "unable to download vulnerability report from url")
 	}
 
 	rptFileName := fmt.Sprintf("%s-vulnerability-report.%s", strings.ReplaceAll(project.Name, "/", "_"), options.VulnerabilityReportFormat)
 	rptFileName = filepath.Join(options.ReportDirectory, rptFileName)
 	if err := utils.FileWrite(rptFileName, reportBytes, 0644); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "unable to copy content from url to file %v", rptFileName)
 	}
 
 	log.Entry().Infof("Successfully downloaded vulnerability report to %s", rptFileName)
@@ -64,13 +65,13 @@ func downloadVulnerabilityReport(options ReportOptions, project Project, utils s
 func downloadRiskReport(options ReportOptions, project Project, utils scanUtils, sys whitesource) (*piperutils.Path, error) {
 	reportBytes, err := sys.GetProjectRiskReport(project.Token)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "unable to download risk report from url")
 	}
 
 	rptFileName := fmt.Sprintf("%s-risk-report.pdf", strings.ReplaceAll(project.Name, "/", "_"))
 	rptFileName = filepath.Join(options.ReportDirectory, rptFileName)
 	if err := utils.FileWrite(rptFileName, reportBytes, 0644); err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "unable to copy content from url to file %v", rptFileName)
 	}
 
 	log.Entry().Infof("Successfully downloaded risk report to %s", rptFileName)

--- a/pkg/whitesource/scanReports_test.go
+++ b/pkg/whitesource/scanReports_test.go
@@ -78,7 +78,7 @@ func TestDownloadReports(t *testing.T) {
 		// test
 		paths, err := scan.DownloadReports(options, utils, system)
 		// assert
-		assert.EqualError(t, err, "no project with token '' found in Whitesource")
+		assert.EqualError(t, err, "unable to download vulnerability report from url: no project with token '' found in Whitesource")
 		assert.Nil(t, paths)
 	})
 	t.Run("multiple scanned projects", func(t *testing.T) {


### PR DESCRIPTION
This PR adds logging output to the report download mechanism of the WhiteSource step.
The extended logging mechanism supports us in resolving issues with downloaded files from WS.

# Changes

- [x] Tests
- [ ] Documentation
