### PR TITLE
fix (mtaBuild) keep mtar artifact name in synch with maven gav

### DIFF
--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -281,7 +281,7 @@ func runMtaBuild(config mtaBuildOptions,
 				mtarArtifactName := mtarName
 
 				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, ".mtar", "")
-				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, ".", "/")
+				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, ".", "-")
 
 				config.MtaDeploymentRepositoryURL += config.MtarGroup + "/" + mtarArtifactName + "/" + config.Version + "/" + fmt.Sprintf("%v-%v.%v", mtarArtifactName, config.Version, "mtar")
 

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -281,7 +281,9 @@ func runMtaBuild(config mtaBuildOptions,
 				mtarArtifactName := mtarName
 
 				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, ".mtar", "")
+				/* mta artifact are pushed to maven like repo so the artifact name must follow maven conventions */
 				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, ".", "-")
+				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, "/", "-")
 
 				config.MtaDeploymentRepositoryURL += config.MtarGroup + "/" + mtarArtifactName + "/" + config.Version + "/" + fmt.Sprintf("%v-%v.%v", mtarArtifactName, config.Version, "mtar")
 

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -281,9 +281,6 @@ func runMtaBuild(config mtaBuildOptions,
 				mtarArtifactName := mtarName
 
 				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, ".mtar", "")
-				/* mta artifact are pushed to maven like repo so the artifact name must follow maven conventions */
-				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, ".", "-")
-				mtarArtifactName = strings.ReplaceAll(mtarArtifactName, "/", "-")
 
 				config.MtaDeploymentRepositoryURL += config.MtarGroup + "/" + mtarArtifactName + "/" + config.Version + "/" + fmt.Sprintf("%v-%v.%v", mtarArtifactName, config.Version, "mtar")
 


### PR DESCRIPTION
# Changes

mtaBuild mtars are pushed into a maven like repo when `publish `is set to `true `, so the artifact name from the mta yaml can contain `.` which we replace with `-` to keep it in synch with the maven gav co-ordinate naming convention

- [ ] Tests
- [ ] Documentation

EDIT: mtar can consist of dotted string, so in the final change we do not replace the dots , but keep it as it is