### PR TITLE
kubernetesDeploy - Add option to replace instead of apply

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -268,10 +268,13 @@ func runKubectlDeploy(config kubernetesDeployOptions, command command.ExecRunner
 		log.Entry().WithError(err).Fatalf("Error when updating appTemplate '%v'", config.AppTemplate)
 	}
 
-	if config.Replace == false {
-		kubeParams = append(kubeParams, "apply", "--filename", config.AppTemplate)
-	} else {
-		kubeParams = append(kubeParams, "replace", "--force", "--filename", config.AppTemplate)
+	kubeParams = append(kubeParams, config.DeployCommand, "--filename", config.AppTemplate)
+	if config.ForceUpdates == true {
+		if config.DeployCommand == "replace" {
+			kubeParams = append(kubeParams, "--force")
+		} else {
+			log.Entry().Warn("Ignoring --force flag as it is only applicable for deployCommand replace")
+		}
 	}
 
 	if len(config.AdditionalParameters) > 0 {

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -268,13 +268,18 @@ func runKubectlDeploy(config kubernetesDeployOptions, command command.ExecRunner
 		log.Entry().WithError(err).Fatalf("Error when updating appTemplate '%v'", config.AppTemplate)
 	}
 
-	kubeApplyParams := append(kubeParams, "apply", "--filename", config.AppTemplate)
-	if len(config.AdditionalParameters) > 0 {
-		kubeApplyParams = append(kubeApplyParams, config.AdditionalParameters...)
+	if config.Replace == false {
+		kubeParams = append(kubeParams, "apply", "--filename", config.AppTemplate)
+	} else {
+		kubeParams = append(kubeParams, "replace", "--force", "--filename", config.AppTemplate)
 	}
 
-	if err := command.RunExecutable("kubectl", kubeApplyParams...); err != nil {
-		log.Entry().Debugf("Running kubectl with following parameters: %v", kubeApplyParams)
+	if len(config.AdditionalParameters) > 0 {
+		kubeParams = append(kubeParams, config.AdditionalParameters...)
+	}
+
+	if err := command.RunExecutable("kubectl", kubeParams...); err != nil {
+		log.Entry().Debugf("Running kubectl with following parameters: %v", kubeParams)
 		log.Entry().WithError(err).Fatal("Deployment with kubectl failed.")
 	}
 	return nil

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -269,12 +269,8 @@ func runKubectlDeploy(config kubernetesDeployOptions, command command.ExecRunner
 	}
 
 	kubeParams = append(kubeParams, config.DeployCommand, "--filename", config.AppTemplate)
-	if config.ForceUpdates == true {
-		if config.DeployCommand == "replace" {
-			kubeParams = append(kubeParams, "--force")
-		} else {
-			log.Entry().Warn("Ignoring --force flag as it is only applicable for deployCommand replace")
-		}
+	if config.ForceUpdates == true && config.DeployCommand == "replace" {
+		kubeParams = append(kubeParams, "--force")
 	}
 
 	if len(config.AdditionalParameters) > 0 {

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -175,7 +175,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringVar(&stepConfig.Namespace, "namespace", `default`, "Defines the target Kubernetes namespace for the deployment.")
 	cmd.Flags().StringVar(&stepConfig.TillerNamespace, "tillerNamespace", os.Getenv("PIPER_tillerNamespace"), "Defines optional tiller namespace for deployments using helm.")
 	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")
-	cmd.Flags().StringVar(&stepConfig.DeployCommand, "deployCommand", `apply`, "kubectl only: defines the command apply or replace. default is apply")
+	cmd.Flags().StringVar(&stepConfig.DeployCommand, "deployCommand", `apply`, "Only for `deployTool: kubectl`: defines the command `apply` or `replace`. The default is `apply`.")
 
 	cmd.MarkFlagRequired("containerRegistryUrl")
 	cmd.MarkFlagRequired("deployTool")

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -41,6 +41,7 @@ type kubernetesDeployOptions struct {
 	Namespace                  string   `json:"namespace,omitempty"`
 	TillerNamespace            string   `json:"tillerNamespace,omitempty"`
 	DockerConfigJSON           string   `json:"dockerConfigJSON,omitempty"`
+	Replace                    bool     `json:"replace,omitempty"`
 }
 
 // KubernetesDeployCommand Deployment to Kubernetes test or production namespace within the specified Kubernetes cluster.
@@ -174,6 +175,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringVar(&stepConfig.Namespace, "namespace", `default`, "Defines the target Kubernetes namespace for the deployment.")
 	cmd.Flags().StringVar(&stepConfig.TillerNamespace, "tillerNamespace", os.Getenv("PIPER_tillerNamespace"), "Defines optional tiller namespace for deployments using helm.")
 	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")
+	cmd.Flags().BoolVar(&stepConfig.Replace, "replace", false, "Defines whether to run `replace --force` instead of `apply` kubectl command.")
 
 	cmd.MarkFlagRequired("containerRegistryUrl")
 	cmd.MarkFlagRequired("deployTool")
@@ -483,6 +485,15 @@ func kubernetesDeployMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_dockerConfigJSON"),
+					},
+					{
+						Name:        "replace",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
 					},
 				},
 			},

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -163,7 +163,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().BoolVar(&stepConfig.CreateDockerRegistrySecret, "createDockerRegistrySecret", false, "Only for `deployTool:kubectl`: Toggle to turn on `containerRegistrySecret` creation.")
 	cmd.Flags().StringVar(&stepConfig.DeploymentName, "deploymentName", os.Getenv("PIPER_deploymentName"), "Defines the name of the deployment. It is a mandatory parameter when `deployTool:helm` or `deployTool:helm3`.")
 	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", `kubectl`, "Defines the tool which should be used for deployment.")
-	cmd.Flags().BoolVar(&stepConfig.ForceUpdates, "forceUpdates", true, "add `--force` flag to a helm resource update or kubectl replace command")
+	cmd.Flags().BoolVar(&stepConfig.ForceUpdates, "forceUpdates", true, "Adds `--force` flag to a helm resource update command or to a kubectl replace command")
 	cmd.Flags().IntVar(&stepConfig.HelmDeployWaitSeconds, "helmDeployWaitSeconds", 300, "Number of seconds before helm deploy returns.")
 	cmd.Flags().StringSliceVar(&stepConfig.HelmValues, "helmValues", []string{}, "List of helm values as YAML file reference or URL (as per helm parameter description for `-f` / `--values`)")
 	cmd.Flags().StringVar(&stepConfig.Image, "image", os.Getenv("PIPER_image"), "Full name of the image to be deployed.")

--- a/cmd/kubernetesDeploy_test.go
+++ b/cmd/kubernetesDeploy_test.go
@@ -587,6 +587,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			KubeConfig:                 "This is my kubeconfig",
 			KubeContext:                "testCluster",
 			Namespace:                  "deploymentNamespace",
+			DeployCommand:              "apply",
 		}
 
 		kubeYaml := `kind: Deployment
@@ -666,6 +667,7 @@ spec:
 			KubeConfig:                 "This is my kubeconfig",
 			KubeContext:                "testCluster",
 			Namespace:                  "deploymentNamespace",
+			DeployCommand:              "apply",
 		}
 
 		kubeYaml := `kind: Deployment
@@ -715,6 +717,7 @@ spec:
 			Image:                      "path/to/Image:latest",
 			KubeConfig:                 "This is my kubeconfig",
 			Namespace:                  "deploymentNamespace",
+			DeployCommand:              "apply",
 		}
 
 		ioutil.WriteFile(opts.AppTemplate, []byte("testYaml"), 0755)
@@ -759,6 +762,7 @@ spec:
 			Image:                     "path/to/Image:latest",
 			KubeToken:                 "testToken",
 			Namespace:                 "deploymentNamespace",
+			DeployCommand:             "apply",
 		}
 
 		ioutil.WriteFile(opts.AppTemplate, []byte("testYaml"), 0755)
@@ -798,6 +802,7 @@ spec:
 			ContainerImageName:        "path/to/Image",
 			KubeConfig:                "This is my kubeconfig",
 			Namespace:                 "deploymentNamespace",
+			DeployCommand:             "apply",
 		}
 
 		ioutil.WriteFile(opts.AppTemplate, []byte("image: <image-name>"), 0755)
@@ -829,6 +834,7 @@ spec:
 			DeployTool:                "kubectl",
 			KubeConfig:                "This is my kubeconfig",
 			Namespace:                 "deploymentNamespace",
+			DeployCommand:             "apply",
 		}
 
 		ioutil.WriteFile(opts.AppTemplate, []byte("testYaml"), 0755)
@@ -840,7 +846,7 @@ spec:
 		assert.EqualError(t, err, "image information not given - please either set image or containerImageName and containerImageTag")
 	})
 
-	t.Run("test kubectl - use replace --force", func(t *testing.T) {
+	t.Run("test kubectl - use replace deploy command", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "")
 		defer os.RemoveAll(dir) // clean up
 		assert.NoError(t, err, "Error when creating temp dir")
@@ -858,7 +864,7 @@ spec:
 			KubeConfig:                 "This is my kubeconfig",
 			KubeContext:                "testCluster",
 			Namespace:                  "deploymentNamespace",
-			Replace:                    true,
+			DeployCommand:              "replace",
 		}
 
 		kubeYaml := `kind: Deployment
@@ -883,9 +889,63 @@ spec:
 			fmt.Sprintf("--namespace=%v", opts.Namespace),
 			fmt.Sprintf("--context=%v", opts.KubeContext),
 			"replace",
-			"--force",
 			"--filename",
 			opts.AppTemplate,
+			"--testParam",
+			"testValue",
+		}, e.Calls[1].Params, "kubectl parameters incorrect")
+
+		appTemplate, err := ioutil.ReadFile(opts.AppTemplate)
+		assert.Contains(t, string(appTemplate), "my.registry:55555/path/to/Image:latest")
+	})
+
+	t.Run("test kubectl - use replace --force deploy command", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "")
+		defer os.RemoveAll(dir) // clean up
+		assert.NoError(t, err, "Error when creating temp dir")
+
+		opts := kubernetesDeployOptions{
+			AppTemplate:                filepath.Join(dir, "test.yaml"),
+			ContainerRegistryURL:       "https://my.registry:55555",
+			ContainerRegistryUser:      "registryUser",
+			ContainerRegistryPassword:  "********",
+			ContainerRegistrySecret:    "regSecret",
+			CreateDockerRegistrySecret: true,
+			DeployTool:                 "kubectl",
+			Image:                      "path/to/Image:latest",
+			AdditionalParameters:       []string{"--testParam", "testValue"},
+			KubeConfig:                 "This is my kubeconfig",
+			KubeContext:                "testCluster",
+			Namespace:                  "deploymentNamespace",
+			DeployCommand:              "replace",
+			ForceUpdates:               true,
+		}
+
+		kubeYaml := `kind: Deployment
+metadata:
+spec:
+  spec:
+    image: <image-name>`
+
+		err = ioutil.WriteFile(opts.AppTemplate, []byte(kubeYaml), 0755)
+		assert.NoError(t, err, "Error when writing app template file")
+
+		e := mock.ExecMockRunner{}
+		var stdout bytes.Buffer
+		err = runKubernetesDeploy(opts, &e, &stdout)
+		assert.NoError(t, err, "Command should not fail")
+
+		assert.Equal(t, e.Env, []string{"KUBECONFIG=This is my kubeconfig"})
+
+		assert.Equal(t, "kubectl", e.Calls[1].Exec, "Wrong replace command")
+		assert.Equal(t, []string{
+			"--insecure-skip-tls-verify=true",
+			fmt.Sprintf("--namespace=%v", opts.Namespace),
+			fmt.Sprintf("--context=%v", opts.KubeContext),
+			"replace",
+			"--filename",
+			opts.AppTemplate,
+			"--force",
 			"--testParam",
 			"testValue",
 		}, e.Calls[1].Params, "kubectl parameters incorrect")

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -198,7 +198,7 @@ spec:
         aliases:
           - name: force
         type: bool
-        description: "add `--force` flag to a helm resource update or kubectl replace command"
+        description: "Adds `--force` flag to a helm resource update command or to a kubectl replace command"
         mandatory: false
         scope:
           - PARAMETERS

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -329,7 +329,7 @@ spec:
             default: docker-config
       - name: deployCommand
         type: string
-        description: "kubectl only: defines the command apply or replace. default is apply"
+        description: "Only for `deployTool: kubectl`: defines the command `apply` or `replace`. The default is `apply`."
         mandatory: false
         scope:
           - PARAMETERS

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -195,8 +195,10 @@ spec:
           - helm
           - helm3
       - name: forceUpdates
+        aliases:
+          - name: force
         type: bool
-        description: "Helm only: force resource updates with helm parameter `--force`"
+        description: "add `--force` flag to a helm resource update or kubectl replace command"
         mandatory: false
         scope:
           - PARAMETERS
@@ -325,14 +327,18 @@ spec:
           - type: vaultSecretFile
             name: dockerConfigFileVaultSecretName
             default: docker-config
-      - name: replace
-        type: bool
-        description: Defines whether to run `replace --force` instead of `apply` kubectl command.
-        default: false
+      - name: deployCommand
+        type: string
+        description: "kubectl only: defines the command apply or replace. default is apply"
+        mandatory: false
         scope:
           - PARAMETERS
           - STAGES
           - STEPS
+        default: apply
+        possibleValues:
+          - apply
+          - replace
   containers:
     - image: dtzar/helm-kubectl:3.4.1
       workingDir: /config

--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -325,6 +325,14 @@ spec:
           - type: vaultSecretFile
             name: dockerConfigFileVaultSecretName
             default: docker-config
+      - name: replace
+        type: bool
+        description: Defines whether to run `replace --force` instead of `apply` kubectl command.
+        default: false
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
   containers:
     - image: dtzar/helm-kubectl:3.4.1
       workingDir: /config


### PR DESCRIPTION
# Changes

Add an optional parameter to run `replace --force` instead of `apply` when running the kubernetesDeploy step with the kubectl flavor.

- [x] Tests
- [x] Documentation
