### PR TITLE
fix(getConfig): custom metadata

### DIFF
--- a/cmd/getConfig.go
+++ b/cmd/getConfig.go
@@ -240,7 +240,7 @@ func resolveMetadata() (config.StepData, error) {
 		}
 	} else {
 		if configOptions.stepName != "" {
-			metadataMap := GetAllStepMetadata()
+			metadataMap := GeneralConfig.MetaDataResolver()
 			var ok bool
 			metadata, ok = metadataMap[configOptions.stepName]
 			if !ok {

--- a/cmd/getConfig_test.go
+++ b/cmd/getConfig_test.go
@@ -314,6 +314,7 @@ func TestPrepareOutputEnvironment(t *testing.T) {
 
 func TestResolveMetadata(t *testing.T) {
 
+	GeneralConfig.MetaDataResolver = GetAllStepMetadata
 	t.Run("Succes - stepName", func(t *testing.T) {
 		configOptions.stepName = "githubCreateIssue"
 		stepData, err := resolveMetadata()

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -41,6 +41,7 @@ type GeneralConfigOptions struct {
 	VaultNamespace       string
 	VaultPath            string
 	HookConfig           HookConfiguration
+	MetaDataResolver     func() map[string]config.StepData
 }
 
 // HookConfiguration contains the configuration for supported hooks, so far Sentry and Splunk are supported.
@@ -76,6 +77,8 @@ var GeneralConfig GeneralConfigOptions
 
 // Execute is the starting point of the piper command line tool
 func Execute() {
+
+	GeneralConfig.MetaDataResolver = GetAllStepMetadata
 
 	rootCmd.AddCommand(ArtifactPrepareVersionCommand())
 	rootCmd.AddCommand(ConfigCommand())


### PR DESCRIPTION
when re-using getConfig it is now possible to provide a custom metadata resolver

# Changes

- [x] Tests
- [x] ~Documentation~
