### PR TITLE
sonarqube coverage: additional metrics

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -233,7 +233,7 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 		return err
 	}
 
-	componentService := SonarUtils.NewMeasuresComponentService(taskReport.ServerURL, config.Token, taskReport.ProjectKey, config.Organization, apiClient)
+	componentService := SonarUtils.NewMeasuresComponentService(taskReport.ServerURL, config.Token, taskReport.ProjectKey, config.Organization, config.BranchName, apiClient)
 	cov, err := componentService.GetCoverage()
 	if err != nil {
 		return err // No wrap, description already added one level below

--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -239,6 +239,11 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 		return err // No wrap, description already added one level below
 	}
 
+	loc, err := componentService.GetLinesOfCode()
+	if err != nil {
+		return err // No wrap, description already added one level below
+	}
+
 	log.Entry().Debugf("Influx values: %v", influx.sonarqube_data.fields)
 	err = SonarUtils.WriteReport(SonarUtils.ReportData{
 		ServerURL:    taskReport.ServerURL,
@@ -254,7 +259,8 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 			Minor:    influx.sonarqube_data.fields.minor_issues,
 			Info:     influx.sonarqube_data.fields.info_issues,
 		},
-		Coverage: *cov,
+		Coverage:    *cov,
+		LinesOfCode: *loc,
 	}, sonar.workingDir, ioutil.WriteFile)
 	if err != nil {
 		return err

--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -233,7 +233,7 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 		return err
 	}
 
-	componentService := SonarUtils.NewMeasuresComponentService(taskReport.ServerURL, config.Token, taskReport.ProjectKey, config.Organization, config.BranchName, apiClient)
+	componentService := SonarUtils.NewMeasuresComponentService(taskReport.ServerURL, config.Token, taskReport.ProjectKey, config.Organization, config.BranchName, config.ChangeID, apiClient)
 	cov, err := componentService.GetCoverage()
 	if err != nil {
 		return err // No wrap, description already added one level below

--- a/integration/integration_sonar_test.go
+++ b/integration/integration_sonar_test.go
@@ -67,7 +67,7 @@ func TestSonarMeasuresComponentSearch(t *testing.T) {
 		componentKey = "SAP_jenkins-library"
 	}
 
-	componentService := sonar.NewMeasuresComponentService(host, token, componentKey, organization, "", &piperhttp.Client{})
+	componentService := sonar.NewMeasuresComponentService(host, token, componentKey, organization, "", "", &piperhttp.Client{})
 	// test
 	_, err := componentService.GetCoverage()
 	// assert
@@ -92,7 +92,7 @@ func TestSonarGetLinesOfCode(t *testing.T) {
 		componentKey = "SAP_jenkins-library"
 	}
 
-	componentService := sonar.NewMeasuresComponentService(host, token, componentKey, organization, "", &piperhttp.Client{})
+	componentService := sonar.NewMeasuresComponentService(host, token, componentKey, organization, "", "", &piperhttp.Client{})
 	// test
 	_, err := componentService.GetLinesOfCode()
 	// assert

--- a/integration/integration_sonar_test.go
+++ b/integration/integration_sonar_test.go
@@ -67,9 +67,34 @@ func TestSonarMeasuresComponentSearch(t *testing.T) {
 		componentKey = "SAP_jenkins-library"
 	}
 
-	componentService := sonar.NewMeasuresComponentService(host, token, componentKey, organization, &piperhttp.Client{})
+	componentService := sonar.NewMeasuresComponentService(host, token, componentKey, organization, "", &piperhttp.Client{})
 	// test
 	_, err := componentService.GetCoverage()
+	// assert
+	assert.NoError(t, err)
+}
+
+func TestSonarGetLinesOfCode(t *testing.T) {
+	t.Parallel()
+	// init
+	token := os.Getenv("PIPER_INTEGRATION_SONAR_TOKEN")
+	require.NotEmpty(t, token, "SonarQube API Token is missing")
+	host := os.Getenv("PIPER_INTEGRATION_SONAR_HOST")
+	if len(host) == 0 {
+		host = "https://sonarcloud.io"
+	}
+	organization := os.Getenv("PIPER_INTEGRATION_SONAR_ORGANIZATION")
+	if len(organization) == 0 {
+		organization = "sap-1"
+	}
+	componentKey := os.Getenv("PIPER_INTEGRATION_SONAR_PROJECT")
+	if len(componentKey) == 0 {
+		componentKey = "SAP_jenkins-library"
+	}
+
+	componentService := sonar.NewMeasuresComponentService(host, token, componentKey, organization, "", &piperhttp.Client{})
+	// test
+	_, err := componentService.GetLinesOfCode()
 	// assert
 	assert.NoError(t, err)
 }

--- a/pkg/sonar/componentService.go
+++ b/pkg/sonar/componentService.go
@@ -22,23 +22,23 @@ type ComponentService struct {
 }
 
 type SonarCoverage struct {
-	Coverage          float32 `json:"coverage,omitempty"`
-	LineCoverage      float32 `json:"lineCoverage,omitempty"`
-	LinesToCover      int     `json:"linesToCover,omitempty"`
-	UncoveredLines    int     `json:"uncoveredLines,omitempty"`
-	BranchCoverage    float32 `json:"branchCoverage,omitempty"`
-	BranchesToCover   int     `json:"branchesToCover,omitempty"`
-	UncoveredBranches int     `json:"uncoveredBranches,omitempty"`
+	Coverage          float32 `json:"coverage"`
+	LineCoverage      float32 `json:"lineCoverage"`
+	LinesToCover      int     `json:"linesToCover"`
+	UncoveredLines    int     `json:"uncoveredLines"`
+	BranchCoverage    float32 `json:"branchCoverage"`
+	BranchesToCover   int     `json:"branchesToCover"`
+	UncoveredBranches int     `json:"uncoveredBranches"`
 }
 
 type SonarLinesOfCode struct {
-	Total                int                         `json:"total,omitempty"`
+	Total                int                         `json:"total"`
 	LanguageDistribution []SonarLanguageDistribution `json:"languageDistribution,omitempty"`
 }
 
 type SonarLanguageDistribution struct {
 	LanguageKey string `json:"languageKey,omitempty"` // Description:"key of the language as retrieved from sonarqube. All languages (key + name) are available as API https://<sonarqube-instance>/api/languages/list ",ExampleValue:"java,js,web,go"
-	LinesOfCode int    `json:"linesOfCode,omitempty"`
+	LinesOfCode int    `json:"linesOfCode"`
 }
 
 func (service *ComponentService) Component(options *MeasuresComponentOption) (*sonargo.MeasuresComponentObject, *http.Response, error) {

--- a/pkg/sonar/componentService.go
+++ b/pkg/sonar/componentService.go
@@ -18,6 +18,7 @@ type ComponentService struct {
 	Organization string
 	Project      string
 	Branch       string
+	PullRequest  string
 	apiClient    *Requester
 }
 
@@ -44,6 +45,9 @@ type SonarLanguageDistribution struct {
 func (service *ComponentService) Component(options *MeasuresComponentOption) (*sonargo.MeasuresComponentObject, *http.Response, error) {
 	if len(service.Branch) > 0 {
 		options.Branch = service.Branch
+	}
+	if len(service.PullRequest) > 0 {
+		options.PullRequest = service.PullRequest
 	}
 	request, err := service.apiClient.create("GET", EndpointMeasuresComponent, options)
 	if err != nil {
@@ -151,11 +155,12 @@ func (service *ComponentService) GetCoverage() (*SonarCoverage, error) {
 }
 
 // NewMeasuresComponentService returns a new instance of a service for the measures/component endpoint.
-func NewMeasuresComponentService(host, token, project, organization, branch string, client Sender) *ComponentService {
+func NewMeasuresComponentService(host, token, project, organization, branch, pullRequest string, client Sender) *ComponentService {
 	return &ComponentService{
 		Organization: organization,
 		Project:      project,
 		Branch:       branch,
+		PullRequest:  pullRequest,
 		apiClient:    NewAPIClient(host, token, client),
 	}
 }

--- a/pkg/sonar/componentService_test.go
+++ b/pkg/sonar/componentService_test.go
@@ -22,7 +22,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseCoverage))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		cov, err := serviceUnderTest.GetCoverage()
 		// assert
@@ -45,7 +45,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseCoverageInvalidValue))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		cov, err := serviceUnderTest.GetCoverage()
 		// assert
@@ -62,7 +62,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseLinesOfCode))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		loc, err := serviceUnderTest.GetLinesOfCode()
 		// assert
@@ -93,7 +93,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseLinesOfCodeInvalidValue))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		loc, err := serviceUnderTest.GetLinesOfCode()
 		// assert
@@ -110,7 +110,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseLinesOfCodeNoSeparator))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		loc, err := serviceUnderTest.GetLinesOfCode()
 		// assert

--- a/pkg/sonar/componentService_test.go
+++ b/pkg/sonar/componentService_test.go
@@ -27,7 +27,13 @@ func TestComponentService(t *testing.T) {
 		cov, err := serviceUnderTest.GetCoverage()
 		// assert
 		assert.NoError(t, err)
+		assert.Equal(t, float32(80.7), cov.Coverage)
+		assert.Equal(t, float32(80.4), cov.LineCoverage)
+		assert.Equal(t, 121, cov.LinesToCover)
+		assert.Equal(t, 91, cov.UncoveredLines)
 		assert.Equal(t, float32(81), cov.BranchCoverage)
+		assert.Equal(t, 8, cov.BranchesToCover)
+		assert.Equal(t, 5, cov.UncoveredBranches)
 		assert.Equal(t, 1, httpmock.GetTotalCallCount(), "unexpected number of requests")
 	})
 	t.Run("invalid metric value", func(t *testing.T) {
@@ -50,33 +56,21 @@ func TestComponentService(t *testing.T) {
 }
 
 const responseCoverage = `{
-  "component": {
-    "key": "com.sap.piper.test",
-    "name": "com.sap.piper.test",
-    "qualifier": "TRK",
-    "measures": [
-      {
-        "metric": "line_coverage",
-        "value": "80.4",
-        "bestValue": false
-      },
-      {
-        "metric": "branch_coverage",
-        "value": "81.0",
-        "bestValue": false
-      },
-      {
-        "metric": "coverage",
-        "value": "80.7",
-        "bestValue": false
-      },
-      {
-        "metric": "extra_valie",
-        "value": "42.7",
-        "bestValue": false
-      }
-    ]
-  }
+	"component": {
+		"key": "com.sap.piper.test",
+		"name": "com.sap.piper.test",
+		"qualifier": "TRK",
+		"measures": [
+			{ "metric": "line_coverage", "value": "80.4", "bestValue": false },
+			{ "metric": "branch_coverage", "value": "81.0", "bestValue": false },
+			{ "metric": "coverage", "value": "80.7", "bestValue": false },
+			{ "metric": "extra_valie", "value": "42.7", "bestValue": false },
+			{ "metric": "lines_to_cover", "value": "121" },
+			{ "metric": "uncovered_lines", "value": "91", "bestValue": false },
+			{ "metric": "conditions_to_cover", "value": "8" },
+			{ "metric": "uncovered_conditions", "value": "5", "bestValue": false }
+		]
+	}
 }`
 
 const responseCoverageInvalidValue = `{
@@ -85,11 +79,8 @@ const responseCoverageInvalidValue = `{
 	  "name": "com.sap.piper.test",
 	  "qualifier": "TRK",
 	  "measures": [
-		{
-		  "metric": "line_coverage",
-		  "value": "xyz",
-		  "bestValue": false
-		}
+		  { "metric": "line_coverage", "value": "xyz", "bestValue": false },
+		  { "metric": "uncovered_conditions", "value": "abc", "bestValue": false }
 	  ]
 	}
   }`

--- a/pkg/sonar/componentService_test.go
+++ b/pkg/sonar/componentService_test.go
@@ -22,7 +22,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseCoverage))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		cov, err := serviceUnderTest.GetCoverage()
 		// assert
@@ -45,7 +45,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseCoverageInvalidValue))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		cov, err := serviceUnderTest.GetCoverage()
 		// assert
@@ -62,7 +62,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseLinesOfCode))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		loc, err := serviceUnderTest.GetLinesOfCode()
 		// assert
@@ -93,7 +93,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseLinesOfCodeInvalidValue))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		loc, err := serviceUnderTest.GetLinesOfCode()
 		// assert
@@ -110,7 +110,7 @@ func TestComponentService(t *testing.T) {
 		// add response handler
 		httpmock.RegisterResponder(http.MethodGet, testURL+"/api/"+EndpointMeasuresComponent+"", httpmock.NewStringResponder(http.StatusOK, responseLinesOfCodeNoSeparator))
 		// create service instance
-		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, sender)
+		serviceUnderTest := NewMeasuresComponentService(testURL, mock.Anything, mock.Anything, mock.Anything, mock.Anything, sender)
 		// test
 		loc, err := serviceUnderTest.GetLinesOfCode()
 		// assert

--- a/pkg/sonar/report.go
+++ b/pkg/sonar/report.go
@@ -10,14 +10,15 @@ const reportFileName = "sonarscan.json"
 
 //ReportData is representing the data of the step report JSON
 type ReportData struct {
-	ServerURL      string        `json:"serverUrl"`
-	ProjectKey     string        `json:"projectKey"`
-	TaskID         string        `json:"taskId"`
-	ChangeID       string        `json:"changeID,omitempty"`
-	BranchName     string        `json:"branchName,omitempty"`
-	Organization   string        `json:"organization,omitempty"`
-	NumberOfIssues Issues        `json:"numberOfIssues"`
-	Coverage       SonarCoverage `json:"coverage"`
+	ServerURL      string           `json:"serverUrl"`
+	ProjectKey     string           `json:"projectKey"`
+	TaskID         string           `json:"taskId"`
+	ChangeID       string           `json:"changeID,omitempty"`
+	BranchName     string           `json:"branchName,omitempty"`
+	Organization   string           `json:"organization,omitempty"`
+	NumberOfIssues Issues           `json:"numberOfIssues"`
+	Coverage       SonarCoverage    `json:"coverage"`
+	LinesOfCode    SonarLinesOfCode `json:"linesOfCode"`
 }
 
 // Issues ...

--- a/pkg/sonar/report_test.go
+++ b/pkg/sonar/report_test.go
@@ -19,7 +19,7 @@ func writeToFileMock(f string, d []byte, p os.FileMode) error {
 
 func TestWriteReport(t *testing.T) {
 	// init
-	const expected = `{"serverUrl":"https://sonarcloud.io","projectKey":"Piper-Validation/Golang","taskId":"mock.Anything","numberOfIssues":{"blocker":0,"critical":1,"major":2,"minor":3,"info":4},"coverage":{"coverage":13.7,"lineCoverage":37.1,"branchCoverage":42},"linesOfCode":{"total":327,"languageDistribution":[{"languageKey":"java","linesOfCode":327}]}}`
+	const expected = `{"serverUrl":"https://sonarcloud.io","projectKey":"Piper-Validation/Golang","taskId":"mock.Anything","numberOfIssues":{"blocker":0,"critical":1,"major":2,"minor":3,"info":4},"coverage":{"coverage":13.7,"lineCoverage":37.1,"linesToCover":123,"uncoveredLines":23,"branchCoverage":42,"branchesToCover":30,"uncoveredBranches":3},"linesOfCode":{"total":327,"languageDistribution":[{"languageKey":"java","linesOfCode":327}]}}`
 	testData := ReportData{
 		ServerURL:  "https://sonarcloud.io",
 		ProjectKey: "Piper-Validation/Golang",
@@ -31,9 +31,13 @@ func TestWriteReport(t *testing.T) {
 			Info:     4,
 		},
 		Coverage: SonarCoverage{
-			Coverage:       13.7,
-			BranchCoverage: 42,
-			LineCoverage:   37.1,
+			Coverage:          13.7,
+			BranchCoverage:    42,
+			LineCoverage:      37.1,
+			LinesToCover:      123,
+			UncoveredLines:    23,
+			BranchesToCover:   30,
+			UncoveredBranches: 3,
 		},
 		LinesOfCode: SonarLinesOfCode{
 			Total:                327,

--- a/pkg/sonar/report_test.go
+++ b/pkg/sonar/report_test.go
@@ -19,7 +19,7 @@ func writeToFileMock(f string, d []byte, p os.FileMode) error {
 
 func TestWriteReport(t *testing.T) {
 	// init
-	const expected = `{"serverUrl":"https://sonarcloud.io","projectKey":"Piper-Validation/Golang","taskId":"mock.Anything","numberOfIssues":{"blocker":0,"critical":1,"major":2,"minor":3,"info":4},"coverage":{"coverage":13.7,"lineCoverage":37.1,"branchCoverage":42}}`
+	const expected = `{"serverUrl":"https://sonarcloud.io","projectKey":"Piper-Validation/Golang","taskId":"mock.Anything","numberOfIssues":{"blocker":0,"critical":1,"major":2,"minor":3,"info":4},"coverage":{"coverage":13.7,"lineCoverage":37.1,"branchCoverage":42},"linesOfCode":{"total":327,"languageDistribution":[{"languageKey":"java","linesOfCode":327}]}}`
 	testData := ReportData{
 		ServerURL:  "https://sonarcloud.io",
 		ProjectKey: "Piper-Validation/Golang",
@@ -34,6 +34,10 @@ func TestWriteReport(t *testing.T) {
 			Coverage:       13.7,
 			BranchCoverage: 42,
 			LineCoverage:   37.1,
+		},
+		LinesOfCode: SonarLinesOfCode{
+			Total:                327,
+			LanguageDistribution: []SonarLanguageDistribution{{LanguageKey: "java", LinesOfCode: 327}},
 		},
 	}
 	// test

--- a/pkg/sonar/types.go
+++ b/pkg/sonar/types.go
@@ -37,7 +37,8 @@ type IssuesSearchOption struct {
 
 // MeasuresComponentOption is a copy from magicsong/sonargo plus the "internal" field branch.
 type MeasuresComponentOption struct {
-	Branch string `url:"branch,omitempty"` // Description:"Branch key"
+	Branch      string `url:"branch,omitempty"`      // Description:"Branch key"
+	PullRequest string `url:"pullRequest,omitempty"` // Description:"Pull request id"
 	// copied from https://github.com/magicsong/sonargo/blob/master/sonar/measures_service.go#L53
 	AdditionalFields string `url:"additionalFields,omitempty"` // Description:"Comma-separated list of additional fields that can be returned in the response.",ExampleValue:"periods,metrics"
 	Component        string `url:"component,omitempty"`        // Description:"Component key",ExampleValue:"my_project"

--- a/pkg/sonar/types.go
+++ b/pkg/sonar/types.go
@@ -35,6 +35,16 @@ type IssuesSearchOption struct {
 	Types              string `url:"types,omitempty"`              // Description:"Comma-separated list of types.",ExampleValue:"CODE_SMELL,BUG"
 }
 
+// MeasuresComponentOption is a copy from magicsong/sonargo plus the "internal" field branch.
+type MeasuresComponentOption struct {
+	Branch string `url:"branch,omitempty"` // Description:"Branch key"
+	// copied from https://github.com/magicsong/sonargo/blob/master/sonar/measures_service.go#L53
+	AdditionalFields string `url:"additionalFields,omitempty"` // Description:"Comma-separated list of additional fields that can be returned in the response.",ExampleValue:"periods,metrics"
+	Component        string `url:"component,omitempty"`        // Description:"Component key",ExampleValue:"my_project"
+	ComponentId      string `url:"componentId,omitempty"`      // Description:"Component id",ExampleValue:"AU-Tpxb--iU5OvuD2FLy"
+	MetricKeys       string `url:"metricKeys,omitempty"`       // Description:"Comma-separated list of metric keys",ExampleValue:"ncloc,complexity,violations"
+}
+
 type issueSeverity string
 
 func (s issueSeverity) ToString() string {


### PR DESCRIPTION
# Changes

Add additional metrix from sonarqube to sonarscan.json:
1. add uncovered_lines,lines_to_cover,conditions_to_cover,uncovered_conditions so that weighted aggregations can be done for multiple sonar projects
2. add ncloc_language_distribution(Non Commenting Lines of Code Distributed By Language), ncloc (Non commenting lines of code) for language detection including distribution
3. consider branch in sonar componentService

- [x] Tests
