### PR TITLE
fix(dockerOptions) properly pass empty values

### DIFF
--- a/cmd/containerExecuteStructureTests_generated.go
+++ b/cmd/containerExecuteStructureTests_generated.go
@@ -170,7 +170,7 @@ func containerExecuteStructureTestsMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "ppiper/container-structure-test", Options: []config.Option{{Name: "-u", Value: "0"}, {Name: "--entrypoint", Value: "''"}}},
+				{Image: "ppiper/container-structure-test", Options: []config.Option{{Name: "-u", Value: "0"}, {Name: "--entrypoint", Value: ""}}},
 			},
 		},
 	}

--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -283,7 +283,7 @@ func kanikoExecuteMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "gcr.io/kaniko-project/executor:v1.3.0-debug", Options: []config.Option{{Name: "-u", Value: "0"}, {Name: "--entrypoint", Value: "''"}}},
+				{Image: "gcr.io/kaniko-project/executor:v1.3.0-debug", Options: []config.Option{{Name: "-u", Value: "0"}, {Name: "--entrypoint", Value: ""}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -434,7 +434,12 @@ func EnvVarsAsMap(envVars []EnvVar) map[string]string {
 func OptionsAsStringSlice(options []Option) []string {
 	e := []string{}
 	for _, v := range options {
-		e = append(e, fmt.Sprintf("%v %v", v.Name, v.Value))
+		if len(v.Value) != 0 {
+			e = append(e, fmt.Sprintf("%v %v", v.Name, v.Value))
+		} else {
+			e = append(e, fmt.Sprintf("%v=''", v.Name))
+		}
+
 	}
 	return e
 }

--- a/pkg/config/stepmeta_test.go
+++ b/pkg/config/stepmeta_test.go
@@ -538,6 +538,28 @@ func TestGetContextDefaults(t *testing.T) {
 		assert.Equal(t, nil, d.Defaults[0].Steps["testStep"]["sidecarPullImage"], "sidecarPullImage default not available")
 	})
 
+	t.Run("Empty docker parameter values", func(t *testing.T) {
+		metadata := StepData{
+			Spec: StepSpec{
+				Containers: []Container{
+					{
+						Image:   "testImage1:tag",
+						Options: []Option{{Name: "entrypoint", Value: ""}},
+					},
+				},
+			},
+		}
+
+		cd, err := metadata.GetContextDefaults("testStep")
+
+		assert.NoError(t, err)
+
+		var d PipelineDefaults
+		d.ReadPipelineDefaults([]io.ReadCloser{cd})
+
+		assert.Equal(t, []interface{}{"entrypoint=''"}, d.Defaults[0].Steps["testStep"]["dockerOptions"])
+	})
+
 	t.Run("Negative case", func(t *testing.T) {
 		metadataErr := []StepData{
 			{},
@@ -698,6 +720,22 @@ func TestAvoidEmptyFields(t *testing.T) {
 		putMapIfNotEmpty(m, "key", value)
 		assert.Equal(t, value, m["key"])
 	})
+}
+
+func TestOptionsAsStringSlice(t *testing.T) {
+	tt := []struct {
+		options  []Option
+		expected []string
+	}{
+		{options: []Option{}, expected: []string{}},
+		{options: []Option{{Name: "name1", Value: "value1"}}, expected: []string{"name1 value1"}},
+		{options: []Option{{Name: "name1", Value: "value1"}, {Name: "name2", Value: "value2"}}, expected: []string{"name1 value1", "name2 value2"}},
+		{options: []Option{{Name: "empty", Value: ""}}, expected: []string{"empty=''"}},
+	}
+
+	for _, test := range tt {
+		assert.Equal(t, test.expected, OptionsAsStringSlice(test.options))
+	}
 }
 
 func defaultParams(params ...string) []string {

--- a/resources/metadata/containerExecuteStructureTests.yaml
+++ b/resources/metadata/containerExecuteStructureTests.yaml
@@ -57,4 +57,4 @@ spec:
         - name: -u
           value: "0"
         - name: --entrypoint
-          value: "''"
+          value: ''

--- a/resources/metadata/kaniko.yaml
+++ b/resources/metadata/kaniko.yaml
@@ -129,4 +129,4 @@ spec:
         - name: -u
           value: "0"
         - name: --entrypoint
-          value: "''"
+          value: ''


### PR DESCRIPTION
# Changes

it is possible to overwrite the entrypoint for docker execution:
https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime

This is ideally done by passing `entrypoint=''` and not pass two options to the call.
This also helps with escaping issues of the empty value on other systems.

- [x] Tests
- [x] Documentation
