### PR TITLE
CPI- Change resourceRef of apiServiceKey

### DIFF
--- a/cmd/integrationArtifactDeploy_generated.go
+++ b/cmd/integrationArtifactDeploy_generated.go
@@ -123,8 +123,8 @@ func integrationArtifactDeployMetadata() config.StepData {
 						Name: "apiServiceKey",
 						ResourceRef: []config.ResourceReference{
 							{
-								Name:  "cpiServiceKeyCredentialId",
-								Param: "serviceKey",
+								Name:  "cpiApiServiceKeyCredentialsId",
+								Param: "apiServiceKey",
 								Type:  "secret",
 							},
 						},

--- a/cmd/integrationArtifactDownload_generated.go
+++ b/cmd/integrationArtifactDownload_generated.go
@@ -124,8 +124,8 @@ func integrationArtifactDownloadMetadata() config.StepData {
 						Name: "apiServiceKey",
 						ResourceRef: []config.ResourceReference{
 							{
-								Name:  "cpiServiceKeyCredentialId",
-								Param: "serviceKey",
+								Name:  "cpiApiServiceKeyCredentialsId",
+								Param: "apiServiceKey",
 								Type:  "secret",
 							},
 						},

--- a/cmd/integrationArtifactGetMplStatus_generated.go
+++ b/cmd/integrationArtifactGetMplStatus_generated.go
@@ -152,8 +152,8 @@ func integrationArtifactGetMplStatusMetadata() config.StepData {
 						Name: "apiServiceKey",
 						ResourceRef: []config.ResourceReference{
 							{
-								Name:  "cpiServiceKeyCredentialId",
-								Param: "serviceKey",
+								Name:  "cpiApiServiceKeyCredentialsId",
+								Param: "apiServiceKey",
 								Type:  "secret",
 							},
 						},

--- a/cmd/integrationArtifactGetServiceEndpoint_generated.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_generated.go
@@ -152,8 +152,8 @@ func integrationArtifactGetServiceEndpointMetadata() config.StepData {
 						Name: "apiServiceKey",
 						ResourceRef: []config.ResourceReference{
 							{
-								Name:  "cpiServiceKeyCredentialId",
-								Param: "serviceKey",
+								Name:  "cpiApiServiceKeyCredentialsId",
+								Param: "apiServiceKey",
 								Type:  "secret",
 							},
 						},

--- a/cmd/integrationArtifactUpdateConfiguration_generated.go
+++ b/cmd/integrationArtifactUpdateConfiguration_generated.go
@@ -129,8 +129,8 @@ func integrationArtifactUpdateConfigurationMetadata() config.StepData {
 						Name: "apiServiceKey",
 						ResourceRef: []config.ResourceReference{
 							{
-								Name:  "cpiServiceKeyCredentialId",
-								Param: "serviceKey",
+								Name:  "cpiApiServiceKeyCredentialsId",
+								Param: "apiServiceKey",
 								Type:  "secret",
 							},
 						},

--- a/cmd/integrationArtifactUpload_generated.go
+++ b/cmd/integrationArtifactUpload_generated.go
@@ -130,8 +130,8 @@ func integrationArtifactUploadMetadata() config.StepData {
 						Name: "apiServiceKey",
 						ResourceRef: []config.ResourceReference{
 							{
-								Name:  "cpiServiceKeyCredentialId",
-								Param: "serviceKey",
+								Name:  "cpiApiServiceKeyCredentialsId",
+								Param: "apiServiceKey",
 								Type:  "secret",
 							},
 						},

--- a/resources/metadata/integrationArtifactDeploy.yaml
+++ b/resources/metadata/integrationArtifactDeploy.yaml
@@ -19,9 +19,9 @@ spec:
         mandatory: true
         secret: true
         resourceRef:
-          - name: cpiServiceKeyCredentialId
+          - name: cpiApiServiceKeyCredentialsId
             type: secret
-            param: serviceKey
+            param: apiServiceKey
       - name: integrationFlowId
         type: string
         description: Specifies the ID of the Integration Flow artifact

--- a/resources/metadata/integrationArtifactDownload.yaml
+++ b/resources/metadata/integrationArtifactDownload.yaml
@@ -19,9 +19,9 @@ spec:
         mandatory: true
         secret: true
         resourceRef:
-          - name: cpiServiceKeyCredentialId
+          - name: cpiApiServiceKeyCredentialsId
             type: secret
-            param: serviceKey
+            param: apiServiceKey
       - name: integrationFlowId
         type: string
         description: Specifies the ID of the Integration Flow artifact

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -19,9 +19,9 @@ spec:
         mandatory: true
         secret: true
         resourceRef:
-          - name: cpiServiceKeyCredentialId
+          - name: cpiApiServiceKeyCredentialsId
             type: secret
-            param: serviceKey
+            param: apiServiceKey
       - name: integrationFlowId
         type: string
         description: Specifies the ID of the Integration Flow artifact

--- a/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
+++ b/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
@@ -19,9 +19,9 @@ spec:
         mandatory: true
         secret: true
         resourceRef:
-          - name: cpiServiceKeyCredentialId
+          - name: cpiApiServiceKeyCredentialsId
             type: secret
-            param: serviceKey
+            param: apiServiceKey
       - name: integrationFlowId
         type: string
         description: Specifies the ID of the Integration Flow artifact

--- a/resources/metadata/integrationArtifactUpdateConfiguration.yaml
+++ b/resources/metadata/integrationArtifactUpdateConfiguration.yaml
@@ -19,9 +19,9 @@ spec:
         mandatory: true
         secret: true
         resourceRef:
-          - name: cpiServiceKeyCredentialId
+          - name: cpiApiServiceKeyCredentialsId
             type: secret
-            param: serviceKey
+            param: apiServiceKey
       - name: integrationFlowId
         type: string
         description: Specifies the ID of the Integration Flow artifact

--- a/resources/metadata/integrationArtifactUpload.yaml
+++ b/resources/metadata/integrationArtifactUpload.yaml
@@ -19,9 +19,9 @@ spec:
         mandatory: true
         secret: true
         resourceRef:
-          - name: cpiServiceKeyCredentialId
+          - name: cpiApiServiceKeyCredentialsId
             type: secret
-            param: serviceKey
+            param: apiServiceKey
       - name: integrationFlowId
         type: string
         description: Specifies the ID of the Integration Flow artifact


### PR DESCRIPTION
# Changes

in the params section of the yaml files of each cpi step, change resourceRef name needed to match the name in the secrets at the top of the file (`cpiApiServiceKeyCredentialsId`) , and change param to match the name of the parent param (`apiServiceKey`) 
- [x] Tests
- [x] Documentation
