### PR TITLE
CPI - Change platform to global scope

### DIFF
--- a/cmd/integrationArtifactDeploy_generated.go
+++ b/cmd/integrationArtifactDeploy_generated.go
@@ -18,7 +18,7 @@ type integrationArtifactDeployOptions struct {
 	APIServiceKey          string `json:"apiServiceKey,omitempty"`
 	IntegrationFlowID      string `json:"integrationFlowId,omitempty"`
 	IntegrationFlowVersion string `json:"integrationFlowVersion,omitempty"`
-	Platform               string `json:"platform,omitempty"`
+	CpiPlatform            string `json:"cpiPlatform,omitempty"`
 }
 
 // IntegrationArtifactDeployCommand Deploy a CPI integration flow
@@ -98,7 +98,7 @@ func addIntegrationArtifactDeployFlags(cmd *cobra.Command, stepConfig *integrati
 	cmd.Flags().StringVar(&stepConfig.APIServiceKey, "apiServiceKey", os.Getenv("PIPER_apiServiceKey"), "Service key JSON string to access the Cloud Integration API")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowVersion, "integrationFlowVersion", os.Getenv("PIPER_integrationFlowVersion"), "Specifies the version of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", os.Getenv("PIPER_platform"), "Specifies the running platform of the SAP Cloud platform integraion service")
+	cmd.Flags().StringVar(&stepConfig.CpiPlatform, "cpiPlatform", `cf`, "Specifies the running platform of the SAP Cloud platform integraion service")
 
 	cmd.MarkFlagRequired("apiServiceKey")
 	cmd.MarkFlagRequired("integrationFlowId")
@@ -153,13 +153,13 @@ func integrationArtifactDeployMetadata() config.StepData {
 						Default:     os.Getenv("PIPER_integrationFlowVersion"),
 					},
 					{
-						Name:        "platform",
+						Name:        "cpiPlatform",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"GLOBAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_platform"),
+						Default:     `cf`,
 					},
 				},
 			},

--- a/cmd/integrationArtifactDeploy_test.go
+++ b/cmd/integrationArtifactDeploy_test.go
@@ -42,7 +42,7 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
+			CpiPlatform:            "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "", ResponseBody: ``, TestType: "PositiveAndDeployIntegrationDesigntimeArtifactResBody"}
@@ -76,7 +76,7 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
+			CpiPlatform:            "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "FailIntegrationDesigntimeArtifactDeployment", ResponseBody: ``, TestType: "Negative"}
@@ -110,7 +110,7 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
+			CpiPlatform:            "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "", ResponseBody: ``, TestType: "NegativeAndDeployIntegrationDesigntimeArtifactResBody"}
@@ -136,7 +136,7 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
+			CpiPlatform:            "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "GetIntegrationArtifactDeployStatus", Options: clientOptions, ResponseBody: ``, TestType: "PositiveAndDeployIntegrationDesigntimeArtifactResBody"}
@@ -164,7 +164,7 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
+			CpiPlatform:            "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "GetIntegrationArtifactDeployErrorDetails", Options: clientOptions, ResponseBody: ``, TestType: "PositiveAndGetDeployedIntegrationDesigntimeArtifactErrorResBody"}

--- a/cmd/integrationArtifactGetMplStatus_generated.go
+++ b/cmd/integrationArtifactGetMplStatus_generated.go
@@ -19,7 +19,7 @@ import (
 type integrationArtifactGetMplStatusOptions struct {
 	APIServiceKey     string `json:"apiServiceKey,omitempty"`
 	IntegrationFlowID string `json:"integrationFlowId,omitempty"`
-	Platform          string `json:"platform,omitempty"`
+	CpiPlatform       string `json:"cpiPlatform,omitempty"`
 }
 
 type integrationArtifactGetMplStatusCommonPipelineEnvironment struct {
@@ -128,7 +128,7 @@ func IntegrationArtifactGetMplStatusCommand() *cobra.Command {
 func addIntegrationArtifactGetMplStatusFlags(cmd *cobra.Command, stepConfig *integrationArtifactGetMplStatusOptions) {
 	cmd.Flags().StringVar(&stepConfig.APIServiceKey, "apiServiceKey", os.Getenv("PIPER_apiServiceKey"), "Service key JSON string to access the Cloud Integration API")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", os.Getenv("PIPER_platform"), "Specifies the running platform of the SAP Cloud platform integraion service")
+	cmd.Flags().StringVar(&stepConfig.CpiPlatform, "cpiPlatform", `cf`, "Specifies the running platform of the SAP Cloud platform integraion service")
 
 	cmd.MarkFlagRequired("apiServiceKey")
 	cmd.MarkFlagRequired("integrationFlowId")
@@ -173,13 +173,13 @@ func integrationArtifactGetMplStatusMetadata() config.StepData {
 						Default:     os.Getenv("PIPER_integrationFlowId"),
 					},
 					{
-						Name:        "platform",
+						Name:        "cpiPlatform",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"GLOBAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_platform"),
+						Default:     `cf`,
 					},
 				},
 			},

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -35,7 +35,7 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 		config := integrationArtifactGetMplStatusOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "flow1",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatus", ResponseBody: ``, TestType: "Positive"}
@@ -68,7 +68,7 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 		config := integrationArtifactGetMplStatusOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "flow1",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatus", ResponseBody: ``, TestType: "Negative"}

--- a/cmd/integrationArtifactGetServiceEndpoint_generated.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_generated.go
@@ -19,7 +19,7 @@ import (
 type integrationArtifactGetServiceEndpointOptions struct {
 	APIServiceKey     string `json:"apiServiceKey,omitempty"`
 	IntegrationFlowID string `json:"integrationFlowId,omitempty"`
-	Platform          string `json:"platform,omitempty"`
+	CpiPlatform       string `json:"cpiPlatform,omitempty"`
 }
 
 type integrationArtifactGetServiceEndpointCommonPipelineEnvironment struct {
@@ -128,7 +128,7 @@ func IntegrationArtifactGetServiceEndpointCommand() *cobra.Command {
 func addIntegrationArtifactGetServiceEndpointFlags(cmd *cobra.Command, stepConfig *integrationArtifactGetServiceEndpointOptions) {
 	cmd.Flags().StringVar(&stepConfig.APIServiceKey, "apiServiceKey", os.Getenv("PIPER_apiServiceKey"), "Service key JSON string to access the Cloud Integration API")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", os.Getenv("PIPER_platform"), "Specifies the running platform of the SAP Cloud platform integraion service")
+	cmd.Flags().StringVar(&stepConfig.CpiPlatform, "cpiPlatform", `cf`, "Specifies the running platform of the SAP Cloud platform integraion service")
 
 	cmd.MarkFlagRequired("apiServiceKey")
 	cmd.MarkFlagRequired("integrationFlowId")
@@ -173,13 +173,13 @@ func integrationArtifactGetServiceEndpointMetadata() config.StepData {
 						Default:     os.Getenv("PIPER_integrationFlowId"),
 					},
 					{
-						Name:        "platform",
+						Name:        "cpiPlatform",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"GLOBAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_platform"),
+						Default:     `cf`,
 					},
 				},
 			},

--- a/cmd/integrationArtifactGetServiceEndpoint_test.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_test.go
@@ -35,7 +35,7 @@ func TestRunIntegrationArtifactGetServiceEndpoint(t *testing.T) {
 		config := integrationArtifactGetServiceEndpointOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetServiceEndpoint", ResponseBody: ``, TestType: "PositiveAndGetetIntegrationArtifactGetServiceResBody"}
@@ -68,7 +68,7 @@ func TestRunIntegrationArtifactGetServiceEndpoint(t *testing.T) {
 		config := integrationArtifactGetServiceEndpointOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetServiceEndpoint", ResponseBody: ``, TestType: "Negative"}

--- a/cmd/integrationArtifactTriggerIntegrationTest_generated.go
+++ b/cmd/integrationArtifactTriggerIntegrationTest_generated.go
@@ -17,7 +17,7 @@ import (
 type integrationArtifactTriggerIntegrationTestOptions struct {
 	IFlowServiceKey         string `json:"iFlowServiceKey,omitempty"`
 	IntegrationFlowID       string `json:"integrationFlowId,omitempty"`
-	Platform                string `json:"platform,omitempty"`
+	CpiPlatform             string `json:"cpiPlatform,omitempty"`
 	IFlowServiceEndpointURL string `json:"iFlowServiceEndpointUrl,omitempty"`
 	ContentType             string `json:"contentType,omitempty"`
 	MessageBodyPath         string `json:"messageBodyPath,omitempty"`
@@ -99,7 +99,7 @@ func IntegrationArtifactTriggerIntegrationTestCommand() *cobra.Command {
 func addIntegrationArtifactTriggerIntegrationTestFlags(cmd *cobra.Command, stepConfig *integrationArtifactTriggerIntegrationTestOptions) {
 	cmd.Flags().StringVar(&stepConfig.IFlowServiceKey, "iFlowServiceKey", os.Getenv("PIPER_iFlowServiceKey"), "User to authenticate to the SAP Cloud Platform Integration Service")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", `cf`, "Specifies the running platform of the SAP Cloud platform integraion service")
+	cmd.Flags().StringVar(&stepConfig.CpiPlatform, "cpiPlatform", `cf`, "Specifies the running platform of the SAP Cloud platform integraion service")
 	cmd.Flags().StringVar(&stepConfig.IFlowServiceEndpointURL, "iFlowServiceEndpointUrl", os.Getenv("PIPER_iFlowServiceEndpointUrl"), "Specifies the URL endpoint of the iFlow. Please provide in the format `<protocol>://<host>:<port>`. Supported protocols are `http` and `https`.")
 	cmd.Flags().StringVar(&stepConfig.ContentType, "contentType", os.Getenv("PIPER_contentType"), "Specifies the content type of the file defined in messageBodyPath e.g. application/json")
 	cmd.Flags().StringVar(&stepConfig.MessageBodyPath, "messageBodyPath", os.Getenv("PIPER_messageBodyPath"), "Speficfies the relative file path to the message body.")
@@ -148,9 +148,9 @@ func integrationArtifactTriggerIntegrationTestMetadata() config.StepData {
 						Default:     os.Getenv("PIPER_integrationFlowId"),
 					},
 					{
-						Name:        "platform",
+						Name:        "cpiPlatform",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"GLOBAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},

--- a/cmd/integrationArtifactTriggerIntegrationTest_test.go
+++ b/cmd/integrationArtifactTriggerIntegrationTest_test.go
@@ -37,7 +37,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 		config := integrationArtifactTriggerIntegrationTestOptions{
 			IFlowServiceKey:   iFlowServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 			MessageBodyPath:   "/file.txt",
 			ContentType:       "",
 		}
@@ -66,7 +66,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 		config := integrationArtifactTriggerIntegrationTestOptions{
 			IFlowServiceKey:   iFlowServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 			MessageBodyPath:   "test.txt",
 			ContentType:       "txt",
 		}
@@ -98,7 +98,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 		config := integrationArtifactTriggerIntegrationTestOptions{
 			IFlowServiceKey:   iFlowServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 			MessageBodyPath:   filepath.Join(dir, "test.txt"),
 			ContentType:       "txt",
 		}
@@ -130,7 +130,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 		config := integrationArtifactTriggerIntegrationTestOptions{
 			IFlowServiceKey:   iFlowServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 			MessageBodyPath:   "",
 			ContentType:       "txt",
 		}
@@ -166,7 +166,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 		config := integrationArtifactTriggerIntegrationTestOptions{
 			IFlowServiceKey:   iFlowServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
+			CpiPlatform:       "cf",
 			MessageBodyPath:   filepath.Join(dir, "test.txt"),
 			ContentType:       "txt",
 		}

--- a/resources/metadata/integrationArtifactDeploy.yaml
+++ b/resources/metadata/integrationArtifactDeploy.yaml
@@ -40,11 +40,16 @@ spec:
           - STAGES
           - STEPS
         mandatory: true
-      - name: platform
+      - name: cpiPlatform
         type: string
         description: Specifies the running platform of the SAP Cloud platform integraion service
         scope:
+          - GLOBAL
           - PARAMETERS
           - STAGES
           - STEPS
         mandatory: false
+        default: cf
+        possibleValues:
+          - cf
+          - neo

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -31,14 +31,19 @@ spec:
           - STAGES
           - STEPS
         mandatory: true
-      - name: platform
+      - name: cpiPlatform
         type: string
         description: Specifies the running platform of the SAP Cloud platform integraion service
         scope:
+          - GLOBAL
           - PARAMETERS
           - STAGES
           - STEPS
         mandatory: false
+        default: cf
+        possibleValues:
+          - cf
+          - neo
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
+++ b/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
@@ -31,14 +31,19 @@ spec:
           - STAGES
           - STEPS
         mandatory: true
-      - name: platform
+      - name: cpiPlatform
         type: string
         description: Specifies the running platform of the SAP Cloud platform integraion service
         scope:
+          - GLOBAL
           - PARAMETERS
           - STAGES
           - STEPS
         mandatory: false
+        default: cf
+        possibleValues:
+          - cf
+          - neo
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/integrationArtifactTriggerIntegrationTest.yaml
+++ b/resources/metadata/integrationArtifactTriggerIntegrationTest.yaml
@@ -31,10 +31,11 @@ spec:
           - STEPS
           - GENERAL
         mandatory: true
-      - name: platform
+      - name: cpiPlatform
         type: string
         description: Specifies the running platform of the SAP Cloud platform integraion service
         scope:
+          - GLOBAL
           - PARAMETERS
           - STAGES
           - STEPS


### PR DESCRIPTION
# Changes

As the platform parameter is used by many CPI steps it should be possible to set them globally.

- [x] Tests
- [x] Documentation
