### PR TITLE
mavenExecuteIntegration: add maven lifecycle goal as parameter

### DIFF
--- a/cmd/mavenExecuteIntegration.go
+++ b/cmd/mavenExecuteIntegration.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/maven"
-	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/maven"
+	"github.com/SAP/jenkins-library/pkg/telemetry"
 )
 
 func mavenExecuteIntegration(config mavenExecuteIntegrationOptions, _ *telemetry.CustomData) {
@@ -48,7 +49,7 @@ func runMavenExecuteIntegration(config *mavenExecuteIntegrationOptions, utils ma
 		M2Path:              config.M2Path,
 		ProjectSettingsFile: config.ProjectSettingsFile,
 		GlobalSettingsFile:  config.GlobalSettingsFile,
-		Goals:               []string{"org.jacoco:jacoco-maven-plugin:prepare-agent", "test"},
+		Goals:               []string{"org.jacoco:jacoco-maven-plugin:prepare-agent", config.Goal},
 		Defines:             []string{retryDefine, forkCountDefine},
 	}
 

--- a/cmd/mavenExecuteIntegration.go
+++ b/cmd/mavenExecuteIntegration.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/maven"
+	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
-
-	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/maven"
-	"github.com/SAP/jenkins-library/pkg/telemetry"
 )
 
 func mavenExecuteIntegration(config mavenExecuteIntegrationOptions, _ *telemetry.CustomData) {

--- a/cmd/mavenExecuteIntegration_generated.go
+++ b/cmd/mavenExecuteIntegration_generated.go
@@ -17,6 +17,7 @@ import (
 type mavenExecuteIntegrationOptions struct {
 	Retry                       int    `json:"retry,omitempty"`
 	ForkCount                   string `json:"forkCount,omitempty"`
+	Goal                        string `json:"goal,omitempty"`
 	InstallArtifacts            bool   `json:"installArtifacts,omitempty"`
 	ProjectSettingsFile         string `json:"projectSettingsFile,omitempty"`
 	GlobalSettingsFile          string `json:"globalSettingsFile,omitempty"`
@@ -100,6 +101,7 @@ the integration tests via the Jacoco Maven-plugin.`,
 func addMavenExecuteIntegrationFlags(cmd *cobra.Command, stepConfig *mavenExecuteIntegrationOptions) {
 	cmd.Flags().IntVar(&stepConfig.Retry, "retry", 1, "The number of times that integration tests will be retried before failing the step. Note: This will consume more time for the step execution.")
 	cmd.Flags().StringVar(&stepConfig.ForkCount, "forkCount", `1C`, "The number of JVM processes that are spawned to run the tests in parallel in case of using a maven based project structure. For more details visit the Surefire documentation at https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#forkCount.")
+	cmd.Flags().StringVar(&stepConfig.Goal, "goal", `test`, "The name of the Maven goal to execute.")
 	cmd.Flags().BoolVar(&stepConfig.InstallArtifacts, "installArtifacts", true, "If enabled, it will install all artifacts to the local maven repository to make them available before running the tests. This is required if the integration test module has dependencies to other modules in the repository and they were not installed before.")
 	cmd.Flags().StringVar(&stepConfig.ProjectSettingsFile, "projectSettingsFile", os.Getenv("PIPER_projectSettingsFile"), "Path to the mvn settings file that should be used as project settings file.")
 	cmd.Flags().StringVar(&stepConfig.GlobalSettingsFile, "globalSettingsFile", os.Getenv("PIPER_globalSettingsFile"), "Path to the mvn settings file that should be used as global settings file.")
@@ -136,6 +138,15 @@ func mavenExecuteIntegrationMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     `1C`,
+					},
+					{
+						Name:        "goal",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `test`,
 					},
 					{
 						Name:        "installArtifacts",

--- a/cmd/mavenExecuteIntegration_test.go
+++ b/cmd/mavenExecuteIntegration_test.go
@@ -36,6 +36,7 @@ func TestHappyPathIntegrationTests(t *testing.T) {
 	config := mavenExecuteIntegrationOptions{
 		Retry:     2,
 		ForkCount: "1C",
+		Goal:      "post-integration-test",
 	}
 
 	err := runMavenExecuteIntegration(&config, utils)
@@ -51,7 +52,7 @@ func TestHappyPathIntegrationTests(t *testing.T) {
 		"-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn",
 		"--batch-mode",
 		"org.jacoco:jacoco-maven-plugin:prepare-agent",
-		"test",
+		"post-integration-test",
 	}
 
 	assert.Equal(t, mock.ExecCall{Exec: "mvn", Params: expectedParameters1}, utils.ExecMockRunner.Calls[0])

--- a/resources/metadata/mavenExecuteIntegration.yaml
+++ b/resources/metadata/mavenExecuteIntegration.yaml
@@ -40,7 +40,7 @@ spec:
           - STEPS
           - STAGES
           - PARAMETERS
-        default: "test"        
+        default: "test"
       - name: installArtifacts
         type: bool
         description:

--- a/resources/metadata/mavenExecuteIntegration.yaml
+++ b/resources/metadata/mavenExecuteIntegration.yaml
@@ -32,6 +32,15 @@ spec:
           - STEPS
           - STAGES
         default: "1C"
+      - name: goal
+        type: string
+        description:
+          "The name of the Maven goal to execute."
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        default: "test"        
       - name: installArtifacts
         type: bool
         description:


### PR DESCRIPTION
# Changes

adds the ability to define a maven lifecycle goal different from default `test`.
Required for Mojo's `integration-tests` and `report-aggregate`which only come later.

Ref: https://github.wdf.sap.corp/ContinuousDelivery/piper-library/issues/3600

- [ ] Tests
- [X] Documentation
