### PR TITLE
Update npmExecuteScripts step

### DIFF
--- a/cmd/npmExecuteScripts.go
+++ b/cmd/npmExecuteScripts.go
@@ -18,26 +18,38 @@ func npmExecuteScripts(config npmExecuteScriptsOptions, telemetryData *telemetry
 }
 
 func runNpmExecuteScripts(npmExecutor npm.Executor, config *npmExecuteScriptsOptions) error {
-	if config.Install {
-		packageJSONFiles, err := npmExecutor.FindPackageJSONFilesWithExcludes(config.BuildDescriptorExcludeList)
-		if err != nil {
-			return err
-		}
 
-		err = npmExecutor.InstallAllDependencies(packageJSONFiles)
-		if err != nil {
-			return err
+	if config.Install {
+		if len(config.BuildDescriptorList) > 0 {
+			if err := npmExecutor.InstallAllDependencies(config.BuildDescriptorList); err != nil {
+				return err
+			}
+		} else {
+			packageJSONFiles, err := npmExecutor.FindPackageJSONFilesWithExcludes(config.BuildDescriptorExcludeList)
+			if err != nil {
+				return err
+			}
+
+			if err := npmExecutor.InstallAllDependencies(packageJSONFiles); err != nil {
+				return err
+			}
 		}
 	}
 
 	if config.CreateBOM {
-		packageJSONFiles, err := npmExecutor.FindPackageJSONFilesWithExcludes(config.BuildDescriptorExcludeList)
-		if err != nil {
-			return err
-		}
+		if len(config.BuildDescriptorList) > 0 {
+			if err := npmExecutor.CreateBOM(config.BuildDescriptorList); err != nil {
+				return err
+			}
+		} else {
+			packageJSONFiles, err := npmExecutor.FindPackageJSONFilesWithExcludes(config.BuildDescriptorExcludeList)
+			if err != nil {
+				return err
+			}
 
-		if err := npmExecutor.CreateBOM(packageJSONFiles); err != nil {
-			return err
+			if err := npmExecutor.CreateBOM(packageJSONFiles); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/cmd/npmExecuteScripts_test.go
+++ b/cmd/npmExecuteScripts_test.go
@@ -27,7 +27,7 @@ func newNpmMockUtilsBundle() NpmMockUtilsBundle {
 
 func TestNpmExecuteScripts(t *testing.T) {
 	t.Run("Call with packagesList", func(t *testing.T) {
-		config := npmExecuteScriptsOptions{Install: true, RunScripts: []string{"ci-build", "ci-test"}, BuildDescriptorList: []string{"src/package.json"}}
+		config := npmExecuteScriptsOptions{Install: true, RunScripts: []string{"ci-build", "ci-test"}, BuildDescriptorList: []string{"package.json", "src/package.json"}}
 		utils := npm.NewNpmMockUtilsBundle()
 		utils.AddFile("package.json", []byte("{\"name\": \"Test\" }"))
 		utils.AddFile("src/package.json", []byte("{\"name\": \"Test\" }"))

--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -358,36 +358,15 @@ func (exec *Execute) CreateBOM(packageJSONFiles []string) error {
 		return err
 	}
 	if len(packageJSONFiles) > 0 {
-		path := filepath.Dir(packageJSONFiles[0])
-		createBOMConfig := []string{
-			// https://github.com/CycloneDX/cyclonedx-node-module does not contain schema parameter hence bom creation fails
-			//"--schema", "1.2", // Target schema version
-			"--include-license-text", "false",
-			"--include-dev", "false", // Include devDependencies
-			"--output", "bom.xml",
-		}
-
-		params := []string{
-			"cyclonedx-bom",
-			path,
-		}
-		params = append(params, createBOMConfig...)
-		// Generate BOM from first package.json
-		err := execRunner.RunExecutable("npx", params...)
-		if err != nil {
-			return err
-		}
-
-		// Merge BOM(s) into the current BOM
-		for _, packageJSONFile := range packageJSONFiles[1:] {
+		for _, packageJSONFile := range packageJSONFiles {
 			path := filepath.Dir(packageJSONFile)
-			params = []string{
+			params := []string{
 				"cyclonedx-bom",
 				path,
-				"--append",
-				"bom.xml",
+				"--include-license-text", "false",
+				"--include-dev", "false", // Include devDependencies
+				"--output", path + "/bom.xml",
 			}
-			params = append(params, createBOMConfig...)
 			err := execRunner.RunExecutable("npx", params...)
 			if err != nil {
 				return err

--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -359,9 +359,9 @@ func TestNpm(t *testing.T) {
 			if assert.Equal(t, 3, len(utils.execRunner.Calls)) {
 				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "@cyclonedx/bom", "--no-save"}}, utils.execRunner.Calls[0])
 				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", ".",
-					"--include-license-text", "false", "--include-dev", "false", "--output", "bom.xml"}}, utils.execRunner.Calls[1])
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", "src", "--append", "bom.xml",
-					"--include-license-text", "false", "--include-dev", "false", "--output", "bom.xml"}}, utils.execRunner.Calls[2])
+					"--include-license-text", "false", "--include-dev", "false", "--output", "./bom.xml"}}, utils.execRunner.Calls[1])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", "src",
+					"--include-license-text", "false", "--include-dev", "false", "--output", "src/bom.xml"}}, utils.execRunner.Calls[2])
 			}
 		}
 	})


### PR DESCRIPTION
# Problem description:
 - The previous implementation never considered --buildDescriptorList param and as per the documentation, 
 `--buildDescriptorList: List of build descriptors and therefore modules for execution of the npm scripts. The elements have to be paths to the build descriptors. **If set, buildDescriptorExcludeList will be ignored.*`
if the buildDescriptorList is set then it should be considered for the step execution but it is not the case. To reproduce create any package.json in one folder and keep the piper binary in another and try to createBom using npmExecuteScripts step
-  As per the previous implementation if there were many package.json files specified through --buildDescriptorList  parameter a single cycloneDx bom was supposed to be created by appending previously created bom and this is not working and it fails with fatal error of --append parameter not found. To reproduce try too create cycloneDx BoM with multiple package.json list

# Changes
- Working buildDescriptorList param as per the documentation
- Creating cycloneDx BoM for all the specified buildDescriptorList in a separate file in the build descriptor path itself rather than creating single cycloneDx BoM for the all buildDescriptorList
- Adjusted tests as per the implementation change
