### PR TITLE
feat(kanikoExecute): allow building multiple images with explicit config

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/buildsettings"
@@ -52,9 +52,11 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 
 	// prepare kaniko container for running with proper Docker config.json and custom certificates
 	// custom certificates will be downloaded and appended to ca-certificates.crt file used in container
-	prepCommand := strings.Split(config.ContainerPreparationCommand, " ")
-	if err := execRunner.RunExecutable(prepCommand[0], prepCommand[1:]...); err != nil {
-		return errors.Wrap(err, "failed to initialize Kaniko container")
+	if len(config.ContainerPreparationCommand) > 0 {
+		prepCommand := strings.Split(config.ContainerPreparationCommand, " ")
+		if err := execRunner.RunExecutable(prepCommand[0], prepCommand[1:]...); err != nil {
+			return errors.Wrap(err, "failed to initialize Kaniko container")
+		}
 	}
 
 	if len(config.CustomTLSCertificateLinks) > 0 {
@@ -66,6 +68,39 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 		log.Entry().Info("skipping updation of certificates")
 	}
 
+	dockerConfig := []byte(`{"auths":{}}`)
+	if len(config.DockerConfigJSON) > 0 {
+		var err error
+		dockerConfig, err = fileUtils.FileRead(config.DockerConfigJSON)
+		if err != nil {
+			return errors.Wrapf(err, "failed to read file '%v'", config.DockerConfigJSON)
+		}
+	}
+
+	if err := fileUtils.FileWrite("/kaniko/.docker/config.json", dockerConfig, 0644); err != nil {
+		return errors.Wrap(err, "failed to write file '/kaniko/.docker/config.json'")
+	}
+
+	log.Entry().Debugf("preparing build settings information...")
+	stepName := "kanikoExecute"
+	// ToDo: better testability required. So far retrieval of config is rather non deterministic
+	dockerImage, err := getDockerImageValue(stepName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve dockerImage configuration: %w", err)
+	}
+
+	kanikoConfig := buildsettings.BuildOptions{
+		DockerImage:       dockerImage,
+		BuildSettingsInfo: config.BuildSettingsInfo,
+	}
+
+	log.Entry().Debugf("creating build settings information...")
+	buildSettingsInfo, err := buildsettings.CreateBuildSettingsInfo(&kanikoConfig, stepName)
+	if err != nil {
+		log.Entry().Warnf("failed to create build settings info: %v", err)
+	}
+	commonPipelineEnvironment.custom.buildSettingsInfo = buildSettingsInfo
+
 	if !piperutils.ContainsString(config.BuildOptions, "--destination") {
 		dest := []string{"--no-push"}
 		if len(config.ContainerRegistryURL) > 0 && len(config.ContainerImageName) > 0 && len(config.ContainerImageTag) > 0 {
@@ -75,6 +110,33 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 				return errors.Wrapf(err, "failed to read registry url %v", config.ContainerRegistryURL)
 			}
 			containerImageTag := fmt.Sprintf("%v:%v", config.ContainerImageName, strings.ReplaceAll(config.ContainerImageTag, "+", "-"))
+
+			if len(config.ContainerDockerfiles) > 0 {
+				log.Entry().Debugf("Multi-image build activated for image name '%v'", config.ContainerImageName)
+				for image, file := range config.ContainerDockerfiles {
+					log.Entry().Debugf("Building image '%v' using file '%v'", image, file)
+					containerImageNameAndTag := fmt.Sprintf("%v:%v", image, containerImageTag)
+					dest = []string{"--destination", fmt.Sprintf("%v/%v", containerRegistry, containerImageNameAndTag)}
+					buildOpts := append(config.BuildOptions, dest...)
+					err = runKaniko(file.(string), buildOpts, execRunner)
+					if err != nil {
+						return fmt.Errorf("failed to build image '%v' using '%v': %w", image, file, err)
+					}
+					commonPipelineEnvironment.container.imageNames = append(commonPipelineEnvironment.container.imageNames, image)
+					commonPipelineEnvironment.container.imageNameTags = append(commonPipelineEnvironment.container.imageNameTags, containerImageNameAndTag)
+				}
+
+				// for compatibility reasons also fill single imageNameTag field with "root" image in commonPipelineEnvironment
+				// only consider if it has been built
+				// ToDo: reconsider and possibly remove at a later point
+				if _, ok := config.ContainerDockerfiles[config.ContainerImageName]; ok {
+					containerImageNameAndTag := fmt.Sprintf("%v:%v", config.ContainerImageName, containerImageTag)
+					commonPipelineEnvironment.container.imageNameTag = containerImageNameAndTag
+				}
+
+				return nil
+			}
+
 			dest = []string{"--destination", fmt.Sprintf("%v/%v", containerRegistry, containerImageTag)}
 			commonPipelineEnvironment.container.registryURL = config.ContainerRegistryURL
 			commonPipelineEnvironment.container.imageNameTag = containerImageTag
@@ -93,43 +155,14 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 		config.BuildOptions = append(config.BuildOptions, dest...)
 	}
 
-	dockerConfig := []byte(`{"auths":{}}`)
-	if len(config.DockerConfigJSON) > 0 {
-		var err error
-		dockerConfig, err = fileUtils.FileRead(config.DockerConfigJSON)
-		if err != nil {
-			return errors.Wrapf(err, "failed to read file '%v'", config.DockerConfigJSON)
-		}
-	}
+	return runKaniko(config.DockerfilePath, config.BuildOptions, execRunner)
+}
 
-	log.Entry().Debugf("creating build settings information...")
-	stepName := "kanikoExecute"
-	dockerImage, err := getDockerImageValue(stepName)
-	if err != nil {
-		return err
-	}
+func runKaniko(dockerFilepath string, buildOptions []string, execRunner command.ExecRunner) error {
+	kanikoOpts := []string{"--dockerfile", dockerFilepath, "--context", filepath.Dir(dockerFilepath)}
+	kanikoOpts = append(kanikoOpts, buildOptions...)
 
-	kanikoConfig := buildsettings.BuildOptions{
-		DockerImage: dockerImage,
-	}
-	buildSettingsInfo, err := buildsettings.CreateBuildSettingsInfo(&kanikoConfig, stepName)
-	if err != nil {
-		log.Entry().Warnf("failed to create build settings info: %v", err)
-	}
-	commonPipelineEnvironment.custom.buildSettingsInfo = buildSettingsInfo
-
-	if err := fileUtils.FileWrite("/kaniko/.docker/config.json", dockerConfig, 0644); err != nil {
-		return errors.Wrap(err, "failed to write file '/kaniko/.docker/config.json'")
-	}
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		return errors.Wrap(err, "failed to get current working directory")
-	}
-	kanikoOpts := []string{"--dockerfile", config.DockerfilePath, "--context", cwd}
-	kanikoOpts = append(kanikoOpts, config.BuildOptions...)
-
-	err = execRunner.RunExecutable("/kaniko/executor", kanikoOpts...)
+	err := execRunner.RunExecutable("/kaniko/executor", kanikoOpts...)
 	if err != nil {
 		log.SetErrorCategory(log.ErrorBuild)
 		return errors.Wrap(err, "execution of '/kaniko/executor' failed")

--- a/resources/metadata/kanikoExecute.yaml
+++ b/resources/metadata/kanikoExecute.yaml
@@ -58,6 +58,24 @@ spec:
         resourceRef:
           - name: commonPipelineEnvironment
             param: artifactVersion
+      - name: buildSettingsInfo
+        type: string
+        description: Build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build. This information is typically used for compliance related processes.
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/buildSettingsInfo
+      - name: containerDockerfiles
+        type: "map[string]interface{}"
+        description: "Images that should be build in case there is more than one Dockerfile (name => path of Dockerfile)."
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: containerPreparationCommand
         type: string
         description: Defines the command to prepare the Kaniko container. By default the contained credentials are removed in order to allow anonymous access to container registries.
@@ -119,6 +137,10 @@ spec:
         params:
           - name: container/registryUrl
           - name: container/imageNameTag
+          - name: container/imageNames
+            type: "[]string"
+          - name: container/imageNameTags
+            type: "[]string"
           - name: custom/buildSettingsInfo
   containers:
     - image: gcr.io/kaniko-project/executor:debug


### PR DESCRIPTION
Alternative proposal to https://github.com/SAP/jenkins-library/pull/3443.

Being more explicit in the configuration and rely less on automatic behaviour.

We see some advantages in this:

- The user has control over the image names (e.g. the directory structure of the project has no implications on the image names)
- Could be extended to also support build options and tags per Dockerfile
- This would even allow to build the same Dockerfile twice with different build options