### PR TITLE
hotfix: Don't write SonarQube coverage metrics to InfluxDB

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -237,9 +237,6 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 	if err != nil {
 		return err // No wrap, description already added one level below
 	}
-	influx.sonarqube_data.fields.coverage = cov.Coverage
-	influx.sonarqube_data.fields.branch_coverage = cov.BranchCoverage
-	influx.sonarqube_data.fields.line_coverage = cov.LineCoverage
 
 	log.Entry().Debugf("Influx values: %v", influx.sonarqube_data.fields)
 	err = SonarUtils.WriteReport(SonarUtils.ReportData{

--- a/cmd/sonarExecuteScan_generated.go
+++ b/cmd/sonarExecuteScan_generated.go
@@ -62,9 +62,6 @@ type sonarExecuteScanInflux struct {
 			major_issues    int
 			minor_issues    int
 			info_issues     int
-			coverage        float32
-			branch_coverage float32
-			line_coverage   float32
 		}
 		tags struct {
 		}
@@ -84,9 +81,6 @@ func (i *sonarExecuteScanInflux) persist(path, resourceName string) {
 		{valType: config.InfluxField, measurement: "sonarqube_data", name: "major_issues", value: i.sonarqube_data.fields.major_issues},
 		{valType: config.InfluxField, measurement: "sonarqube_data", name: "minor_issues", value: i.sonarqube_data.fields.minor_issues},
 		{valType: config.InfluxField, measurement: "sonarqube_data", name: "info_issues", value: i.sonarqube_data.fields.info_issues},
-		{valType: config.InfluxField, measurement: "sonarqube_data", name: "coverage", value: i.sonarqube_data.fields.coverage},
-		{valType: config.InfluxField, measurement: "sonarqube_data", name: "branch_coverage", value: i.sonarqube_data.fields.branch_coverage},
-		{valType: config.InfluxField, measurement: "sonarqube_data", name: "line_coverage", value: i.sonarqube_data.fields.line_coverage},
 	}
 
 	errCount := 0
@@ -532,7 +526,7 @@ func sonarExecuteScanMetadata() config.StepData {
 						Type: "influx",
 						Parameters: []map[string]interface{}{
 							{"Name": "step_data"}, {"fields": []map[string]string{{"name": "sonar"}}},
-							{"Name": "sonarqube_data"}, {"fields": []map[string]string{{"name": "blocker_issues"}, {"name": "critical_issues"}, {"name": "major_issues"}, {"name": "minor_issues"}, {"name": "info_issues"}, {"name": "coverage"}, {"name": "branch_coverage"}, {"name": "line_coverage"}}},
+							{"Name": "sonarqube_data"}, {"fields": []map[string]string{{"name": "blocker_issues"}, {"name": "critical_issues"}, {"name": "major_issues"}, {"name": "minor_issues"}, {"name": "info_issues"}}},
 						},
 					},
 				},

--- a/resources/metadata/sonarExecuteScan.yaml
+++ b/resources/metadata/sonarExecuteScan.yaml
@@ -288,12 +288,6 @@ spec:
                 type: int
               - name: info_issues
                 type: int
-              - name: coverage
-                type: float32
-              - name: branch_coverage
-                type: float32
-              - name: line_coverage
-                type: float32
   containers:
     - name: sonar
       image: sonarsource/sonar-scanner-cli:4.6


### PR DESCRIPTION
Somehow, either InfluxDB itself or the logic that writes values to it automatically casts .0 floats to integers. So, if you had 33.9% coverage, write a test and then have 35.0% coverage, one will write a float and the other an integer in Influx and that always fails with Type Mismatch.

This pull request removes the coverage metrics of SonarQube/SonarCloud from InfluxDB and only writes them to the sonarscan.json.

