### PR TITLE
[FIX] Ignore violations if failOn is NONE

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -163,7 +163,7 @@ func runDetect(config detectExecuteScanOptions, utils detectUtils, influx *detec
 		if strings.Contains(reportingErr.Error(), "License Policy Violations found") {
 			log.Entry().Errorf("License Policy Violations found")
 			log.SetErrorCategory(log.ErrorCompliance)
-			if err == nil {
+			if err == nil && !piperutils.ContainsStringPart(config.FailOn, "NONE") {
 				err = errors.New("License Policy Violations found")
 			}
 		} else {


### PR DESCRIPTION
# Changes
If the failOn variable for detect is set to NONE and policy violations are found we don't want the pipeline to fail. Anyways an error will be thrown. This behaviour is already documented.
- [ ] Tests
- [x] Documentation
