### PR TITLE
CPI- Remove platform parameter

### DIFF
--- a/cmd/integrationArtifactDeploy_generated.go
+++ b/cmd/integrationArtifactDeploy_generated.go
@@ -18,7 +18,6 @@ type integrationArtifactDeployOptions struct {
 	APIServiceKey          string `json:"apiServiceKey,omitempty"`
 	IntegrationFlowID      string `json:"integrationFlowId,omitempty"`
 	IntegrationFlowVersion string `json:"integrationFlowVersion,omitempty"`
-	Platform               string `json:"platform,omitempty"`
 }
 
 // IntegrationArtifactDeployCommand Deploy a CPI integration flow
@@ -98,7 +97,6 @@ func addIntegrationArtifactDeployFlags(cmd *cobra.Command, stepConfig *integrati
 	cmd.Flags().StringVar(&stepConfig.APIServiceKey, "apiServiceKey", os.Getenv("PIPER_apiServiceKey"), "Service key JSON string to access the Cloud Integration API")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowVersion, "integrationFlowVersion", os.Getenv("PIPER_integrationFlowVersion"), "Specifies the version of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", os.Getenv("PIPER_platform"), "Specifies the running platform of the SAP Cloud platform integraion service")
 
 	cmd.MarkFlagRequired("apiServiceKey")
 	cmd.MarkFlagRequired("integrationFlowId")
@@ -151,15 +149,6 @@ func integrationArtifactDeployMetadata() config.StepData {
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_integrationFlowVersion"),
-					},
-					{
-						Name:        "platform",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_platform"),
 					},
 				},
 			},

--- a/cmd/integrationArtifactDeploy_test.go
+++ b/cmd/integrationArtifactDeploy_test.go
@@ -42,7 +42,6 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "", ResponseBody: ``, TestType: "PositiveAndDeployIntegrationDesigntimeArtifactResBody"}
@@ -76,7 +75,6 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "FailIntegrationDesigntimeArtifactDeployment", ResponseBody: ``, TestType: "Negative"}
@@ -110,7 +108,6 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "", ResponseBody: ``, TestType: "NegativeAndDeployIntegrationDesigntimeArtifactResBody"}
@@ -136,7 +133,6 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "GetIntegrationArtifactDeployStatus", Options: clientOptions, ResponseBody: ``, TestType: "PositiveAndDeployIntegrationDesigntimeArtifactResBody"}
@@ -164,7 +160,6 @@ func TestRunIntegrationArtifactDeploy(t *testing.T) {
 			APIServiceKey:          apiServiceKey,
 			IntegrationFlowID:      "flow1",
 			IntegrationFlowVersion: "1.0.1",
-			Platform:               "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "GetIntegrationArtifactDeployErrorDetails", Options: clientOptions, ResponseBody: ``, TestType: "PositiveAndGetDeployedIntegrationDesigntimeArtifactErrorResBody"}

--- a/cmd/integrationArtifactGetMplStatus_generated.go
+++ b/cmd/integrationArtifactGetMplStatus_generated.go
@@ -19,7 +19,6 @@ import (
 type integrationArtifactGetMplStatusOptions struct {
 	APIServiceKey     string `json:"apiServiceKey,omitempty"`
 	IntegrationFlowID string `json:"integrationFlowId,omitempty"`
-	Platform          string `json:"platform,omitempty"`
 }
 
 type integrationArtifactGetMplStatusCommonPipelineEnvironment struct {
@@ -128,7 +127,6 @@ func IntegrationArtifactGetMplStatusCommand() *cobra.Command {
 func addIntegrationArtifactGetMplStatusFlags(cmd *cobra.Command, stepConfig *integrationArtifactGetMplStatusOptions) {
 	cmd.Flags().StringVar(&stepConfig.APIServiceKey, "apiServiceKey", os.Getenv("PIPER_apiServiceKey"), "Service key JSON string to access the Cloud Integration API")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", os.Getenv("PIPER_platform"), "Specifies the running platform of the SAP Cloud platform integraion service")
 
 	cmd.MarkFlagRequired("apiServiceKey")
 	cmd.MarkFlagRequired("integrationFlowId")
@@ -171,15 +169,6 @@ func integrationArtifactGetMplStatusMetadata() config.StepData {
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_integrationFlowId"),
-					},
-					{
-						Name:        "platform",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_platform"),
 					},
 				},
 			},

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -35,7 +35,6 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 		config := integrationArtifactGetMplStatusOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "flow1",
-			Platform:          "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatus", ResponseBody: ``, TestType: "Positive"}
@@ -68,7 +67,6 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 		config := integrationArtifactGetMplStatusOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "flow1",
-			Platform:          "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatus", ResponseBody: ``, TestType: "Negative"}

--- a/cmd/integrationArtifactGetServiceEndpoint_generated.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_generated.go
@@ -19,7 +19,6 @@ import (
 type integrationArtifactGetServiceEndpointOptions struct {
 	APIServiceKey     string `json:"apiServiceKey,omitempty"`
 	IntegrationFlowID string `json:"integrationFlowId,omitempty"`
-	Platform          string `json:"platform,omitempty"`
 }
 
 type integrationArtifactGetServiceEndpointCommonPipelineEnvironment struct {
@@ -128,7 +127,6 @@ func IntegrationArtifactGetServiceEndpointCommand() *cobra.Command {
 func addIntegrationArtifactGetServiceEndpointFlags(cmd *cobra.Command, stepConfig *integrationArtifactGetServiceEndpointOptions) {
 	cmd.Flags().StringVar(&stepConfig.APIServiceKey, "apiServiceKey", os.Getenv("PIPER_apiServiceKey"), "Service key JSON string to access the Cloud Integration API")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", os.Getenv("PIPER_platform"), "Specifies the running platform of the SAP Cloud platform integraion service")
 
 	cmd.MarkFlagRequired("apiServiceKey")
 	cmd.MarkFlagRequired("integrationFlowId")
@@ -171,15 +169,6 @@ func integrationArtifactGetServiceEndpointMetadata() config.StepData {
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_integrationFlowId"),
-					},
-					{
-						Name:        "platform",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_platform"),
 					},
 				},
 			},

--- a/cmd/integrationArtifactGetServiceEndpoint_test.go
+++ b/cmd/integrationArtifactGetServiceEndpoint_test.go
@@ -35,7 +35,6 @@ func TestRunIntegrationArtifactGetServiceEndpoint(t *testing.T) {
 		config := integrationArtifactGetServiceEndpointOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetServiceEndpoint", ResponseBody: ``, TestType: "PositiveAndGetetIntegrationArtifactGetServiceResBody"}
@@ -68,7 +67,6 @@ func TestRunIntegrationArtifactGetServiceEndpoint(t *testing.T) {
 		config := integrationArtifactGetServiceEndpointOptions{
 			APIServiceKey:     apiServiceKey,
 			IntegrationFlowID: "CPI_IFlow_Call_using_Cert",
-			Platform:          "cf",
 		}
 
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetServiceEndpoint", ResponseBody: ``, TestType: "Negative"}

--- a/cmd/integrationArtifactUpdateConfiguration_generated.go
+++ b/cmd/integrationArtifactUpdateConfiguration_generated.go
@@ -18,7 +18,6 @@ type integrationArtifactUpdateConfigurationOptions struct {
 	APIServiceKey          string `json:"apiServiceKey,omitempty"`
 	IntegrationFlowID      string `json:"integrationFlowId,omitempty"`
 	IntegrationFlowVersion string `json:"integrationFlowVersion,omitempty"`
-	Platform               string `json:"platform,omitempty"`
 	ParameterKey           string `json:"parameterKey,omitempty"`
 	ParameterValue         string `json:"parameterValue,omitempty"`
 }
@@ -100,7 +99,6 @@ func addIntegrationArtifactUpdateConfigurationFlags(cmd *cobra.Command, stepConf
 	cmd.Flags().StringVar(&stepConfig.APIServiceKey, "apiServiceKey", os.Getenv("PIPER_apiServiceKey"), "Service key JSON string to access the Cloud Integration API")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowID, "integrationFlowId", os.Getenv("PIPER_integrationFlowId"), "Specifies the ID of the Integration Flow artifact")
 	cmd.Flags().StringVar(&stepConfig.IntegrationFlowVersion, "integrationFlowVersion", os.Getenv("PIPER_integrationFlowVersion"), "Specifies the version of the Integration Flow artifact")
-	cmd.Flags().StringVar(&stepConfig.Platform, "platform", os.Getenv("PIPER_platform"), "Specifies the running platform of the SAP Cloud platform integraion service")
 	cmd.Flags().StringVar(&stepConfig.ParameterKey, "parameterKey", os.Getenv("PIPER_parameterKey"), "Specifies the externalized parameter name.")
 	cmd.Flags().StringVar(&stepConfig.ParameterValue, "parameterValue", os.Getenv("PIPER_parameterValue"), "Specifies the externalized parameter value.")
 
@@ -157,15 +155,6 @@ func integrationArtifactUpdateConfigurationMetadata() config.StepData {
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_integrationFlowVersion"),
-					},
-					{
-						Name:        "platform",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_platform"),
 					},
 					{
 						Name:        "parameterKey",

--- a/documentation/docs/steps/integrationArtifactDeploy.md
+++ b/documentation/docs/steps/integrationArtifactDeploy.md
@@ -27,5 +27,4 @@ steps:
     cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_NAME'
     integrationFlowVersion: 'MY_INTEGRATION_FLOW_VERSION'
-    platform: cf
 ```

--- a/documentation/docs/steps/integrationArtifactGetServiceEndpoint.md
+++ b/documentation/docs/steps/integrationArtifactGetServiceEndpoint.md
@@ -26,5 +26,4 @@ steps:
   integrationArtifactGetServiceEndpoint:
     cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_ID'
-    platform: cf
 ```

--- a/documentation/docs/steps/integrationArtifactTriggerIntegrationTest.md
+++ b/documentation/docs/steps/integrationArtifactTriggerIntegrationTest.md
@@ -26,5 +26,4 @@ steps:
     integrationFlowId: 'INTEGRATION_FLOW_ID'
     contentType: 'text/plain'
     messageBodyPath: 'myIntegrationsTest/testBody'
-    platform: cf
 ```

--- a/documentation/docs/steps/integrationArtifactUpdateConfiguration.md
+++ b/documentation/docs/steps/integrationArtifactUpdateConfiguration.md
@@ -27,7 +27,6 @@ steps:
     cpiApiServiceKeyCredentialsId: 'MY_API_SERVICE_KEY'
     integrationFlowId: 'MY_INTEGRATION_FLOW_NAME'
     integrationFlowVersion: 'MY_INTEGRATION_FLOW_VERSION'
-    platform: 'cf'
     parameterKey: 'MY_INTEGRATION_FLOW_CONFIG_PARAMETER_NAME'
     parameterValue: 'MY_INTEGRATION_FLOW_CONFIG_PARAMETER_VALUE'
 ```

--- a/resources/metadata/integrationArtifactDeploy.yaml
+++ b/resources/metadata/integrationArtifactDeploy.yaml
@@ -40,11 +40,3 @@ spec:
           - STAGES
           - STEPS
         mandatory: true
-      - name: platform
-        type: string
-        description: Specifies the running platform of the SAP Cloud platform integraion service
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        mandatory: false

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -31,14 +31,6 @@ spec:
           - STAGES
           - STEPS
         mandatory: true
-      - name: platform
-        type: string
-        description: Specifies the running platform of the SAP Cloud platform integraion service
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        mandatory: false
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
+++ b/resources/metadata/integrationArtifactGetServiceEndpoint.yaml
@@ -31,14 +31,6 @@ spec:
           - STAGES
           - STEPS
         mandatory: true
-      - name: platform
-        type: string
-        description: Specifies the running platform of the SAP Cloud platform integraion service
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        mandatory: false
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/integrationArtifactUpdateConfiguration.yaml
+++ b/resources/metadata/integrationArtifactUpdateConfiguration.yaml
@@ -40,14 +40,6 @@ spec:
           - STAGES
           - STEPS
         mandatory: true
-      - name: platform
-        type: string
-        description: Specifies the running platform of the SAP Cloud platform integraion service
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        mandatory: false
       - name: parameterKey
         type: string
         description: Specifies the externalized parameter name.


### PR DESCRIPTION
# Changes
As platform isn't used anywhere in the cpi steps, we should remove it.
It was originally found in 4 of the 6 existing steps: Deploy, GetMPLStatus, GetServiceEndpoint, and UpdateConfig.

- [x] Tests
- [x] Documentation
