### PR TITLE
toolrecord: fix web ui URLs for whitesource

### DIFF
--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -928,7 +928,8 @@ func persistScannedProjects(config *ScanOptions, scan *ws.Scan, commonPipelineEn
 //
 func createToolRecordWhitesource(workspace string, config *whitesourceExecuteScanOptions, scan *ws.Scan) (string, error) {
 	record := toolrecord.New(workspace, "whitesource", config.ServiceURL)
-	productURL := config.ServiceURL + "/Wss/WSS.html#!product;token=" + config.ProductToken
+	wsUiRoot := "https://saas.whitesourcesoftware.com"
+	productURL := wsUiRoot + "/Wss/WSS.html#!product;token=" + config.ProductToken
 	err := record.AddKeyData("product",
 		config.ProductToken,
 		config.ProductName,
@@ -943,7 +944,7 @@ func createToolRecordWhitesource(workspace string, config *whitesourceExecuteSca
 		token := project.Token
 		projectURL := ""
 		if token != "" {
-			projectURL = config.ServiceURL + "/Wss/WSS.html#!project;token=" + token
+			projectURL = wsUiRoot + "/Wss/WSS.html#!project;token=" + token
 		} else {
 			// token is empty, provide a dummy to have an indication
 			token = "unknown"

--- a/pkg/toolrecord/toolrecord_main.go
+++ b/pkg/toolrecord/toolrecord_main.go
@@ -112,7 +112,30 @@ func (tr *Toolrecord) Persist() error {
 	if err != nil {
 		return fmt.Errorf("TR_PERSIST: %v", err)
 	}
-	// convenience aggregation
+
+	// set default display data if required
+	if tr.DisplayName == "" {
+		tr.GenerateDefaultDisplayData()
+	}
+
+	file, err := json.Marshal(tr)
+	if err != nil {
+		return fmt.Errorf("TR_PERSIST: %v", err)
+	}
+	// no json generated ?
+	if len(file) == 0 {
+		return fmt.Errorf("TR_PERSIST: empty json content")
+	}
+	err = ioutil.WriteFile(tr.GetFileName(), file, 0644)
+	if err != nil {
+		return fmt.Errorf("TR_PERSIST: %v", err)
+	}
+	return nil
+}
+
+// default aggregation for overall displayName and URL
+// can be overriden by calling SetOverallDisplayData
+func (tr *Toolrecord) GenerateDefaultDisplayData() {
 	displayName := ""
 	displayURL := ""
 	for _, keyset := range tr.Keys {
@@ -131,20 +154,6 @@ func (tr *Toolrecord) Persist() error {
 	}
 	tr.DisplayName = displayName
 	tr.DisplayURL = displayURL
-
-	file, err := json.Marshal(tr)
-	if err != nil {
-		return fmt.Errorf("TR_PERSIST: %v", err)
-	}
-	// no json generated ?
-	if len(file) == 0 {
-		return fmt.Errorf("TR_PERSIST: empty json content")
-	}
-	err = ioutil.WriteFile(tr.GetFileName(), file, 0644)
-	if err != nil {
-		return fmt.Errorf("TR_PERSIST: %v", err)
-	}
-	return nil
 }
 
 // Override the default generation for DisplayName & DisplayURL


### PR DESCRIPTION
toolrecord: fix generated URLs for the whitesource web UI
- [ x] Tests pass
- [ x] Documentation not required
