### PR TITLE
Fixes time bug in unstash resilience 

### DIFF
--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -87,7 +87,7 @@ def unstash(name, msg = "Unstash failed:") {
     } catch (e) {
         echo "$msg $name (${e.getMessage()})"
         if (e.getMessage().contains("JNLP4-connect")) {
-            sleep(3000) // Wait 3 seconds in case it has been a network hiccup
+            sleep(3) // Wait 3 seconds in case it has been a network hiccup
             try {
                 echo "[Retry JNLP4-connect issue] Unstashing content: ${name}"
                 steps.unstash name


### PR DESCRIPTION
Groovy sleep functionality  takes seconds and not milliseconds leading to a wait time of 50 minutes. Reduced it to 3 seconds.

# Changes

- [ ] Tests
- [ ] Documentation
