### PR TITLE
add more codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,6 +55,12 @@ CnbBuild*                                       @SAP/piper-cnb
 sonarExecuteScan*                               @CCFenner
 SonarExecuteScan*                               @CCFenner
 
+abapAddonAssemblyKit*                           @tiloKo @bluesbrother84 @rosemarieB
+AbapAddonAssemblyKit*                           @tiloKo @bluesbrother84 @rosemarieB
+abapEnvironmentAssemble*                        @tiloKo @bluesbrother84 @rosemarieB
+AbapEnvironmentAssemble*                        @tiloKo @bluesbrother84 @rosemarieB
+abapEnvironmentBuild*                           @tiloKo @bluesbrother84 @rosemarieB
+AbapEnvironmentBuild*                           @tiloKo @bluesbrother84 @rosemarieB
 
 #####################
 # Integration tests #
@@ -76,12 +82,13 @@ integration/testdata/TestCnbIntegration/        @SAP/piper-cnb
 
 /pkg/orchestrator/                              @inf2381
 
+/pkg/abap/                                      @tiloKo @bluesbrother84 @rosemarieB
 
 ####################
 # Misc             #
 ####################
 
-.github/CODEOWNERS                              @phil9909 @OliverNocon
+.github/CODEOWNERS                              @phil9909 @SAP/jenkins-library-admin
 
 
 ####################

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,39 +42,39 @@
 # Default           #
 #####################
 
-*                                               @SAP/jenkins-library-admin
+*                                               @SAP/jenkins-library-core
 
 
 #####################
 # Steps             #
 #####################
 
-cnbBuild*                                       @SAP/piper-cnb
-CnbBuild*                                       @SAP/piper-cnb
+cnbBuild*                                       @SAP/jenkins-library-cnb
+CnbBuild*                                       @SAP/jenkins-library-cnb
 
 sonarExecuteScan*                               @CCFenner
 SonarExecuteScan*                               @CCFenner
 
-abapAddonAssemblyKit*                           @tiloKo @bluesbrother84 @rosemarieB
-AbapAddonAssemblyKit*                           @tiloKo @bluesbrother84 @rosemarieB
-abapEnvironmentAssemble*                        @tiloKo @bluesbrother84 @rosemarieB
-AbapEnvironmentAssemble*                        @tiloKo @bluesbrother84 @rosemarieB
-abapEnvironmentBuild*                           @tiloKo @bluesbrother84 @rosemarieB
-AbapEnvironmentBuild*                           @tiloKo @bluesbrother84 @rosemarieB
+abapAddonAssemblyKit*                           @SAP/jenkins-library-abap
+AbapAddonAssemblyKit*                           @SAP/jenkins-library-abap
+abapEnvironmentAssemble*                        @SAP/jenkins-library-abap
+AbapEnvironmentAssemble*                        @SAP/jenkins-library-abap
+abapEnvironmentBuild*                           @SAP/jenkins-library-abap
+AbapEnvironmentBuild*                           @SAP/jenkins-library-abap
 
 #####################
 # Integration tests #
 #####################
 
-integration/integration_cnb_test.go             @SAP/piper-cnb
-integration/testdata/TestCnbIntegration/        @SAP/piper-cnb
+integration/integration_cnb_test.go             @SAP/jenkins-library-cnb
+integration/testdata/TestCnbIntegration/        @SAP/jenkins-library-cnb
 
 
 ####################
 # Go packages      #
 ####################
 
-/pkg/cnbutils/                                  @SAP/piper-cnb
+/pkg/cnbutils/                                  @SAP/jenkins-library-cnb
 
 /pkg/sonar/                                     @CCFenner
 
@@ -82,7 +82,7 @@ integration/testdata/TestCnbIntegration/        @SAP/piper-cnb
 
 /pkg/orchestrator/                              @inf2381
 
-/pkg/abap/                                      @tiloKo @bluesbrother84 @rosemarieB
+/pkg/abap/                                      @SAP/jenkins-library-abap
 
 ####################
 # Misc             #

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,15 +36,56 @@
 # directory in the root of your repository.
 #/docs/ @doctocat
 
-##### Jenkins #####
-/pkg/jenkins/ @CCFenner
 
-##### Sonar #####
-/pkg/sonar/ @CCFenner
-/resources/metadata/sonarExecuteScan.yaml @CCFenner
-/vars/sonarExecuteScan.groovy @CCFenner
-/cmd/sonarExecuteScan.go @CCFenner
-/cmd/sonarExecuteScan_test.go @CCFenner
 
-##### Orchestrator #####
-pkg/orchestrator/ @inf2381
+#####################
+# Default           #
+#####################
+
+*                                               @SAP/jenkins-library-admin
+
+
+#####################
+# Steps             #
+#####################
+
+cnbBuild*                                       @SAP/piper-cnb
+CnbBuild*                                       @SAP/piper-cnb
+
+sonarExecuteScan*                               @CCFenner
+SonarExecuteScan*                               @CCFenner
+
+
+#####################
+# Integration tests #
+#####################
+
+integration/integration_cnb_test.go             @SAP/piper-cnb
+integration/testdata/TestCnbIntegration/        @SAP/piper-cnb
+
+
+####################
+# Go packages      #
+####################
+
+/pkg/cnbutils/                                  @SAP/piper-cnb
+
+/pkg/sonar/                                     @CCFenner
+
+/pkg/jenkins/                                   @CCFenner
+
+/pkg/orchestrator/                              @inf2381
+
+
+####################
+# Misc             #
+####################
+
+.github/CODEOWNERS                              @phil9909 @OliverNocon
+
+
+####################
+# Generated        #
+####################
+
+*_generated.go


### PR DESCRIPTION
The CODEOWNERS file is now structured into the following sections:

- **Default**: assign all files to the jenkins-library-admin team.
- **Steps**: Assign steps to owners. This is done with two rules per step: `stepName*` and `StepName*`. Something like `[sS]tepName*` is not supported.
- **Integration tests**
- **Go packages**: The remaining go packages (not step or integration tests)
- **Misc** anything else, currently only the `CODEOWNERS` file itself.
- **Generated** generated code is explicitly assigned to nobody. In GitHub the last match in the CODEOWNERS file wins. Therefore this section is the last one.

Notice: The `piper-cnb` team does not yet exist in GitHub.

I used `piper-cnb` instead of `piper-cnb-build` because we might later contribute a `CnbRebase` step. I guess it is better to have less teams (for example we could have one `piper-abap` team instead of `piper-abap-environment-build`, `piper-abap-environment-assemble-packages`, ...)

**EDIT:** Should we use `jenkins-library-cnb`, `jenkins-library-abap` instead?