### PR TITLE
fix (dockerConfigJson) : create directory path before writing to file

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -63,7 +63,7 @@ func CreateDockerConfigJSON(registryURL, username, password, targetPath, configP
 	//always create the target path directories if any before writing
 	err = utils.MkdirAll(filepath.Dir(targetPath), 0666)
 	if err != nil {
-		return "", fmt.Errorf("failed to create the Docker config.json file %v:%w", targetPath, err)
+		return "", fmt.Errorf("failed to create directory path for the Docker config.json file %v:%w", targetPath, err)
 	}
 	err = utils.FileWrite(targetPath, jsonResult, 0666)
 	if err != nil {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/piperutils"
@@ -59,6 +60,11 @@ func CreateDockerConfigJSON(registryURL, username, password, targetPath, configP
 		return "", fmt.Errorf("failed to marshal Docker config.json: %w", err)
 	}
 
+	//always create the target path directories if any before writing
+	err = utils.MkdirAll(filepath.Dir(targetPath), 0666)
+	if err != nil {
+		return "", fmt.Errorf("failed to create the Docker config.json file %v:%w", targetPath, err)
+	}
 	err = utils.FileWrite(targetPath, jsonResult, 0666)
 	if err != nil {
 		return "", fmt.Errorf("failed to write Docker config.json: %w", err)


### PR DESCRIPTION
# Changes
Before writing to docker config json file to `targetPath` , always create directory path first then write or the write will fail with a error of directory not present

- [ ] Tests
- [ ] Documentation
