### PR TITLE
Add configuration for dockerConfigJSON

### DIFF
--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -265,7 +265,7 @@ func kanikoExecuteMetadata() config.StepData {
 								Type:  "vaultSecretFile",
 							},
 						},
-						Scope:     []string{"PARAMETERS"},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
 						Mandatory: false,
 						Aliases:   []config.Alias{},

--- a/resources/metadata/kaniko.yaml
+++ b/resources/metadata/kaniko.yaml
@@ -91,6 +91,8 @@ spec:
         description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).
         scope:
           - PARAMETERS
+          - STAGES
+          - STEPS
         secret: true
         resourceRef:
           - name: commonPipelineEnvironment


### PR DESCRIPTION
# Changes
In order to send in the path to the written dockerConfigJSON using the Build Stage and kanikoExecute step, we need to add the STAGES and STEPS back in to the scope. 
- [ ] Tests
- [x] Documentation
