### PR TITLE
checkmarxExecuteScan fixes

### DIFF
--- a/cmd/checkmarxExecuteScan.go
+++ b/cmd/checkmarxExecuteScan.go
@@ -203,7 +203,7 @@ func loadExistingProject(sys checkmarx.System, initialProjectName, pullRequestNa
 			project = projects[0]
 		} else {
 			for _, current_project := range projects {
-				if project.Name == current_project.Name {
+				if projectName == current_project.Name {
 					project = current_project
 					break
 				}

--- a/cmd/checkmarxExecuteScan_test.go
+++ b/cmd/checkmarxExecuteScan_test.go
@@ -90,11 +90,11 @@ func (sys *systemMock) GetProjectsByNameAndTeam(projectName, teamID string) ([]c
 	sys.previousPName = projectName
 	return []checkmarx.Project{}, fmt.Errorf("no project error")
 }
-func (sys *systemMock) FilterTeamByName(_ []checkmarx.Team, teamName string) checkmarx.Team {
+func (sys *systemMock) FilterTeamByName(_ []checkmarx.Team, teamName string) (checkmarx.Team, error) {
 	if teamName == "OpenSource/Cracks/16" {
-		return checkmarx.Team{ID: json.RawMessage(`"16"`), FullName: "OpenSource/Cracks/16"}
+		return checkmarx.Team{ID: json.RawMessage(`"16"`), FullName: "OpenSource/Cracks/16"}, nil
 	}
-	return checkmarx.Team{ID: json.RawMessage(`15`), FullName: "OpenSource/Cracks/15"}
+	return checkmarx.Team{ID: json.RawMessage(`15`), FullName: "OpenSource/Cracks/15"}, nil
 }
 func (sys *systemMock) FilterTeamByID(_ []checkmarx.Team, teamID json.RawMessage) checkmarx.Team {
 	teamIDBytes, _ := teamID.MarshalJSON()
@@ -177,8 +177,8 @@ func (sys *systemMockForExistingProject) GetProjectByID(int) (checkmarx.Project,
 func (sys *systemMockForExistingProject) GetProjectsByNameAndTeam(projectName, teamID string) ([]checkmarx.Project, error) {
 	return []checkmarx.Project{{ID: 19, Name: projectName, TeamID: teamID, IsPublic: true}}, nil
 }
-func (sys *systemMockForExistingProject) FilterTeamByName([]checkmarx.Team, string) checkmarx.Team {
-	return checkmarx.Team{ID: json.RawMessage(`"16"`), FullName: "OpenSource/Cracks/16"}
+func (sys *systemMockForExistingProject) FilterTeamByName([]checkmarx.Team, string) (checkmarx.Team, error) {
+	return checkmarx.Team{ID: json.RawMessage(`"16"`), FullName: "OpenSource/Cracks/16"}, nil
 }
 func (sys *systemMockForExistingProject) FilterTeamByID([]checkmarx.Team, json.RawMessage) checkmarx.Team {
 	return checkmarx.Team{ID: json.RawMessage(`"15"`), FullName: "OpenSource/Cracks/15"}

--- a/pkg/checkmarx/checkmarx.go
+++ b/pkg/checkmarx/checkmarx.go
@@ -188,7 +188,7 @@ type System interface {
 	FilterPresetByName(presets []Preset, presetName string) Preset
 	FilterPresetByID(presets []Preset, presetID int) Preset
 	FilterProjectByName(projects []Project, projectName string) Project
-	FilterTeamByName(teams []Team, teamName string) Team
+	FilterTeamByName(teams []Team, teamName string) (Team, error)
 	FilterTeamByID(teams []Team, teamID json.RawMessage) Team
 	DownloadReport(reportID int) ([]byte, error)
 	GetReportStatus(reportID int) (ReportStatusResponse, error)
@@ -623,13 +623,13 @@ func (sys *SystemInstance) DownloadReport(reportID int) ([]byte, error) {
 }
 
 // FilterTeamByName filters a team by its name
-func (sys *SystemInstance) FilterTeamByName(teams []Team, teamName string) Team {
+func (sys *SystemInstance) FilterTeamByName(teams []Team, teamName string) (Team, error) {
 	for _, team := range teams {
 		if team.FullName == teamName || team.FullName == strings.ReplaceAll(teamName, `\`, `/`) {
-			return team
+			return team, nil
 		}
 	}
-	return Team{}
+	return Team{}, errors.New("Failed to find team with name " + teamName)
 }
 
 // FilterTeamByID filters a team by its ID

--- a/pkg/checkmarx/checkmarx_test.go
+++ b/pkg/checkmarx/checkmarx_test.go
@@ -181,13 +181,13 @@ func TestGetTeams(t *testing.T) {
 		assert.Equal(t, "/Team/4", teams[3].FullName, "Team name 4 incorrect")
 
 		t.Run("test filter teams by name", func(t *testing.T) {
-			team2 := sys.FilterTeamByName(teams, "Team2")
+			team2, _ := sys.FilterTeamByName(teams, "Team2")
 			assert.Equal(t, "Team2", team2.FullName, "Team name incorrect")
 			assert.Equal(t, json.RawMessage([]byte(strconv.Itoa(2))), team2.ID, "Team id incorrect")
 		})
 
 		t.Run("test filter teams by name with backslash/forward slash", func(t *testing.T) {
-			team4 := sys.FilterTeamByName(teams, "\\Team\\4")
+			team4, _ := sys.FilterTeamByName(teams, "\\Team\\4")
 			assert.Equal(t, "/Team/4", team4.FullName, "Team name incorrect")
 			assert.Equal(t, json.RawMessage([]byte(strconv.Itoa(4))), team4.ID, "Team id incorrect")
 		})
@@ -205,8 +205,9 @@ func TestGetTeams(t *testing.T) {
 		})
 
 		t.Run("test fail Filter teams by name", func(t *testing.T) {
-			team := sys.FilterTeamByName(teams, "Team")
+			team, err := sys.FilterTeamByName(teams, "Team")
 			assert.Equal(t, "", team.FullName, "Team name incorrect")
+			assert.Contains(t, fmt.Sprint(err), "Failed to find team")
 		})
 	})
 


### PR DESCRIPTION
# Changes

- Fix a bug causing Piper to send an incorrect request to Checkmarx when the team is not found
- Fix a bug causing Piper to send an incorrect request to Checkmarx when attempting to create a new project without providing the team
- Fix a bug causing an incorrect project to be used when loading an existing project

