### PR TITLE
[kubernetesDeploy] add support for containerImageName and containerImageTag

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -64,9 +64,19 @@ func runHelmDeploy(config kubernetesDeployOptions, command command.ExecRunner, s
 	if err != nil {
 		log.Entry().WithError(err).Fatalf("Container registry url '%v' incorrect", config.ContainerRegistryURL)
 	}
-	containerImageName, containerImageTag, err := splitFullImageName(config.Image)
-	if err != nil {
-		log.Entry().WithError(err).Fatalf("Container image '%v' incorrect", config.Image)
+	//support either image or containerImageName and containerImageTag
+	containerImageName := ""
+	containerImageTag := ""
+	if len(config.ContainerImageName) > 0 && len(config.ContainerImageTag) > 0 {
+		containerImageName = config.ContainerImageName
+		containerImageTag = config.ContainerImageTag
+	} else if len(config.Image) > 0 {
+		containerImageName, containerImageTag, err = splitFullImageName(config.Image)
+		if err != nil {
+			log.Entry().WithError(err).Fatalf("Container image '%v' incorrect", config.Image)
+		}
+	} else {
+		log.Entry().WithError(err).Fatalf("Image information not given. Please either set containerImageName, containerImageTag, and containerRegistryURL, or set image and containerRegistryURL.")
 	}
 	helmLogFields := map[string]interface{}{}
 	helmLogFields["Chart Path"] = config.ChartPath
@@ -237,9 +247,19 @@ func runKubectlDeploy(config kubernetesDeployOptions, command command.ExecRunner
 		log.Entry().WithError(err).Fatalf("Error when reading appTemplate '%v'", config.AppTemplate)
 	}
 
+	//support either image or containerImageName and containerImageTag
+	fullImage := ""
+	if len(config.ContainerImageName) > 0 && len(config.ContainerImageTag) > 0 {
+		fullImage = containerRegistry + "/" + config.ContainerImageName + ":" + config.ContainerImageTag
+	} else if len(config.Image) > 0 {
+		fullImage = config.Image
+	} else {
+		log.Entry().WithError(err).Fatalf("Image information not given. Please either set containerImageName, containerImageTag, and containerRegistryURL, or set image and containerRegistryURL.")
+	}
+
 	// Update image name in deployment yaml, expects placeholder like 'image: <image-name>'
 	re := regexp.MustCompile(`image:[ ]*<image-name>`)
-	appTemplate = []byte(re.ReplaceAllString(string(appTemplate), fmt.Sprintf("image: %v/%v", containerRegistry, config.Image)))
+	appTemplate = []byte(re.ReplaceAllString(string(appTemplate), fmt.Sprintf("image: %v/%v", containerRegistry, fullImage)))
 
 	err = ioutil.WriteFile(config.AppTemplate, appTemplate, 0700)
 	if err != nil {

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -21,6 +21,8 @@ type kubernetesDeployOptions struct {
 	AppTemplate                string   `json:"appTemplate,omitempty"`
 	ChartPath                  string   `json:"chartPath,omitempty"`
 	ContainerRegistryPassword  string   `json:"containerRegistryPassword,omitempty"`
+	ContainerImageName         string   `json:"containerImageName,omitempty"`
+	ContainerImageTag          string   `json:"containerImageTag,omitempty"`
 	ContainerRegistryURL       string   `json:"containerRegistryUrl,omitempty"`
 	ContainerRegistryUser      string   `json:"containerRegistryUser,omitempty"`
 	ContainerRegistrySecret    string   `json:"containerRegistrySecret,omitempty"`
@@ -152,6 +154,8 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringVar(&stepConfig.AppTemplate, "appTemplate", os.Getenv("PIPER_appTemplate"), "Defines the filename for the kubernetes app template (e.g. k8s_apptemplate.yaml)")
 	cmd.Flags().StringVar(&stepConfig.ChartPath, "chartPath", os.Getenv("PIPER_chartPath"), "Defines the chart path for deployments using helm. It is a mandatory parameter when `deployTool:helm` or `deployTool:helm3`.")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryPassword, "containerRegistryPassword", os.Getenv("PIPER_containerRegistryPassword"), "Password for container registry access - typically provided by the CI/CD environment.")
+	cmd.Flags().StringVar(&stepConfig.ContainerImageName, "containerImageName", os.Getenv("PIPER_containerImageName"), "Name of the container which will be built - will be used instead of parameter `containerImage`")
+	cmd.Flags().StringVar(&stepConfig.ContainerImageTag, "containerImageTag", os.Getenv("PIPER_containerImageTag"), "Tag of the container which will be built - will be used instead of parameter `containerImage`")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryURL, "containerRegistryUrl", os.Getenv("PIPER_containerRegistryUrl"), "http(s) url of the Container registry where the image to deploy is located.")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryUser, "containerRegistryUser", os.Getenv("PIPER_containerRegistryUser"), "Username for container registry access - typically provided by the CI/CD environment.")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistrySecret, "containerRegistrySecret", `regsecret`, "Name of the container registry secret used for pulling containers from the registry.")
@@ -246,6 +250,29 @@ func kubernetesDeployMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_containerRegistryPassword"),
+					},
+					{
+						Name:        "containerImageName",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "dockerImageName"}},
+						Default:     os.Getenv("PIPER_containerImageName"),
+					},
+					{
+						Name: "containerImageTag",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "artifactVersion",
+							},
+						},
+						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{{Name: "artifactVersion"}},
+						Default:   os.Getenv("PIPER_containerImageTag"),
 					},
 					{
 						Name: "containerRegistryUrl",

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -96,6 +96,29 @@ spec:
           - name: dockerCredentialsId
             type: secret
             param: password
+      - name: containerImageName
+        aliases:
+          - name: dockerImageName
+        type: string
+        description: Name of the container which will be built - will be used instead of parameter `containerImage`
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
+      - name: containerImageTag
+        aliases:
+          - name: artifactVersion
+        type: string
+        description: Tag of the container which will be built - will be used instead of parameter `containerImage`
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: artifactVersion
       - name: containerRegistryUrl
         aliases:
           - name: dockerRegistryUrl


### PR DESCRIPTION
# Changes
This helps to support using kanikoExecute and kubernetesDeploy within the same pipeline. Otherwise we have to give the image information in multiple forms.

- [ ] Tests
- [x] Documentation
