### PR TITLE
fix (mtaBuild) Mtar file includes multi-form data metadata in the final artifact

### DIFF
--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -247,7 +247,7 @@ func runMtaBuild(config mtaBuildOptions,
 		if (len(config.MtaDeploymentRepositoryPassword) > 0) && (len(config.MtaDeploymentRepositoryUser) > 0) &&
 			(len(config.MtaDeploymentRepositoryURL) > 0) {
 			if (len(config.MtarGroup) > 0) && (len(config.Version) > 0) {
-				/* downloadClient := &piperhttp.Client{} */
+				httpClient := &piperhttp.Client{}
 
 				credentialsEncoded := "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", config.MtaDeploymentRepositoryUser, config.MtaDeploymentRepositoryPassword)))
 				headers := http.Header{}
@@ -266,17 +266,22 @@ func runMtaBuild(config mtaBuildOptions,
 
 				log.Entry().Infof("pushing mtar artifact to repository : %s", config.MtaDeploymentRepositoryURL)
 
-				/* _, httpErr := downloadClient.UploadRequest(http.MethodPut, config.MtaDeploymentRepositoryURL, mtarName, mtarName, headers, nil) */
-				var uploadCall []string
+				/* _, httpErr := httpClient.UploadRequest(http.MethodPut, config.MtaDeploymentRepositoryURL, mtarName, mtarName, headers, nil) */
+				data, err := os.Open(mtarName)
+				if err != nil {
+					return errors.Wrap(err, "failed to open mtar archive for upload")
+				}
+				_, httpErr := httpClient.SendRequest("PUT", config.MtaDeploymentRepositoryURL, data, headers, nil)
+				/* var uploadCall []string
 
 				uploadCall = append(uploadCall, "curl", "--upload-file", mtarName, "-u", config.MtaDeploymentRepositoryUser+":"+config.MtaDeploymentRepositoryPassword, config.MtaDeploymentRepositoryURL)
 				if err := utils.RunExecutable(uploadCall[0], uploadCall[1:]...); err != nil {
 					log.SetErrorCategory(log.ErrorBuild)
 					return errors.Wrap(err, "failed to upload mtar to repository")
-				}
-				/* if httpErr != nil {
-					return errors.Wrap(err, "failed to upload mtar to repository")
 				} */
+				if httpErr != nil {
+					return errors.Wrap(err, "failed to upload mtar to repository")
+				}
 			} else {
 				return errors.New("mtarGroup, version not found and must be present")
 

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -247,7 +247,7 @@ func runMtaBuild(config mtaBuildOptions,
 		if (len(config.MtaDeploymentRepositoryPassword) > 0) && (len(config.MtaDeploymentRepositoryUser) > 0) &&
 			(len(config.MtaDeploymentRepositoryURL) > 0) {
 			if (len(config.MtarGroup) > 0) && (len(config.Version) > 0) {
-				downloadClient := &piperhttp.Client{}
+				/* downloadClient := &piperhttp.Client{} */
 
 				credentialsEncoded := "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", config.MtaDeploymentRepositoryUser, config.MtaDeploymentRepositoryPassword)))
 				headers := http.Header{}
@@ -266,10 +266,17 @@ func runMtaBuild(config mtaBuildOptions,
 
 				log.Entry().Infof("pushing mtar artifact to repository : %s", config.MtaDeploymentRepositoryURL)
 
-				_, httpErr := downloadClient.UploadRequest(http.MethodPut, config.MtaDeploymentRepositoryURL, mtarName, mtarName, headers, nil)
-				if httpErr != nil {
+				/* _, httpErr := downloadClient.UploadRequest(http.MethodPut, config.MtaDeploymentRepositoryURL, mtarName, mtarName, headers, nil) */
+				var uploadCall []string
+
+				uploadCall = append(uploadCall, "curl", "--upload-file", mtarName, "-u", config.MtaDeploymentRepositoryUser+":"+config.MtaDeploymentRepositoryPassword, config.MtaDeploymentRepositoryURL)
+				if err := utils.RunExecutable(uploadCall[0], uploadCall[1:]...); err != nil {
+					log.SetErrorCategory(log.ErrorBuild)
 					return errors.Wrap(err, "failed to upload mtar to repository")
 				}
+				/* if httpErr != nil {
+					return errors.Wrap(err, "failed to upload mtar to repository")
+				} */
 			} else {
 				return errors.New("mtarGroup, version not found and must be present")
 

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -266,19 +266,12 @@ func runMtaBuild(config mtaBuildOptions,
 
 				log.Entry().Infof("pushing mtar artifact to repository : %s", config.MtaDeploymentRepositoryURL)
 
-				/* _, httpErr := httpClient.UploadRequest(http.MethodPut, config.MtaDeploymentRepositoryURL, mtarName, mtarName, headers, nil) */
 				data, err := os.Open(mtarName)
 				if err != nil {
 					return errors.Wrap(err, "failed to open mtar archive for upload")
 				}
 				_, httpErr := httpClient.SendRequest("PUT", config.MtaDeploymentRepositoryURL, data, headers, nil)
-				/* var uploadCall []string
 
-				uploadCall = append(uploadCall, "curl", "--upload-file", mtarName, "-u", config.MtaDeploymentRepositoryUser+":"+config.MtaDeploymentRepositoryPassword, config.MtaDeploymentRepositoryURL)
-				if err := utils.RunExecutable(uploadCall[0], uploadCall[1:]...); err != nil {
-					log.SetErrorCategory(log.ErrorBuild)
-					return errors.Wrap(err, "failed to upload mtar to repository")
-				} */
 				if httpErr != nil {
 					return errors.Wrap(err, "failed to upload mtar to repository")
 				}


### PR DESCRIPTION
# Changes
 
mtar file upload to remote repository like nexus or artifactory used multi-form data in the header which got included in http body and also in the final mtar artifact

curl avoids this issue using --upload-file parameter, but the mtar build container does not contain curl so had to modify the http to upload without multi-form data

- [x] Tests
- [x] Documentation
