### PR TITLE
ABAP - add scm info to init stage

### DIFF
--- a/cmd/cloudFoundryCreateSpace.go
+++ b/cmd/cloudFoundryCreateSpace.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/SAP/jenkins-library/pkg/cloudfoundry"
 	"github.com/SAP/jenkins-library/pkg/command"
 	"github.com/SAP/jenkins-library/pkg/log"
@@ -27,34 +25,5 @@ func cloudFoundryCreateSpace(config cloudFoundryCreateSpaceOptions, telemetryDat
 }
 
 func runCloudFoundryCreateSpace(config *cloudFoundryCreateSpaceOptions, telemetryData *telemetry.CustomData, cf cloudfoundry.CFUtils, s command.ShellRunner) (err error) {
-
-	var c = cf.Exec
-
-	cfLoginError := s.RunShell("/bin/sh", fmt.Sprintf("yes '' | cf login -a %s -u %s -p %s", config.CfAPIEndpoint, config.Username, config.Password))
-
-	if cfLoginError != nil {
-		return fmt.Errorf("Error while logging in occured: %w", cfLoginError)
-	}
-	log.Entry().Info("Successfully logged into cloud foundry.")
-
-	defer func() {
-		logoutErr := cf.Logout()
-		if logoutErr != nil {
-			err = fmt.Errorf("Error while logging out occured: %w", logoutErr)
-		}
-	}()
-
-	log.Entry().Infof("Creating Cloud Foundry Space: '%s'", config.CfSpace)
-
-	cfCreateSpaceScript := []string{"create-space", config.CfSpace, "-o", config.CfOrg}
-
-	err = c.RunExecutable("cf", cfCreateSpaceScript...)
-
-	if err != nil {
-		return fmt.Errorf("Creating a cf space has failed: %w", err)
-	}
-
-	log.Entry().Info("Cloud foundry space has been created successfully")
-
-	return err
+	return cloudfoundry.CreateSpace((*cloudfoundry.CloudFoundryCreateSpaceOptions)(config), telemetryData, cf, s)
 }

--- a/cmd/cloudFoundryCreateSpace_test.go
+++ b/cmd/cloudFoundryCreateSpace_test.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/SAP/jenkins-library/pkg/cloudfoundry"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +14,6 @@ func TestCloudFoundryCreateSpace(t *testing.T) {
 	s := mock.ShellMockRunner{}
 
 	cf := cloudfoundry.CFUtils{Exec: m}
-	cfUtilsMock := cloudfoundry.CfUtilsMock{}
 	var telemetryData telemetry.CustomData
 
 	config := cloudFoundryCreateSpaceOptions{
@@ -27,48 +24,12 @@ func TestCloudFoundryCreateSpace(t *testing.T) {
 		Password:      "testPassword",
 	}
 
-	t.Run("CF login: Success", func(t *testing.T) {
-
+	// Business code has moved to pkg/cloudfoundry/CreateSpace.go and is tested in that package
+	t.Run("happy path", func(t *testing.T) {
+		// test
 		err := runCloudFoundryCreateSpace(&config, &telemetryData, cf, &s)
-		if assert.NoError(t, err) {
-			assert.Contains(t, s.Calls[0], "yes '' | cf login -a https://api.endpoint.com -u testUser -p testPassword")
-		}
-	})
 
-	t.Run("CF login: failure case", func(t *testing.T) {
-
-		errorMessage := "cf login failed"
-
-		defer func() {
-			s.Calls = nil
-			s.ShouldFailOnCommand = nil
-		}()
-
-		s.ShouldFailOnCommand = map[string]error{"yes '' | cf login -a https://api.endpoint.com -u testUser -p testPassword ": fmt.Errorf(errorMessage)}
-
-		e := runCloudFoundryCreateSpace(&config, &telemetryData, cf, &s)
-		assert.EqualError(t, e, "Error while logging in occured: "+errorMessage)
-	})
-
-	t.Run("CF space creation: Success", func(t *testing.T) {
-
-		err := runCloudFoundryCreateSpace(&config, &telemetryData, cf, &s)
-		if assert.NoError(t, err) {
-			assert.Equal(t, "cf", m.Calls[0].Exec)
-			assert.Equal(t, []string{"create-space", "testSpace", "-o", "testOrg"}, m.Calls[0].Params)
-		}
-	})
-
-	t.Run("CF space creation: FAILURE", func(t *testing.T) {
-
-		defer cfUtilsMock.Cleanup()
-		errorMessage := "cf space creation error"
-
-		m.ShouldFailOnCommand = map[string]error{"cf create-space testSpace -o testOrg": fmt.Errorf(errorMessage)}
-
-		cfUtilsMock.LoginError = errors.New(errorMessage)
-
-		gotError := runCloudFoundryCreateSpace(&config, &telemetryData, cf, &s)
-		assert.EqualError(t, gotError, "Creating a cf space has failed: "+errorMessage, "Wrong error message")
+		// assert
+		assert.NoError(t, err)
 	})
 }

--- a/pkg/cloudfoundry/CreateSpace.go
+++ b/pkg/cloudfoundry/CreateSpace.go
@@ -1,0 +1,49 @@
+package cloudfoundry
+
+import (
+	"fmt"
+
+	"github.com/SAP/jenkins-library/pkg/command"
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/telemetry"
+)
+
+type CloudFoundryCreateSpaceOptions struct {
+	CfAPIEndpoint string `json:"cfApiEndpoint,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	CfOrg         string `json:"cfOrg,omitempty"`
+	CfSpace       string `json:"cfSpace,omitempty"`
+}
+
+func CreateSpace(config *CloudFoundryCreateSpaceOptions, telemetryData *telemetry.CustomData, cf CFUtils, s command.ShellRunner) (err error) {
+	var c = cf.Exec
+
+	cfLoginError := s.RunShell("/bin/sh", fmt.Sprintf("yes '' | cf login -a %s -u %s -p %s", config.CfAPIEndpoint, config.Username, config.Password))
+
+	if cfLoginError != nil {
+		return fmt.Errorf("Error while logging in occured: %w", cfLoginError)
+	}
+	log.Entry().Info("Successfully logged into cloud foundry.")
+
+	defer func() {
+		logoutErr := cf.Logout()
+		if logoutErr != nil {
+			err = fmt.Errorf("Error while logging out occured: %w", logoutErr)
+		}
+	}()
+
+	log.Entry().Infof("Creating Cloud Foundry Space: '%s'", config.CfSpace)
+
+	cfCreateSpaceScript := []string{"create-space", config.CfSpace, "-o", config.CfOrg}
+
+	err = c.RunExecutable("cf", cfCreateSpaceScript...)
+
+	if err != nil {
+		return fmt.Errorf("Creating a cf space has failed: %w", err)
+	}
+
+	log.Entry().Info("Cloud foundry space has been created successfully")
+
+	return err
+}

--- a/pkg/cloudfoundry/CreateSpace_test.go
+++ b/pkg/cloudfoundry/CreateSpace_test.go
@@ -1,0 +1,74 @@
+package cloudfoundry
+
+import (
+	"fmt"
+	"github.com/SAP/jenkins-library/pkg/mock"
+	"github.com/SAP/jenkins-library/pkg/telemetry"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCloudFoundryCreateSpace(t *testing.T) {
+	t.Parallel()
+
+	m := &mock.ExecMockRunner{}
+	s := mock.ShellMockRunner{}
+
+	cf := CFUtils{Exec: m}
+	cfUtilsMock := CfUtilsMock{}
+	var telemetryData telemetry.CustomData
+
+	config := CloudFoundryCreateSpaceOptions{
+		CfAPIEndpoint: "https://api.endpoint.com",
+		CfOrg:         "testOrg",
+		CfSpace:       "testSpace",
+		Username:      "testUser",
+		Password:      "testPassword",
+	}
+
+	t.Run("CF login: Success", func(t *testing.T) {
+
+		err := CreateSpace(&config, &telemetryData, cf, &s)
+		if assert.NoError(t, err) {
+			assert.Contains(t, s.Calls[0], "yes '' | cf login -a https://api.endpoint.com -u testUser -p testPassword")
+		}
+	})
+
+	t.Run("CF login: failure case", func(t *testing.T) {
+
+		errorMessage := "cf login failed"
+
+		defer func() {
+			s.Calls = nil
+			s.ShouldFailOnCommand = nil
+		}()
+
+		s.ShouldFailOnCommand = map[string]error{"yes '' | cf login -a https://api.endpoint.com -u testUser -p testPassword ": fmt.Errorf(errorMessage)}
+
+		e := CreateSpace(&config, &telemetryData, cf, &s)
+		assert.EqualError(t, e, "Error while logging in occured: "+errorMessage)
+	})
+
+	t.Run("CF space creation: Success", func(t *testing.T) {
+
+		err := CreateSpace(&config, &telemetryData, cf, &s)
+		if assert.NoError(t, err) {
+			assert.Equal(t, "cf", m.Calls[0].Exec)
+			assert.Equal(t, []string{"create-space", "testSpace", "-o", "testOrg"}, m.Calls[0].Params)
+		}
+	})
+
+	t.Run("CF space creation: FAILURE", func(t *testing.T) {
+
+		defer cfUtilsMock.Cleanup()
+		errorMessage := "cf space creation error"
+
+		m.ShouldFailOnCommand = map[string]error{"cf create-space testSpace -o testOrg": fmt.Errorf(errorMessage)}
+
+		cfUtilsMock.LoginError = errors.New(errorMessage)
+
+		gotError := CreateSpace(&config, &telemetryData, cf, &s)
+		assert.EqualError(t, gotError, "Creating a cf space has failed: "+errorMessage, "Wrong error message")
+	})
+}


### PR DESCRIPTION
# Changes

When skipping the checkout it is good if the setupCommonPipelineEnvironement step gets the scmInfo separately, used to [set git related information in the cpe](https://github.com/SAP/jenkins-library/blob/master/vars/setupCommonPipelineEnvironment.groovy#L119).


- [ ] Tests
- [x] Documentation
