### PR TITLE
regex: ReplaceAllString -> ReplaceAllLiteralString

### DIFF
--- a/cmd/checkmarxExecuteScan.go
+++ b/cmd/checkmarxExecuteScan.go
@@ -341,7 +341,7 @@ func verifyCxProjectCompliance(config checkmarxExecuteScanOptions, sys checkmarx
 func createReportName(workspace, reportFileNameTemplate string) string {
 	regExpFileName := regexp.MustCompile(`[^\w\d]`)
 	timeStamp, _ := time.Now().Local().MarshalText()
-	return filepath.Join(workspace, fmt.Sprintf(reportFileNameTemplate, regExpFileName.ReplaceAllString(string(timeStamp), "_")))
+	return filepath.Join(workspace, fmt.Sprintf(reportFileNameTemplate, regExpFileName.ReplaceAllLiteralString(string(timeStamp), "_")))
 }
 
 func pollScanStatus(sys checkmarx.System, scan checkmarx.Scan) error {

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -783,7 +783,7 @@ func handleMtaExtensionCredentials(extFile string, credentials map[string]interf
 }
 
 func toEnvVarKey(key string) string {
-	key = regexp.MustCompile(`[^A-Za-z0-9]`).ReplaceAllString(key, "_")
+	key = regexp.MustCompile(`[^A-Za-z0-9]`).ReplaceAllLiteralString(key, "_")
 	return strings.ToUpper(regexp.MustCompile(`([a-z0-9])([A-Z])`).ReplaceAllString(key, "${1}_${2}"))
 }
 

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -289,7 +289,7 @@ func runKubectlDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUti
 
 	// Update image name in deployment yaml, expects placeholder like 'image: <image-name>'
 	re := regexp.MustCompile(`image:[ ]*<image-name>`)
-	appTemplate = []byte(re.ReplaceAllString(string(appTemplate), fmt.Sprintf("image: %v/%v", containerRegistry, fullImage)))
+	appTemplate = []byte(re.ReplaceAllLiteralString(string(appTemplate), fmt.Sprintf("image: %v/%v", containerRegistry, fullImage)))
 
 	err = utils.FileWrite(config.AppTemplate, appTemplate, 0700)
 	if err != nil {

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -353,7 +353,7 @@ func convertEnvVar(s string) string {
 	if err != nil {
 		log.Entry().Debugf("could not compile regex of convertEnvVar: %v", err)
 	}
-	replacedString := reg.ReplaceAllString(r, "")
+	replacedString := reg.ReplaceAllLiteralString(r, "")
 	return replacedString
 }
 


### PR DESCRIPTION
Follow up of: #3532

In order to be on the safe side we should use `ReplaceAllLiteralString` rather than `ReplaceAllString`. The later expands `$xx`. I think that is not wanted normally. For 3 of the 4 changed lines that is irrelevant since the replacement string does not contain a placeholder which gets expanded. But since there is not expansion required here we should use the `Literal` version also here. For the fourth case (`vault.go`) we should check _carefully_ if we expect expansion.