### PR TITLE
TransportRequestUploadFile migration to Go - CTS

### DIFF
--- a/cmd/transportRequestUploadCTS_generated.go
+++ b/cmd/transportRequestUploadCTS_generated.go
@@ -179,7 +179,7 @@ func transportRequestUploadCTSMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:        "string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{},
+						Aliases:     []config.Alias{{Name: "applicationDescription"}},
 						Default:     `Deployed with Piper based on SAP Fiori tools`,
 					},
 					{

--- a/resources/metadata/transportRequestUploadCTS.yaml
+++ b/resources/metadata/transportRequestUploadCTS.yaml
@@ -18,6 +18,8 @@ spec:
       - name: description
         type: string
         description: "The description of the application. The description is only taken into account for a new upload. In case of an update the description will not be updated."
+        aliases:
+          - name: applicationDescription
         default: "Deployed with Piper based on SAP Fiori tools"
         scope:
           - PARAMETERS

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -167,8 +167,8 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
     @Test
     public void uploadFileToTransportRequestCTSSuccessTest() {
 
-//        loggingRule.expect("[INFO] Uploading application 'myApp' to transport request '002'.")
- //       loggingRule.expect("[INFO] Application 'myApp' has been successfully uploaded to transport request '002'.")
+        loggingRule.expect("[INFO] Uploading application 'myApp' to transport request '002'.")
+        loggingRule.expect("[INFO] Application 'myApp' has been successfully uploaded to transport request '002'.")
 
         def calledWithParameters,
             calledWithStepName,

--- a/test/groovy/TransportRequestUploadFileTest.groovy
+++ b/test/groovy/TransportRequestUploadFileTest.groovy
@@ -131,7 +131,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
         thrown.expect(AbortException)
         thrown.expectMessage("Exception message")
 
-        helper.registerAllowedMethod('piperExecuteBin', [Map, String, String, List], { 
+        helper.registerAllowedMethod('piperExecuteBin', [Map, String, String, List], {
                 throw new AbortException('Exception message')
             }
         )
@@ -161,7 +161,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
             calledWithMetadata,
             calledWithCredentials
 
-        helper.registerAllowedMethod( 'piperExecuteBin', [Map, String, String, List], {
+        helper.registerAllowedMethod('piperExecuteBin', [Map, String, String, List], {
             params, stepName, metaData, creds ->
                 calledWithParameters = params
                 calledWithStepName = stepName
@@ -318,7 +318,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
 
         loggingRule.expect("[INFO] Uploading file '/path' to transport request '002' of change document '001'.")
         loggingRule.expect("[INFO] File '/path' has been successfully uploaded to transport request '002' of change document '001'.")
-        
+
         def calledWithParameters,
             calledWithStepName,
             calledWithMetadata,
@@ -372,7 +372,7 @@ public class TransportRequestUploadFileTest extends BasePiperTest {
                 calledWithCredentials = creds
             }
         )
-        
+
         nullScript.commonPipelineEnvironment.configuration.put(['steps',
                                                                    [transportRequestUploadFile:
                                                                        [applicationId: 'AppIdfromConfig']]])

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -257,19 +257,18 @@ void call(Map parameters = [:]) {
 
                         echo "[INFO] Uploading application '${configuration.applicationName}' to transport request '${configuration.transportRequestId}'."
 
-                        cm.uploadFileToTransportRequestCTS(
-                            configuration.changeManagement.cts?.nodeDocker ?: [:],
-                            configuration.transportRequestId,
-                            configuration.changeManagement.endpoint,
-                            configuration.changeManagement.client,
-                            configuration.applicationName,
-                            configuration.applicationDescription,
-                            configuration.abapPackage,
-                            configuration.changeManagement.cts.osDeployUser,
-                            configuration.changeManagement.cts.deployToolDependencies,
-                            configuration.changeManagement.cts.npmInstallOpts,
-                            configuration.changeManagement.cts.deployConfigFile,
-                            configuration.changeManagement.credentialsId)
+                        transportRequestUploadCTS(script: script,
+                            transportRequestId: configuration.transportRequestId,
+                            endpoint: configuration.changeManagement.endpoint,
+                            client: configuration.changeManagement.client,
+                            applicationName: configuration.applicationName,
+                            description: configuration.applicationDescription,
+                            abapPackage: configuration.abapPackage,
+                            osDeployUser: configuration.changeManagement.cts.osDeployUser,
+                            deployToolDependencies: configuration.changeManagement.cts.deployToolDependencies,
+                            npmInstallOpts: configuration.changeManagement.cts.npmInstallOpts,
+                            deployConfigFile: configuration.changeManagement.cts.deployConfigFile,
+                            uploadCredentialsId: configuration.changeManagement.credentialsId)
 
                         echo "[INFO] Application '${configuration.applicationName}' has been successfully uploaded to transport request '${configuration.transportRequestId}'."
 


### PR DESCRIPTION
This PR directs the CTS upload request of the TransportRequestUploadFile step to transportRequestUploadCTS.

- [x] Tests
- [ ] Documentation
