### PR TITLE
docs: remove hadolint docs in Groovy

### DIFF
--- a/vars/hadolintExecute.groovy
+++ b/vars/hadolintExecute.groovy
@@ -1,5 +1,4 @@
 import static com.sap.piper.Prerequisites.checkScript
-import com.sap.piper.GenerateDocumentation
 import com.sap.piper.ConfigurationHelper
 import com.sap.piper.JenkinsUtils
 import com.sap.piper.Utils


### PR DESCRIPTION
Remove Groovy docs generator annotation to use GOlang based docs generation.