### PR TITLE
fix(golangBuild): keep track of the artifactversion in binary names

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -348,9 +348,9 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 		}
 
 		if len(config.ArtifactVersion) == 0 {
-			binaryName = fmt.Sprintf("%v-%v.%v%v", config.Output, goos, goarch, fileExtension)
+			binaryName = fmt.Sprintf("%v.%v-%v%v", config.Output, goos, goarch, fileExtension)
 		} else {
-			binaryName = fmt.Sprintf("%v-%v-%v.%v%v", config.Output, goos, config.ArtifactVersion, goarch, fileExtension)
+			binaryName = fmt.Sprintf("%v-%v.%v-%v%v", config.Output, config.ArtifactVersion, goos, goarch, fileExtension)
 		}
 
 		buildOptions = append(buildOptions, "-o", binaryName)

--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -346,7 +346,13 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 		if goos == "windows" {
 			fileExtension = ".exe"
 		}
-		binaryName = fmt.Sprintf("%v-%v.%v%v", config.Output, goos, goarch, fileExtension)
+
+		if len(config.ArtifactVersion) == 0 {
+			binaryName = fmt.Sprintf("%v-%v.%v%v", config.Output, goos, goarch, fileExtension)
+		} else {
+			binaryName = fmt.Sprintf("%v-%v-%v.%v%v", config.Output, goos, config.ArtifactVersion, goarch, fileExtension)
+		}
+
 		buildOptions = append(buildOptions, "-o", binaryName)
 	}
 	buildOptions = append(buildOptions, config.BuildFlags...)

--- a/cmd/golangBuild_generated.go
+++ b/cmd/golangBuild_generated.go
@@ -37,6 +37,7 @@ type golangBuildOptions struct {
 	TestResultFormat             string   `json:"testResultFormat,omitempty" validate:"possible-values=junit standard"`
 	PrivateModules               string   `json:"privateModules,omitempty"`
 	PrivateModulesGitToken       string   `json:"privateModulesGitToken,omitempty"`
+	ArtifactVersion              string   `json:"artifactVersion,omitempty"`
 }
 
 // GolangBuildCommand This step will execute a golang build.
@@ -157,6 +158,7 @@ func addGolangBuildFlags(cmd *cobra.Command, stepConfig *golangBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.TestResultFormat, "testResultFormat", `junit`, "Defines the output format of the test results.")
 	cmd.Flags().StringVar(&stepConfig.PrivateModules, "privateModules", os.Getenv("PIPER_privateModules"), "Tells go which modules shall be considered to be private (by setting [GOPRIVATE](https://pkg.go.dev/cmd/go#hdr-Configuration_for_downloading_non_public_code)).")
 	cmd.Flags().StringVar(&stepConfig.PrivateModulesGitToken, "privateModulesGitToken", os.Getenv("PIPER_privateModulesGitToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line.")
+	cmd.Flags().StringVar(&stepConfig.ArtifactVersion, "artifactVersion", os.Getenv("PIPER_artifactVersion"), "Version of the artifact to be built.")
 
 	cmd.MarkFlagRequired("targetArchitectures")
 }
@@ -389,6 +391,20 @@ func golangBuildMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_privateModulesGitToken"),
+					},
+					{
+						Name: "artifactVersion",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "artifactVersion",
+							},
+						},
+						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_artifactVersion"),
 					},
 				},
 			},

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -515,6 +515,20 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		assert.Equal(t, "testBin-windows.amd64.exe", binaryName)
 	})
 
+	t.Run("success - with artifactversion set", func(t *testing.T) {
+		t.Parallel()
+		config := golangBuildOptions{Output: "testBin", ArtifactVersion: "1.0.0"}
+		utils := newGolangBuildTestsUtils()
+		ldflags := ""
+		architecture := "windows,amd64"
+
+		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		assert.NoError(t, err)
+		assert.Contains(t, utils.Calls[0].Params, "-o")
+		assert.Contains(t, utils.Calls[0].Params, "testBin-windows-1.0.0.amd64.exe")
+		assert.Equal(t, "testBin-windows-1.0.0.amd64.exe", binaryName)
+	})
+
 	t.Run("execution error", func(t *testing.T) {
 		t.Parallel()
 		config := golangBuildOptions{}

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -148,10 +148,10 @@ func TestRunGolangBuild(t *testing.T) {
 		err := runGolangBuild(&config, &telemetryData, utils)
 		assert.NoError(t, err)
 		assert.Equal(t, "go", utils.ExecMockRunner.Calls[0].Exec)
-		assert.Equal(t, []string{"build", "-o", "testBin-linux.amd64"}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, []string{"build", "-o", "testBin.linux-amd64"}, utils.ExecMockRunner.Calls[0].Params)
 
 		assert.Equal(t, 1, len(utils.fileUploads))
-		assert.Equal(t, "https://my.target.repository.local/testBin-linux.amd64", utils.fileUploads["testBin-linux.amd64"])
+		assert.Equal(t, "https://my.target.repository.local/testBin.linux-amd64", utils.fileUploads["testBin.linux-amd64"])
 	})
 
 	t.Run("failure - install pre-requisites", func(t *testing.T) {
@@ -494,11 +494,11 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Contains(t, utils.Calls[0].Params, "-o")
-		assert.Contains(t, utils.Calls[0].Params, "testBin-linux.amd64")
+		assert.Contains(t, utils.Calls[0].Params, "testBin.linux-amd64")
 		assert.Contains(t, utils.Calls[0].Params, "./test/..")
 		assert.Contains(t, utils.Calls[0].Params, "-ldflags")
 		assert.Contains(t, utils.Calls[0].Params, "-X test=test")
-		assert.Equal(t, "testBin-linux.amd64", binaryName)
+		assert.Equal(t, "testBin.linux-amd64", binaryName)
 	})
 
 	t.Run("success - windows", func(t *testing.T) {
@@ -511,8 +511,8 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Contains(t, utils.Calls[0].Params, "-o")
-		assert.Contains(t, utils.Calls[0].Params, "testBin-windows.amd64.exe")
-		assert.Equal(t, "testBin-windows.amd64.exe", binaryName)
+		assert.Contains(t, utils.Calls[0].Params, "testBin.windows-amd64.exe")
+		assert.Equal(t, "testBin.windows-amd64.exe", binaryName)
 	})
 
 	t.Run("success - with artifactversion set", func(t *testing.T) {
@@ -525,8 +525,8 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Contains(t, utils.Calls[0].Params, "-o")
-		assert.Contains(t, utils.Calls[0].Params, "testBin-windows-1.0.0.amd64.exe")
-		assert.Equal(t, "testBin-windows-1.0.0.amd64.exe", binaryName)
+		assert.Contains(t, utils.Calls[0].Params, "testBin-1.0.0.windows-amd64.exe")
+		assert.Equal(t, "testBin-1.0.0.windows-amd64.exe", binaryName)
 	})
 
 	t.Run("execution error", func(t *testing.T) {

--- a/resources/metadata/golangBuild.yaml
+++ b/resources/metadata/golangBuild.yaml
@@ -205,6 +205,17 @@ spec:
           - type: vaultSecret
             name: golangPrivateModulesGitTokenVaultSecret
             default: golang
+      - name: artifactVersion
+        type: string
+        description: Version of the artifact to be built.
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: artifactVersion
   containers:
     - name: golang
       image: golang:1


### PR DESCRIPTION
# Changes

Automatically adds the artifact version (if available) to the filename of the generated binaries.

- [x] Tests
- [x] Documentation
