### PR TITLE
Allow empty default stashes

### DIFF
--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 
 
-def stash(name, include = '**/*.*', exclude = '', useDefaultExcludes = true) {
+def stash(name, include = '**/*.*', exclude = '', useDefaultExcludes = true, allowEmpty = false) {
     echo "Stash content: ${name} (include: ${include}, exclude: ${exclude}, useDefaultExcludes: ${useDefaultExcludes})"
 
     Map stashParams = [
@@ -19,6 +19,10 @@ def stash(name, include = '**/*.*', exclude = '', useDefaultExcludes = true) {
     //only set the optional parameter if default excludes should not be applied
     if (!useDefaultExcludes) {
         stashParams.useDefaultExcludes = useDefaultExcludes
+    }
+    //only set the optional parameter if allowEmpty should be allowed
+    if (allowEmpty) {
+        stashParams.allowEmpty = allowEmpty
     }
     steps.stash stashParams
 }

--- a/vars/pipelineStashFilesAfterBuild.groovy
+++ b/vars/pipelineStashFilesAfterBuild.groovy
@@ -55,7 +55,7 @@ void call(Map parameters = [:]) {
 
         config.stashIncludes.each {stashKey, stashIncludes ->
             def useDefaultExcludes = !config.noDefaultExludes.contains(stashKey)
-            utils.stashWithMessage(stashKey, "[${STEP_NAME}] no files detected for stash '${stashKey}': ", stashIncludes, config.stashExcludes[stashKey]?:'', useDefaultExcludes)
+            utils.stash(stashKey, stashIncludes, config.stashExcludes[stashKey]?:'', useDefaultExcludes, true);
         }
     }
 }

--- a/vars/pipelineStashFilesBeforeBuild.groovy
+++ b/vars/pipelineStashFilesBeforeBuild.groovy
@@ -53,7 +53,7 @@ void call(Map parameters = [:]) {
 
         config.stashIncludes.each {stashKey, stashIncludes ->
             def useDefaultExcludes = !config.noDefaultExludes.contains(stashKey)
-            utils.stashWithMessage(stashKey, "[${STEP_NAME}] no files detected for stash '${stashKey}': ", stashIncludes, config.stashExcludes[stashKey]?:'', useDefaultExcludes)
+            utils.stash(stashKey, stashIncludes, config.stashExcludes[stashKey]?:'', useDefaultExcludes, true);
         }
     }
 }


### PR DESCRIPTION
# Changes

This makes it so that for the default stash/unstash (before and after build)
allowEmpty is set to true therefore not generating an Error. The corresponding
Exception is caught however generating an Error leads to the Error getting
recorded in Jenkins. Since Piper defaults - which can not be easily changed -
include a minimum set of stashes to be created it leads to more user happiness
if no messages are created.

One reason for wanting to change this is that with GitHub integration enabled GitHub checks look like this:
![image](https://user-images.githubusercontent.com/66731536/138476519-630c8f04-8622-44a0-aefb-81aa31727688.png)
The errors created by failing steps can also be easily seen on the Jenkins Blue Ocean view. 

With this change unfortunatly the message about stashes being empty is lost. While this message certainly is useful in some situations it is likely that in many other situations it does not add value as in my experience it's a more common problem that "not the right things" are inside the stashes and not that they are empty.

In general: I think step failure errors should not be caught but instead step failure should be prevented at all cost as their errors will always be bubbled up to the user which is the wrong level of abstraction (the user called piper not a Jenkins step) - see https://github.com/jenkinsci/workflow-step-api-plugin/blob/master/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java#L51-L55

(This https://github.com/SAP/jenkins-library/blob/master/src/com/sap/piper/analytics/InfluxData.groovy#L64-L72 is another offender - I don't have a good idea for that yet though)