### PR TITLE
feat (npmExecuteScripts) create seperate npmrc file for publish to private repo

### DIFF
--- a/documentation/docs/infrastructure/vault.md
+++ b/documentation/docs/infrastructure/vault.md
@@ -115,7 +115,7 @@ The `vaultCredentialPath` parameter is the endpoint of your credential path in V
 2. `<vaultBasePath>/<vaultPipelineName>/<vaultCredentialPath>`
 3. `<vaultBasePath>/GROUP-SECRETS/<vaultCredentialPath>`
 
-The `vaultCredentialKeys`parameter is a list of credential IDs. The secret value of the credential will be exposed as an environment variable prefixed by "PIPER_VAULTCREDENTIAL_" and transformed to a valid variable name. For a credential ID named `myAppId` the forwarded environment variable to the step will be `PIPER_VAULTCREDENTIAL_MYAPPID` containing the secret. Hyphens will be replaced by underscores and other non-alphanumeric characters will be removed.
+The `vaultCredentialKeys`parameter is a list of credential IDs. The secret value of the credential will be exposed as an environment variable prefixed by "PIPER_VAULTCREDENTIAL_" and transformed to a valid variable name. For a credential ID named `myAppId` the forwarded environment variable to the step will be `PIPER_VAULTCREDENTIAL_MYAPPID` containing the secret. The Base64 encoded secret value will be exposed as environment variable to the step as  `PIPER_VAULTCREDENTIAL_MYAPPID_BASE64`. Hyphens will be replaced by underscores and other non-alphanumeric characters will be removed.
 
 !!! hint "Using a custom prefix for test credentials"
     By default the prefix for test credentials is `PIPER_VAULTCREDENTIAL_`.

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -284,6 +284,7 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 				envVariable = vaultCredentialEnvPrefix + convertEnvVar(secretKey) + "_BASE64"
 				log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
 				os.Setenv(envVariable, CredentialUtils.EncodeString(secretValue))
+				log.Entry().Debugf("value is %v", os.Getenv(envVariable))
 				matched = true
 			}
 		}

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -284,7 +284,6 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 				envVariable = vaultCredentialEnvPrefix + convertEnvVar(secretKey) + "_BASE64"
 				log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
 				os.Setenv(envVariable, CredentialUtils.EncodeString(secretValue))
-				log.Entry().Debugf("value is %v", os.Getenv(envVariable))
 				matched = true
 			}
 		}

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/SAP/jenkins-library/pkg/config/interpolation"
 	"github.com/SAP/jenkins-library/pkg/log"
+	CredentialUtils "github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/SAP/jenkins-library/pkg/vault"
 	"github.com/hashicorp/vault/api"
 )
@@ -282,7 +283,7 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 				os.Setenv(envVariable, secretValue)
 				envVariable = vaultCredentialEnvPrefix + convertEnvVar(secretKey) + "_BASE64"
 				log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
-				os.Setenv(envVariable, secretValue)
+				os.Setenv(envVariable, CredentialUtils.EncodeString(secretValue))
 				matched = true
 			}
 		}
@@ -300,7 +301,7 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 					os.Setenv(envVariable, secretValue)
 					envVariable = vaultCredentialEnvPrefixDefault + convertEnvVar(secretKey) + "_BASE64"
 					log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
-					os.Setenv(envVariable, secretValue)
+					os.Setenv(envVariable, CredentialUtils.EncodeString(secretValue))
 					matched = true
 				}
 			}

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -280,6 +280,9 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 				envVariable := vaultCredentialEnvPrefix + convertEnvVar(secretKey)
 				log.Entry().Debugf("Exposing general purpose credential '%v' as '%v'", key, envVariable)
 				os.Setenv(envVariable, secretValue)
+				envVariable = vaultCredentialEnvPrefix + convertEnvVar(secretKey) + "_BASE64"
+				log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
+				os.Setenv(envVariable, secretValue)
 				matched = true
 			}
 		}
@@ -294,6 +297,9 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 					log.RegisterSecret(secretValue)
 					envVariable := vaultCredentialEnvPrefixDefault + convertEnvVar(secretKey)
 					log.Entry().Debugf("Exposing general purpose credential '%v' as '%v'", key, envVariable)
+					os.Setenv(envVariable, secretValue)
+					envVariable = vaultCredentialEnvPrefixDefault + convertEnvVar(secretKey) + "_BASE64"
+					log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
 					os.Setenv(envVariable, secretValue)
 					matched = true
 				}

--- a/pkg/npm/config.go
+++ b/pkg/npm/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	configFilename = ".piperStagingNpmrc"
+	configFilename = ".piperNpmrc"
 )
 
 var (

--- a/pkg/npm/config.go
+++ b/pkg/npm/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	configFilename = ".npmrc"
+	configFilename = ".piperStagingNpmrc"
 )
 
 var (

--- a/pkg/npm/config_test.go
+++ b/pkg/npm/config_test.go
@@ -21,9 +21,9 @@ func TestNewNPMRC(t *testing.T) {
 		want string
 	}{
 		{name: "current dir", args: args{""}, want: configFilename},
-		{name: "sub dir", args: args{mock.Anything}, want: filepath.Join(mock.Anything, ".piperStagingNpmrc")},
-		{name: "file path in current dir", args: args{".piperStagingNpmrc"}, want: ".piperStagingNpmrc"},
-		{name: "file path in sub dir", args: args{filepath.Join(mock.Anything, ".piperStagingNpmrc")}, want: filepath.Join(mock.Anything, ".piperStagingNpmrc")},
+		{name: "sub dir", args: args{mock.Anything}, want: filepath.Join(mock.Anything, ".piperNpmrc")},
+		{name: "file path in current dir", args: args{".piperNpmrc"}, want: ".piperNpmrc"},
+		{name: "file path in sub dir", args: args{filepath.Join(mock.Anything, ".piperNpmrc")}, want: filepath.Join(mock.Anything, ".piperNpmrc")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/npm/config_test.go
+++ b/pkg/npm/config_test.go
@@ -1,6 +1,7 @@
 package npm
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -20,9 +21,9 @@ func TestNewNPMRC(t *testing.T) {
 		want string
 	}{
 		{name: "current dir", args: args{""}, want: configFilename},
-		{name: "sub dir", args: args{mock.Anything}, want: mock.Anything + "/.npmrc"},
-		{name: "file path in current dir", args: args{".npmrc"}, want: ".npmrc"},
-		{name: "file path in sub dir", args: args{mock.Anything + "/.npmrc"}, want: mock.Anything + "/.npmrc"},
+		{name: "sub dir", args: args{mock.Anything}, want: filepath.Join(mock.Anything, ".piperStagingNpmrc")},
+		{name: "file path in current dir", args: args{".piperStagingNpmrc"}, want: ".piperStagingNpmrc"},
+		{name: "file path in sub dir", args: args{filepath.Join(mock.Anything, ".piperStagingNpmrc")}, want: filepath.Join(mock.Anything, ".piperStagingNpmrc")},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/npm/publish.go
+++ b/pkg/npm/publish.go
@@ -50,15 +50,17 @@ func (exec *Execute) publish(packageJSON, registry, username, password string) e
 	npmignore.Add("**/piper")
 	log.Entry().Debug("adding **/sap-piper")
 	npmignore.Add("**/sap-piper")
-	// update .npmrc
+
+	npmrc := NewNPMRC(filepath.Dir(packageJSON))
+
+	log.Entry().Debugf("adding piper npmrc file %v", npmrc.filepath)
+	npmignore.Add(npmrc.filepath)
+
 	if err := npmignore.Write(); err != nil {
 		return errors.Wrapf(err, "failed to update %s file", npmignore.filepath)
 	}
-	npmrc := NewNPMRC(filepath.Dir(packageJSON))
 
-	log.Entry().Debugf("adding piper npmrc file %v to ignore", npmrc.filepath)
-	npmignore.Add(npmrc.filepath)
-
+	// update .piperNpmrc
 	if len(registry) > 0 {
 		// check existing .npmrc file
 		if exists, err := FileUtils.FileExists(npmrc.filepath); exists {

--- a/pkg/npm/publish.go
+++ b/pkg/npm/publish.go
@@ -86,7 +86,7 @@ func (exec *Execute) publish(packageJSON, registry, username, password string) e
 		log.Entry().Debug("no registry provided")
 	}
 
-	err := execRunner.RunExecutable("npm", "publish", "--userconfig", npmrc.filepath)
+	err := execRunner.RunExecutable("npm", "publish", "--userconfig", npmrc.filepath, "--registry", registry)
 	if err != nil {
 		return err
 	}

--- a/pkg/npm/publish.go
+++ b/pkg/npm/publish.go
@@ -54,9 +54,9 @@ func (exec *Execute) publish(packageJSON, registry, username, password string) e
 	if err := npmignore.Write(); err != nil {
 		return errors.Wrapf(err, "failed to update %s file", npmignore.filepath)
 	}
+	npmrc := NewNPMRC(filepath.Dir(packageJSON))
 
 	if len(registry) > 0 {
-		npmrc := NewNPMRC(filepath.Dir(packageJSON))
 		// check existing .npmrc file
 		if exists, err := FileUtils.FileExists(npmrc.filepath); exists {
 			if err != nil {
@@ -67,7 +67,7 @@ func (exec *Execute) publish(packageJSON, registry, username, password string) e
 				return errors.Wrapf(err, "failed to read existing %s file", npmrc.filepath)
 			}
 		} else {
-			log.Entry().Debug("creating .npmrc file")
+			log.Entry().Debugf("creating new npmrc file at %s", npmrc.filepath)
 		}
 		// set registry
 		log.Entry().Debugf("adding registry %s", registry)
@@ -86,7 +86,7 @@ func (exec *Execute) publish(packageJSON, registry, username, password string) e
 		log.Entry().Debug("no registry provided")
 	}
 
-	err := execRunner.RunExecutable("npm", "publish", filepath.Dir(packageJSON))
+	err := execRunner.RunExecutable("npm", "publish", "--userconfig", npmrc.filepath)
 	if err != nil {
 		return err
 	}

--- a/pkg/npm/publish.go
+++ b/pkg/npm/publish.go
@@ -56,6 +56,9 @@ func (exec *Execute) publish(packageJSON, registry, username, password string) e
 	}
 	npmrc := NewNPMRC(filepath.Dir(packageJSON))
 
+	log.Entry().Debugf("adding piper npmrc file %v to ignore", npmrc.filepath)
+	npmignore.Add(npmrc.filepath)
+
 	if len(registry) > 0 {
 		// check existing .npmrc file
 		if exists, err := FileUtils.FileExists(npmrc.filepath); exists {


### PR DESCRIPTION
# Changes

Curently the `npmExecuteScripts` overwrites the registry parameter in `.npmrc` file if this file is present .  Rather than modifying a user provided .npmrc file we create a new npmrc file and use this during `npm publish`  

Since npmrc files need to contain the authentication for scoped dependencies from private registries , the vault general purpose credential feature is enhanced to expose a base64 encoded environment variable of the vault secret in addition to the vault secret env variable 
- [x] Tests
- [x] Documentation
