### PR TITLE
fix replacement of credentials placeholders in extension files for cf-deploy

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -739,7 +739,7 @@ func handleMtaExtensionCredentials(extFile string, credentials map[string]interf
 				missingCredentials = append(missingCredentials, credKey)
 				continue
 			}
-			content = pattern.ReplaceAllString(content, cred)
+			content = pattern.ReplaceAllLiteralString(content, cred)
 			updated = true
 			log.Entry().Debugf("Mta extension credentials handling: Placeholder '%s' has been replaced by credential denoted by '%s'/'%s' in file '%s'", name, credKey, toEnvVarKey(credKey), extFile)
 		} else {

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -1302,8 +1302,8 @@ func TestMtaExtensionCredentials(t *testing.T) {
 
 	_environ = func() []string {
 		return []string{
-			"MY_CRED_ENV_VAR1=******",
-			"MY_CRED_ENV_VAR2=++++++",
+			"MY_CRED_ENV_VAR1=**$0****",
+			"MY_CRED_ENV_VAR2=++$1++++",
 		}
 	}
 
@@ -1406,11 +1406,11 @@ func TestMtaExtensionCredentials(t *testing.T) {
 				assert.Fail(t, "Cannot read mta extension file: %v", e)
 			}
 			content := string(b)
-			assert.Contains(t, content, "test-credentials1: \"******\"")
-			assert.Contains(t, content, "test-credentials2: \"++++++\"")
-			assert.Contains(t, content, "test-credentials3: \"++++++\"")
-			assert.Contains(t, content, "test-credentials4: \"++++++\"")
-			assert.Contains(t, content, "test-credentials5: \"++++++\"")
+			assert.Contains(t, content, "test-credentials1: \"**$0****\"")
+			assert.Contains(t, content, "test-credentials2: \"++$1++++\"")
+			assert.Contains(t, content, "test-credentials3: \"++$1++++\"")
+			assert.Contains(t, content, "test-credentials4: \"++$1++++\"")
+			assert.Contains(t, content, "test-credentials5: \"++$1++++\"")
 
 			assert.True(t, updated)
 			assert.False(t, containsUnresolved)


### PR DESCRIPTION
See #3531 

Bug was introduced with #3489

Nota bene: there is another potential bug: In case a password contains "a placeholder", e.g. `<% x %>` in lets say: `abc<% x %>123` this placeholder will be replaced in later iterations or it will be found as unresolved placeholder after all replacement are done. Should be adressed in another pull request ...

# Changes

- [ ] Tests
- [ ] Documentation
