### PR TITLE
feat(cnbBuild): support for paketo bindings

### DIFF
--- a/cmd/cnbBuild_generated.go
+++ b/cmd/cnbBuild_generated.go
@@ -18,16 +18,17 @@ import (
 )
 
 type cnbBuildOptions struct {
-	ContainerImageName        string   `json:"containerImageName,omitempty"`
-	ContainerImageTag         string   `json:"containerImageTag,omitempty"`
-	ContainerRegistryURL      string   `json:"containerRegistryUrl,omitempty"`
-	Buildpacks                []string `json:"buildpacks,omitempty"`
-	BuildEnvVars              []string `json:"buildEnvVars,omitempty"`
-	Path                      string   `json:"path,omitempty"`
-	ProjectDescriptor         string   `json:"projectDescriptor,omitempty"`
-	DockerConfigJSON          string   `json:"dockerConfigJSON,omitempty"`
-	CustomTLSCertificateLinks []string `json:"customTlsCertificateLinks,omitempty"`
-	AdditionalTags            []string `json:"additionalTags,omitempty"`
+	ContainerImageName        string                 `json:"containerImageName,omitempty"`
+	ContainerImageTag         string                 `json:"containerImageTag,omitempty"`
+	ContainerRegistryURL      string                 `json:"containerRegistryUrl,omitempty"`
+	Buildpacks                []string               `json:"buildpacks,omitempty"`
+	BuildEnvVars              []string               `json:"buildEnvVars,omitempty"`
+	Path                      string                 `json:"path,omitempty"`
+	ProjectDescriptor         string                 `json:"projectDescriptor,omitempty"`
+	DockerConfigJSON          string                 `json:"dockerConfigJSON,omitempty"`
+	CustomTLSCertificateLinks []string               `json:"customTlsCertificateLinks,omitempty"`
+	AdditionalTags            []string               `json:"additionalTags,omitempty"`
+	Bindings                  map[string]interface{} `json:"bindings,omitempty"`
 }
 
 type cnbBuildCommonPipelineEnvironment struct {
@@ -292,6 +293,14 @@ func cnbBuildMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     []string{},
+					},
+					{
+						Name:        "bindings",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "map[string]interface{}",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
 					},
 				},
 			},

--- a/cmd/cnbBuild_test.go
+++ b/cmd/cnbBuild_test.go
@@ -55,8 +55,8 @@ func TestRunCnbBuild(t *testing.T) {
 		assert.Equal(t, "/cnb/lifecycle/detector", runner.Calls[0].Exec)
 		assert.Equal(t, "/cnb/lifecycle/builder", runner.Calls[1].Exec)
 		assert.Equal(t, "/cnb/lifecycle/exporter", runner.Calls[2].Exec)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml", "-platform", "/platform"}, runner.Calls[0].Params)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-platform", "/platform"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml", "-platform", "/tmp/platform"}, runner.Calls[0].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-platform", "/tmp/platform"}, runner.Calls[1].Params)
 		assert.Equal(t, []string{fmt.Sprintf("%s/%s:%s", registry, config.ContainerImageName, config.ContainerImageTag)}, runner.Calls[2].Params)
 	})
 
@@ -82,8 +82,8 @@ func TestRunCnbBuild(t *testing.T) {
 		assert.Equal(t, "/cnb/lifecycle/detector", runner.Calls[0].Exec)
 		assert.Equal(t, "/cnb/lifecycle/builder", runner.Calls[1].Exec)
 		assert.Equal(t, "/cnb/lifecycle/exporter", runner.Calls[2].Exec)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml", "-platform", "/platform"}, runner.Calls[0].Params)
-		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-platform", "/platform"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-order", "/cnb/order.toml", "-platform", "/tmp/platform"}, runner.Calls[0].Params)
+		assert.Equal(t, []string{"-buildpacks", "/cnb/buildpacks", "-platform", "/tmp/platform"}, runner.Calls[1].Params)
 		assert.Equal(t, []string{fmt.Sprintf("%s/%s:%s", registry, config.ContainerImageName, config.ContainerImageTag)}, runner.Calls[2].Params)
 	})
 
@@ -157,8 +157,8 @@ func TestRunCnbBuild(t *testing.T) {
 		assert.Equal(t, "/cnb/lifecycle/detector", runner.Calls[0].Exec)
 		assert.Equal(t, "/cnb/lifecycle/builder", runner.Calls[1].Exec)
 		assert.Equal(t, "/cnb/lifecycle/exporter", runner.Calls[2].Exec)
-		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks", "-order", "/tmp/buildpacks/order.toml", "-platform", "/platform"}, runner.Calls[0].Params)
-		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks", "-platform", "/platform"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks", "-order", "/tmp/buildpacks/order.toml", "-platform", "/tmp/platform"}, runner.Calls[0].Params)
+		assert.Equal(t, []string{"-buildpacks", "/tmp/buildpacks", "-platform", "/tmp/platform"}, runner.Calls[1].Params)
 		assert.Equal(t, []string{fmt.Sprintf("%s/%s:%s", registry, config.ContainerImageName, config.ContainerImageTag)}, runner.Calls[2].Params)
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/magicsong/color-glog v0.0.1 // indirect
 	github.com/magicsong/sonargo v0.0.1
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/motemen/go-nuts v0.0.0-20210915132349-615a782f2c69
 	github.com/pelletier/go-toml v1.9.4
 	github.com/piper-validation/fortify-client-go v0.0.0-20210114140201-1261216783c6

--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -56,7 +56,7 @@ func TestZipPath(t *testing.T) {
 		TestDir: []string{"testdata", "TestCnbIntegration", "zip"},
 	})
 
-	container.whenRunningPiperCommand("cnbBuild", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test", "--path", "go.zip")
+	container.whenRunningPiperCommand("cnbBuild", "--customConfig", "config.yml", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test", "--path", "go.zip")
 
 	container.assertHasOutput(t, "running command: /cnb/lifecycle/detector")
 	container.assertHasOutput(t, "Installing Go")

--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -56,7 +56,7 @@ func TestZipPath(t *testing.T) {
 		TestDir: []string{"testdata", "TestCnbIntegration", "zip"},
 	})
 
-	container.whenRunningPiperCommand("cnbBuild", "--customConfig", "config.yml", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test", "--path", "go.zip")
+	container.whenRunningPiperCommand("cnbBuild", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test", "--path", "go.zip")
 
 	container.assertHasOutput(t, "running command: /cnb/lifecycle/detector")
 	container.assertHasOutput(t, "Installing Go")
@@ -123,4 +123,19 @@ func TestWrongBuilderProject(t *testing.T) {
 	container.whenRunningPiperCommand("cnbBuild", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test")
 
 	container.assertHasOutput(t, "the provided dockerImage is not a valid builder")
+}
+
+func TestBindings(t *testing.T) {
+	t.Parallel()
+	container := givenThisContainer(t, IntegrationTestDockerExecRunnerBundle{
+		Image:   "paketobuildpacks/builder:full",
+		User:    "cnb",
+		TestDir: []string{"testdata"},
+	})
+
+	container.whenRunningPiperCommand("cnbBuild", "--customConfig", "TestCnbIntegration/config.yml", "--containerImageName", "not-found", "--containerImageTag", "0.0.1", "--containerRegistryUrl", "test", "--path", "TestMtaIntegration/maven")
+
+	container.assertHasOutput(t, "bindings/maven-settings/settings.xml: only whitespace content allowed before start tag")
+	container.assertHasFile(t, "/tmp/platform/bindings/dummy-binding/type")
+	container.assertHasFile(t, "/tmp/platform/bindings/dummy-binding/dummy.yml")
 }

--- a/integration/testdata/TestCnbIntegration/config.yml
+++ b/integration/testdata/TestCnbIntegration/config.yml
@@ -1,0 +1,11 @@
+steps:
+  cnbBuild:
+    bindings:
+      maven-settings:
+        type: maven
+        secret: settings.xml
+        content: "invalid xml"
+      dummy-binding:
+        type: dummy
+        secret: dummy.yml
+        file: TestCnbIntegration/config.yml

--- a/integration/testdata/TestCnbIntegration/config.yml
+++ b/integration/testdata/TestCnbIntegration/config.yml
@@ -3,9 +3,9 @@ steps:
     bindings:
       maven-settings:
         type: maven
-        secret: settings.xml
+        key: settings.xml
         content: "invalid xml"
       dummy-binding:
         type: dummy
-        secret: dummy.yml
+        key: dummy.yml
         file: TestCnbIntegration/config.yml

--- a/integration/testdata/TestCnbIntegration/zip/config.yml
+++ b/integration/testdata/TestCnbIntegration/zip/config.yml
@@ -1,0 +1,6 @@
+steps:
+  cnbBuild:
+    bindings:
+      maven-settings:
+        type: maven
+        secret: settings.xml

--- a/integration/testdata/TestCnbIntegration/zip/config.yml
+++ b/integration/testdata/TestCnbIntegration/zip/config.yml
@@ -1,6 +1,0 @@
-steps:
-  cnbBuild:
-    bindings:
-      maven-settings:
-        type: maven
-        secret: settings.xml

--- a/pkg/cnbutils/bindings/bindings.go
+++ b/pkg/cnbutils/bindings/bindings.go
@@ -13,7 +13,7 @@ import (
 
 type binding struct {
 	Type    string  `json:"type"`
-	Secret  string  `json:"secret"`
+	Key     string  `json:"key"`
 	Content *string `json:"content,omitempty"`
 	File    *string `json:"file,omitempty"`
 }
@@ -56,12 +56,12 @@ func processBinding(utils cnbutils.BuildUtils, platformPath string, name string,
 	}
 
 	if binding.Content != nil {
-		err = utils.FileWrite(filepath.Join(bindingDir, binding.Secret), []byte(*binding.Content), 0644)
+		err = utils.FileWrite(filepath.Join(bindingDir, binding.Key), []byte(*binding.Content), 0644)
 		if err != nil {
 			return err
 		}
 	} else {
-		_, err = utils.Copy(*binding.File, filepath.Join(bindingDir, binding.Secret))
+		_, err = utils.Copy(*binding.File, filepath.Join(bindingDir, binding.Key))
 		if err != nil {
 			return err
 		}
@@ -71,11 +71,11 @@ func processBinding(utils cnbutils.BuildUtils, platformPath string, name string,
 
 func validateBinding(name string, binding binding) error {
 	if !validName(name) {
-		return fmt.Errorf("invalid binding name: %s", name)
+		return fmt.Errorf("invalid binding name: '%s'", name)
 	}
 
-	if !validName(binding.Secret) {
-		return fmt.Errorf("invalid secret name: %s", binding.Secret)
+	if !validName(binding.Key) {
+		return fmt.Errorf("invalid key: '%s'", binding.Key)
 	}
 
 	if (binding.Content == nil && binding.File == nil) || (binding.Content != nil && binding.File != nil) {

--- a/pkg/cnbutils/bindings/bindings.go
+++ b/pkg/cnbutils/bindings/bindings.go
@@ -1,0 +1,89 @@
+// Package bindings provides utility function to create buildpack bindings folder structures
+package bindings
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/SAP/jenkins-library/pkg/cnbutils"
+)
+
+type Binding struct {
+	Type    string  `json:"type"`
+	Secret  string  `json:"secret"`
+	Content *string `json:"content,omitempty"`
+	File    *string `json:"file,omitempty"`
+}
+
+func ProcessBindings(utils cnbutils.BuildUtils, platformPath string, bindings map[string]interface{}) error {
+	for n, v := range bindings {
+		if !validName(n) {
+			return fmt.Errorf("invalid binding name: %s", n)
+		}
+
+		binding, err := toStruct(v)
+		if err != nil {
+			return err
+		}
+
+		if !validName(binding.Secret) {
+			return fmt.Errorf("invalid secret name: %s", binding.Secret)
+		}
+
+		if (binding.Content == nil && binding.File == nil) || (binding.Content != nil && binding.File != nil) {
+			return errors.New("either 'file' or 'content' property must be specified for binding")
+		}
+
+		bindingDir := filepath.Join(platformPath, "bindings", n)
+		err = utils.MkdirAll(bindingDir, 0755)
+		if err != nil {
+			return err
+		}
+
+		err = utils.FileWrite(filepath.Join(bindingDir, "type"), []byte(binding.Type), 0644)
+		if err != nil {
+			return err
+		}
+
+		if binding.Content != nil {
+			err = utils.FileWrite(filepath.Join(bindingDir, binding.Secret), []byte(*binding.Content), 0644)
+			if err != nil {
+				return err
+			}
+		} else {
+			_, err = utils.Copy(*binding.File, filepath.Join(bindingDir, binding.Secret))
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+func toStruct(rawData interface{}) (Binding, error) {
+	var b Binding
+	byteData, err := json.Marshal(rawData)
+	if err != nil {
+		return Binding{}, err
+	}
+
+	err = json.Unmarshal(byteData, &b)
+	if err != nil {
+		return Binding{}, err
+	}
+
+	return b, nil
+}
+
+func validName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+
+	return !strings.ContainsAny(name, "/")
+}

--- a/pkg/cnbutils/bindings/bindings_test.go
+++ b/pkg/cnbutils/bindings/bindings_test.go
@@ -127,7 +127,22 @@ func TestProcessBindings(t *testing.T) {
 		})
 
 		if assert.Error(t, err) {
-			assert.Contains(t, err.Error(), "cannot unmarshal")
+			assert.Equal(t, "1 error(s) decoding:\n\n* '[binding]' expected a map, got 'int'", err.Error())
+
+		}
+	})
+
+	t.Run("fails with invalid map", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
+			"test": map[string]interface{}{
+				"secret": "test.yaml",
+				"typo":   "test",
+			},
+		})
+
+		if assert.Error(t, err) {
+			assert.Equal(t, "1 error(s) decoding:\n\n* '[test]' has invalid keys: typo", err.Error())
 		}
 	})
 }

--- a/pkg/cnbutils/bindings/bindings_test.go
+++ b/pkg/cnbutils/bindings/bindings_test.go
@@ -23,14 +23,14 @@ func TestProcessBindings(t *testing.T) {
 		var utils = mockUtils()
 		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
 			"a": map[string]interface{}{
-				"secret":  "inline.yaml",
+				"key":     "inline.yaml",
 				"type":    "inline",
 				"content": "my inline content",
 			},
 			"b": map[string]interface{}{
-				"secret": "from-file.yaml",
-				"type":   "file",
-				"file":   "/tmp/somefile.yaml",
+				"key":  "from-file.yaml",
+				"type": "file",
+				"file": "/tmp/somefile.yaml",
 			},
 		})
 
@@ -64,29 +64,29 @@ func TestProcessBindings(t *testing.T) {
 		var utils = mockUtils()
 		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
 			"..": map[string]interface{}{
-				"secret":  "inline.yaml",
+				"key":     "inline.yaml",
 				"type":    "inline",
 				"content": "my inline content",
 			},
 		})
 
 		if assert.Error(t, err) {
-			assert.Equal(t, "invalid binding name: ..", err.Error())
+			assert.Equal(t, "invalid binding name: '..'", err.Error())
 		}
 	})
 
-	t.Run("fails with the secret being invalid", func(t *testing.T) {
+	t.Run("fails with the key being invalid", func(t *testing.T) {
 		var utils = mockUtils()
 		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
 			"binding": map[string]interface{}{
-				"secret":  "test/test.yaml",
+				"key":     "test/test.yaml",
 				"type":    "inline",
 				"content": "my inline content",
 			},
 		})
 
 		if assert.Error(t, err) {
-			assert.Equal(t, "invalid secret name: test/test.yaml", err.Error())
+			assert.Equal(t, "invalid key: 'test/test.yaml'", err.Error())
 		}
 	})
 
@@ -94,7 +94,7 @@ func TestProcessBindings(t *testing.T) {
 		var utils = mockUtils()
 		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
 			"binding": map[string]interface{}{
-				"secret":  "test.yaml",
+				"key":     "test.yaml",
 				"type":    "both",
 				"content": "my inline content",
 				"file":    "/tmp/somefile.yaml",
@@ -110,8 +110,8 @@ func TestProcessBindings(t *testing.T) {
 		var utils = mockUtils()
 		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
 			"binding": map[string]interface{}{
-				"secret": "test.yaml",
-				"type":   "none",
+				"key":  "test.yaml",
+				"type": "none",
 			},
 		})
 
@@ -136,8 +136,8 @@ func TestProcessBindings(t *testing.T) {
 		var utils = mockUtils()
 		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
 			"test": map[string]interface{}{
-				"secret": "test.yaml",
-				"typo":   "test",
+				"key":  "test.yaml",
+				"typo": "test",
 			},
 		})
 

--- a/pkg/cnbutils/bindings/bindings_test.go
+++ b/pkg/cnbutils/bindings/bindings_test.go
@@ -1,0 +1,25 @@
+package bindings_test
+
+import "testing"
+
+func TestProcessBindings(t *testing.T) {
+	t.Run("writes bindings to files", func(t *testing.T) {
+
+	})
+
+	t.Run("fails with the name being invalid", func(t *testing.T) {
+
+	})
+
+	t.Run("fails with the secret being invalid", func(t *testing.T) {
+
+	})
+
+	t.Run("fails with both content and file being specified", func(t *testing.T) {
+
+	})
+
+	t.Run("fails with no content or file being specified", func(t *testing.T) {
+
+	})
+}

--- a/pkg/cnbutils/bindings/bindings_test.go
+++ b/pkg/cnbutils/bindings/bindings_test.go
@@ -1,25 +1,133 @@
 package bindings_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/SAP/jenkins-library/pkg/cnbutils"
+	"github.com/SAP/jenkins-library/pkg/cnbutils/bindings"
+	"github.com/SAP/jenkins-library/pkg/mock"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestProcessBindings(t *testing.T) {
-	t.Run("writes bindings to files", func(t *testing.T) {
 
+	var mockUtils = func() cnbutils.MockUtils {
+		var utils = cnbutils.MockUtils{
+			FilesMock: &mock.FilesMock{},
+		}
+		utils.AddFile("/tmp/somefile.yaml", []byte("some file content"))
+		return utils
+	}
+
+	t.Run("writes bindings to files", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
+			"a": map[string]interface{}{
+				"secret":  "inline.yaml",
+				"type":    "inline",
+				"content": "my inline content",
+			},
+			"b": map[string]interface{}{
+				"secret": "from-file.yaml",
+				"type":   "file",
+				"file":   "/tmp/somefile.yaml",
+			},
+		})
+
+		if assert.NoError(t, err) {
+			if assert.True(t, utils.HasFile("/tmp/platform/bindings/a/inline.yaml")) {
+				content, err := utils.FileRead("/tmp/platform/bindings/a/inline.yaml")
+				if assert.NoError(t, err) {
+					assert.Equal(t, string(content), "my inline content")
+				}
+			}
+
+			if assert.True(t, utils.HasFile("/tmp/platform/bindings/a/type")) {
+				content, err := utils.FileRead("/tmp/platform/bindings/a/type")
+				if assert.NoError(t, err) {
+					assert.Equal(t, string(content), "inline")
+				}
+			}
+
+			assert.True(t, utils.HasCopiedFile("/tmp/somefile.yaml", "/tmp/platform/bindings/b/from-file.yaml"))
+
+			if assert.True(t, utils.HasFile("/tmp/platform/bindings/b/type")) {
+				content, err := utils.FileRead("/tmp/platform/bindings/b/type")
+				if assert.NoError(t, err) {
+					assert.Equal(t, string(content), "file")
+				}
+			}
+		}
 	})
 
 	t.Run("fails with the name being invalid", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
+			"..": map[string]interface{}{
+				"secret":  "inline.yaml",
+				"type":    "inline",
+				"content": "my inline content",
+			},
+		})
 
+		if assert.Error(t, err) {
+			assert.Equal(t, "invalid binding name: ..", err.Error())
+		}
 	})
 
 	t.Run("fails with the secret being invalid", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
+			"binding": map[string]interface{}{
+				"secret":  "test/test.yaml",
+				"type":    "inline",
+				"content": "my inline content",
+			},
+		})
 
+		if assert.Error(t, err) {
+			assert.Equal(t, "invalid secret name: test/test.yaml", err.Error())
+		}
 	})
 
 	t.Run("fails with both content and file being specified", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
+			"binding": map[string]interface{}{
+				"secret":  "test.yaml",
+				"type":    "both",
+				"content": "my inline content",
+				"file":    "/tmp/somefile.yaml",
+			},
+		})
 
+		if assert.Error(t, err) {
+			assert.Equal(t, "either 'file' or 'content' property must be specified for binding", err.Error())
+		}
 	})
 
 	t.Run("fails with no content or file being specified", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
+			"binding": map[string]interface{}{
+				"secret": "test.yaml",
+				"type":   "none",
+			},
+		})
 
+		if assert.Error(t, err) {
+			assert.Equal(t, "either 'file' or 'content' property must be specified for binding", err.Error())
+		}
+	})
+
+	t.Run("fails with not a map", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, "/tmp/platform", map[string]interface{}{
+			"binding": 42,
+		})
+
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "cannot unmarshal")
+		}
 	})
 }

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -135,6 +135,13 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: bindings
+        type: "map[string]interface{}"
+        description: List buildpack bindings.
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -137,7 +137,28 @@ spec:
           - STEPS
       - name: bindings
         type: "map[string]interface{}"
-        description: List buildpack bindings.
+        description: |
+          Map of bindings that should be offered to the buildpack. The type of bindings depend on the buildpack. For documentation about bindings in general see [the paketo documentation](https://paketo.io/docs/howto/configuration/#bindings).
+
+          Example: Custom maven settings.xml for the Java Buildpack
+
+          ```yaml
+          bindings:
+            maven-settings:
+              type: maven
+              secret: settings.xml
+              file: path/to/settings.xml
+          ```
+
+          or inline
+
+          ```yaml
+          bindings:
+            maven-settings:
+              type: maven
+              secret: settings.xml
+              content: "inline settings.xml"
+          ```
         scope:
           - PARAMETERS
           - STAGES

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -146,7 +146,7 @@ spec:
           bindings:
             maven-settings:
               type: maven
-              secret: settings.xml
+              key: settings.xml
               file: path/to/settings.xml
           ```
 
@@ -156,7 +156,7 @@ spec:
           bindings:
             maven-settings:
               type: maven
-              secret: settings.xml
+              key: settings.xml
               content: "inline settings.xml"
           ```
         scope:


### PR DESCRIPTION
# Changes

Added support for configuring ["bindings" provided by paketo buildpacks](https://paketo.io/docs/howto/configuration/#bindings). They can be used e.g. for custom maven `settings.xml`, but this depends on the buildpack used.

- [x] Tests
- [x] Documentation
