### PR TITLE
fix(hadolint): change docker image

### DIFF
--- a/cmd/hadolintExecute_generated.go
+++ b/cmd/hadolintExecute_generated.go
@@ -219,7 +219,7 @@ func hadolintExecuteMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "hadolint", Image: "hadolint/hadolint:latest-debian"},
+				{Name: "hadolint", Image: "hadolint/hadolint:latest-alpine"},
 			},
 		},
 	}

--- a/resources/metadata/hadolintExecute.yaml
+++ b/resources/metadata/hadolintExecute.yaml
@@ -82,4 +82,4 @@ spec:
           - STEPS
   containers:
     - name: hadolint
-      image: hadolint/hadolint:latest-debian
+      image: hadolint/hadolint:latest-alpine


### PR DESCRIPTION
Use the [HaDoLint alpine image](https://hub.docker.com/r/hadolint/hadolint/tags) to cope with Vault certificate issue.