### PR TITLE
fix: permission issues on unix

### DIFF
--- a/cmd/init_unix.go
+++ b/cmd/init_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package cmd
+
+import "syscall"
+
+func init() {
+	// unset umask otherwise permissions on file or directory
+	// creation are altered in unpredictable ways.
+	syscall.Umask(0)
+}


### PR DESCRIPTION
# Changes

`cmd/init_unix.go` got accidentally deleted with (#3175) and now we're facing weird permission issues in our builds.

`error when writing common Pipeline environment: open .pipeline/commonPipelineEnvironment/container/imageNameTag: permission denied`

- [x] Tests
- [x] Documentation
