### PR TITLE
cnbBuild: buildEnvVars argument for setting custom build env vars

### DIFF
--- a/cmd/cnbBuild_generated.go
+++ b/cmd/cnbBuild_generated.go
@@ -21,6 +21,7 @@ type cnbBuildOptions struct {
 	ContainerImageTag    string   `json:"containerImageTag,omitempty"`
 	ContainerRegistryURL string   `json:"containerRegistryUrl,omitempty"`
 	Buildpacks           []string `json:"buildpacks,omitempty"`
+	BuildEnvVars         []string `json:"buildEnvVars,omitempty"`
 	Path                 string   `json:"path,omitempty"`
 	DockerConfigJSON     string   `json:"dockerConfigJSON,omitempty"`
 }
@@ -137,6 +138,7 @@ func addCnbBuildFlags(cmd *cobra.Command, stepConfig *cnbBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.ContainerImageTag, "containerImageTag", os.Getenv("PIPER_containerImageTag"), "Tag of the container which will be built")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryURL, "containerRegistryUrl", os.Getenv("PIPER_containerRegistryUrl"), "Container registry where the image should be pushed to")
 	cmd.Flags().StringSliceVar(&stepConfig.Buildpacks, "buildpacks", []string{}, "List of custom buildpacks to use in the form of '<hostname>/<repo>[:<tag>]'.")
+	cmd.Flags().StringSliceVar(&stepConfig.BuildEnvVars, "buildEnvVars", []string{}, "List of custom environment variables used during a build in the form of 'KEY=VALUE'.")
 	cmd.Flags().StringVar(&stepConfig.Path, "path", os.Getenv("PIPER_path"), "The path should either point to a directory with your sources or an artifact in zip format.")
 	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")
 
@@ -199,6 +201,15 @@ func cnbBuildMetadata() config.StepData {
 					},
 					{
 						Name:        "buildpacks",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "[]string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     []string{},
+					},
+					{
+						Name:        "buildEnvVars",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",

--- a/cmd/cnbBuild_test.go
+++ b/cmd/cnbBuild_test.go
@@ -52,8 +52,8 @@ func TestRunCnbBuild(t *testing.T) {
 		assert.Equal(t, "/cnb/lifecycle/detector", runner.Calls[0].Exec)
 		assert.Equal(t, "/cnb/lifecycle/builder", runner.Calls[1].Exec)
 		assert.Equal(t, "/cnb/lifecycle/exporter", runner.Calls[2].Exec)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml"}, runner.Calls[0].Params)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml", "-platform", "/platform"}, runner.Calls[0].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-platform", "/platform"}, runner.Calls[1].Params)
 		assert.Equal(t, []string{fmt.Sprintf("%s/%s:%s", registry, config.ContainerImageName, config.ContainerImageTag), fmt.Sprintf("%s/%s:latest", registry, config.ContainerImageName)}, runner.Calls[2].Params)
 	})
 
@@ -79,12 +79,12 @@ func TestRunCnbBuild(t *testing.T) {
 		assert.Equal(t, "/cnb/lifecycle/detector", runner.Calls[0].Exec)
 		assert.Equal(t, "/cnb/lifecycle/builder", runner.Calls[1].Exec)
 		assert.Equal(t, "/cnb/lifecycle/exporter", runner.Calls[2].Exec)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml"}, runner.Calls[0].Params)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml", "-platform", "/platform"}, runner.Calls[0].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-platform", "/platform"}, runner.Calls[1].Params)
 		assert.Equal(t, []string{fmt.Sprintf("%s/%s:%s", registry, config.ContainerImageName, config.ContainerImageTag), fmt.Sprintf("%s/%s:latest", registry, config.ContainerImageName)}, runner.Calls[2].Params)
 	})
 
-	t.Run("success case (custom buildpacks)", func(t *testing.T) {
+	t.Run("success case (custom buildpacks and custom env variables)", func(t *testing.T) {
 		t.Parallel()
 		registry := "some-registry"
 		config := cnbBuildOptions{
@@ -93,6 +93,7 @@ func TestRunCnbBuild(t *testing.T) {
 			ContainerRegistryURL: registry,
 			DockerConfigJSON:     "/path/to/config.json",
 			Buildpacks:           []string{"test"},
+			BuildEnvVars:         []string{"FOO=BAR"},
 		}
 
 		utils := newCnbBuildTestsUtils()
@@ -107,8 +108,8 @@ func TestRunCnbBuild(t *testing.T) {
 		assert.Equal(t, "/cnb/lifecycle/detector", runner.Calls[0].Exec)
 		assert.Equal(t, "/cnb/lifecycle/builder", runner.Calls[1].Exec)
 		assert.Equal(t, "/cnb/lifecycle/exporter", runner.Calls[2].Exec)
-		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks", "-order", "/tmp/buildpacks/order.toml"}, runner.Calls[0].Params)
-		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks", "-order", "/tmp/buildpacks/order.toml", "-platform", "/tmp/platform"}, runner.Calls[0].Params)
+		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks", "-platform", "/tmp/platform"}, runner.Calls[1].Params)
 		assert.Equal(t, []string{fmt.Sprintf("%s/%s:%s", registry, config.ContainerImageName, config.ContainerImageTag), fmt.Sprintf("%s/%s:latest", registry, config.ContainerImageName)}, runner.Calls[2].Params)
 	})
 

--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -17,9 +17,10 @@ func TestNpmProject(t *testing.T) {
 		TestDir: []string{"testdata", "TestMtaIntegration", "npm"},
 	})
 
-	container.whenRunningPiperCommand("cnbBuild", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test")
+	container.whenRunningPiperCommand("cnbBuild", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test", "--buildEnvVars", "BP_NODE_VERSION=15.14.0")
 
 	container.assertHasOutput(t, "running command: /cnb/lifecycle/detector")
+	container.assertHasOutput(t, "Selected Node Engine version (using BP_NODE_VERSION): 15.14.0")
 	container.assertHasOutput(t, "Paketo NPM Start Buildpack")
 	container.assertHasOutput(t, "Saving test/not-found:0.0.1")
 	container.assertHasOutput(t, "failed to write image to the following tags: [test/not-found:0.0.1")

--- a/pkg/cnbutils/env.go
+++ b/pkg/cnbutils/env.go
@@ -1,0 +1,29 @@
+package cnbutils
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func CreateEnvFiles(utils BuildUtils, platformPath string, env []string) error {
+	envDir := filepath.Join(platformPath, "env")
+	err := utils.MkdirAll(envDir, 0755)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range env {
+		eSplit := strings.SplitN(e, "=", 2)
+
+		if len(eSplit) != 2 {
+			return fmt.Errorf("invalid environment variable: %s", e)
+		}
+
+		err = utils.FileWrite(filepath.Join(envDir, eSplit[0]), []byte(eSplit[1]), 0644)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/cnbutils/env_test.go
+++ b/pkg/cnbutils/env_test.go
@@ -1,0 +1,60 @@
+package cnbutils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/SAP/jenkins-library/pkg/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateEnvFiles(t *testing.T) {
+	t.Run("successfully writes environment files", func(t *testing.T) {
+		mockUtils := MockUtils{
+			FilesMock: &mock.FilesMock{},
+		}
+
+		err := CreateEnvFiles(mockUtils, "/tmp/platform", []string{"FOO=BAR", "BAR=BAZ", "COMPLEX={\"foo\": \"bar=3\"}"})
+
+		assert.NoError(t, err)
+		assert.True(t, mockUtils.HasWrittenFile("/tmp/platform/env/FOO"))
+		assert.True(t, mockUtils.HasWrittenFile("/tmp/platform/env/BAR"))
+		assert.True(t, mockUtils.HasWrittenFile("/tmp/platform/env/COMPLEX"))
+
+		result1, err := mockUtils.FileRead("/tmp/platform/env/FOO")
+		assert.NoError(t, err)
+		assert.Equal(t, "BAR", string(result1))
+
+		result2, err := mockUtils.FileRead("/tmp/platform/env/BAR")
+		assert.NoError(t, err)
+		assert.Equal(t, "BAZ", string(result2))
+
+		result3, err := mockUtils.FileRead("/tmp/platform/env/COMPLEX")
+		assert.NoError(t, err)
+		assert.Equal(t, "{\"foo\": \"bar=3\"}", string(result3))
+	})
+
+	t.Run("raises an error if environment variable is invalid", func(t *testing.T) {
+		mockUtils := MockUtils{
+			FilesMock: &mock.FilesMock{},
+		}
+
+		err := CreateEnvFiles(mockUtils, "/tmp/platform", []string{"FOOBAR"})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "invalid environment variable: FOOBAR")
+	})
+
+	t.Run("raises an error if unable to write to a file", func(t *testing.T) {
+		mockUtils := MockUtils{
+			FilesMock: &mock.FilesMock{
+				FileWriteErrors: map[string]error{
+					"/tmp/platform/env/FOO": fmt.Errorf("unable to create dir"),
+				},
+			},
+		}
+
+		err := CreateEnvFiles(mockUtils, "/tmp/platform", []string{"FOO=BAR"})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "unable to create dir")
+	})
+}

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -55,6 +55,13 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: buildEnvVars
+        type: "[]string"
+        description: List of custom environment variables used during a build in the form of 'KEY=VALUE'.
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: path
         type: string
         description: The path should either point to a directory with your sources or an artifact in zip format.

--- a/test/groovy/CnbBuildTest.groovy
+++ b/test/groovy/CnbBuildTest.groovy
@@ -43,15 +43,24 @@ public class CnbBuildTest extends BasePiperTest {
             }
         )
 
-        stepRule.step.cnbBuild(script: nullScript, buildpacks: ['test1', 'test2'], containerImageName: 'foo', containerImageTag: 'bar', containerRegistryUrl: 'test', dockerConfigJsonCredentialsId: 'DOCKER_CREDENTIALS')
+        stepRule.step.cnbBuild(
+            script: nullScript,
+            buildpacks: ['test1', 'test2'],
+            containerImageName: 'foo',
+            containerImageTag: 'bar',
+            containerRegistryUrl: 'test',
+            dockerConfigJsonCredentialsId: 'DOCKER_CREDENTIALS',
+            buildEnvVars: ['foo=bar', 'bar=baz']
+        )
 
-        assertThat(calledWithParameters.size(), is(6))
+        assertThat(calledWithParameters.size(), is(7))
         assertThat(calledWithParameters.script, is(nullScript))
         assertThat(calledWithParameters.buildpacks, is(['test1', 'test2']))
         assertThat(calledWithParameters.containerImageName, is('foo'))
         assertThat(calledWithParameters.containerImageTag, is('bar'))
         assertThat(calledWithParameters.containerRegistryUrl, is('test'))
         assertThat(calledWithParameters.dockerConfigJsonCredentialsId, is('DOCKER_CREDENTIALS'))
+        assertThat(calledWithParameters.buildEnvVars, is(['foo=bar', 'bar=baz']))
 
         assertThat(calledWithStepName, is('cnbBuild'))
         assertThat(calledWithMetadata, is('metadata/cnbBuild.yaml'))


### PR DESCRIPTION
# Changes
New `buildEnvVars` argument for `cnbBuild` step which allows users to set environment variables which should be passed to buildpacks during a build phase.
#3020

- [x] Tests
- [x] Documentation
