### PR TITLE
fix(cnbBuild): put all custom buildpacks under single order entry

### DIFF
--- a/pkg/cnbutils/order.go
+++ b/pkg/cnbutils/order.go
@@ -12,13 +12,7 @@ type Order struct {
 }
 
 type OrderEntry struct {
-	Group []BuildpackRef `toml:"group" json:"group"`
-}
-
-type BuildpackRef struct {
-	ID       string `toml:"id"`
-	Version  string `toml:"version"`
-	Optional bool   `toml:"optional,omitempty" json:"optional,omitempty" yaml:"optional,omitempty"`
+	Group []BuildPackMetadata `toml:"group" json:"group"`
 }
 
 func (o Order) Save(path string) error {

--- a/pkg/cnbutils/order_test.go
+++ b/pkg/cnbutils/order_test.go
@@ -9,22 +9,30 @@ import (
 )
 
 func TestOrderSave(t *testing.T) {
-	t.Run("successfully Encode struct to toml format", func(t *testing.T) {
+	t.Run("successfully Encode struct to toml format (multiple buildpacks)", func(t *testing.T) {
 		mockUtils := MockUtils{
 			ExecMockRunner: &mock.ExecMockRunner{},
 			FilesMock:      &mock.FilesMock{},
 			DockerMock:     &DockerMock{},
 		}
+
+		testBuildpacks := []BuildPackMetadata{
+			{
+				ID:      "paketo-buildpacks/sap-machine",
+				Version: "1.1.1",
+			},
+			{
+				ID:      "paketo-buildpacks/java",
+				Version: "2.2.2",
+			},
+		}
 		testOrder := Order{
-			Order: []OrderEntry{{
-				Group: []BuildpackRef{{
-					ID:       "test",
-					Version:  "0.0.1",
-					Optional: true,
-				}},
-			}},
 			Utils: mockUtils,
 		}
+
+		var testEntry OrderEntry
+		testEntry.Group = append(testEntry.Group, testBuildpacks...)
+		testOrder.Order = []OrderEntry{testEntry}
 
 		err := testOrder.Save("/tmp/order.toml")
 
@@ -32,7 +40,7 @@ func TestOrderSave(t *testing.T) {
 		assert.True(t, mockUtils.HasWrittenFile("/tmp/order.toml"))
 		result, err := mockUtils.FileRead("/tmp/order.toml")
 		assert.NoError(t, err)
-		assert.Equal(t, "\n[[order]]\n\n  [[order.group]]\n    id = \"test\"\n    optional = true\n    version = \"0.0.1\"\n", string(result))
+		assert.Equal(t, "\n[[order]]\n\n  [[order.group]]\n    id = \"paketo-buildpacks/sap-machine\"\n    version = \"1.1.1\"\n\n  [[order.group]]\n    id = \"paketo-buildpacks/java\"\n    version = \"2.2.2\"\n", string(result))
 	})
 
 	t.Run("raises an error if unable to write the file", func(t *testing.T) {
@@ -45,13 +53,6 @@ func TestOrderSave(t *testing.T) {
 			"/tmp/order.toml": fmt.Errorf("unable to write to file"),
 		}
 		testOrder := Order{
-			Order: []OrderEntry{{
-				Group: []BuildpackRef{{
-					ID:       "test",
-					Version:  "0.0.1",
-					Optional: true,
-				}},
-			}},
 			Utils: mockUtils,
 		}
 


### PR DESCRIPTION
# Changes
All custom buildpacks will be put under a single order entry when generating `order.toml` file.


- [x] Tests
- [ ] Documentation
