### PR TITLE
Remove findbugs

### DIFF
--- a/vars/checksPublishResults.groovy
+++ b/vars/checksPublishResults.groovy
@@ -33,11 +33,6 @@ import groovy.transform.Field
      */
     'cpd',
     /**
-     * Publishes Findbugs findings with the [Findbugs plugin](https://plugins.jenkins.io/findbugs).
-     * @possibleValues `true`, `false`, `Map`
-     */
-    'findbugs',
-    /**
      * Publishes Checkstyle findings with the [Checkstyle plugin](https://plugins.jenkins.io/checkstyle).
      * @possibleValues `true`, `false`, `Map`
      */
@@ -102,7 +97,6 @@ void call(Map parameters = [:]) {
         // JAVA
         report(pmdParser(createToolOptions(configuration.pmd)), configuration.pmd, configuration.archive)
         report(cpd(createToolOptions(configuration.cpd)), configuration.cpd, configuration.archive)
-        report(findBugs(createToolOptions(configuration.findbugs, [useRankAsPriority: true])), configuration.findbugs, configuration.archive)
         report(checkStyle(createToolOptions(configuration.checkstyle)), configuration.checkstyle, configuration.archive)
         // JAVA SCRIPT
         report(esLint(createToolOptions(configuration.eslint)), configuration.eslint, configuration.archive)


### PR DESCRIPTION
The plugin is deprecated and has also been removed from cx-server.

This is not a ready-to-merge pull request, but more a starting point for getting #2881 resolved.

To me it looks like the findbugs plugin is not available anymore. It has also been removed from the cx-server which serves a reference runtime for our shared lib.

Of course we should discuss how the current findbugs based functionality can be replaced.