### PR TITLE
Unstash source in kubernetesDeploy

### DIFF
--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -194,6 +194,7 @@ func kubernetesDeployMetadata() config.StepData {
 				},
 				Resources: []config.StepResources{
 					{Name: "deployDescriptor", Type: "stash"},
+					{Name: "source", Type: "stash"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -46,6 +46,8 @@ spec:
     resources:
       - name: deployDescriptor
         type: stash
+      - name: source
+        type: stash
     params:
       - name: additionalParameters
         aliases:


### PR DESCRIPTION
# Changes
Add the source stash to the kubernetesDeploy resources so that files from the application repository can be found (for example [`appTemplate`](https://www.project-piper.io/steps/kubernetesDeploy/#apptemplate) with kubectl deployTool). 

- [ ] Tests
- [ ] Documentation
