### PR TITLE
Fix(gctsCloneRepository,gctsRollback) : Http retry disabling during errors

### DIFF
--- a/cmd/gctsCloneRepository.go
+++ b/cmd/gctsCloneRepository.go
@@ -33,9 +33,10 @@ func cloneRepository(config *gctsCloneRepositoryOptions, telemetryData *telemetr
 		return errors.Wrap(cookieErr, "creating a cookie jar failed")
 	}
 	clientOptions := piperhttp.ClientOptions{
-		CookieJar: cookieJar,
-		Username:  config.Username,
-		Password:  config.Password,
+		CookieJar:  cookieJar,
+		Username:   config.Username,
+		Password:   config.Password,
+		MaxRetries: -1,
 	}
 	httpClient.SetOptions(clientOptions)
 

--- a/cmd/gctsRollback.go
+++ b/cmd/gctsRollback.go
@@ -39,9 +39,10 @@ func rollback(config *gctsRollbackOptions, telemetryData *telemetry.CustomData, 
 		return cookieErr
 	}
 	clientOptions := piperhttp.ClientOptions{
-		CookieJar: cookieJar,
-		Username:  config.Username,
-		Password:  config.Password,
+		CookieJar:  cookieJar,
+		Username:   config.Username,
+		Password:   config.Password,
+		MaxRetries: -1,
 	}
 	httpClient.SetOptions(clientOptions)
 
@@ -113,7 +114,8 @@ func getLastSuccessfullCommit(config *gctsRollbackOptions, telemetryData *teleme
 		return "", cookieErr
 	}
 	clientOptions := piperhttp.ClientOptions{
-		CookieJar: cookieJar,
+		CookieJar:  cookieJar,
+		MaxRetries: -1,
 	}
 
 	if config.GithubPersonalAccessToken != "" {


### PR DESCRIPTION
# Changes
Fixed the retry issues in the Clone repository and rollback for gcts endpoints