### PR TITLE
checksPublishResults: prepare reports only if the reporting is active

### DIFF
--- a/test/groovy/ChecksPublishResultsTest.groovy
+++ b/test/groovy/ChecksPublishResultsTest.groovy
@@ -20,8 +20,6 @@ import static org.hamcrest.Matchers.hasSize
 import static org.hamcrest.Matchers.hasEntry
 import static org.junit.Assert.assertThat
 
-import org.hamcrest.Matchers
-
 import util.Rules
 import util.JenkinsReadYamlRule
 import util.JenkinsStepRule

--- a/test/groovy/ChecksPublishResultsTest.groovy
+++ b/test/groovy/ChecksPublishResultsTest.groovy
@@ -11,6 +11,7 @@ import util.BasePiperTest
 
 import static org.hamcrest.Matchers.hasItem
 import static org.hamcrest.Matchers.containsInAnyOrder
+import static org.hamcrest.Matchers.empty
 import static org.hamcrest.Matchers.not
 import static org.hamcrest.Matchers.allOf
 import static org.hamcrest.Matchers.is
@@ -18,6 +19,8 @@ import static org.hamcrest.Matchers.hasKey
 import static org.hamcrest.Matchers.hasSize
 import static org.hamcrest.Matchers.hasEntry
 import static org.junit.Assert.assertThat
+
+import org.hamcrest.Matchers
 
 import util.Rules
 import util.JenkinsReadYamlRule
@@ -27,6 +30,7 @@ import util.JenkinsStepRule
 class ChecksPublishResultsTest extends BasePiperTest {
     Map publisherStepOptions
     List archiveStepPatterns
+    List invokedReportingTools
 
     private JenkinsStepRule stepRule = new JenkinsStepRule(this)
 
@@ -40,30 +44,49 @@ class ChecksPublishResultsTest extends BasePiperTest {
     void init() {
         publisherStepOptions = [:]
         archiveStepPatterns = []
+        invokedReportingTools = []
+
         // add handler for generic step call
         helper.registerAllowedMethod("recordIssues", [Map.class], {
-            parameters -> publisherStepOptions[parameters.tools[0].publisher] = parameters
+            parameters ->
+            if(parameters.tools[0] in Map && parameters.tools[0].containsKey('publisher')) {
+              publisherStepOptions[parameters.tools[0].publisher] = parameters;
+            }
         })
         helper.registerAllowedMethod("pmdParser", [Map.class], {
-            parameters -> return parameters.plus([publisher: "PmdPublisher"])
+            parameters ->
+                invokedReportingTools << "pmdParser";
+                return parameters.plus([publisher: "PmdPublisher"])
         })
         helper.registerAllowedMethod("cpd", [Map.class], {
-            parameters -> return parameters.plus([publisher: "DryPublisher"])
+            parameters ->
+                invokedReportingTools << "cpd";
+                return parameters.plus([publisher: "DryPublisher"])
         })
         helper.registerAllowedMethod("findBugs", [Map.class], {
-            parameters -> return parameters.plus([publisher: "FindBugsPublisher"])
+            parameters ->
+                invokedReportingTools << "findBugs";
+                return parameters.plus([publisher: "FindBugsPublisher"])
         })
         helper.registerAllowedMethod("checkStyle", [Map.class], {
-            parameters -> return parameters.plus([publisher: "CheckStylePublisher"])
+            parameters ->
+                invokedReportingTools << "checkStyle";
+                return parameters.plus([publisher: "CheckStylePublisher"])
         })
         helper.registerAllowedMethod("esLint", [Map.class], {
-            parameters -> return parameters.plus([publisher: "ESLintPublisher"])
+            parameters ->
+                invokedReportingTools << "esLint";
+                return parameters.plus([publisher: "ESLintPublisher"])
         })
         helper.registerAllowedMethod("pyLint", [Map.class], {
-            parameters -> return parameters.plus([publisher: "PyLintPublisher"])
+            parameters ->
+                invokedReportingTools << "pyLint";
+                return parameters.plus([publisher: "PyLintPublisher"])
         })
         helper.registerAllowedMethod("taskScanner", [Map.class], {
-            parameters -> return parameters.plus([publisher: "TaskPublisher"])
+            parameters ->
+                invokedReportingTools << "taskScanner";
+                return parameters.plus([publisher: "TaskPublisher"])
         })
         helper.registerAllowedMethod("archiveArtifacts", [Map.class], {
             parameters -> archiveStepPatterns.push(parameters.artifacts)
@@ -89,6 +112,8 @@ class ChecksPublishResultsTest extends BasePiperTest {
         assertThat(publisherStepOptions, not(hasKey('ESLintPublisher')))
         assertThat(publisherStepOptions, not(hasKey('PyLintPublisher')))
         assertThat(publisherStepOptions, not(hasKey('TaskPublisher')))
+
+        assertThat(invokedReportingTools, is(empty()))
     }
 
     @Test
@@ -306,7 +331,7 @@ class ChecksPublishResultsTest extends BasePiperTest {
     @Test
     void testPublishWithCustomThresholds() throws Exception {
         // test
-        stepRule.step.checksPublishResults(script: nullScript, pmd: [qualityGates: [[threshold: 20, type: 'TOTAL_LOW', unstable: false],[threshold: 10, type: 'TOTAL_NORMAL', unstable: false]]])
+        stepRule.step.checksPublishResults(script: nullScript, pmd: [active: true, qualityGates: [[threshold: 20, type: 'TOTAL_LOW', unstable: false],[threshold: 10, type: 'TOTAL_NORMAL', unstable: false]]])
         // assert
         assertThat(publisherStepOptions, hasKey('PmdPublisher'))
         assertThat(publisherStepOptions['PmdPublisher'], hasKey('qualityGates'))

--- a/vars/checksPublishResults.groovy
+++ b/vars/checksPublishResults.groovy
@@ -100,22 +100,35 @@ void call(Map parameters = [:]) {
         ], configuration)
 
         // JAVA
-        report(pmdParser(createToolOptions(configuration.pmd)), configuration.pmd, configuration.archive)
-        report(cpd(createToolOptions(configuration.cpd)), configuration.cpd, configuration.archive)
-        report(findBugs(createToolOptions(configuration.findbugs, [useRankAsPriority: true])), configuration.findbugs, configuration.archive)
-        report(checkStyle(createToolOptions(configuration.checkstyle)), configuration.checkstyle, configuration.archive)
+        if(configuration.pmd.active) {
+          report(pmdParser(createToolOptions(configuration.pmd)), configuration.pmd, configuration.archive)
+        }
+        if(configuration.cpd.active) {
+          report(cpd(createToolOptions(configuration.cpd)), configuration.cpd, configuration.archive)
+        }
+        if(configuration.findbugs.active) {
+          report(findBugs(createToolOptions(configuration.findbugs, [useRankAsPriority: true])), configuration.findbugs, configuration.archive)
+        }
+        if(configuration.checkstyle.active) {
+          report(checkStyle(createToolOptions(configuration.checkstyle)), configuration.checkstyle, configuration.archive)
+        }
         // JAVA SCRIPT
-        report(esLint(createToolOptions(configuration.eslint)), configuration.eslint, configuration.archive)
+        if(configuration.eslint.active) {
+          report(esLint(createToolOptions(configuration.eslint)), configuration.eslint, configuration.archive)
+        }
         // PYTHON
-        report(pyLint(createToolOptions(configuration.pylint)), configuration.pylint, configuration.archive)
+        if(configuration.pylint.active) {
+          report(pyLint(createToolOptions(configuration.pylint)), configuration.pylint, configuration.archive)
+        }
         // GENERAL
-        report(taskScanner(createToolOptions(configuration.tasks, [
-            includePattern: configuration.tasks.get('pattern'),
-            highTags: configuration.tasks.get('high'),
-            normalTags: configuration.tasks.get('normal'),
-            lowTags: configuration.tasks.get('low'),
-        ]).minus([pattern: configuration.tasks.get('pattern')])), configuration.tasks, configuration.archive)
-
+        if(configuration.tasks.active) {
+          report(taskScanner(createToolOptions(configuration.tasks, [
+              includePattern: configuration.tasks.get('pattern'),
+              highTags: configuration.tasks.get('high'),
+              normalTags: configuration.tasks.get('normal'),
+              lowTags: configuration.tasks.get('low'),
+          ]).minus([pattern: configuration.tasks.get('pattern')])), configuration.tasks, configuration.archive)
+        }
         if (configuration.failOnError && 'FAILURE' == script.currentBuild?.result){
             script.currentBuild.result = 'FAILURE'
             error "[${STEP_NAME}] Some checks failed!"
@@ -124,14 +137,12 @@ void call(Map parameters = [:]) {
 }
 
 def report(tool, settings, doArchive){
-    if (settings.active) {
-        def options = createOptions(settings).plus([tools: [tool]])
-        echo "recordIssues OPTIONS: ${options}"
-        // publish
-        recordIssues(options)
-        // archive check results
-        archiveResults(doArchive && settings.get('archive'), settings.get('pattern'), true)
-    }
+    def options = createOptions(settings).plus([tools: [tool]])
+    echo "recordIssues OPTIONS: ${options}"
+    // publish
+    recordIssues(options)
+    // archive check results
+    archiveResults(doArchive && settings.get('archive'), settings.get('pattern'), true)
 }
 
 def archiveResults(archive, pattern, allowEmpty){


### PR DESCRIPTION
This change attempts to fix #2881

`findbugs` plugin and some other related plugins has been [removed](https://issues.jenkins.io/browse/INFRA-2487) from the updated center.  After purging a Jenkins instance these plugins cannot be installed anymore in an automated way. Nevertheless these plugins are still referenced by our shared lib.

It is still possible to manually install these plugins from the [archive](https://archives.jenkins-ci.org/plugins/), but installing plugins manually is clearly not a sustainable approach.

The approach here is to avoid calling the reporting tools (`findBugs`, `eslint`, ...) in case the corresponding tool in not activated. 

Up to now we had a two step approach. In a first step the reporting tool was called anyway (e.g. `findBugs()`, `esLint()`, ...). Later in the code flow `recordIssues` has been called, but only in case the reporting tool is active in the configuration.

Now we first check if the reporting tool is active. If not, we even don't call the reporting tool at all.

@CCFenner : since you has been involved in this step in the past, could you share your opinion please: is it valid not to call e.g. `findBugs()`, `esLint()`, ...) in case the reporting tool is not active? Was there a specific reason for having that call even if the reporting tool was not active in the configuration?