### PR TITLE
Change executor to shell runner

### DIFF
--- a/cmd/uiVeri5ExecuteTests.go
+++ b/cmd/uiVeri5ExecuteTests.go
@@ -24,7 +24,7 @@ func uiVeri5ExecuteTests(config uiVeri5ExecuteTestsOptions, telemetryData *telem
 	}
 }
 
-func runUIVeri5(config *uiVeri5ExecuteTestsOptions, command command.ExecRunner) error {
+func runUIVeri5(config *uiVeri5ExecuteTestsOptions, command command.ShellRunner) error {
 	envs := []string{"NPM_CONFIG_PREFIX=~/.npm-global"}
 	path := "PATH=" + os.Getenv("PATH") + ":~/.npm-global/bin"
 	envs = append(envs, path)
@@ -33,8 +33,7 @@ func runUIVeri5(config *uiVeri5ExecuteTestsOptions, command command.ExecRunner) 
 	}
 	command.SetEnv(envs)
 
-	installCommandTokens := strings.Split(config.InstallCommand, " ")
-	if err := command.RunExecutable(installCommandTokens[0], installCommandTokens[1:]...); err != nil {
+	if err := command.RunShell("/bin/bash", config.InstallCommand); err != nil {
 		log.SetErrorCategory(log.ErrorCustom)
 		return errors.Wrapf(err, "failed to execute install command: %v", config.InstallCommand)
 	}
@@ -43,7 +42,7 @@ func runUIVeri5(config *uiVeri5ExecuteTestsOptions, command command.ExecRunner) 
 		log.SetErrorCategory(log.ErrorConfiguration)
 		return errors.Errorf("parameter testOptions no longer supported, please use runOptions parameter instead.")
 	}
-	if err := command.RunExecutable(config.RunCommand, config.RunOptions...); err != nil {
+	if err := command.RunShell("/bin/bash", strings.Join(append([]string{config.RunCommand}, config.RunOptions...), " ")); err != nil {
 		log.SetErrorCategory(log.ErrorTest)
 		return errors.Wrapf(err, "failed to execute run command: %v %v", config.RunCommand, strings.Join(config.RunOptions, " "))
 	}

--- a/cmd/uiVeri5ExecuteTests_test.go
+++ b/cmd/uiVeri5ExecuteTests_test.go
@@ -17,16 +17,16 @@ func TestRunUIVeri5(t *testing.T) {
 			TestServerURL:  "http://path/to/deployment",
 		}
 
-		e := mock.ExecMockRunner{}
+		e := mock.ShellMockRunner{}
 		runUIVeri5(opts, &e)
 
 		assert.Equal(t, e.Env[0], "NPM_CONFIG_PREFIX=~/.npm-global", "NPM_CONFIG_PREFIX not set as expected")
 		assert.Contains(t, e.Env[1], "PATH", "PATH not in env list")
 		assert.Equal(t, e.Env[2], "TARGET_SERVER_URL=http://path/to/deployment", "TARGET_SERVER_URL not set as expected")
 
-		assert.Equal(t, e.Calls[0], mock.ExecCall{Exec: "npm", Params: []string{"install", "ui5/uiveri5"}}, "install command/params incorrect")
+		assert.Equal(t, e.Calls[0], "npm install ui5/uiveri5", "install command/params incorrect")
 
-		assert.Equal(t, e.Calls[1], mock.ExecCall{Exec: "uiveri5", Params: []string{"conf.js"}}, "run command/params incorrect")
+		assert.Equal(t, e.Calls[1], "uiveri5 conf.js", "run command/params incorrect")
 
 	})
 
@@ -35,7 +35,7 @@ func TestRunUIVeri5(t *testing.T) {
 
 		opts := &uiVeri5ExecuteTestsOptions{InstallCommand: "fail install test", RunCommand: "uiveri5"}
 
-		e := mock.ExecMockRunner{ShouldFailOnCommand: map[string]error{"fail install test": errors.New("error case")}}
+		e := mock.ShellMockRunner{ShouldFailOnCommand: map[string]error{"fail install test": errors.New("error case")}}
 		err := runUIVeri5(opts, &e)
 		assert.EqualErrorf(t, err, wantError, "expected comman to exit with error")
 	})
@@ -45,7 +45,7 @@ func TestRunUIVeri5(t *testing.T) {
 
 		opts := &uiVeri5ExecuteTestsOptions{InstallCommand: "npm install ui5/uiveri5", RunCommand: "fail uiveri5", RunOptions: []string{"testParam"}}
 
-		e := mock.ExecMockRunner{ShouldFailOnCommand: map[string]error{"fail uiveri5": errors.New("error case")}}
+		e := mock.ShellMockRunner{ShouldFailOnCommand: map[string]error{"fail uiveri5": errors.New("error case")}}
 		err := runUIVeri5(opts, &e)
 		assert.EqualErrorf(t, err, wantError, "expected comman to exit with error")
 	})

--- a/cmd/uiVeri5ExecuteTests_test.go
+++ b/cmd/uiVeri5ExecuteTests_test.go
@@ -20,13 +20,13 @@ func TestRunUIVeri5(t *testing.T) {
 		e := mock.ShellMockRunner{}
 		runUIVeri5(opts, &e)
 
-		assert.Equal(t, e.Env[0], "NPM_CONFIG_PREFIX=~/.npm-global", "NPM_CONFIG_PREFIX not set as expected")
+		assert.Equal(t, "NPM_CONFIG_PREFIX=~/.npm-global", e.Env[0], "NPM_CONFIG_PREFIX not set as expected")
 		assert.Contains(t, e.Env[1], "PATH", "PATH not in env list")
-		assert.Equal(t, e.Env[2], "TARGET_SERVER_URL=http://path/to/deployment", "TARGET_SERVER_URL not set as expected")
+		assert.Equal(t, "TARGET_SERVER_URL=http://path/to/deployment", e.Env[2], "TARGET_SERVER_URL not set as expected")
 
-		assert.Equal(t, e.Calls[0], "npm install ui5/uiveri5", "install command/params incorrect")
+		assert.Equal(t, "npm install ui5/uiveri5", e.Calls[0], "install command/params incorrect")
 
-		assert.Equal(t, e.Calls[1], "uiveri5 conf.js", "run command/params incorrect")
+		assert.Equal(t, "uiveri5 conf.js", e.Calls[1], "run command/params incorrect")
 
 	})
 


### PR DESCRIPTION
We have the case that we want to define environment variables in the config.yaml file like so:
```
  # Acceptance stage steps
  uiVeri5ExecuteTests:
    credentialsId: myUI5Credential
    runOptions: ['--config.connectionConfigs.direct.binaries.chromedriver.localPath=$CHROMEDRIVER_BIN', '--params.user=$ui5Username', '--params.pass=$ui5Password', "./path/to/uiveri5/conf.js"]
```

These environment variables are not replaced when using `ExecRunner`. While they are replaced with the env variable when using `ShellRunner`.

# Changes

- [x] Tests
