### PR TITLE
feat (cpe) ability to write an empty string to an existing cpe string value

### DIFF
--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -92,7 +92,7 @@ func dirToMap(m map[string]interface{}, dirPath, prefix string) error {
 			if err != nil {
 				return err
 			}
-			log.Entry().Debugf("Writing empty contents to file on disk: %v", dirPath)
+			log.Entry().Infof("Writing empty contents to file on disk: %v", dirPath)
 
 			m[path.Join(prefix, mapKey)] = ""
 

--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -92,7 +92,7 @@ func dirToMap(m map[string]interface{}, dirPath, prefix string) error {
 			if err != nil {
 				return err
 			}
-			log.Entry().Infof("Writing empty contents to file on disk: %v", dirPath)
+			log.Entry().Debugf("Writing empty contents to file on disk: %v", path.Join(dirPath, dirItem.Name()))
 
 			m[path.Join(prefix, mapKey)] = ""
 

--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -131,7 +131,7 @@ func readFileContent(fullPath string) (string, interface{}, bool, error) {
 		}
 		return strings.TrimSuffix(fileName, ".json"), value, toBeEmptied, nil
 	}
-	if string(fileContent) == "toBeEmptied" {
+	if string(fileContent) == "" {
 		toBeEmptied = true
 	}
 	return fileName, string(fileContent), toBeEmptied, nil

--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -131,7 +131,7 @@ func readFileContent(fullPath string) (string, interface{}, bool, error) {
 		}
 		return strings.TrimSuffix(fileName, ".json"), value, toBeEmptied, nil
 	}
-	if string(fileContent) == "" {
+	if string(fileContent) == "toBeEmptied" {
 		toBeEmptied = true
 	}
 	return fileName, string(fileContent), toBeEmptied, nil

--- a/pkg/piperenv/CPEMap_test.go
+++ b/pkg/piperenv/CPEMap_test.go
@@ -74,7 +74,7 @@ func TestCPEMap_LoadFromDisk(t *testing.T) {
 	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Bruce"), []byte("Wayne"), 0644)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path.Join(subPath, "Robin"), []byte(""), 0644)
+	err = ioutil.WriteFile(path.Join(subPath, "Robin"), []byte("toBeEmptied"), 0644)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Test.json"), []byte("54"), 0644)
 	require.NoError(t, err)

--- a/pkg/piperenv/CPEMap_test.go
+++ b/pkg/piperenv/CPEMap_test.go
@@ -74,7 +74,7 @@ func TestCPEMap_LoadFromDisk(t *testing.T) {
 	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Bruce"), []byte("Wayne"), 0644)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path.Join(subPath, "Robin"), []byte("toBeEmptied"), 0644)
+	err = ioutil.WriteFile(path.Join(subPath, "Robin"), []byte(""), 0644)
 	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Test.json"), []byte("54"), 0644)
 	require.NoError(t, err)

--- a/pkg/piperenv/CPEMap_test.go
+++ b/pkg/piperenv/CPEMap_test.go
@@ -3,11 +3,12 @@ package piperenv
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_writeMapToDisk(t *testing.T) {
@@ -73,6 +74,8 @@ func TestCPEMap_LoadFromDisk(t *testing.T) {
 	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Bruce"), []byte("Wayne"), 0644)
 	require.NoError(t, err)
+	err = ioutil.WriteFile(path.Join(subPath, "Robin"), []byte("toBeEmptied"), 0644)
+	require.NoError(t, err)
 	err = ioutil.WriteFile(path.Join(subPath, "Test.json"), []byte("54"), 0644)
 	require.NoError(t, err)
 
@@ -82,6 +85,7 @@ func TestCPEMap_LoadFromDisk(t *testing.T) {
 
 	require.Equal(t, "Bar", cpe["Foo"])
 	require.Equal(t, "World", cpe["Hello"])
+	require.Equal(t, "", cpe["Batman/Robin"])
 	require.Equal(t, "Wayne", cpe["Batman/Bruce"])
 	require.Equal(t, json.Number("54"), cpe["Batman/Test"])
 }


### PR DESCRIPTION
# Changes
- CPE values with user id and password for private staging repos must be cleared post promotion of the artifact from the staging repo
- cpe variables with value 'toBeEmptied' will be removed during the readPipelineEnvironment.go step execution and empty values will be written to the file and the cpeMap

- [x] Tests
- [x] Documentation
