### PR TITLE
fix(npmExecuteScripts): respect BuildDescriptorList during install phase

### DIFF
--- a/cmd/npmExecuteScripts.go
+++ b/cmd/npmExecuteScripts.go
@@ -28,7 +28,7 @@ func findPackageDescriptors(npmExecutor npm.Executor, config *npmExecuteScriptsO
 func runNpmExecuteScripts(npmExecutor npm.Executor, config *npmExecuteScriptsOptions) error {
 	packageJSONFiles, err := findPackageDescriptors(npmExecutor, config)
 
-        if err != nil {
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
`npmExecuteScripts` shall not run the package installation for descriptors marked to be ignored using the `buildDescriptorList` parameter.

# Changes

- [ ] Tests
- [ ] Documentation
