### PR TITLE
GetIntegrationArtifactMPLError function

### DIFF
--- a/cmd/integrationArtifactGetMplStatus.go
+++ b/cmd/integrationArtifactGetMplStatus.go
@@ -110,7 +110,7 @@ func runIntegrationArtifactGetMplStatus(
 			mplStatus := jsonResponse.Path("d.results.0.Status").Data().(string)
 			commonPipelineEnvironment.custom.iFlowMplStatus = mplStatus
 
-			//if error, then return immediately with error details
+			//if error, then return immediately with the error details
 			if mplStatus == "FAILED" {
 				mplID := jsonResponse.Path("d.results.0.MessageGuid").Data().(string)
 				resp, err := getIntegrationArtifactMPLError(commonPipelineEnvironment, mplID, httpClient, serviceKey.OAuth.Host)

--- a/cmd/integrationArtifactGetMplStatus.go
+++ b/cmd/integrationArtifactGetMplStatus.go
@@ -133,11 +133,11 @@ func runIntegrationArtifactGetMplStatus(
 }
 
 //getIntegrationArtifactMPLError - Get integration artifact MPL error details
-func getIntegrationArtifactMPLError(commonPipelineEnvironment *integrationArtifactGetMplStatusCommonPipelineEnvironment, mplId string, httpClient piperhttp.Sender, apiHost string) (string, error) {
+func getIntegrationArtifactMPLError(commonPipelineEnvironment *integrationArtifactGetMplStatusCommonPipelineEnvironment, mplID string, httpClient piperhttp.Sender, apiHost string) (string, error) {
 	httpMethod := "GET"
 	header := make(http.Header)
 	header.Add("content-type", "application/json")
-	errorStatusURL := fmt.Sprintf("%s/api/v1/MessageProcessingLogs('%s')/ErrorInformation/$value", apiHost, mplId)
+	errorStatusURL := fmt.Sprintf("%s/api/v1/MessageProcessingLogs('%s')/ErrorInformation/$value", apiHost, mplID)
 	errorStatusResp, httpErr := httpClient.SendRequest(httpMethod, errorStatusURL, nil, header, nil)
 
 	if errorStatusResp != nil && errorStatusResp.Body != nil {
@@ -150,7 +150,7 @@ func getIntegrationArtifactMPLError(commonPipelineEnvironment *integrationArtifa
 
 	if errorStatusResp.StatusCode == http.StatusOK {
 		log.Entry().
-			WithField("MPLID", mplId).
+			WithField("MPLID", mplID).
 			Info("Successfully retrieved Integration Flow artefact message processing error")
 		responseBody, readErr := ioutil.ReadAll(errorStatusResp.Body)
 		if readErr != nil {

--- a/cmd/integrationArtifactGetMplStatus.go
+++ b/cmd/integrationArtifactGetMplStatus.go
@@ -110,7 +110,7 @@ func runIntegrationArtifactGetMplStatus(
 			mplStatus := jsonResponse.Path("d.results.0.Status").Data().(string)
 			commonPipelineEnvironment.custom.iFlowMplStatus = mplStatus
 
-			//if error return immediately with error details
+			//if error, then return immediately with error details
 			if mplStatus == "FAILED" {
 				mplID := jsonResponse.Path("d.results.0.MessageGuid").Data().(string)
 				resp, err := getIntegrationArtifactMPLError(commonPipelineEnvironment, mplID, httpClient, serviceKey.OAuth.Host)

--- a/cmd/integrationArtifactGetMplStatus.go
+++ b/cmd/integrationArtifactGetMplStatus.go
@@ -106,8 +106,20 @@ func runIntegrationArtifactGetMplStatus(
 		if parsingErr != nil {
 			return errors.Wrapf(parsingErr, "HTTP response body could not be parsed as JSON: %v", string(bodyText))
 		}
-		mplStatus := jsonResponse.Path("d.results.0.Status").Data().(string)
-		commonPipelineEnvironment.custom.iFlowMplStatus = mplStatus
+		if jsonResponse.Exists("d", "results", "0") {
+			mplStatus := jsonResponse.Path("d.results.0.Status").Data().(string)
+			commonPipelineEnvironment.custom.iFlowMplStatus = mplStatus
+
+			mplId := jsonResponse.Path("d.results.0.MessageGuid").Data().(string)
+			//if error return immediately with error details
+			if mplStatus == "FAILED" {
+				resp, err := getIntegrationArtifactMPLError(commonPipelineEnvironment, mplId, httpClient, serviceKey.OAuth.Host)
+				if err != nil {
+					return err
+				}
+				return errors.New(resp)
+			}
+		}
 		return nil
 	}
 	responseBody, readErr := ioutil.ReadAll(mplStatusResp.Body)
@@ -118,4 +130,38 @@ func runIntegrationArtifactGetMplStatus(
 
 	log.Entry().Errorf("a HTTP error occurred! Response body: %v, Response status code: %v", responseBody, mplStatusResp.StatusCode)
 	return errors.Errorf("Unable to get integration flow MPL status, Response Status code: %v", mplStatusResp.StatusCode)
+}
+
+//getIntegrationArtifactMPLError - Get integration artifact MPL error details
+func getIntegrationArtifactMPLError(commonPipelineEnvironment *integrationArtifactGetMplStatusCommonPipelineEnvironment, mplId string, httpClient piperhttp.Sender, apiHost string) (string, error) {
+	httpMethod := "GET"
+	header := make(http.Header)
+	header.Add("content-type", "application/json")
+	errorStatusURL := fmt.Sprintf("%s/api/v1/MessageProcessingLogs('%s')/ErrorInformation/$value", apiHost, mplId)
+	errorStatusResp, httpErr := httpClient.SendRequest(httpMethod, errorStatusURL, nil, header, nil)
+
+	if errorStatusResp != nil && errorStatusResp.Body != nil {
+		defer errorStatusResp.Body.Close()
+	}
+
+	if errorStatusResp == nil {
+		return "", errors.Errorf("did not retrieve a HTTP response: %v", httpErr)
+	}
+
+	if errorStatusResp.StatusCode == http.StatusOK {
+		log.Entry().
+			WithField("MPLID", mplId).
+			Info("Successfully retrieved Integration Flow artefact message processing error")
+		responseBody, readErr := ioutil.ReadAll(errorStatusResp.Body)
+		if readErr != nil {
+			return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", errorStatusResp.StatusCode)
+		}
+		mplErrorDetails := string(responseBody)
+		commonPipelineEnvironment.custom.iFlowMplError = mplErrorDetails
+		return mplErrorDetails, nil
+	}
+	if httpErr != nil {
+		return getHTTPErrorMessage(httpErr, errorStatusResp, httpMethod, errorStatusURL)
+	}
+	return "", errors.Errorf("failed to get Integration Flow artefact message processing error, response Status code: %v", errorStatusResp.StatusCode)
 }

--- a/cmd/integrationArtifactGetMplStatus.go
+++ b/cmd/integrationArtifactGetMplStatus.go
@@ -110,10 +110,10 @@ func runIntegrationArtifactGetMplStatus(
 			mplStatus := jsonResponse.Path("d.results.0.Status").Data().(string)
 			commonPipelineEnvironment.custom.iFlowMplStatus = mplStatus
 
-			mplId := jsonResponse.Path("d.results.0.MessageGuid").Data().(string)
 			//if error return immediately with error details
 			if mplStatus == "FAILED" {
-				resp, err := getIntegrationArtifactMPLError(commonPipelineEnvironment, mplId, httpClient, serviceKey.OAuth.Host)
+				mplID := jsonResponse.Path("d.results.0.MessageGuid").Data().(string)
+				resp, err := getIntegrationArtifactMPLError(commonPipelineEnvironment, mplID, httpClient, serviceKey.OAuth.Host)
 				if err != nil {
 					return err
 				}

--- a/cmd/integrationArtifactGetMplStatus_generated.go
+++ b/cmd/integrationArtifactGetMplStatus_generated.go
@@ -24,6 +24,7 @@ type integrationArtifactGetMplStatusOptions struct {
 type integrationArtifactGetMplStatusCommonPipelineEnvironment struct {
 	custom struct {
 		iFlowMplStatus string
+		iFlowMplError  string
 	}
 }
 
@@ -34,6 +35,7 @@ func (p *integrationArtifactGetMplStatusCommonPipelineEnvironment) persist(path,
 		value    interface{}
 	}{
 		{category: "custom", name: "iFlowMplStatus", value: p.custom.iFlowMplStatus},
+		{category: "custom", name: "iFlowMplError", value: p.custom.iFlowMplError},
 	}
 
 	errCount := 0
@@ -181,6 +183,7 @@ func integrationArtifactGetMplStatusMetadata() config.StepData {
 						Type: "piperEnvironment",
 						Parameters: []map[string]interface{}{
 							{"Name": "custom/iFlowMplStatus"},
+							{"Name": "custom/iFlowMplError"},
 						},
 					},
 				},

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -83,7 +83,7 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 	t.Run(" Integration flow message processing get Error message test", func(t *testing.T) {
 		clientOptions := piperhttp.ClientOptions{}
 		clientOptions.Token = fmt.Sprintf("Bearer %s", "Demo")
-		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatusError",Options: clientOptions, ResponseBody: ``, TestType: "Negative"}
+		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatusError", Options: clientOptions, ResponseBody: ``, TestType: "Negative"}
 		seOut := integrationArtifactGetMplStatusCommonPipelineEnvironment{}
 		message, err := getIntegrationArtifactMPLError(&seOut, "1000111", &httpClient, "demo")
 		assert.NoError(t, err)

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"testing"
-	
+
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"testing"
 	"fmt"
+	"testing"
+	
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -81,11 +81,9 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 	})
 
 	t.Run(" Integration flow message processing get Error message test", func(t *testing.T) {
-		
 		clientOptions := piperhttp.ClientOptions{}
 		clientOptions.Token = fmt.Sprintf("Bearer %s", "Demo")
 		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatusError",Options: clientOptions, ResponseBody: ``, TestType: "Negative"}
-
 		seOut := integrationArtifactGetMplStatusCommonPipelineEnvironment{}
 		message, err := getIntegrationArtifactMPLError(&seOut, "1000111", &httpClient, "demo")
 		assert.NoError(t, err)
@@ -94,4 +92,3 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 	})
 
 }
-

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -2,7 +2,8 @@ package cmd
 
 import (
 	"testing"
-
+	"fmt"
+	 piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"
 )
@@ -78,4 +79,19 @@ func TestRunIntegrationArtifactGetMplStatus(t *testing.T) {
 			"Id+eq+'flow1'+and+Status+ne+'DISCARDED'&$orderby=LogEnd+desc&$top=1 failed with error: "+
 			"Unable to get integration flow MPL status, Response Status code:400")
 	})
+
+	t.Run(" Integration flow message processing get Error message test", func(t *testing.T) {
+		
+		clientOptions := piperhttp.ClientOptions{}
+		clientOptions.Token = fmt.Sprintf("Bearer %s", "Demo")
+		httpClient := httpMockCpis{CPIFunction: "IntegrationArtifactGetMplStatusError",Options: clientOptions, ResponseBody: ``, TestType: "Negative"}
+
+		seOut := integrationArtifactGetMplStatusCommonPipelineEnvironment{}
+		message, err := getIntegrationArtifactMPLError(&seOut, "1000111", &httpClient, "demo")
+		assert.NoError(t, err)
+		assert.NotNil(t, message)
+		assert.EqualValues(t, seOut.custom.iFlowMplError, "{\"message\": \"java.lang.IllegalStateException: No credentials for 'smtp' found\"}")
+	})
+
 }
+

--- a/cmd/integrationArtifactGetMplStatus_test.go
+++ b/cmd/integrationArtifactGetMplStatus_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"testing"
 	"fmt"
-	 piperhttp "github.com/SAP/jenkins-library/pkg/http"
+	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/cpi/mockingUtils.go
+++ b/pkg/cpi/mockingUtils.go
@@ -50,6 +50,8 @@ func GetCPIFunctionMockResponse(functionName, testType string) (*http.Response, 
 		return GetIntegrationArtifactDeployErrorDetailsMockResponse(testType)
 	case "TriggerIntegrationTest":
 		return TriggerIntegrationTestMockResponse(testType)
+	case "IntegrationArtifactGetMplStatusError":
+		return GetIntegrationArtifactDeployErrorStatusMockResponseBody()
 	default:
 		res := http.Response{
 			StatusCode: 404,

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -38,4 +38,3 @@ spec:
         params:
           - name: custom/iFlowMplStatus
           - name: custom/iFlowMplError
-

--- a/resources/metadata/integrationArtifactGetMplStatus.yaml
+++ b/resources/metadata/integrationArtifactGetMplStatus.yaml
@@ -37,3 +37,5 @@ spec:
         type: piperEnvironment
         params:
           - name: custom/iFlowMplStatus
+          - name: custom/iFlowMplError
+


### PR DESCRIPTION
# Changes
Adding GetIntegrationArtifactMPLError function to return error if message processing fails. error will be captured in CommonPipelineEnvironment varibale i.e. iFlowMplError
- [ ] Tests
- [ ] Documentation
