### PR TITLE
docs(cloudFoundryDeploy): remove legacy alias

### DIFF
--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -9,8 +9,6 @@ spec:
       - name: cfCredentialsId
         description: Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Cloud Foundry API.
         type: jenkins
-        aliases:
-          - name: cloudFoundry/credentialsId
       - name: dockerCredentialsId
         description: Jenkins 'Username with password' credentials ID containing user and password to authenticate to the Docker registry.
         type: jenkins


### PR DESCRIPTION
# Changes
Removes legacy alias for cloudFoundry credentials. This is a complement to: https://github.com/SAP/jenkins-library/pull/3289