### PR TITLE
chore: noise reduction

### DIFF
--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -103,6 +103,6 @@ func getEnv(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}
-	log.Entry().Warnf("Could not read env variable %v using fallback value %v", key, fallback)
+	log.Entry().Debugf("Could not read env variable %v using fallback value %v", key, fallback)
 	return fallback
 }

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -119,13 +119,13 @@ func (t *Telemetry) GetData() Data {
 
 // Send telemetry information to SWA
 func (t *Telemetry) Send() {
+	// always log step telemetry data to logfile used for internal use-case
+	t.logStepTelemetryData()
+
 	// skip if telemetry is disabled
 	if t.disabled {
 		return
 	}
-
-	// always log step telemetry data to logfile used for internal use-case
-	t.logStepTelemetryData()
 
 	request, _ := url.Parse(t.BaseURL)
 	request.Path = t.Endpoint

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -119,13 +119,13 @@ func (t *Telemetry) GetData() Data {
 
 // Send telemetry information to SWA
 func (t *Telemetry) Send() {
-	// always log step telemetry data to logfile used for internal use-case
-	t.logStepTelemetryData()
-
 	// skip if telemetry is disabled
 	if t.disabled {
 		return
 	}
+
+	// always log step telemetry data to logfile used for internal use-case
+	t.logStepTelemetryData()
 
 	request, _ := url.Parse(t.BaseURL)
 	request.Path = t.Endpoint


### PR DESCRIPTION
# Changes

This PR reduces the verbosity of piper.

* on jenkins it's not guaranteed that the GIT_* env vars are always set. It depends on the plugin which is used for cloning the repo (e.g. the Git plugin supports it, the github plugin does not). Since this is solely used for collecting telemetry data and thus not mission critical, we shouldn't consider this a `warning` but `debug` message.

```
17:34:22  warn  artifactPrepareVersion - Could not read env variable GIT_COMMIT using fallback value n/a
17:34:22  warn  artifactPrepareVersion - Could not read env variable GIT_URL using fallback value n/a
17:34:22  warn  artifactPrepareVersion - Could not read env variable GIT_URL using fallback value n/a
```

- [ ] Tests
- [ ] Documentation
