### PR TITLE
feat(golangBuild): add support for publishing binaries

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -35,7 +35,7 @@ type golangBuildUtils interface {
 	goget.Client
 
 	piperutils.FileUtils
-	piperhttp.Sender
+	piperhttp.Uploader
 
 	// Add more methods here, or embed additional interfaces, or remove/replace as required.
 	// The golangBuildUtils interface should be descriptive of your runtime dependencies,
@@ -46,7 +46,7 @@ type golangBuildUtils interface {
 type golangBuildUtilsBundle struct {
 	*command.Command
 	*piperutils.Files
-	piperhttp.Sender
+	piperhttp.Uploader
 	goget.Client
 
 	// Embed more structs as necessary to implement methods or interfaces you add to golangBuildUtils.
@@ -67,9 +67,9 @@ func newGolangBuildUtils(config golangBuildOptions) golangBuildUtils {
 	httpClient.SetOptions(httpClientOptions)
 
 	utils := golangBuildUtilsBundle{
-		Command: &command.Command{},
-		Files:   &piperutils.Files{},
-		Sender:  &httpClient,
+		Command:  &command.Command{},
+		Files:    &piperutils.Files{},
+		Uploader: &httpClient,
 		Client: &goget.ClientImpl{
 			HTTPClient: &httpClient,
 		},
@@ -146,10 +146,45 @@ func runGolangBuild(config *golangBuildOptions, telemetryData *telemetry.CustomD
 		log.Entry().Infof("ldflags from template: '%v'", ldflags)
 	}
 
+	binaries := []string{}
+
 	for _, architecture := range config.TargetArchitectures {
-		err := runGolangBuildPerArchitecture(config, utils, ldflags, architecture)
+		binary, err := runGolangBuildPerArchitecture(config, utils, ldflags, architecture)
+
 		if err != nil {
 			return err
+		}
+
+		if len(binary) > 0 {
+			binaries = append(binaries, binary)
+		}
+	}
+
+	if config.Publish {
+		if len(config.TargetRepositoryURL) == 0 {
+			return fmt.Errorf("there's no target repository for binary publishing configured")
+		}
+
+		repoClientOptions := piperhttp.ClientOptions{
+			Username:     config.TargetRepositoryUser,
+			Password:     config.TargetRepositoryPassword,
+			TrustedCerts: config.CustomTLSCertificateLinks,
+		}
+
+		utils.SetOptions(repoClientOptions)
+
+		for _, binary := range binaries {
+			log.Entry().Infof("publishing artifact '%s'", binary)
+
+			response, err := utils.UploadFile(fmt.Sprintf("%s/%s", config.TargetRepositoryURL, binary), binary, "", nil, nil, "binary")
+
+			if err != nil {
+				return fmt.Errorf("couldn't upload artifact: %w", err)
+			}
+
+			if response.StatusCode != 200 {
+				return fmt.Errorf("couldn't upload artifact, received status code %d", response.StatusCode)
+			}
 		}
 	}
 
@@ -293,7 +328,9 @@ func prepareLdflags(config *golangBuildOptions, utils golangBuildUtils, envRootP
 	return generatedLdflags.String(), nil
 }
 
-func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuildUtils, ldflags, architecture string) error {
+func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuildUtils, ldflags, architecture string) (string, error) {
+	var binaryName string
+
 	envVars := os.Environ()
 	goos, goarch := splitTargetArchitecture(architecture)
 	envVars = append(envVars, fmt.Sprintf("GOOS=%v", goos), fmt.Sprintf("GOARCH=%v", goarch))
@@ -309,7 +346,8 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 		if goos == "windows" {
 			fileExtension = ".exe"
 		}
-		buildOptions = append(buildOptions, "-o", fmt.Sprintf("%v-%v.%v%v", config.Output, goos, goarch, fileExtension))
+		binaryName = fmt.Sprintf("%v-%v.%v%v", config.Output, goos, goarch, fileExtension)
+		buildOptions = append(buildOptions, "-o", binaryName)
 	}
 	buildOptions = append(buildOptions, config.BuildFlags...)
 	buildOptions = append(buildOptions, config.Packages...)
@@ -320,9 +358,9 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 	if err := utils.RunExecutable("go", buildOptions...); err != nil {
 		log.Entry().Debugf("buildOptions: %v", buildOptions)
 		log.SetErrorCategory(log.ErrorBuild)
-		return fmt.Errorf("failed to run build for %v.%v: %w", goos, goarch, err)
+		return "", fmt.Errorf("failed to run build for %v.%v: %w", goos, goarch, err)
 	}
-	return nil
+	return binaryName, nil
 }
 
 func splitTargetArchitecture(architecture string) (string, string) {

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -18,6 +18,12 @@ import (
 type golangBuildMockUtils struct {
 	*mock.ExecMockRunner
 	*mock.FilesMock
+
+	returnFileUploadStatus int   // expected to be set upfront
+	returnFileUploadError  error // expected to be set upfront
+
+	clientOptions []piperhttp.ClientOptions // set by mock
+	fileUploads   map[string]string         // set by mock
 }
 
 func (utils golangBuildMockUtils) GetRepositoryURL(module string) (string, error) {
@@ -29,13 +35,33 @@ func (utils golangBuildMockUtils) SendRequest(method string, url string, r io.Re
 }
 
 func (utils golangBuildMockUtils) SetOptions(options piperhttp.ClientOptions) {
-	// not implemented
+	utils.clientOptions = append(utils.clientOptions, options)
+}
+
+func (utils golangBuildMockUtils) UploadRequest(method, url, file, fieldName string, header http.Header, cookies []*http.Cookie, uploadType string) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (utils golangBuildMockUtils) UploadFile(url, file, fieldName string, header http.Header, cookies []*http.Cookie, uploadType string) (*http.Response, error) {
+	utils.fileUploads[file] = url
+
+	response := http.Response{
+		StatusCode: utils.returnFileUploadStatus,
+	}
+
+	return &response, utils.returnFileUploadError
+}
+
+func (utils golangBuildMockUtils) Upload(data piperhttp.UploadRequestData) (*http.Response, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func newGolangBuildTestsUtils() golangBuildMockUtils {
 	utils := golangBuildMockUtils{
 		ExecMockRunner: &mock.ExecMockRunner{},
 		FilesMock:      &mock.FilesMock{},
+		//clientOptions:  []piperhttp.ClientOptions{},
+		fileUploads: map[string]string{},
 	}
 	return utils
 }
@@ -106,6 +132,28 @@ func TestRunGolangBuild(t *testing.T) {
 		assert.Equal(t, []string{"build"}, utils.ExecMockRunner.Calls[2].Params)
 	})
 
+	t.Run("success - publishes binaries", func(t *testing.T) {
+		config := golangBuildOptions{
+			TargetArchitectures:      []string{"linux,amd64"},
+			Output:                   "testBin",
+			Publish:                  true,
+			TargetRepositoryURL:      "https://my.target.repository.local",
+			TargetRepositoryUser:     "user",
+			TargetRepositoryPassword: "password",
+		}
+		utils := newGolangBuildTestsUtils()
+		utils.returnFileUploadStatus = 200
+		telemetryData := telemetry.CustomData{}
+
+		err := runGolangBuild(&config, &telemetryData, utils)
+		assert.NoError(t, err)
+		assert.Equal(t, "go", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"build", "-o", "testBin-linux.amd64"}, utils.ExecMockRunner.Calls[0].Params)
+
+		assert.Equal(t, 1, len(utils.fileUploads))
+		assert.Equal(t, "https://my.target.repository.local/testBin-linux.amd64", utils.fileUploads["testBin-linux.amd64"])
+	})
+
 	t.Run("failure - install pre-requisites", func(t *testing.T) {
 		config := golangBuildOptions{
 			RunTests: true,
@@ -168,6 +216,36 @@ func TestRunGolangBuild(t *testing.T) {
 
 		err := runGolangBuild(&config, &telemetryData, utils)
 		assert.EqualError(t, err, "failed to run build for linux.amd64: build failure")
+	})
+
+	t.Run("failure - publish - no target repository defined", func(t *testing.T) {
+		config := golangBuildOptions{
+			TargetArchitectures: []string{"linux,amd64"},
+			Output:              "testBin",
+			Publish:             true,
+		}
+		utils := newGolangBuildTestsUtils()
+		telemetryData := telemetry.CustomData{}
+
+		err := runGolangBuild(&config, &telemetryData, utils)
+		assert.EqualError(t, err, "there's no target repository for binary publishing configured")
+	})
+
+	t.Run("failure - publish - received unexpected status code", func(t *testing.T) {
+		config := golangBuildOptions{
+			TargetArchitectures:      []string{"linux,amd64"},
+			Output:                   "testBin",
+			Publish:                  true,
+			TargetRepositoryURL:      "https://my.target.repository.local",
+			TargetRepositoryUser:     "user",
+			TargetRepositoryPassword: "password",
+		}
+		utils := newGolangBuildTestsUtils()
+		utils.returnFileUploadStatus = 500
+		telemetryData := telemetry.CustomData{}
+
+		err := runGolangBuild(&config, &telemetryData, utils)
+		assert.EqualError(t, err, "couldn't upload artifact, received status code 500")
 	})
 }
 
@@ -395,7 +473,7 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		ldflags := ""
 		architecture := "linux,amd64"
 
-		err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Greater(t, len(utils.Env), 3)
 		assert.Contains(t, utils.Env, "CGO_ENABLED=0")
@@ -403,6 +481,7 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		assert.Contains(t, utils.Env, "GOARCH=amd64")
 		assert.Equal(t, utils.Calls[0].Exec, "go")
 		assert.Equal(t, utils.Calls[0].Params[0], "build")
+		assert.Empty(t, binaryName)
 	})
 
 	t.Run("success - custom params", func(t *testing.T) {
@@ -412,13 +491,14 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		ldflags := "-X test=test"
 		architecture := "linux,amd64"
 
-		err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Contains(t, utils.Calls[0].Params, "-o")
 		assert.Contains(t, utils.Calls[0].Params, "testBin-linux.amd64")
 		assert.Contains(t, utils.Calls[0].Params, "./test/..")
 		assert.Contains(t, utils.Calls[0].Params, "-ldflags")
 		assert.Contains(t, utils.Calls[0].Params, "-X test=test")
+		assert.Equal(t, "testBin-linux.amd64", binaryName)
 	})
 
 	t.Run("success - windows", func(t *testing.T) {
@@ -428,10 +508,11 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		ldflags := ""
 		architecture := "windows,amd64"
 
-		err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Contains(t, utils.Calls[0].Params, "-o")
 		assert.Contains(t, utils.Calls[0].Params, "testBin-windows.amd64.exe")
+		assert.Equal(t, "testBin-windows.amd64.exe", binaryName)
 	})
 
 	t.Run("execution error", func(t *testing.T) {
@@ -442,7 +523,7 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		ldflags := ""
 		architecture := "linux,amd64"
 
-		err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		_, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.EqualError(t, err, "failed to run build for linux.amd64: execution error")
 	})
 

--- a/resources/metadata/golangBuild.yaml
+++ b/resources/metadata/golangBuild.yaml
@@ -99,6 +99,38 @@ spec:
           - STEPS
           - STAGES
           - PARAMETERS
+      - name: targetRepositoryPassword
+        description: "Password for the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment."
+        type: string
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        secret: true
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/repositoryPassword
+      - name: targetRepositoryUser
+        description: "Username for the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment."
+        type: string
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        secret: true
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/repositoryUsername
+      - name: targetRepositoryURL
+        description: "URL of the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment."
+        type: string
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/repositoryURL
       - name: reportCoverage
         type: bool
         description: Defines if a coverage report should be created.


### PR DESCRIPTION
# Changes

One may want to publish the binaries to a central repository. The `publish` flag was already there but not implemented.

- [x] Tests
- [x] Documentation
