### PR TITLE
feat: Add support for deprecating step parameters

### DIFF
--- a/cmd/fortifyExecuteScan_generated.go
+++ b/cmd/fortifyExecuteScan_generated.go
@@ -354,6 +354,7 @@ func addFortifyExecuteScanFlags(cmd *cobra.Command, stepConfig *fortifyExecuteSc
 	cmd.Flags().BoolVar(&stepConfig.CreateResultIssue, "createResultIssue", false, "Whether the step creates a GitHub issue containing the scan results in the originating repo. Since optimized pipelines are headless the creation is implicitly activated for schedules runs.")
 
 	cmd.MarkFlagRequired("authToken")
+	cmd.Flags().MarkDeprecated("pythonAdditionalPath", "this is deprecated")
 	cmd.MarkFlagRequired("serverUrl")
 }
 
@@ -726,13 +727,14 @@ func fortifyExecuteScanMetadata() config.StepData {
 						Default:     `PDF`,
 					},
 					{
-						Name:        "pythonAdditionalPath",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "[]string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     []string{`./lib`, `.`},
+						Name:               "pythonAdditionalPath",
+						ResourceRef:        []config.ResourceReference{},
+						Scope:              []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:               "[]string",
+						Mandatory:          false,
+						Aliases:            []config.Alias{},
+						Default:            []string{`./lib`, `.`},
+						DeprecationMessage: "this is deprecated",
 					},
 					{
 						Name:        "artifactUrl",

--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -45,19 +45,20 @@ type StepInputs struct {
 
 // StepParameters defines the parameters for a step
 type StepParameters struct {
-	Name            string                `json:"name"`
-	Description     string                `json:"description"`
-	LongDescription string                `json:"longDescription,omitempty"`
-	ResourceRef     []ResourceReference   `json:"resourceRef,omitempty"`
-	Scope           []string              `json:"scope"`
-	Type            string                `json:"type"`
-	Mandatory       bool                  `json:"mandatory,omitempty"`
-	Default         interface{}           `json:"default,omitempty"`
-	PossibleValues  []interface{}         `json:"possibleValues,omitempty"`
-	Aliases         []Alias               `json:"aliases,omitempty"`
-	Conditions      []Condition           `json:"conditions,omitempty"`
-	Secret          bool                  `json:"secret,omitempty"`
-	MandatoryIf     []ParameterDependence `json:"mandatoryIf,omitempty"`
+	Name               string                `json:"name"`
+	Description        string                `json:"description"`
+	LongDescription    string                `json:"longDescription,omitempty"`
+	ResourceRef        []ResourceReference   `json:"resourceRef,omitempty"`
+	Scope              []string              `json:"scope"`
+	Type               string                `json:"type"`
+	Mandatory          bool                  `json:"mandatory,omitempty"`
+	Default            interface{}           `json:"default,omitempty"`
+	PossibleValues     []interface{}         `json:"possibleValues,omitempty"`
+	Aliases            []Alias               `json:"aliases,omitempty"`
+	Conditions         []Condition           `json:"conditions,omitempty"`
+	Secret             bool                  `json:"secret,omitempty"`
+	MandatoryIf        []ParameterDependence `json:"mandatoryIf,omitempty"`
+	DeprecationMessage string                `json:"deprecationMessage,omitempty"`
 }
 
 type ParameterDependence struct {

--- a/pkg/documentation/generator/parameters.go
+++ b/pkg/documentation/generator/parameters.go
@@ -105,6 +105,10 @@ func parameterFurtherInfo(paramName string, stepData *config.StepData, execution
 	// handle step-parameters (incl. secrets)
 	for _, param := range stepData.Spec.Inputs.Parameters {
 		if paramName == param.Name {
+			furtherInfo := ""
+			if param.DeprecationMessage != "" {
+				furtherInfo += "![deprecated](https://img.shields.io/badge/-deprecated-red)"
+			}
 			if param.Secret {
 				secretInfo := "[![Secret](https://img.shields.io/badge/-Secret-yellowgreen)](#) pass via ENV or Jenkins credentials"
 				if param.GetReference("vaultSecret") != nil || param.GetReference("vaultSecretFile") != nil {
@@ -116,9 +120,9 @@ func parameterFurtherInfo(paramName string, stepData *config.StepData, execution
 						secretInfo += fmt.Sprintf(" ([`%v`](#%v))", res.Name, strings.ToLower(res.Name))
 					}
 				}
-				return checkParameterInfo(secretInfo, true, executionEnvironment)
+				return checkParameterInfo(furtherInfo+secretInfo, true, executionEnvironment)
 			}
-			return checkParameterInfo("", true, executionEnvironment)
+			return checkParameterInfo(furtherInfo, true, executionEnvironment)
 		}
 	}
 	return checkParameterInfo("", true, executionEnvironment)
@@ -159,6 +163,9 @@ func createParameterDetails(stepData *config.StepData) string {
 		details += "| Scope | Details |\n"
 		details += "| ---- | --------- |\n"
 
+		if param.DeprecationMessage != "" {
+			details += fmt.Sprintf("| Deprecated | %v |\n", param.DeprecationMessage)
+		}
 		details += fmt.Sprintf("| Aliases | %v |\n", aliasList(param.Aliases))
 		details += fmt.Sprintf("| Type | `%v` |\n", param.Type)
 		mandatory, mandatoryString, furtherInfo := parameterMandatoryInformation(param, "")

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -209,8 +209,14 @@ func {{.FlagsFunc}}(cmd *cobra.Command, stepConfig *{{.StepName}}Options) {
 	{{- range $key, $value := uniqueName .StepParameters }}
 	{{ if isCLIParam $value.Type }}cmd.Flags().{{ $value.Type | flagType }}(&stepConfig.{{ $value.Name | golangName }}, {{ $value.Name | quote }}, {{ $value.Default }}, {{ $value.Description | quote }}){{end}}{{ end }}
 	{{- printf "\n" }}
-	{{- range $key, $value := .StepParameters }}{{ if $value.Mandatory }}
-	cmd.MarkFlagRequired({{ $value.Name | quote }}){{ end }}{{ end }}
+	{{- range $key, $value := .StepParameters }}
+	{{- if $value.Mandatory }}
+	cmd.MarkFlagRequired({{ $value.Name | quote }})
+	{{- end }}
+	{{- if $value.DeprecationMessage }}
+	cmd.Flags().MarkDeprecated({{ $value.Name | quote }}, {{ $value.DeprecationMessage | quote }})
+	{{- end }}
+	{{- end }}
 }
 
 {{ define "resourceRefs"}}
@@ -272,6 +278,9 @@ func {{ .StepName }}Metadata() config.StepData {
 						Aliases:   []config.Alias{{ "{" }}{{ range $notused, $alias := $value.Aliases }}{{ "{" }}Name: {{ $alias.Name | quote }}{{ if $alias.Deprecated }}, Deprecated: {{$alias.Deprecated}}{{ end }}{{ "}" }},{{ end }}{{ "}" }},
 						{{ if $value.Default -}} Default:   {{ $value.Default }}, {{- end}}{{ if $value.Conditions }}
 						Conditions: []config.Condition{ {{- range $i, $cond := $value.Conditions }} {ConditionRef: {{ $cond.ConditionRef | quote }}, Params: []config.Param{ {{- range $j, $p := $cond.Params}} { Name: {{ $p.Name | quote }}, Value: {{ $p.Value | quote }} }, {{end -}} } }, {{ end -}} },{{- end }}
+						{{- if $value.DeprecationMessage }}
+						DeprecationMessage: {{ $value.DeprecationMessage | quote }},
+						{{- end}}
 					},{{ end }}
 				},
 			},

--- a/pkg/generator/helper/helper_test.go
+++ b/pkg/generator/helper/helper_test.go
@@ -76,6 +76,7 @@ spec:
         - value1
         - value2
         - value3
+        deprecationMessage: use param3 instead
       - name: param2
         type: string
         description: param2 description

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
@@ -242,6 +242,7 @@ func addTestStepFlags(cmd *cobra.Command, stepConfig *testStepOptions) {
 	cmd.Flags().StringVar(&stepConfig.Param3, "param3", os.Getenv("PIPER_param3"), "param3 description")
 
 	cmd.MarkFlagRequired("param0")
+	cmd.Flags().MarkDeprecated("param1", "use param3 instead")
 }
 
 // retrieve step metadata
@@ -276,6 +277,7 @@ func testStepMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{{Name: "oldparam1", Deprecated: true},},
 						Default:   os.Getenv("PIPER_param1"),
+						DeprecationMessage: "use param3 instead",
 					},
 					{
 						Name:      "param2",

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
@@ -241,6 +241,7 @@ func addTestStepFlags(cmd *cobra.Command, stepConfig *testStepOptions) {
 	cmd.Flags().StringVar(&stepConfig.Param3, "param3", os.Getenv("PIPER_param3"), "param3 description")
 
 	cmd.MarkFlagRequired("param0")
+	cmd.Flags().MarkDeprecated("param1", "use param3 instead")
 }
 
 // retrieve step metadata
@@ -275,6 +276,7 @@ func testStepMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{{Name: "oldparam1", Deprecated: true},},
 						Default:   os.Getenv("PIPER_param1"),
+						DeprecationMessage: "use param3 instead",
 					},
 					{
 						Name:      "param2",

--- a/resources/metadata/fortifyExecuteScan.yaml
+++ b/resources/metadata/fortifyExecuteScan.yaml
@@ -388,7 +388,7 @@ spec:
           - STAGES
           - STEPS
         default: ["./lib", "."]
-        deprecated: true
+        deprecationMessage: this is deprecated
       - name: artifactUrl
         type: string
         description:


### PR DESCRIPTION
this was already used in `fortifyExecuteScan`, but had no effect.

Deprecation will be shown in the documentation "Paramerters" > "Overview - Step" table > "Additional information" column and the parameter details.

# Changes

- [x] Tests
- [ ] Documentation
