### PR TITLE
[fix] remove schema parameter from cycloneDX for npm build

### DIFF
--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -360,7 +360,8 @@ func (exec *Execute) CreateBOM(packageJSONFiles []string) error {
 	if len(packageJSONFiles) > 0 {
 		path := filepath.Dir(packageJSONFiles[0])
 		createBOMConfig := []string{
-			"--schema", "1.2", // Target schema version
+			// https://github.com/CycloneDX/cyclonedx-node-module does not contain schema parameter hence bom creation fails
+			//"--schema", "1.2", // Target schema version
 			"--include-license-text", "false",
 			"--include-dev", "false", // Include devDependencies
 			"--output", "bom.xml",

--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -358,10 +358,10 @@ func TestNpm(t *testing.T) {
 		if assert.NoError(t, err) {
 			if assert.Equal(t, 3, len(utils.execRunner.Calls)) {
 				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "@cyclonedx/bom", "--no-save"}}, utils.execRunner.Calls[0])
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", ".", "--schema", "1.2",
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", ".",
 					"--include-license-text", "false", "--include-dev", "false", "--output", "bom.xml"}}, utils.execRunner.Calls[1])
 				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", "src", "--append", "bom.xml",
-					"--schema", "1.2", "--include-license-text", "false", "--include-dev", "false", "--output", "bom.xml"}}, utils.execRunner.Calls[2])
+					"--include-license-text", "false", "--include-dev", "false", "--output", "bom.xml"}}, utils.execRunner.Calls[2])
 			}
 		}
 	})


### PR DESCRIPTION
# Changes

- https://www.npmjs.com/package/@cyclonedx/bom does not contain schema parameter hence removing that during npm build when Bom creation is required 

fixes #3031