### PR TITLE
feat(protecodeExecuteScan): use dockerConfigJSON from the commonPipel…

### DIFF
--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -278,6 +278,11 @@ func protecodeExecuteScanMetadata() config.StepData {
 						Name: "dockerConfigJSON",
 						ResourceRef: []config.ResourceReference{
 							{
+								Name:  "commonPipelineEnvironment",
+								Param: "custom/dockerConfigJSON",
+							},
+
+							{
 								Name: "dockerConfigJsonCredentialsId",
 								Type: "secret",
 							},

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -371,11 +371,13 @@ steps:
       checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html'
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
       sonar: '**/jacoco*.exec, **/sonar-project.properties'
+      pipelineConfigAndTests: '.pipeline/**'
     stashExcludes:
       buildResult: ''
       checkmarx: '**/*.mockserver.js, node_modules/**/*.js'
       classFiles: ''
       sonar: ''
+      pipelineConfigAndTests: ''
     noDefaultExludes: []
   pipelineStashFilesBeforeBuild:
     stashIncludes:

--- a/resources/metadata/protecodeExecuteScan.yaml
+++ b/resources/metadata/protecodeExecuteScan.yaml
@@ -72,6 +72,8 @@ spec:
           - STEPS
         secret: true
         resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/dockerConfigJSON
           - name: dockerConfigJsonCredentialsId
             type: secret
           - type: vaultSecretFile


### PR DESCRIPTION
# Changes

Allow `protecodeExecuteScan` to use the dockerConfigJson property from the CPE. Also added stash overwrite of the pipeline configs after the Central Build stage, since the stage can populate it with necessary information for later use.

- [ ] Tests
- [ ] Documentation
