### PR TITLE
removed pipelineConfigAndTests from the stashing after build

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -371,13 +371,11 @@ steps:
       checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html'
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
       sonar: '**/jacoco*.exec, **/sonar-project.properties'
-      pipelineConfigAndTests: '.pipeline/**'
     stashExcludes:
       buildResult: ''
       checkmarx: '**/*.mockserver.js, node_modules/**/*.js'
       classFiles: ''
       sonar: ''
-      pipelineConfigAndTests: ''
     noDefaultExludes: []
   pipelineStashFilesBeforeBuild:
     stashIncludes:


### PR DESCRIPTION
# Changes

removed pipelineConfigAndTests from the stashing after build (introduced in #3248)
In some cases end users include the `pipelineStashFilesAfterBuild` into their custom pipelines after the steps, where no `.pipeline` folder unstashed.

- [ ] Tests
- [ ] Documentation
