### PR TITLE
Make packageId optional

### DIFF
--- a/cmd/integrationArtifactUpload_generated.go
+++ b/cmd/integrationArtifactUpload_generated.go
@@ -107,7 +107,6 @@ func addIntegrationArtifactUploadFlags(cmd *cobra.Command, stepConfig *integrati
 	cmd.MarkFlagRequired("apiServiceKey")
 	cmd.MarkFlagRequired("integrationFlowId")
 	cmd.MarkFlagRequired("integrationFlowName")
-	cmd.MarkFlagRequired("packageId")
 	cmd.MarkFlagRequired("filePath")
 }
 
@@ -163,7 +162,7 @@ func integrationArtifactUploadMetadata() config.StepData {
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
-						Mandatory:   true,
+						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_packageId"),
 					},

--- a/resources/metadata/integrationArtifactUpload.yaml
+++ b/resources/metadata/integrationArtifactUpload.yaml
@@ -46,7 +46,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        mandatory: true
+        mandatory: false
       - name: filePath
         type: string
         description: Specifies integration artifact relative file path.


### PR DESCRIPTION
The `packageId` parameter is only mandatory when creating on upload. In case of an update to an existing artifact it is not necessary.

# Changes

- [ ] Tests
- [ ] Documentation
