### PR TITLE
feat(cnbBuild): preserve maven test results in the workspace

### DIFF
--- a/pkg/mock/fileUtils.go
+++ b/pkg/mock/fileUtils.go
@@ -1,3 +1,4 @@
+//go:build !release
 // +build !release
 
 package mock
@@ -38,6 +39,8 @@ func (fInfo fileInfoMock) Sys() interface{}   { return nil }
 type fileProperties struct {
 	content *[]byte
 	mode    os.FileMode
+	isLink  bool
+	target  string
 }
 
 // isDir returns true when the properties describe a directory entry.
@@ -151,6 +154,18 @@ func (f *FilesMock) HasWrittenFile(path string) bool {
 // and it was written via CopyFile().
 func (f *FilesMock) HasCopiedFile(src string, dest string) bool {
 	return f.copiedFiles[f.toAbsPath(src)] == f.toAbsPath(dest)
+}
+
+// HasCreatedSymlink returns true if the virtual file system has a symlink with a specific target.
+func (f *FilesMock) HasCreatedSymlink(oldname, newname string) bool {
+	if f.files == nil {
+		return false
+	}
+	props, exists := f.files[f.toAbsPath(newname)]
+	if !exists {
+		return false
+	}
+	return props.isLink && props.target == oldname
 }
 
 // FileExists returns true if file content has been associated with the given path, false otherwise.
@@ -453,6 +468,33 @@ func (f *FilesMock) Chmod(path string, mode os.FileMode) error {
 func (f *FilesMock) Abs(path string) (string, error) {
 	f.init()
 	return f.toAbsPath(path), nil
+}
+
+func (f *FilesMock) Symlink(oldname, newname string) error {
+	if f.FileWriteError != nil {
+		return f.FileWriteError
+	}
+
+	if f.FileWriteErrors[newname] != nil {
+		return f.FileWriteErrors[newname]
+	}
+
+	parentExists, err := f.DirExists(filepath.Dir(newname))
+	if err != nil {
+		return err
+	}
+	if !parentExists {
+		return fmt.Errorf("failed to create symlink: parent directory %s doesn't exist", filepath.Dir(newname))
+	}
+
+	f.init()
+
+	f.files[newname] = &fileProperties{
+		isLink: true,
+		target: oldname,
+	}
+
+	return nil
 }
 
 // FileMock can be used in places where a io.Closer, io.StringWriter or io.Writer is expected.

--- a/pkg/piperutils/FileUtils.go
+++ b/pkg/piperutils/FileUtils.go
@@ -32,6 +32,7 @@ type FileUtils interface {
 	RemoveAll(string) error
 	FileRename(string, string) error
 	Getwd() (string, error)
+	Symlink(oldname string, newname string) error
 }
 
 // Files ...
@@ -383,4 +384,9 @@ func (f Files) Stat(path string) (os.FileInfo, error) {
 // Abs is a wrapper for filepath.Abs()
 func (f Files) Abs(path string) (string, error) {
 	return filepath.Abs(path)
+}
+
+// Symlink is a wrapper for os.Symlink
+func (f Files) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
 }

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -548,5 +548,5 @@ steps:
       whitesource: 'whitesourceExecuteScan'
     labelPrefix: pr_
   cnbBuild:
-    stashExcludes:
-      stashBack: '**/*'
+    stashIncludes:
+      stashBack: '**/target/*.exec, **/*.jtl, **/target/**/*.xml'


### PR DESCRIPTION
# Changes
`cnbBuild` will create a symlink for the maven's `target` folder, pointing out to the jenkins workspace `target`, in order to preserve a maven test result for being able to publish it afterwards

- [X] Tests
- [ ] Documentation
