### PR TITLE
Missing default Vault path for parameter dockerConfigJSON in step kubernetesDeploy

### DIFF
--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -436,8 +436,9 @@ func kubernetesDeployMetadata() config.StepData {
 							},
 
 							{
-								Name: "dockerConfigFileVaultSecretName",
-								Type: "vaultSecretFile",
+								Name:    "dockerConfigFileVaultSecretName",
+								Type:    "vaultSecretFile",
+								Default: "docker-config",
 							},
 						},
 						Scope:     []string{"PARAMETERS"},

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -299,6 +299,7 @@ spec:
             type: secret
           - type: vaultSecretFile
             name: dockerConfigFileVaultSecretName
+            default: docker-config
   containers:
     - image: dtzar/helm-kubectl:3.4.1
       workingDir: /config


### PR DESCRIPTION
# Changes
In the step **kubernetesDeploy**, some secrets including kubeconfig and dockerConfigJSON are fetched from Vault.
In the case of kubeconfig, which works as intended, the logs indicate the following:
```
10:07:34  debug kubernetesDeploy - Trying to resolve vault parameter 'kubeConfig' at 'piper/PIPELINE-GROUP-***/PIPELINE-****/kube-config'
10:07:34  debug kubernetesDeploy - Trying to resolve vault parameter 'kubeConfig' at 'piper/PIPELINE-GROUP-***/GROUP-SECRETS/kube-config'
10:07:34  debug kubernetesDeploy - Resolved param 'kubeConfig' with vault path 'piper/PIPELINE-GROUP-***/GROUP-SECRETS/kube-config'
```
We see that Piper attempts to resolve a secret called kube-config from the default Vault paths. In the case of dockerConfigJSON, the following happens:
```
10:07:34  debug kubernetesDeploy - Trying to resolve vault parameter 'dockerConfigJSON' at 'piper/PIPELINE-GROUP-***/PIPELINE-****'
10:07:34  debug kubernetesDeploy - Trying to resolve vault parameter 'dockerConfigJSON' at 'piper/PIPELINE-GROUP-***/GROUP-SECRETS'
10:07:34  warn  kubernetesDeploy - Could not resolve param 'dockerConfigJSON' from vault
```
No secret name is specified in the path.

From kubernetesdeploy.yaml, we get the following snippet:
```yaml
      - name: kubeConfig
        type: string
        description: Defines the path to the \"kubeconfig\" file.
        scope:
          - GENERAL
          - PARAMETERS
          - STAGES
          - STEPS
        secret: true
        resourceRef:
          - name: kubeConfigFileCredentialsId
            type: secret
          - type: vaultSecretFile
            name: kubeConfigFileSecretName
            default: kube-config

      - name: dockerConfigJSON
        type: string
        description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).
        scope:
          - PARAMETERS
        secret: true
        resourceRef:
          - name: commonPipelineEnvironment
            param: custom/dockerConfigJSON
          - name: dockerConfigJsonCredentialsId
            type: secret
          - type: vaultSecretFile
            name: dockerConfigFileVaultSecretName
```
In this, we see that the kubeConfig secret has a default vault path of "kube-config", whereas dockerConfigJSON does not have a default Vault path. This has been forgotten in a recent refactoring (see [here](https://github.com/SAP/jenkins-library/commit/56be54c504960185e3157488af3262ee7cc6e347#diff-7cec9e307a27aa34c134f2aa2e24ddc74bcee2ba177e4d4789aff7918db1dabf)) where the paths were changed from hard-coded to a default name, and no default path was added for dockerConfigJSON.

The proposed change adds this path while respecting the previous behaviour and re-ran the step generator.

- [ X ] Tests
- [ ] Documentation
