### PR TITLE
Fix whitesource issue

### DIFF
--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -540,13 +540,18 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Default:     true,
 					},
 					{
-						Name:        "scanImage",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_scanImage"),
+						Name: "scanImage",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/imageNameTag",
+							},
+						},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_scanImage"),
 					},
 					{
 						Name:        "scanImageIncludeLayers",
@@ -558,13 +563,18 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Default:     true,
 					},
 					{
-						Name:        "scanImageRegistryUrl",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_scanImageRegistryUrl"),
+						Name: "scanImageRegistryUrl",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/registryUrl",
+							},
+						},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_scanImageRegistryUrl"),
 					},
 					{
 						Name:        "securityVulnerabilities",

--- a/resources/metadata/whitesource.yaml
+++ b/resources/metadata/whitesource.yaml
@@ -292,6 +292,9 @@ spec:
       - name: scanImage
         type: string
         description: "For `buildTool: docker`: Defines the docker image which should be scanned."
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/imageNameTag
         scope:
           - PARAMETERS
           - STAGES
@@ -307,6 +310,9 @@ spec:
       - name: scanImageRegistryUrl
         type: string
         description: "For `buildTool: docker`: Defines the registry where the scanImage is located."
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/registryUrl
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
# Changes
This pull request fixes an issue when executing whiteSource steps after xmake. This way whitesource step will read the image and registry from `commonPipelineEnvironment`. Using the same params as protecode scan 
- [ ] Tests
- [ ] Documentation
