### PR TITLE
Improve determining PR key in Azure DevOps provider

### DIFF
--- a/pkg/orchestrator/azureDevOps.go
+++ b/pkg/orchestrator/azureDevOps.go
@@ -25,10 +25,20 @@ func (a *AzureDevOpsConfigProvider) GetRepoUrl() string {
 }
 
 func (a *AzureDevOpsConfigProvider) GetPullRequestConfig() PullRequestConfig {
+	prKey := os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
+
+	// This variable is populated for pull requests which have a different pull request ID and pull request number.
+	// In this case the pull request ID will contain an internal numeric ID and the pull request number will be provided
+	// as part of the 'SYSTEM_PULLREQUEST_PULLREQUESTNUMBER' environment variable.
+	prNumber, prNumberEnvVarSet := os.LookupEnv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
+	if prNumberEnvVarSet == true {
+		prKey = prNumber
+	}
+
 	return PullRequestConfig{
 		Branch: os.Getenv("SYSTEM_PULLREQUEST_SOURCEBRANCH"),
 		Base:   os.Getenv("SYSTEM_PULLREQUEST_TARGETBRANCH"),
-		Key:    os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID"),
+		Key:    prKey,
 	}
 }
 

--- a/pkg/orchestrator/azureDevOps_test.go
+++ b/pkg/orchestrator/azureDevOps_test.go
@@ -45,6 +45,24 @@ func TestAzure(t *testing.T) {
 		assert.Equal(t, "42", c.Key)
 	})
 
+	t.Run("PR - Branch Policy", func(t *testing.T) {
+		defer resetEnv(os.Environ())
+		os.Clearenv()
+		os.Setenv("SYSTEM_PULLREQUEST_SOURCEBRANCH", "feat/test-azure")
+		os.Setenv("SYSTEM_PULLREQUEST_TARGETBRANCH", "main")
+		os.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "123456789")
+		os.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER", "42")
+		os.Setenv("BUILD_REASON", "PullRequest")
+
+		p := AzureDevOpsConfigProvider{}
+		c := p.GetPullRequestConfig()
+
+		assert.True(t, p.IsPullRequest())
+		assert.Equal(t, "feat/test-azure", c.Branch)
+		assert.Equal(t, "main", c.Base)
+		assert.Equal(t, "42", c.Key)
+	})
+
 	t.Run("Azure DevOps - false", func(t *testing.T) {
 		defer resetEnv(os.Environ())
 		os.Clearenv()


### PR DESCRIPTION
# Changes

This pull request introduces changes which aim to improve determining the PR key from the environment if the provider is an Azure DevOps pipeline.

The existing implementation used the `SYSTEM_PULLREQUEST_PULLREQUESTID` environment variable as the PR key in the pull request configuration. Yet there are cases where this environment variable doesn't contain the pull request number but an internal ID. In these scenarios the environment variable `SYSTEM_PULLREQUEST_PULLREQUESTNUMBER` will be set and contain the number of the pull request ( see `System.PullRequest.PullRequestNumber` in [Azure Pipeline variable reference](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)).

Some tools for which the piper library provides predefined steps (e.g. SonarQube) rely on the PR key being the number of the pull request and not an internal id. We for example observed problems with the SonarQube GitHub pull request decorator to not work if the pull request key used in the sonar scanner CLI call by the `sonarExecuteScan` step is an internal ID and not the pull request number.

- [x] Tests
- [ ] Documentation