### PR TITLE
No such property: commonPipelineEnvironment for class: com.sap.piper.cm.StepHelpers

### DIFF
--- a/src/com/sap/piper/cm/StepHelpers.groovy
+++ b/src/com/sap/piper/cm/StepHelpers.groovy
@@ -106,7 +106,7 @@ public class StepHelpers {
             "to: ${configuration.changeManagement.git.to}]." +
             "transportRequestLabel: '${configuration.changeManagement.transportRequestLabel}']."
 
-        script.transportRequestReqIDFromGit(script: this,
+        script.transportRequestReqIDFromGit(script: script,
             gitFrom: configuration.changeManagement.git.from,
             gitTo: configuration.changeManagement.git.to,
             transportRequestLabel: configuration.changeManagement.transportRequestLabel
@@ -148,7 +148,7 @@ public class StepHelpers {
             "to: ${configuration.changeManagement.git.to}, " +
             "changeDocumentLabel: '${configuration.changeManagement.changeDocumentLabel}']."
 
-        script.transportRequestDocIDFromGit(script: this,
+        script.transportRequestDocIDFromGit(script: script,
             gitFrom: configuration.changeManagement.git.from,
             gitTo: configuration.changeManagement.git.to,
             changeDocumentLabel: configuration.changeManagement.changeDocumentLabel

--- a/vars/transportRequestUploadFile.groovy
+++ b/vars/transportRequestUploadFile.groovy
@@ -242,7 +242,6 @@ void call(Map parameters = [:]) {
 
                         Map paramsUpload = [
                             script: script,
-                            cmClientOpts: configuration.changeManagement.clientOpts?: [:],
                             filePath: configuration.filePath,
                             uploadCredentialsId: configuration.changeManagement.credentialsId,
                             endpoint: configuration.changeManagement.endpoint,
@@ -251,6 +250,9 @@ void call(Map parameters = [:]) {
                             transportRequestId: configuration.transportRequestId
                             ]
 
+                        if(configuration.changeManagement.clientOpts) {
+                            paramsUpload.cmClientOpts = configuration.changeManagement.clientOpts
+                        }
                         paramsUpload = addDockerParams(script, paramsUpload, configuration.changeManagement.solman?.docker)
 
                         transportRequestUploadSOLMAN(paramsUpload)


### PR DESCRIPTION
Solves #3131 

and hidden `cmClientOpts `issue: passing wrong type.

- [ ] Tests
- [ ] Documentation
