### PR TITLE
Adds retry for whitesource download in case of 404 not found

### DIFF
--- a/pkg/whitesource/scanUA.go
+++ b/pkg/whitesource/scanUA.go
@@ -180,9 +180,9 @@ func downloadAgent(config *ScanOptions, utils Utils) error {
 		if err != nil {
 			// we check if the copy error occurs and retry the download
 			// if the copy error did not happen, we rerun the whole download mechanism once
-			if strings.Contains(err.Error(), "unable to copy content from url to file") {
+			if strings.Contains(err.Error(), "unable to copy content from url to file") || strings.Contains(err.Error(), "returned with response 404 Not Found") {
 				// retry the download once again
-				log.Entry().Warnf("Previous Download failed due to %v", err)
+				log.Entry().Warnf("[Retry] Previous download failed due to %v", err)
 				err = nil // reset error to nil
 				err = utils.DownloadFile(config.AgentDownloadURL, agentFile, nil, nil)
 			}

--- a/pkg/whitesource/scanUA_test.go
+++ b/pkg/whitesource/scanUA_test.go
@@ -290,7 +290,7 @@ func TestDownloadAgent(t *testing.T) {
 		err := downloadAgent(&config, utilsMock)
 		assert.Contains(t, fmt.Sprint(err), "failed to download unified agent from URL")
 	})
-	t.Run("error - download with retry", func(t *testing.T) {
+	t.Run("error - download with retry unable to copy content from file", func(t *testing.T) {
 		config := ScanOptions{
 			AgentDownloadURL: "errorCopyFile", // Misusing this ScanOptions to tell DownloadFile Mock to raise an error
 			AgentFileName:    "unified-agent.jar",
@@ -300,6 +300,17 @@ func TestDownloadAgent(t *testing.T) {
 
 		err := downloadAgent(&config, utilsMock)
 		assert.Contains(t, fmt.Sprint(err), "unable to copy content from url to file")
+	})
+	t.Run("error - download with retry not found 404", func(t *testing.T) {
+		config := ScanOptions{
+			AgentDownloadURL: "error404NotFound", // Misusing this ScanOptions to tell DownloadFile Mock to raise an error
+			AgentFileName:    "unified-agent.jar",
+		}
+		utilsMock := NewScanUtilsMock()
+		utilsMock.DownloadError = map[string]error{"https://download.ua.org/agent.jar": fmt.Errorf("returned with response 404 Not Found")}
+
+		err := downloadAgent(&config, utilsMock)
+		assert.Contains(t, fmt.Sprint(err), "returned with response 404 Not Found")
 	})
 }
 

--- a/pkg/whitesource/utilsMock.go
+++ b/pkg/whitesource/utilsMock.go
@@ -71,6 +71,9 @@ func (m *ScanUtilsMock) DownloadFile(url, filename string, _ http.Header, _ []*h
 	if url == "errorCopyFile" {
 		return errors.New("unable to copy content from url to file")
 	}
+	if url == "error404NotFound" {
+		return errors.New("returned with response 404 Not Found")
+	}
 	if m.DownloadError[url] != nil {
 		return m.DownloadError[url]
 	}


### PR DESCRIPTION
# Changes
We encountered the error 404 that the file wss-unified-agent.jar could not been downloaded. After manual check the file is present under the known url. For better resilience we want to have *one* retry in case we see this error.

- [x] Tests
- [ ] Documentation
