### PR TITLE
fix(kubernetesDeploy): created secret type incorrectly set because of double quotes

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -302,7 +302,7 @@ func defineKubeSecretParams(config kubernetesDeployOptions, containerRegistry st
 			"generic",
 			config.ContainerRegistrySecret,
 			fmt.Sprintf("--from-file=.dockerconfigjson=%v", config.DockerConfigJSON),
-			"--type=\"kubernetes.io/dockerconfigjson\"",
+			"--type=kubernetes.io/dockerconfigjson",
 		)
 	}
 	return append(

--- a/cmd/kubernetesDeploy_test.go
+++ b/cmd/kubernetesDeploy_test.go
@@ -93,7 +93,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		k8sSecretSpec := `{"kind": "Secret","data":{".dockerconfigjson": "ThisIsOurBase64EncodedSecret=="}}`
 		e := mock.ExecMockRunner{
 			StdoutReturn: map[string]string{
-				`kubectl create secret --insecure-skip-tls-verify=true --dry-run=true --output=json generic testSecret --from-file=.dockerconfigjson=/path/to/.docker/config.json --type="kubernetes.io/dockerconfigjson"`: k8sSecretSpec,
+				`kubectl create secret --insecure-skip-tls-verify=true --dry-run=true --output=json generic testSecret --from-file=.dockerconfigjson=/path/to/.docker/config.json --type=kubernetes.io/dockerconfigjson`: k8sSecretSpec,
 			},
 		}
 
@@ -115,7 +115,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			"generic",
 			"testSecret",
 			"--from-file=.dockerconfigjson=/path/to/.docker/config.json",
-			`--type="kubernetes.io/dockerconfigjson"`,
+			`--type=kubernetes.io/dockerconfigjson`,
 		}, e.Calls[1].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", e.Calls[2].Exec, "Wrong upgrade command")
@@ -569,7 +569,7 @@ spec:
 			"generic",
 			opts.ContainerRegistrySecret,
 			fmt.Sprintf("--from-file=.dockerconfigjson=%v", opts.DockerConfigJSON),
-			`--type="kubernetes.io/dockerconfigjson"`,
+			`--type=kubernetes.io/dockerconfigjson`,
 		}, e.Calls[1].Params, "kubectl parameters incorrect")
 	})
 


### PR DESCRIPTION
A docker registry created with Piper ended up not being recognized as of type **kubernetes.io/dockerconfigjson** because of double quotes placed and escaped in the program code. Command runs fine in a terminal without double quotes. This should allow secrets created by Piper to correctly access private Docker Repositories

Difference can easily be seen in the following screenshot:

<img width="1412" alt="Screenshot 2021-07-26 at 16 36 16" src="https://user-images.githubusercontent.com/86716549/127008225-cf1a7b12-19fb-46c7-8f3c-9fae80c91c91.png">


# Changes

- [ ] Tests
- [ ] Documentation
