### PR TITLE
fix(whitesourceExecuteScan): added missing credential declaration for the docker config

### DIFF
--- a/vars/whitesourceExecuteScan.groovy
+++ b/vars/whitesourceExecuteScan.groovy
@@ -16,6 +16,7 @@ void call(Map parameters = [:]) {
     List credentials = [
         [type: 'token', id: 'orgAdminUserTokenCredentialsId', env: ['PIPER_orgToken']],
         [type: 'token', id: 'userTokenCredentialsId', env: ['PIPER_userToken']],
+        [type: 'file', id: 'dockerConfigJsonCredentialsId', env: ['PIPER_dockerConfigJSON']],
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes
Currrently `whiteSourceExecuteScan` has an declared `dockerConfigJsonCredentialsId` input, as well as it has corresponding `resourceRef` of type secret for the `dockerConfigJSON` property, however the credentials map passed to the `piperExecuteBin` doesn't contain it.

- [ ] Tests
- [ ] Documentation
