### PR TITLE
fix: correct env var name for git branch for Jenkins orchestrator implementation

### DIFF
--- a/pkg/orchestrator/jenkins.go
+++ b/pkg/orchestrator/jenkins.go
@@ -143,7 +143,7 @@ func (a *JenkinsConfigProvider) GetStageName() string {
 }
 
 func (j *JenkinsConfigProvider) GetBranch() string {
-	return getEnv("GIT_BRANCH", "n/a")
+	return getEnv("BRANCH_NAME", "n/a")
 }
 
 func (j *JenkinsConfigProvider) GetBuildUrl() string {

--- a/pkg/orchestrator/jenkins_test.go
+++ b/pkg/orchestrator/jenkins_test.go
@@ -13,7 +13,7 @@ func TestJenkins(t *testing.T) {
 		os.Clearenv()
 		os.Setenv("JENKINS_URL", "FOO BAR BAZ")
 		os.Setenv("BUILD_URL", "jaas.com/foo/bar/main/42")
-		os.Setenv("GIT_BRANCH", "main")
+		os.Setenv("BRANCH_NAME", "main")
 		os.Setenv("GIT_COMMIT", "abcdef42713")
 		os.Setenv("GIT_URL", "github.com/foo/bar")
 


### PR DESCRIPTION
> The multibranch pipeline jobs do posess the environment variable env.BRANCH_NAME which describes the branch. Use multibranch pipeline job type, not the plain pipeline job type. 

https://stackoverflow.com/a/43962998/1500953