### PR TITLE
CPI- Refactor Credential ID

### DIFF
--- a/cmd/integrationArtifactDeploy_generated.go
+++ b/cmd/integrationArtifactDeploy_generated.go
@@ -116,7 +116,7 @@ func integrationArtifactDeployMetadata() config.StepData {
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
-					{Name: "cpiAPIServiceKeyCredentialId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
+					{Name: "cpiApiServiceKeyCredentialsId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/cmd/integrationArtifactDownload_generated.go
+++ b/cmd/integrationArtifactDownload_generated.go
@@ -117,7 +117,7 @@ func integrationArtifactDownloadMetadata() config.StepData {
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
-					{Name: "cpiAPIServiceKeyCredentialId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
+					{Name: "cpiApiServiceKeyCredentialsId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/cmd/integrationArtifactGetMplStatus_generated.go
+++ b/cmd/integrationArtifactGetMplStatus_generated.go
@@ -145,7 +145,7 @@ func integrationArtifactGetMplStatusMetadata() config.StepData {
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
-					{Name: "cpiAPIServiceKeyCredentialId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
+					{Name: "cpiApiServiceKeyCredentialsId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/cmd/integrationArtifactGetServiceEndpoint_generated.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_generated.go
@@ -145,7 +145,7 @@ func integrationArtifactGetServiceEndpointMetadata() config.StepData {
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
-					{Name: "cpiAPIServiceKeyCredentialId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
+					{Name: "cpiApiServiceKeyCredentialsId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/cmd/integrationArtifactUpdateConfiguration_generated.go
+++ b/cmd/integrationArtifactUpdateConfiguration_generated.go
@@ -122,7 +122,7 @@ func integrationArtifactUpdateConfigurationMetadata() config.StepData {
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
-					{Name: "cpiAPIServiceKeyCredentialId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
+					{Name: "cpiApiServiceKeyCredentialsId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/cmd/integrationArtifactUpload_generated.go
+++ b/cmd/integrationArtifactUpload_generated.go
@@ -123,7 +123,7 @@ func integrationArtifactUploadMetadata() config.StepData {
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
-					{Name: "cpiAPIServiceKeyCredentialId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
+					{Name: "cpiApiServiceKeyCredentialsId", Description: "Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API", Type: "jenkins"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/documentation/docs/steps/integrationArtifactDeploy.md
+++ b/documentation/docs/steps/integrationArtifactDeploy.md
@@ -24,7 +24,7 @@ Example of a YAML configuration file (such as `.pipeline/config.yaml`).
 steps:
   <...>
   integrationArtifactDeploy:
-    cpiAPIServiceKeyCredentialId: 'MY_API_SERVICE_KEY'
+    cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_NAME'
     integrationFlowVersion: 'MY_INTEGRATION_FLOW_VERSION'
     platform: cf

--- a/documentation/docs/steps/integrationArtifactDownload.md
+++ b/documentation/docs/steps/integrationArtifactDownload.md
@@ -24,7 +24,7 @@ Example for the use in a YAML configuration file (such as `.pipeline/config.yaml
 steps:
   <...>
   integrationArtifactDownload:
-    cpiAPIServiceKeyCredentialId: 'MY_API_SERVICE_KEY'
+    cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_NAME'
     integrationFlowVersion: 'MY_INTEGRATION_FLOW_VERSION'
     downloadPath: MY_INTEGRATION_FLOW_DOWNLOAD_PATH

--- a/documentation/docs/steps/integrationArtifactGetMplStatus.md
+++ b/documentation/docs/steps/integrationArtifactGetMplStatus.md
@@ -24,7 +24,7 @@ Example for the use in a YAML configuration file (such as `.pipeline/config.yaml
 steps:
   <...>
   integrationArtifactGetMplStatus:
-    cpiAPIServiceKeyCredentialId: 'MY_API_SERVICE_KEY'
+    cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'INTEGRATION_FLOW_ID'
     platform: cf
 ```

--- a/documentation/docs/steps/integrationArtifactGetServiceEndpoint.md
+++ b/documentation/docs/steps/integrationArtifactGetServiceEndpoint.md
@@ -24,7 +24,7 @@ Example for the use in a YAML configuration file (such as `.pipeline/config.yaml
 steps:
   <...>
   integrationArtifactGetServiceEndpoint:
-    cpiAPIServiceKeyCredentialId: 'MY_API_SERVICE_KEY'
+    cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_ID'
     platform: cf
 ```

--- a/documentation/docs/steps/integrationArtifactUpdateConfiguration.md
+++ b/documentation/docs/steps/integrationArtifactUpdateConfiguration.md
@@ -24,7 +24,7 @@ Example of a YAML configuration file (such as `.pipeline/config.yaml`).
 steps:
   <...>
   integrationArtifactUpdateConfiguration:
-    cpiAPIServiceKeyCredentialId: 'MY_API_SERVICE_KEY'
+    cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_NAME'
     integrationFlowVersion: 'MY_INTEGRATION_FLOW_VERSION'
     platform: 'cf'

--- a/documentation/docs/steps/integrationArtifactUpload.md
+++ b/documentation/docs/steps/integrationArtifactUpload.md
@@ -24,7 +24,7 @@ Example for the use in a YAML configuration file (such as `.pipeline/config.yaml
 steps:
   <...>
   integrationArtifactUpload:
-    cpiAPIServiceKeyCredentialId: 'MY_API_SERVICE_KEY'
+    cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_ID'
     integrationFlowVersion: 'MY_INTEGRATION_FLOW_VERSION'
     integrationFlowName: 'MY_INTEGRATION_FLOW_Name'

--- a/resources/metadata/integrationArtifactDeploy.yaml
+++ b/resources/metadata/integrationArtifactDeploy.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   inputs:
     secrets:
-      - name: cpiAPIServiceKeyCredentialId
+      - name: cpiApiServiceKeyCredentialsId
         description: Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API
         type: jenkins
     params:

--- a/resources/metadata/integrationArtifactDownload.yaml
+++ b/resources/metadata/integrationArtifactDownload.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   inputs:
     secrets:
-      - name: cpiAPIServiceKeyCredentialId
+      - name: cpiApiServiceKeyCredentialsId
         description: Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API
         type: jenkins
     params:

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   inputs:
     secrets:
-      - name: cpiAPIServiceKeyCredentialId
+      - name: cpiApiServiceKeyCredentialsId
         description: Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API
         type: jenkins
     params:

--- a/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
+++ b/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   inputs:
     secrets:
-      - name: cpiAPIServiceKeyCredentialId
+      - name: cpiApiServiceKeyCredentialsId
         description: Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API
         type: jenkins
     params:

--- a/resources/metadata/integrationArtifactUpdateConfiguration.yaml
+++ b/resources/metadata/integrationArtifactUpdateConfiguration.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   inputs:
     secrets:
-      - name: cpiAPIServiceKeyCredentialId
+      - name: cpiApiServiceKeyCredentialsId
         description: Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API
         type: jenkins
     params:

--- a/resources/metadata/integrationArtifactUpload.yaml
+++ b/resources/metadata/integrationArtifactUpload.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   inputs:
     secrets:
-      - name: cpiAPIServiceKeyCredentialId
+      - name: cpiApiServiceKeyCredentialsId
         description: Jenkins credential ID for secret text containing the service key to the SAP Cloud Integration API
         type: jenkins
     params:

--- a/vars/integrationArtifactDeploy.groovy
+++ b/vars/integrationArtifactDeploy.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
     List credentials = [
-        [type: 'token', id: 'cpiAPIServiceKeyCredentialId', env: ['PIPER_apiServiceKey']]
+        [type: 'token', id: 'cpiApiServiceKeyCredentialsId', env: ['PIPER_apiServiceKey']]
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }

--- a/vars/integrationArtifactDownload.groovy
+++ b/vars/integrationArtifactDownload.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
     List credentials = [
-        [type: 'token', id: 'cpiAPIServiceKeyCredentialId', env: ['PIPER_apiServiceKey']]
+        [type: 'token', id: 'cpiApiServiceKeyCredentialsId', env: ['PIPER_apiServiceKey']]
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }

--- a/vars/integrationArtifactGetMplStatus.groovy
+++ b/vars/integrationArtifactGetMplStatus.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
     List credentials = [
-        [type: 'token', id: 'cpiAPIServiceKeyCredentialId', env: ['PIPER_apiServiceKey']]
+        [type: 'token', id: 'cpiApiServiceKeyCredentialsId', env: ['PIPER_apiServiceKey']]
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }

--- a/vars/integrationArtifactGetServiceEndpoint.groovy
+++ b/vars/integrationArtifactGetServiceEndpoint.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
     List credentials = [
-        [type: 'token', id: 'cpiAPIServiceKeyCredentialId', env: ['PIPER_apiServiceKey']]
+        [type: 'token', id: 'cpiApiServiceKeyCredentialsId', env: ['PIPER_apiServiceKey']]
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }

--- a/vars/integrationArtifactUpdateConfiguration.groovy
+++ b/vars/integrationArtifactUpdateConfiguration.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
     List credentials = [
-        [type: 'token', id: 'cpiAPIServiceKeyCredentialId', env: ['PIPER_apiServiceKey']]
+        [type: 'token', id: 'cpiApiServiceKeyCredentialsId', env: ['PIPER_apiServiceKey']]
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }

--- a/vars/integrationArtifactUpload.groovy
+++ b/vars/integrationArtifactUpload.groovy
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
     List credentials = [
-        [type: 'token', id: 'cpiAPIServiceKeyCredentialId', env: ['PIPER_apiServiceKey']]
+        [type: 'token', id: 'cpiApiServiceKeyCredentialsId', env: ['PIPER_apiServiceKey']]
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes

Change `cpiAPIServiceKeyCredentialId` to `cpiApiServiceKeyCredentialsId` in all CPI Steps so that the variable name can be consistent.

- [x] Tests
- [x] Documentation
