### PR TITLE
fix(kanikoExecute): always update the images arrays in commonPipelineEnv

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -157,6 +157,8 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 			containerImageNameAndTag := fmt.Sprintf("%v:%v", config.ContainerImageName, containerImageTag)
 			dest = []string{"--destination", fmt.Sprintf("%v/%v", containerRegistry, containerImageNameAndTag)}
 			commonPipelineEnvironment.container.imageNameTag = containerImageNameAndTag
+			commonPipelineEnvironment.container.imageNames = append(commonPipelineEnvironment.container.imageNames, config.ContainerImageName)
+			commonPipelineEnvironment.container.imageNameTags = append(commonPipelineEnvironment.container.imageNameTags, containerImageNameAndTag)
 		} else if len(config.ContainerImage) > 0 {
 			log.Entry().Debugf("Single image build for image '%v'", config.ContainerImage)
 			containerRegistry, err := docker.ContainerRegistryFromImage(config.ContainerImage)
@@ -166,9 +168,13 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 			}
 			// errors are already caught with previous call to docker.ContainerRegistryFromImage
 			containerImageNameTag, _ := docker.ContainerImageNameTagFromImage(config.ContainerImage)
+			// errors are already caught with previous call to docker.ContainerRegistryFromImage
+			containerImageName, _ := docker.ContainerImageNameFromImage(config.ContainerImage)
 			dest = []string{"--destination", config.ContainerImage}
 			commonPipelineEnvironment.container.registryURL = fmt.Sprintf("https://%v", containerRegistry)
 			commonPipelineEnvironment.container.imageNameTag = containerImageNameTag
+			commonPipelineEnvironment.container.imageNames = append(commonPipelineEnvironment.container.imageNames, containerImageName)
+			commonPipelineEnvironment.container.imageNameTags = append(commonPipelineEnvironment.container.imageNameTags, containerImageNameTag)
 		}
 		config.BuildOptions = append(config.BuildOptions, dest...)
 	} else {

--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -127,6 +127,9 @@ func TestRunKanikoExecute(t *testing.T) {
 		cwd, _ := fileUtils.Getwd()
 		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--destination", "my.registry.com:50000/myImage:1.2.3-a-x"}, runner.Calls[1].Params)
 
+		assert.Equal(t, "myImage:1.2.3-a-x", commonPipelineEnvironment.container.imageNameTag)
+		assert.Equal(t, []string{"myImage"}, commonPipelineEnvironment.container.imageNames)
+		assert.Equal(t, []string{"myImage:1.2.3-a-x"}, commonPipelineEnvironment.container.imageNameTags)
 	})
 
 	t.Run("no error case - when cert update skipped", func(t *testing.T) {
@@ -208,6 +211,10 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.NoError(t, err)
 		cwd, _ := fileUtils.Getwd()
 		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
+
+		assert.Equal(t, "myImage:tag", commonPipelineEnvironment.container.imageNameTag)
+		assert.Equal(t, []string{"myImage"}, commonPipelineEnvironment.container.imageNames)
+		assert.Equal(t, []string{"myImage:tag"}, commonPipelineEnvironment.container.imageNameTags)
 	})
 
 	t.Run("success case - multi image build with root image", func(t *testing.T) {

--- a/pkg/docker/container.go
+++ b/pkg/docker/container.go
@@ -39,3 +39,16 @@ func ContainerImageNameTagFromImage(fullImage string) (string, error) {
 	registryOnly := fmt.Sprintf("%v/", ref.Context().RegistryStr())
 	return strings.ReplaceAll(fullImage, registryOnly, ""), nil
 }
+
+// ContainerImageNameFromImage provides the name part of a full image name
+func ContainerImageNameFromImage(fullImage string) (string, error) {
+	nameTag, err := ContainerImageNameTagFromImage(fullImage)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.Contains(nameTag, "@") {
+		return strings.Split(nameTag, "@")[0], nil
+	}
+	return strings.Split(nameTag, ":")[0], nil
+}

--- a/pkg/docker/container_test.go
+++ b/pkg/docker/container_test.go
@@ -105,3 +105,36 @@ func TestContainerImageNameTagFromImage(t *testing.T) {
 		})
 	}
 }
+
+func TestContainerImageNameFromImage(t *testing.T) {
+	tt := []struct {
+		image         string
+		expected      string
+		expectedError string
+	}{
+		{image: "", expected: "", expectedError: "failed to parse image name"},
+		{image: "onlyImage", expected: "onlyImage"},
+		{image: "onlyimage", expected: "onlyimage"},
+		{image: "onlyimage:withTag", expected: "onlyimage"},
+		{image: "onlyimage@sha256:152f65865ae43b143b1e42dacdb5e9c473dd70b3adc5b79af7cf585cc8605205", expected: "onlyimage"},
+		{image: "path/to/image", expected: "path/to/image"},
+		{image: "my.registry.com/onlyimage", expected: "onlyimage"},
+		{image: "my.registry.com:50000/onlyimage", expected: "onlyimage"},
+		{image: "my.registry.com:50000/onlyimage:withTag", expected: "onlyimage"},
+		{image: "my.registry.com:50000/onlyimage@sha256:152f65865ae43b143b1e42dacdb5e9c473dd70b3adc5b79af7cf585cc8605205", expected: "onlyimage"},
+		{image: "my.registry.com:50000/path/to/image:withTag", expected: "path/to/image"},
+		{image: "my.registry.com:50000/path/to/image@sha256:152f65865ae43b143b1e42dacdb5e9c473dd70b3adc5b79af7cf585cc8605205", expected: "path/to/image"},
+	}
+
+	for _, test := range tt {
+		t.Run(test.image, func(t *testing.T) {
+			got, err := ContainerImageNameFromImage(test.image)
+			if len(test.expectedError) > 0 {
+				assert.Contains(t, fmt.Sprint(err), test.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
even when building a single image

CC @loewenstein 

# Changes

- [x] Tests
- [ ] Documentation
