### PR TITLE
kubernetesDeploy- add documentation for <image-name>

### DIFF
--- a/resources/metadata/kubernetesdeploy.yaml
+++ b/resources/metadata/kubernetesdeploy.yaml
@@ -70,7 +70,7 @@ spec:
         aliases:
           - name: k8sAppTemplate
         type: string
-        description: Defines the filename for the kubernetes app template (e.g. k8s_apptemplate.yaml)
+        description: 'Defines the filename for the kubernetes app template (e.g. k8s_apptemplate.yaml). Within this file `image` needs to be set as `image: <image-name>` for the image to be overwritten with other parameters.'
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
# Changes
If image is not set like `image: <image-name>` then the image data given in the pipeline configuration will not work. It needs to be this exact string so that the replacement can work.

- [ ] Tests
- [x] Documentation
