### PR TITLE
fix(detectEcecuteScan) remove possible values for multi-value fields

### DIFF
--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -21,14 +21,14 @@ type detectExecuteScanOptions struct {
 	Token                      string   `json:"token,omitempty"`
 	CodeLocation               string   `json:"codeLocation,omitempty"`
 	ProjectName                string   `json:"projectName,omitempty"`
-	Scanners                   []string `json:"scanners,omitempty" validate:"oneof=signature source"`
+	Scanners                   []string `json:"scanners,omitempty"`
 	ScanPaths                  []string `json:"scanPaths,omitempty"`
 	DependencyPath             string   `json:"dependencyPath,omitempty"`
 	Unmap                      bool     `json:"unmap,omitempty"`
 	ScanProperties             []string `json:"scanProperties,omitempty"`
 	ServerURL                  string   `json:"serverUrl,omitempty"`
 	Groups                     []string `json:"groups,omitempty"`
-	FailOn                     []string `json:"failOn,omitempty" validate:"oneof=ALL BLOCKER CRITICAL MAJOR MINOR NONE"`
+	FailOn                     []string `json:"failOn,omitempty"`
 	VersioningModel            string   `json:"versioningModel,omitempty" validate:"oneof=major major-minor semantic full"`
 	Version                    string   `json:"version,omitempty"`
 	CustomScanVersion          string   `json:"customScanVersion,omitempty"`

--- a/resources/metadata/detect.yaml
+++ b/resources/metadata/detect.yaml
@@ -65,9 +65,9 @@ spec:
         type: "[]string"
         default:
           - signature
-        possibleValues:
-          - signature
-          - source
+        #possibleValues:
+        #  - signature
+        #  - source
         scope:
           - PARAMETERS
           - STAGES
@@ -146,13 +146,13 @@ spec:
         type: "[]string"
         default:
           - BLOCKER
-        possibleValues:
-          - ALL
-          - BLOCKER
-          - CRITICAL
-          - MAJOR
-          - MINOR
-          - NONE
+        #possibleValues:
+        #  - ALL
+        #  - BLOCKER
+        #  - CRITICAL
+        #  - MAJOR
+        #  - MINOR
+        #  - NONE
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
Looks like validation introduced with PR #3125 has issues with
validation of possible values for multi-value parameters.

This is a workaround to remove the list of possible values for some parameters
and prevent the issue from happening

