### PR TITLE
fix(dockerOptions) allow proper usage of empty values

### DIFF
--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -437,7 +437,7 @@ func OptionsAsStringSlice(options []Option) []string {
 		if len(v.Value) != 0 {
 			e = append(e, fmt.Sprintf("%v %v", v.Name, v.Value))
 		} else {
-			e = append(e, fmt.Sprintf("%v=''", v.Name))
+			e = append(e, fmt.Sprintf("%v=", v.Name))
 		}
 
 	}

--- a/pkg/config/stepmeta_test.go
+++ b/pkg/config/stepmeta_test.go
@@ -557,7 +557,7 @@ func TestGetContextDefaults(t *testing.T) {
 		var d PipelineDefaults
 		d.ReadPipelineDefaults([]io.ReadCloser{cd})
 
-		assert.Equal(t, []interface{}{"entrypoint=''"}, d.Defaults[0].Steps["testStep"]["dockerOptions"])
+		assert.Equal(t, []interface{}{"entrypoint="}, d.Defaults[0].Steps["testStep"]["dockerOptions"])
 	})
 
 	t.Run("Negative case", func(t *testing.T) {
@@ -730,7 +730,7 @@ func TestOptionsAsStringSlice(t *testing.T) {
 		{options: []Option{}, expected: []string{}},
 		{options: []Option{{Name: "name1", Value: "value1"}}, expected: []string{"name1 value1"}},
 		{options: []Option{{Name: "name1", Value: "value1"}, {Name: "name2", Value: "value2"}}, expected: []string{"name1 value1", "name2 value2"}},
-		{options: []Option{{Name: "empty", Value: ""}}, expected: []string{"empty=''"}},
+		{options: []Option{{Name: "empty", Value: ""}}, expected: []string{"empty="}},
 	}
 
 	for _, test := range tt {


### PR DESCRIPTION
# Changes

This follows up on #3024
Setting emptyValue to s.th. like `--entrypoint=''` will break in case the argument is properly escaped.

Docker will return with
`container process caused: exec: "''": executable file not found in $PATH`

- [x] Tests
- [x] Documentation
