### PR TITLE
Use the latest released version of the cf-cli image.

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -211,10 +211,10 @@ steps:
       - 'deployDescriptor'
       - 'pipelineConfigAndTests'
     cf_native:
-      dockerImage: 'ppiper/cf-cli:6'
+      dockerImage: 'ppiper/cf-cli:v10'
       dockerWorkspace: '/home/piper'
     mtaDeployPlugin:
-      dockerImage: 'ppiper/cf-cli:6'
+      dockerImage: 'ppiper/cf-cli:v10'
       dockerWorkspace: '/home/piper'
     mta:
       deployTool: 'mtaDeployPlugin'


### PR DESCRIPTION
The current default version uses a very old multiapps (mta) CF plugin, which is missing some new features. 
The latest released version of the image is ppiper/cf-cli:v10

# Changes

- [ ] Tests
- [ ] Documentation
