### PR TITLE
chore(kubernetesDeploy): bump docker image to helm 3.8.1

### DIFF
--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -598,7 +598,7 @@ func kubernetesDeployMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "dtzar/helm-kubectl:3.4.1", WorkingDir: "/config", Options: []config.Option{{Name: "-u", Value: "0"}}, Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "deployTool", Value: "helm3"}}}}},
+				{Image: "dtzar/helm-kubectl:3.8.1", WorkingDir: "/config", Options: []config.Option{{Name: "-u", Value: "0"}}, Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "deployTool", Value: "helm3"}}}}},
 				{Image: "dtzar/helm-kubectl:2.17.0", WorkingDir: "/config", Options: []config.Option{{Name: "-u", Value: "0"}}, Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "deployTool", Value: "helm"}}}}},
 				{Image: "dtzar/helm-kubectl:2.17.0", WorkingDir: "/config", Options: []config.Option{{Name: "-u", Value: "0"}}, Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "deployTool", Value: "kubectl"}}}}},
 			},

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -461,7 +461,7 @@ spec:
           - apply
           - replace
   containers:
-    - image: dtzar/helm-kubectl:3.4.1
+    - image: dtzar/helm-kubectl:3.8.1
       workingDir: /config
       options:
         - name: -u


### PR DESCRIPTION
For `deployTool == "kubectl"` we still use tag `2.17.0` should we also bump this to `3.x`?

The 2.17 version contains a rather outdated kubectl and alpine version:

> - 3.8.0 - helm v3.8.0, kubectl v1.23.2, alpine 3.15
> - 3.4.1 - helm v3.4.1, kubectl v1.19.4, alpine 3.12
> - 2.17.0 - helm v2.17.0, kubectl v1.19.4, alpine 3.12
>
> source: https://hub.docker.com/r/dtzar/helm-kubectl