### PR TITLE
fix(generator): use quote template function instead of direct quotes

### DIFF
--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -280,7 +278,7 @@ func {{ .StepName }}Metadata() config.StepData {
 						{{ if $res.Type }}Type: {{ $res.Type | quote }}, {{- end }}
 						{{ if $res.Parameters }}Parameters: []map[string]interface{}{ {{- end -}}
 						{{ range $i, $p := $res.Parameters }}
-							{{ if $p.name}}{"Name": {{ $p.Name | quote }}},{{ end -}}
+							{{ if $p.name}}{"Name": {{ $p.name | quote }}},{{ end -}}
 							{{ if $p.fields}}{"fields": []map[string]string{ {{- range $j, $f := $p.fields}} {"name": {{ $f.name | quote }}}, {{end -}} } },{{ end -}}
 							{{ if $p.tags}}{"tags": []map[string]string{ {{- range $j, $t := $p.tags}} {"name": {{ $t.name | quote }}}, {{end -}} } },{{ end -}}
 						{{ end }}
@@ -525,20 +523,13 @@ func ProcessMetaFiles(metadataFiles []string, targetDir string, stepHelperData S
 			checkError(err)
 		}
 	}
+
 	// expose metadata functions
-	code := generateCode(allSteps, "metadata", metadataGeneratedTemplate, nil)
+	code := generateCode(allSteps, "metadata", metadataGeneratedTemplate, sprig.HermeticTxtFuncMap())
 	err := stepHelperData.WriteFile(filepath.Join(targetDir, metadataGeneratedFileName), code, 0644)
 	checkError(err)
 
 	return nil
-}
-
-func openMetaFile(name string) (io.ReadCloser, error) {
-	return os.Open(name)
-}
-
-func fileWriter(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
 }
 
 func setDefaultParameters(stepData *config.StepData) (bool, error) {

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -87,7 +87,7 @@ type {{ .StepName }}Options struct {
 
 // {{.CobraCmdFuncName}} {{.Short}}
 func {{.CobraCmdFuncName}}() *cobra.Command {
-	const STEP_NAME = "{{ .StepName }}"
+	const STEP_NAME = {{ .StepName | quote }}
 
 	metadata := {{ .StepName }}Metadata()
 	var stepConfig {{.StepName}}Options
@@ -98,7 +98,7 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 
 	var {{.CreateCmdVar}} = &cobra.Command{
 		Use:   STEP_NAME,
-		Short: "{{.Short}}",
+		Short: {{.Short | quote }},
 		Long: {{ $tick := "` + "`" + `" }}{{ $tick }}{{.Long | longName }}{{ $tick }},
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			startTime = time.Now()
@@ -147,7 +147,7 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 			handler := func() {
 				config.RemoveVaultSecretFiles()
 				{{- range $notused, $oRes := .OutputResources }}
-				{{ index $oRes "name" }}.persist({{if $.ExportPrefix}}{{ $.ExportPrefix }}.{{end}}GeneralConfig.EnvRootPath, "{{ index $oRes "name" }}"){{ end }}
+				{{ index $oRes "name" }}.persist({{if $.ExportPrefix}}{{ $.ExportPrefix }}.{{end}}GeneralConfig.EnvRootPath, {{ index $oRes "name" | quote }}){{ end }}
 				telemetryData.Duration = fmt.Sprintf("%v", time.Since(startTime).Milliseconds())
 				telemetryData.ErrorCategory = log.GetErrorCategory().String()
 				telemetry.Send(&telemetryData)
@@ -177,22 +177,22 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 
 func {{.FlagsFunc}}(cmd *cobra.Command, stepConfig *{{.StepName}}Options) {
 	{{- range $key, $value := uniqueName .StepParameters }}
-	{{ if isCLIParam $value.Type }}cmd.Flags().{{ $value.Type | flagType }}(&stepConfig.{{ $value.Name | golangName }}, "{{ $value.Name }}", {{ $value.Default }}, "{{ $value.Description }}"){{end}}{{ end }}
+	{{ if isCLIParam $value.Type }}cmd.Flags().{{ $value.Type | flagType }}(&stepConfig.{{ $value.Name | golangName }}, {{ $value.Name | quote }}, {{ $value.Default }}, {{ $value.Description | quote }}){{end}}{{ end }}
 	{{- printf "\n" }}
 	{{- range $key, $value := .StepParameters }}{{ if $value.Mandatory }}
-	cmd.MarkFlagRequired("{{ $value.Name }}"){{ end }}{{ end }}
+	cmd.MarkFlagRequired({{ $value.Name | quote }}){{ end }}{{ end }}
 }
 
 {{ define "resourceRefs"}}
 							{{ "{" }}
-								Name: "{{- .Name }}",
+								Name: {{- .Name | quote }},
 								{{- if .Param }}
-								Param: "{{ .Param }}",
+								Param: {{ .Param | quote }},
 								{{- end }}
 								{{- if .Type }}
-								Type: "{{ .Type }}",
+								Type: {{ .Type | quote }},
 								{{- if .Default }}
-								Default: "{{ .Default }}",
+								Default: {{ .Default | quote }},
 								{{- end}}
 								{{- end }}
 							{{ "}" }},
@@ -203,9 +203,9 @@ func {{.FlagsFunc}}(cmd *cobra.Command, stepConfig *{{.StepName}}Options) {
 func {{ .StepName }}Metadata() config.StepData {
 	var theMetaData = config.StepData{
 		Metadata: config.StepMetadata{
-			Name:    "{{ .StepName }}",
-			Aliases: []config.Alias{{ "{" }}{{ range $notused, $alias := .StepAliases }}{{ "{" }}Name: "{{ $alias.Name }}", Deprecated: {{ $alias.Deprecated }}{{ "}" }},{{ end }}{{ "}" }},
-			Description: "{{ .Short }}",
+			Name:    {{ .StepName | quote }},
+			Aliases: []config.Alias{{ "{" }}{{ range $notused, $alias := .StepAliases }}{{ "{" }}Name: {{ $alias.Name | quote }}, Deprecated: {{ $alias.Deprecated }}{{ "}" }},{{ end }}{{ "}" }},
+			Description: {{ .Short | quote }},
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
@@ -213,10 +213,10 @@ func {{ .StepName }}Metadata() config.StepData {
 				Secrets: []config.StepSecrets{
 					{{- range $secrets := .Secrets }}
 					{
-						{{- if $secrets.Name -}} Name: "{{$secrets.Name}}",{{- end }}
+						{{- if $secrets.Name -}} Name: {{ $secrets.Name | quote }},{{- end }}
 						{{- if $secrets.Description -}} Description: {{$secrets.Description | quote}},{{- end }}
-						{{- if $secrets.Type -}} Type: "{{$secrets.Type}}",{{- end }}
-						{{- if $secrets.Aliases -}} Aliases: []config.Alias{ {{- range $i, $a := $secrets.Aliases }} {Name: "{{$a.Name}}", Deprecated: {{$a.Deprecated}}}, {{ end -}}  },{{- end }}
+						{{- if $secrets.Type -}} Type: {{ $secrets.Type | quote }},{{- end }}
+						{{- if $secrets.Aliases -}} Aliases: []config.Alias{ {{- range $i, $a := $secrets.Aliases }} {Name: {{ $a.Name | quote }}, Deprecated: {{$a.Deprecated}}}, {{ end -}}  },{{- end }}
 					}, {{ end }}
 				},
 				{{ end -}}
@@ -224,24 +224,24 @@ func {{ .StepName }}Metadata() config.StepData {
 				Resources: []config.StepResources{
 					{{- range $resource := .Resources }}
 					{
-						{{- if $resource.Name -}} Name: "{{$resource.Name}}",{{- end }}
-						{{- if $resource.Description -}} Description: "{{$resource.Description}}",{{- end }}
-						{{- if $resource.Type -}} Type: "{{$resource.Type}}",{{- end }}
-						{{- if $resource.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $resource.Conditions }} {ConditionRef: "{{$cond.ConditionRef}}", Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: "{{$p.Name}}", Value: "{{$p.Value}}" }, {{end -}} } }, {{ end -}} },{{ end }}
+						{{- if $resource.Name -}} Name: {{ $resource.Name | quote }},{{- end }}
+						{{- if $resource.Description -}} Description: {{ $resource.Description | quote }},{{- end }}
+						{{- if $resource.Type -}} Type: {{ $resource.Type | quote }},{{- end }}
+						{{- if $resource.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $resource.Conditions }} {ConditionRef: {{ $cond.ConditionRef | quote }}, Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: {{ $p.Name | quote }}, Value: {{ $p.Value | quote }} }, {{end -}} } }, {{ end -}} },{{ end }}
 					},{{- end }}
 				},
 				{{ end -}}
 				Parameters: []config.StepParameters{
 					{{- range $key, $value := .StepParameters }}
 					{
-						Name:      "{{ $value.Name }}",
+						Name:      {{ $value.Name | quote }},
 						ResourceRef: []config.ResourceReference{{ "{" }}{{ range $notused, $ref := $value.ResourceRef }}{{ template "resourceRefs" $ref }}{{ end }}{{ "}" }},
-						Scope:     []string{{ "{" }}{{ range $notused, $scope := $value.Scope }}"{{ $scope }}",{{ end }}{{ "}" }},
-						Type:      "{{ $value.Type }}",
+						Scope:     []string{{ "{" }}{{ range $notused, $scope := $value.Scope }}{{ $scope | quote }},{{ end }}{{ "}" }},
+						Type:      {{ $value.Type | quote }},
 						Mandatory: {{ $value.Mandatory }},
-						Aliases:   []config.Alias{{ "{" }}{{ range $notused, $alias := $value.Aliases }}{{ "{" }}Name: "{{ $alias.Name }}"{{ "}" }},{{ end }}{{ "}" }},
+						Aliases:   []config.Alias{{ "{" }}{{ range $notused, $alias := $value.Aliases }}{{ "{" }}Name: {{ $alias.Name | quote }}{{ "}" }},{{ end }}{{ "}" }},
 						{{ if $value.Default -}} Default:   {{ $value.Default }}, {{- end}}{{ if $value.Conditions }}
-						Conditions: []config.Condition{ {{- range $i, $cond := $value.Conditions }} {ConditionRef: "{{$cond.ConditionRef}}", Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: "{{$p.Name}}", Value: "{{$p.Value}}" }, {{end -}} } }, {{ end -}} },{{- end }}
+						Conditions: []config.Condition{ {{- range $i, $cond := $value.Conditions }} {ConditionRef: {{ $cond.ConditionRef | quote }}, Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: {{ $p.Name | quote }}, Value: {{ $p.Value | quote }} }, {{end -}} } }, {{ end -}} },{{- end }}
 					},{{ end }}
 				},
 			},
@@ -249,12 +249,12 @@ func {{ .StepName }}Metadata() config.StepData {
 			Containers: []config.Container{
 				{{- range $container := .Containers }}
 				{
-					{{- if $container.Name -}} Name: "{{$container.Name}}",{{- end }}
-					{{- if $container.Image -}} Image: "{{$container.Image}}",{{- end }}
-					{{- if $container.EnvVars -}} EnvVars: []config.EnvVar{ {{- range $i, $env := $container.EnvVars }} {Name: "{{$env.Name}}", Value: "{{$env.Value}}"}, {{ end -}}  },{{- end }}
-					{{- if $container.WorkingDir -}} WorkingDir: "{{$container.WorkingDir}}",{{- end }}
-					{{- if $container.Options -}} Options: []config.Option{ {{- range $i, $option := $container.Options }} {Name: "{{$option.Name}}", Value: "{{$option.Value}}"}, {{ end -}} },{{ end }}
-					{{- if $container.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $container.Conditions }} {ConditionRef: "{{$cond.ConditionRef}}", Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: "{{$p.Name}}", Value: "{{$p.Value}}" }, {{end -}} } }, {{ end -}} },{{ end }}
+					{{- if $container.Name -}} Name: {{ $container.Name | quote }},{{- end }}
+					{{- if $container.Image -}} Image: {{ $container.Image | quote }},{{- end }}
+					{{- if $container.EnvVars -}} EnvVars: []config.EnvVar{ {{- range $i, $env := $container.EnvVars }} {Name: {{ $env.Name | quote }}, Value: {{ $env.Value | quote }}}, {{ end -}}  },{{- end }}
+					{{- if $container.WorkingDir -}} WorkingDir: {{ $container.WorkingDir | quote }},{{- end }}
+					{{- if $container.Options -}} Options: []config.Option{ {{- range $i, $option := $container.Options }} {Name: {{ $option.Name | quote }}, Value: {{ $option.Value | quote }}}, {{ end -}} },{{ end }}
+					{{- if $container.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $container.Conditions }} {ConditionRef: {{ $cond.ConditionRef | quote }}, Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: {{ $p.Name | quote }}, Value: {{ $p.Value | quote }} }, {{end -}} } }, {{ end -}} },{{ end }}
 				}, {{ end }}
 			},
 			{{ end -}}
@@ -262,12 +262,12 @@ func {{ .StepName }}Metadata() config.StepData {
 			Sidecars: []config.Container{
 				{{- range $container := .Sidecars }}
 				{
-					{{- if $container.Name -}} Name: "{{$container.Name}}", {{- end }}
-					{{- if $container.Image -}} Image: "{{$container.Image}}", {{- end }}
-					{{- if $container.EnvVars -}} EnvVars: []config.EnvVar{ {{- range $i, $env := $container.EnvVars }} {Name: "{{$env.Name}}", Value: "{{$env.Value}}"}, {{ end -}}  }, {{- end }}
-					{{- if $container.WorkingDir -}} WorkingDir: "{{$container.WorkingDir}}", {{- end }}
-					{{- if $container.Options -}} Options: []config.Option{ {{- range $i, $option := $container.Options }} {Name: "{{$option.Name}}", Value: "{{$option.Value}}"}, {{ end -}} }, {{- end }}
-					{{- if $container.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $container.Conditions }} {ConditionRef: "{{$cond.ConditionRef}}", Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: "{{$p.Name}}", Value: "{{$p.Value}}" }, {{end -}} } }, {{ end -}} }, {{- end }}
+					{{- if $container.Name -}} Name: {{ $container.Name | quote }}, {{- end }}
+					{{- if $container.Image -}} Image: {{ $container.Image | quote }}, {{- end }}
+					{{- if $container.EnvVars -}} EnvVars: []config.EnvVar{ {{- range $i, $env := $container.EnvVars }} {Name: {{ $env.Name | quote }}, Value: {{ $env.Value | quote }}}, {{ end -}}  }, {{- end }}
+					{{- if $container.WorkingDir -}} WorkingDir: {{ $container.WorkingDir | quote }}, {{- end }}
+					{{- if $container.Options -}} Options: []config.Option{ {{- range $i, $option := $container.Options }} {Name: {{ $option.Name | quote }}, Value: {{ $option.Value | quote }}}, {{ end -}} }, {{- end }}
+					{{- if $container.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $container.Conditions }} {ConditionRef: {{ $cond.ConditionRef | quote }}, Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: {{ $p.Name | quote }}, Value: {{ $p.Value | quote }} }, {{end -}} } }, {{ end -}} }, {{- end }}
 				}, {{ end }}
 			},
 			{{ end -}}
@@ -276,16 +276,16 @@ func {{ .StepName }}Metadata() config.StepData {
 				Resources: []config.StepResources{
 					{{- range $res := .Outputs.Resources }}
 					{
-						{{ if $res.Name }}Name: "{{$res.Name}}", {{- end }}
-						{{ if $res.Type }}Type: "{{$res.Type}}", {{- end }}
+						{{ if $res.Name }}Name: {{ $res.Name | quote }}, {{- end }}
+						{{ if $res.Type }}Type: {{ $res.Type | quote }}, {{- end }}
 						{{ if $res.Parameters }}Parameters: []map[string]interface{}{ {{- end -}}
 						{{ range $i, $p := $res.Parameters }}
-							{{ if $p.name}}{"Name": "{{$p.name}}"},{{ end -}}
-							{{ if $p.fields}}{"fields": []map[string]string{ {{- range $j, $f := $p.fields}} {"name": "{{$f.name}}"}, {{end -}} } },{{ end -}}
-							{{ if $p.tags}}{"tags": []map[string]string{ {{- range $j, $t := $p.tags}} {"name": "{{$t.name}}"}, {{end -}} } },{{ end -}}
+							{{ if $p.name}}{"Name": {{ $p.Name | quote }}},{{ end -}}
+							{{ if $p.fields}}{"fields": []map[string]string{ {{- range $j, $f := $p.fields}} {"name": {{ $f.name | quote }}}, {{end -}} } },{{ end -}}
+							{{ if $p.tags}}{"tags": []map[string]string{ {{- range $j, $t := $p.tags}} {"name": {{ $t.name | quote }}}, {{end -}} } },{{ end -}}
 						{{ end }}
 						{{ if $res.Parameters -}} }, {{- end }}
-						{{- if $res.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $res.Conditions }} {ConditionRef: "{{$cond.ConditionRef}}", Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: "{{$p.Name}}", Value: "{{$p.Value}}" }, {{end -}} } }, {{ end -}} },{{ end }}
+						{{- if $res.Conditions -}} Conditions: []config.Condition{ {{- range $i, $cond := $res.Conditions }} {ConditionRef: {{ $cond.ConditionRef | quote }}, Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: {{ $p.Name | quote }}, Value: {{ $p.Value | quote }} }, {{end -}} } }, {{ end -}} },{{ end }}
 					}, {{- end }}
 				},
 			}, {{- end }}
@@ -310,7 +310,7 @@ func Test{{.CobraCmdFuncName}}(t *testing.T) {
 	testCmd := {{.CobraCmdFuncName}}()
 
 	// only high level testing performed - details are tested in step generation procedure
-	assert.Equal(t, "{{ .StepName }}", testCmd.Use, "command name incorrect")
+	assert.Equal(t, {{ .StepName | quote }}, testCmd.Use, "command name incorrect")
 
 }
 `
@@ -459,7 +459,7 @@ import "github.com/SAP/jenkins-library/pkg/config"
 // GetStepMetadata return a map with all the step metadata mapped to their stepName
 func GetAllStepMetadata() map[string]config.StepData {
 	return map[string]config.StepData{
-		{{range $stepName := .Steps }} "{{$stepName}}": {{$stepName}}Metadata(),
+		{{range $stepName := .Steps }} {{ $stepName | quote }}: {{$stepName}}Metadata(),
 		{{end}}
 	}
 }

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -51,7 +51,7 @@ spec:
         aliases:
           - name: helmDeploymentParameters
         type: "[]string"
-        description: Defines additional parameters for \"helm install\" or \"kubectl apply\" command.
+        description: Defines additional parameters for "helm install" or "kubectl apply" command.
         scope:
           - PARAMETERS
           - STAGES
@@ -234,7 +234,7 @@ spec:
           - STEPS
       - name: kubeConfig
         type: string
-        description: Defines the path to the \"kubeconfig\" file.
+        description: Defines the path to the "kubeconfig" file.
         scope:
           - GENERAL
           - PARAMETERS
@@ -249,7 +249,7 @@ spec:
             default: kube-config
       - name: kubeContext
         type: string
-        description: Defines the context to use from the \"kubeconfig\" file.
+        description: Defines the context to use from the "kubeconfig" file.
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
# Changes
Use `quote` template function during templates generation, in order to properly escape characters (e.g. `\n`, `"`).

- [ ] Tests
- [ ] Documentation
