### PR TITLE
add stage scope to path parameter, fix project dir exist issue

### DIFF
--- a/cmd/gradleExecuteBuild_generated.go
+++ b/cmd/gradleExecuteBuild_generated.go
@@ -128,7 +128,7 @@ func gradleExecuteBuildMetadata() config.StepData {
 					{
 						Name:        "path",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "buildGradlePath"}},

--- a/pkg/gradle/gradle.go
+++ b/pkg/gradle/gradle.go
@@ -26,7 +26,7 @@ type ExecuteOptions struct {
 
 func Execute(options *ExecuteOptions, utils Utils, fileUtils piperutils.FileUtils) (string, error) {
 
-	exists, err := fileUtils.FileExists(options.BuildGradlePath)
+	exists, err := fileUtils.DirExists(options.BuildGradlePath)
 	if !exists {
 		return "", fmt.Errorf("the specified gradle script could not be found")
 	}

--- a/resources/metadata/gradleExecuteBuild.yaml
+++ b/resources/metadata/gradleExecuteBuild.yaml
@@ -13,6 +13,7 @@ spec:
         description: Path to the folder with gradle.build file which should be executed.
         scope:
           - PARAMETERS
+          - STAGES
           - STEPS
         mandatory: false
       - name: task


### PR DESCRIPTION
# Changes

- [x] add **STAGES** scope to path parameter for gradleExecuteBuild
- [x] fixed issue with check existing project folder