### PR TITLE
append os.Environ to the lifecycle calls

### DIFF
--- a/cmd/cnbBuild.go
+++ b/cmd/cnbBuild.go
@@ -263,6 +263,8 @@ func runCnbBuild(config *cnbBuildOptions, telemetryData *telemetry.CustomData, u
 		return errors.New("containerRegistryUrl, containerImageName and containerImageTag must be present")
 	}
 
+	utils.AppendEnv(os.Environ())
+
 	err = utils.RunExecutable(detectorPath, "-buildpacks", buildpacksPath, "-order", orderPath)
 	if err != nil {
 		log.SetErrorCategory(log.ErrorBuild)


### PR DESCRIPTION
Current os.Environ content should be always appended to the lifecycle calls, to ensure that dockerEnvVars are properly passed to the buildpacks.

# Changes

- [ ] Tests
- [ ] Documentation
