### PR TITLE
Match documentation of buildExecute

### DIFF
--- a/test/groovy/BuildExecuteTest.groovy
+++ b/test/groovy/BuildExecuteTest.groovy
@@ -348,60 +348,16 @@ class BuildExecuteTest extends BasePiperTest {
 
     @Test
     void testKaniko() {
-        def kanikoParams = [:]
+        def buildToolCalled = false
         helper.registerAllowedMethod('kanikoExecute', [Map.class], { m ->
-            kanikoParams = m
+            buildToolCalled = true
             return
         })
-
         stepRule.step.buildExecute(
             script: nullScript,
             buildTool: 'kaniko',
-            dockerImageName: 'path/to/myImage',
-            dockerImageTag: 'myTag',
-            dockerRegistryUrl: 'https://my.registry:55555'
         )
-
-        assertThat(kanikoParams.containerImageNameAndTag.toString(), is('my.registry:55555/path/to/myImage:myTag'))
-    }
-
-    @Test
-    void testKanikoNoPush() {
-        def kanikoParams = [:]
-        helper.registerAllowedMethod('kanikoExecute', [Map.class], { m ->
-            kanikoParams = m
-            return
-        })
-
-        stepRule.step.buildExecute(
-            script: nullScript,
-            buildTool: 'kaniko',
-            dockerImageName: 'path/to/myImage',
-            dockerImageTag: 'myTag',
-            dockerRegistryUrl: ''
-        )
-
-        assertThat(kanikoParams.containerImageNameAndTag, is(''))
-    }
-
-    @Test
-    void testSwitchToKaniko() {
-        shellCallRule.setReturnValue('docker ps -q > /dev/null', 1)
-        def kanikoParams = [:]
-        helper.registerAllowedMethod('kanikoExecute', [Map.class], { m ->
-            kanikoParams = m
-            return
-        })
-
-        stepRule.step.buildExecute(
-            script: nullScript,
-            buildTool: 'kaniko',
-            dockerImageName: 'path/to/myImage',
-            dockerImageTag: 'myTag',
-            dockerRegistryUrl: 'https://my.registry:55555'
-        )
-
-        assertThat(kanikoParams.containerImageNameAndTag.toString(), is('my.registry:55555/path/to/myImage:myTag'))
+        assertThat(buildToolCalled, is(true))
     }
 
 }

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -104,8 +104,8 @@ void call(Map parameters = [:]) {
                     if (config.dockerRegistryUrl) {
                         containerPushToRegistry script: script, dockerBuildImage: dockerBuildImage, dockerRegistryUrl: config.dockerRegistryUrl
                     }
+                    script.commonPipelineEnvironment.setValue('containerImage', dockerImageNameAndTag)
                 }
-                script.commonPipelineEnvironment.setValue('containerImage', dockerImageNameAndTag)
                 break
             default:
                 if (config.dockerImage && config.dockerCommand) {

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -100,7 +100,7 @@ void call(Map parameters = [:]) {
 
                     def dockerImageNameAndTag = "${config.dockerImageName}:${config.dockerImageTag}"
                     def dockerBuildImage = docker.build(dockerImageNameAndTag, "${config.containerBuildOptions ?: ''} .")
-                                        //only push if registry is defined
+                    //only push if registry is defined
                     if (config.dockerRegistryUrl) {
                         containerPushToRegistry script: script, dockerBuildImage: dockerBuildImage, dockerRegistryUrl: config.dockerRegistryUrl
                     }

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -92,7 +92,7 @@ void call(Map parameters = [:]) {
                     echo "[${STEP_NAME}] No Docker daemon available, thus switching to Kaniko build"
                 }
                 if (config.buildTool == 'kaniko'){
-                    kanikoExecute script: script, containerImageNameAndTag: containerImageNameAndTag
+                    kanikoExecute script: script
                 }else{
                     ConfigurationHelper.newInstance(this, config)
                                     .withMandatoryProperty('dockerImageName')

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -91,19 +91,16 @@ void call(Map parameters = [:]) {
                     config.buildTool = 'kaniko'
                     echo "[${STEP_NAME}] No Docker daemon available, thus switching to Kaniko build"
                 }
-
-                ConfigurationHelper.newInstance(this, config)
-                    .withMandatoryProperty('dockerImageName')
-                    .withMandatoryProperty('dockerImageTag')
-
-                def dockerImageNameAndTag = "${config.dockerImageName}:${config.dockerImageTag}"
-
-                if (config.buildTool == 'kaniko') {
-                    def containerImageNameAndTag = config.dockerRegistryUrl ? "${dockerUtils.getRegistryFromUrl(config.dockerRegistryUrl)}/${dockerImageNameAndTag}" : ''
+                if (config.buildTool == 'kaniko'){
                     kanikoExecute script: script, containerImageNameAndTag: containerImageNameAndTag
-                } else {
+                }else{
+                    ConfigurationHelper.newInstance(this, config)
+                                    .withMandatoryProperty('dockerImageName')
+                                    .withMandatoryProperty('dockerImageTag')
+
+                    def dockerImageNameAndTag = "${config.dockerImageName}:${config.dockerImageTag}"
                     def dockerBuildImage = docker.build(dockerImageNameAndTag, "${config.containerBuildOptions ?: ''} .")
-                    //only push if registry is defined
+                                        //only push if registry is defined
                     if (config.dockerRegistryUrl) {
                         containerPushToRegistry script: script, dockerBuildImage: dockerBuildImage, dockerRegistryUrl: config.dockerRegistryUrl
                     }


### PR DESCRIPTION
# Changes
In the documentation of buildExecute, it says that dockerImageName and dockerImageTag [are only mandatory when doing Docker builds](https://www.project-piper.io/steps/buildExecute/#:~:text=dockerImageName%20-%20For%20Docker%20builds%20only%20(mandatory)%3A%20name,tag%20of%20the%20image%20to%20be%20built.), but that wasn't the case in the code. We were seeing that they were mandatory for kanikoExecute and creating a parameter with them called "containerImageNameAndTag" and passing that to kanikoExecute, even though[ containerImageNameAndTag is a deprecated alias in kanikoExecute](https://www.project-piper.io/steps/kanikoExecute/#:~:text=containerImageNameAndTag%20(deprecated)). It's better to have kanikoExecute use the parameters defined in its own step than creating it from parameters meant for the docker buildTool, and kanikoExecute can build without pushing a dockerImage.

- [x] Tests
- [ ] Documentation
