### PR TITLE
feat(Vault): custom prefix for test credentials

### DIFF
--- a/documentation/docs/infrastructure/vault.md
+++ b/documentation/docs/infrastructure/vault.md
@@ -117,4 +117,10 @@ The `vaultTestCredentialPath` parameter is the endpoint of your credential path 
 
 The `vaultTestCredentialKeys`parameter is a list of credential IDs. The secret value of the credential will be exposed as an environment variable prefixed by "PIPER_TESTCREDENTIAL_" and transformed to a valid variable name. For a credential ID named `myAppId` the forwarded environment variable to the step will be `PIPER_TESTCREDENTIAL_MYAPPID` containing the secret. Hyphens will be replaced by underscores and other non-alphanumeric characters will be removed.
 
+!!! hint "Using a custom prefix for test credentials"
+    By default the prefix for test credentials is `PIPER_TESTCREDENTIAL_`.
+
+    It is possible to use a custom prefix by setting for example `vaultTestCredentialEnvPrefix: MY_CUSTOM_PREFIX` in your configuration.
+    With this above credential ID named `myAppId` will be populated into an environment variable with the name `MY_CUSTOM_PREFIX_MYAPPID`.
+
 Extended logging for vault secret fetching (e.g. found credentials and environment variable names) can be activated via `verbose: true` configuration.

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	vaultTestCredentialPath      = "vaultTestCredentialPath"
-	vaultTestCredentialKeys      = "vaultTestCredentialKeys"
-	vaultTestCredentialEnvPrefix = "PIPER_TESTCREDENTIAL_"
+	vaultTestCredentialPath              = "vaultTestCredentialPath"
+	vaultTestCredentialKeys              = "vaultTestCredentialKeys"
+	vaultTestCredentialEnvPrefix_Default = "PIPER_TESTCREDENTIAL_"
 )
 
 var (
@@ -27,6 +27,7 @@ var (
 		"vaultBasePath",
 		"vaultPipelineName",
 		"vaultPath",
+		"vaultTestCredentialEnvPrefix",
 		"skipVault",
 		"vaultDisableOverwrite",
 		vaultTestCredentialPath,
@@ -165,7 +166,7 @@ func resolveVaultTestCredentials(config *StepConfig, client vaultClient) {
 			continue
 		}
 		secretsResolved := false
-		secretsResolved = populateTestCredentialsAsEnvs(secret, keys)
+		secretsResolved = populateTestCredentialsAsEnvs(config, secret, keys)
 		if secretsResolved {
 			// prevent overwriting resolved secrets
 			// only allows vault test credentials on one / the same vault path
@@ -174,7 +175,12 @@ func resolveVaultTestCredentials(config *StepConfig, client vaultClient) {
 	}
 }
 
-func populateTestCredentialsAsEnvs(secret map[string]string, keys []string) (matched bool) {
+func populateTestCredentialsAsEnvs(config *StepConfig, secret map[string]string, keys []string) (matched bool) {
+
+	vaultTestCredentialEnvPrefix, ok := config.Config["vaultTestCredentialEnvPrefix"].(string)
+	if !ok || len(vaultTestCredentialEnvPrefix) == 0 {
+		vaultTestCredentialEnvPrefix = vaultTestCredentialEnvPrefix_Default
+	}
 	for secretKey, secretValue := range secret {
 		for _, key := range keys {
 			if secretKey == key {


### PR DESCRIPTION
# Changes

allow custom prefix for environment variables created for test credentials

- [x] Tests
- [x] Documentation
