### PR TITLE
fix(whitesource): Use batch-mode for maven to not mess up the log

### DIFF
--- a/pkg/whitesource/scanMaven.go
+++ b/pkg/whitesource/scanMaven.go
@@ -103,8 +103,8 @@ func generateMavenWhitesourceFlags(config *ScanOptions, utils Utils) (flags []st
 		if moduleName != "" {
 			flags = append(flags, "-pl", "!"+moduleName)
 		}
-		flags = append(flags, "--batch-mode")
 	}
+	flags = append(flags, "--batch-mode")
 	return flags, excludes
 }
 

--- a/pkg/whitesource/scanMaven.go
+++ b/pkg/whitesource/scanMaven.go
@@ -2,10 +2,11 @@ package whitesource
 
 import (
 	"fmt"
-	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/maven"
 	"path/filepath"
 	"strings"
+
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/maven"
 )
 
 // ExecuteMavenScan constructs maven parameters from the given configuration, and executes the maven goal
@@ -102,6 +103,7 @@ func generateMavenWhitesourceFlags(config *ScanOptions, utils Utils) (flags []st
 		if moduleName != "" {
 			flags = append(flags, "-pl", "!"+moduleName)
 		}
+		flags = append(flags, "--batch-mode")
 	}
 	return flags, excludes
 }


### PR DESCRIPTION
When calling `mvn clean install`, the whitesource step is not setting the flag `--batch-mode` which makes the console output very hard to read because of all the downloading progress. But CI/CD systems should always operate in an non-interactive mode.