### PR TITLE
Changes GetJobName value to repositoryname

### DIFF
--- a/pkg/orchestrator/azureDevOps.go
+++ b/pkg/orchestrator/azureDevOps.go
@@ -78,8 +78,8 @@ func (a *AzureDevOpsConfigProvider) getAPIInformation() map[string]interface{} {
 // GetJobName returns the pipeline job name
 func (a *AzureDevOpsConfigProvider) GetJobName() string {
 	responseInterface := a.getAPIInformation()
-	if val, ok := responseInterface["project"]; ok {
-		return val.(map[string]interface{})["name"].(string)
+	if val, ok := responseInterface["repository"]; ok {
+		return val.(map[string]interface{})["id"].(string)
 	}
 	return "n/a"
 }


### PR DESCRIPTION
# Changes

Changes the value returned by getJobName() for azure to a more meaningful variable. Before
projectname -> gitOrganization/repositoryname.
Previously the project name was equal to the gitOrg. Therefore, we can not distinguish the projects.

- [ ] Tests
- [ ] Documentation
