### PR TITLE
Improve documentation for protecodeExecuteScan

### DIFF
--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -208,7 +208,7 @@ func protecodeExecuteScanMetadata() config.StepData {
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
 					{Name: "protecodeCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing username and password to authenticate to the Protecode system.", Type: "jenkins"},
-					{Name: "dockerConfigJsonCredentialsId", Description: "Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).", Type: "jenkins", Aliases: []config.Alias{{Name: "dockerCredentialsId", Deprecated: true}}},
+					{Name: "dockerConfigJsonCredentialsId", Description: "Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in [Prerequisites](https://www.project-piper.io/steps/protecodeExecuteScan/#prerequisites).", Type: "jenkins", Aliases: []config.Alias{{Name: "dockerCredentialsId", Deprecated: true}}},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -8,9 +8,9 @@
 1. Look up your Group ID using REST API via `curl -u <username> "https://<protecode host>/api/groups/"`.
 
 If the image is on a protected registry you can provide a Docker `config.json` file containing the credential information for the registry.
-You can either use `docker login` (see the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/) for details) or you can create the file manually using the follwing script.
+You can either use `docker login` (see the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/) for details) or you can create the file manually using the following script.
 
-```
+```shell
 #!/bin/bash
 auth=$(echo -n "$USER:$PASSWORD" | base64 -w0)
 cat <<EOF > config.json
@@ -23,6 +23,7 @@ cat <<EOF > config.json
 }
 EOF
 ```
+`REGISTRY` is the URL of the protected registry (Example: https://index.docker.io/v1).
 
 Attention: If you reference the file in --dockerConfigJSON or upload the file to the Jenkins credential store, the file has to be named `config.json`.
 

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -26,7 +26,6 @@ EOF
 
 Attention: If you reference the file in --dockerConfigJSON or upload the file to the Jenkins credential store, the file has to be named `config.json`.
 
-
 ## ${docGenParameters}
 
 ### Details

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -24,7 +24,7 @@ cat <<EOF > config.json
 EOF
 ```
 
-`REGISTRY` is the URL of the protected registry (Example: https://index.docker.io/v1).
+`REGISTRY` is the URL of the protected registry (Example: `https://index.docker.io/v1`).
 
 Attention: If you reference the file in --dockerConfigJSON or upload the file to the Jenkins credential store, the file has to be named `config.json`.
 

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -8,7 +8,7 @@
 1. Look up your Group ID using REST API via `curl -u <username> "https://<protecode host>/api/groups/"`.
 
 If the image is on a protected registry you can provide a Docker `config.json` file containing the credential information for the registry.
-You can either use `docker login` (see the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/) for details) and copy your local `~/.docker/config.json` file or you can create the file manually using the follwing script.
+You can either use `docker login` (see the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/) for details) or you can create the file manually using the follwing script.
 
 ```
 #!/bin/bash

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -8,7 +8,24 @@
 1. Look up your Group ID using REST API via `curl -u <username> "https://<protecode host>/api/groups/"`.
 
 If the image is on a protected registry you can provide a Docker `config.json` file containing the credential information for the registry.
-You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).
+You can either use `docker login` and copy your local `~/.docker/config.json` file or you can create the file manually using the follwing script.
+
+```
+#!/bin/bash
+auth=$(echo -n "$USER:$PASSWORD" | base64 -w0)
+cat <<EOF > config.json
+{
+    "auths": {
+        "$REGISTRY": {
+            "auth": "$auth"
+        }
+    }
+}
+EOF
+```
+
+Attention: If you reference the file in --dockerConfigJSON or upload the file to the Jenkins credential store, the file has to be named `config.json`.
+
 
 ## ${docGenParameters}
 

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -8,7 +8,7 @@
 1. Look up your Group ID using REST API via `curl -u <username> "https://<protecode host>/api/groups/"`.
 
 If the image is on a protected registry you can provide a Docker `config.json` file containing the credential information for the registry.
-You can either use `docker login` and copy your local `~/.docker/config.json` file or you can create the file manually using the follwing script.
+You can either use `docker login` (see the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/) for details) and copy your local `~/.docker/config.json` file or you can create the file manually using the follwing script.
 
 ```
 #!/bin/bash

--- a/documentation/docs/steps/protecodeExecuteScan.md
+++ b/documentation/docs/steps/protecodeExecuteScan.md
@@ -23,6 +23,7 @@ cat <<EOF > config.json
 }
 EOF
 ```
+
 `REGISTRY` is the URL of the protected registry (Example: https://index.docker.io/v1).
 
 Attention: If you reference the file in --dockerConfigJSON or upload the file to the Jenkins credential store, the file has to be named `config.json`.

--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -13,7 +13,7 @@ spec:
         description: Jenkins 'Username with password' credentials ID containing username and password to authenticate to the Protecode system.
         type: jenkins
       - name: dockerConfigJsonCredentialsId
-        description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in [Prerequisites](#Prerequisites).
+        description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in [Prerequisites](https://www.project-piper.io/steps/protecodeExecuteScan/#prerequisites).
         type: jenkins
         aliases:
           - name: dockerCredentialsId
@@ -65,7 +65,7 @@ spec:
           - STEPS
       - name: dockerConfigJSON
         type: string
-        description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in [Prerequisites](#Prerequisites).
+        description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).
         scope:
           - PARAMETERS
           - STAGES

--- a/resources/metadata/protecode.yaml
+++ b/resources/metadata/protecode.yaml
@@ -13,7 +13,7 @@ spec:
         description: Jenkins 'Username with password' credentials ID containing username and password to authenticate to the Protecode system.
         type: jenkins
       - name: dockerConfigJsonCredentialsId
-        description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in the Docker Success Center in the article about [how to generate a new auth in the config.json file](https://success.docker.com/article/generate-new-auth-in-config-json-file).
+        description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)). You can create it like explained in [Prerequisites](#Prerequisites).
         type: jenkins
         aliases:
           - name: dockerCredentialsId
@@ -65,7 +65,7 @@ spec:
           - STEPS
       - name: dockerConfigJSON
         type: string
-        description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).
+        description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in [Prerequisites](#Prerequisites).
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
1) Existing documentation referenced an external article that does not exist.

2) protecodeExecuteScan expects that the docker config file is named 'config.json'. (For example kanikoExecute does not! expect that.)
    
The dockerConfigJSON parameter is used by protecodeExecuteScan to retrieve the directory only (for environment variable DOCKER_CONFIG).


# Changes

- [ ] Tests
- [X] Documentation
