### PR TITLE
feat(kubernetesDeploy): added valuesMapping config option

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -387,7 +387,7 @@ func (hv helmValues) get(key string) string {
 func (hv *helmValues) mapValues() error {
 	for dst, src := range hv.mapping {
 		if reflect.TypeOf(src).Kind() != reflect.String {
-			return fmt.Errorf("invalid path '%#v' is used for valueMapping, only strings are supported", src)
+			return fmt.Errorf("invalid path '%#v' is used for valuesMapping, only strings are supported", src)
 		}
 
 		if val := hv.get(src.(string)); val != "" {

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -386,11 +385,11 @@ func (hv helmValues) get(key string) string {
 
 func (hv *helmValues) mapValues() error {
 	for dst, src := range hv.mapping {
-		if reflect.TypeOf(src).Kind() != reflect.String {
+		srcString, ok := src.(string)
+		if !ok {
 			return fmt.Errorf("invalid path '%#v' is used for valuesMapping, only strings are supported", src)
 		}
-
-		if val := hv.get(src.(string)); val != "" {
+		if val := hv.get(srcString); val != "" {
 			hv.add(dst, val)
 		} else {
 			log.Entry().Warnf("can not map '%s: %s', %s is not set", dst, src, src)

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -16,36 +16,37 @@ import (
 )
 
 type kubernetesDeployOptions struct {
-	AdditionalParameters       []string `json:"additionalParameters,omitempty"`
-	APIServer                  string   `json:"apiServer,omitempty"`
-	AppTemplate                string   `json:"appTemplate,omitempty"`
-	ChartPath                  string   `json:"chartPath,omitempty"`
-	ContainerRegistryPassword  string   `json:"containerRegistryPassword,omitempty"`
-	ContainerImageName         string   `json:"containerImageName,omitempty"`
-	ContainerImageTag          string   `json:"containerImageTag,omitempty"`
-	ContainerRegistryURL       string   `json:"containerRegistryUrl,omitempty"`
-	ContainerRegistryUser      string   `json:"containerRegistryUser,omitempty"`
-	ContainerRegistrySecret    string   `json:"containerRegistrySecret,omitempty"`
-	CreateDockerRegistrySecret bool     `json:"createDockerRegistrySecret,omitempty"`
-	DeploymentName             string   `json:"deploymentName,omitempty"`
-	DeployTool                 string   `json:"deployTool,omitempty" validate:"possible-values=kubectl helm helm3"`
-	ForceUpdates               bool     `json:"forceUpdates,omitempty"`
-	HelmDeployWaitSeconds      int      `json:"helmDeployWaitSeconds,omitempty"`
-	HelmValues                 []string `json:"helmValues,omitempty"`
-	Image                      string   `json:"image,omitempty"`
-	ImageNames                 []string `json:"imageNames,omitempty"`
-	ImageNameTags              []string `json:"imageNameTags,omitempty"`
-	IngressHosts               []string `json:"ingressHosts,omitempty"`
-	KeepFailedDeployments      bool     `json:"keepFailedDeployments,omitempty"`
-	RunHelmTests               bool     `json:"runHelmTests,omitempty"`
-	ShowTestLogs               bool     `json:"showTestLogs,omitempty"`
-	KubeConfig                 string   `json:"kubeConfig,omitempty"`
-	KubeContext                string   `json:"kubeContext,omitempty"`
-	KubeToken                  string   `json:"kubeToken,omitempty"`
-	Namespace                  string   `json:"namespace,omitempty"`
-	TillerNamespace            string   `json:"tillerNamespace,omitempty"`
-	DockerConfigJSON           string   `json:"dockerConfigJSON,omitempty"`
-	DeployCommand              string   `json:"deployCommand,omitempty" validate:"possible-values=apply replace"`
+	AdditionalParameters       []string               `json:"additionalParameters,omitempty"`
+	APIServer                  string                 `json:"apiServer,omitempty"`
+	AppTemplate                string                 `json:"appTemplate,omitempty"`
+	ChartPath                  string                 `json:"chartPath,omitempty"`
+	ContainerRegistryPassword  string                 `json:"containerRegistryPassword,omitempty"`
+	ContainerImageName         string                 `json:"containerImageName,omitempty"`
+	ContainerImageTag          string                 `json:"containerImageTag,omitempty"`
+	ContainerRegistryURL       string                 `json:"containerRegistryUrl,omitempty"`
+	ContainerRegistryUser      string                 `json:"containerRegistryUser,omitempty"`
+	ContainerRegistrySecret    string                 `json:"containerRegistrySecret,omitempty"`
+	CreateDockerRegistrySecret bool                   `json:"createDockerRegistrySecret,omitempty"`
+	DeploymentName             string                 `json:"deploymentName,omitempty"`
+	DeployTool                 string                 `json:"deployTool,omitempty" validate:"possible-values=kubectl helm helm3"`
+	ForceUpdates               bool                   `json:"forceUpdates,omitempty"`
+	HelmDeployWaitSeconds      int                    `json:"helmDeployWaitSeconds,omitempty"`
+	HelmValues                 []string               `json:"helmValues,omitempty"`
+	ValuesMapping              map[string]interface{} `json:"valuesMapping,omitempty"`
+	Image                      string                 `json:"image,omitempty"`
+	ImageNames                 []string               `json:"imageNames,omitempty"`
+	ImageNameTags              []string               `json:"imageNameTags,omitempty"`
+	IngressHosts               []string               `json:"ingressHosts,omitempty"`
+	KeepFailedDeployments      bool                   `json:"keepFailedDeployments,omitempty"`
+	RunHelmTests               bool                   `json:"runHelmTests,omitempty"`
+	ShowTestLogs               bool                   `json:"showTestLogs,omitempty"`
+	KubeConfig                 string                 `json:"kubeConfig,omitempty"`
+	KubeContext                string                 `json:"kubeContext,omitempty"`
+	KubeToken                  string                 `json:"kubeToken,omitempty"`
+	Namespace                  string                 `json:"namespace,omitempty"`
+	TillerNamespace            string                 `json:"tillerNamespace,omitempty"`
+	DockerConfigJSON           string                 `json:"dockerConfigJSON,omitempty"`
+	DeployCommand              string                 `json:"deployCommand,omitempty" validate:"possible-values=apply replace"`
 }
 
 // KubernetesDeployCommand Deployment to Kubernetes test or production namespace within the specified Kubernetes cluster.
@@ -175,6 +176,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().BoolVar(&stepConfig.ForceUpdates, "forceUpdates", true, "Adds `--force` flag to a helm resource update command or to a kubectl replace command")
 	cmd.Flags().IntVar(&stepConfig.HelmDeployWaitSeconds, "helmDeployWaitSeconds", 300, "Number of seconds before helm deploy returns.")
 	cmd.Flags().StringSliceVar(&stepConfig.HelmValues, "helmValues", []string{}, "List of helm values as YAML file reference or URL (as per helm parameter description for `-f` / `--values`)")
+
 	cmd.Flags().StringVar(&stepConfig.Image, "image", os.Getenv("PIPER_image"), "Full name of the image to be deployed.")
 	cmd.Flags().StringSliceVar(&stepConfig.ImageNames, "imageNames", []string{}, "List of names of the images to be deployed.")
 	cmd.Flags().StringSliceVar(&stepConfig.ImageNameTags, "imageNameTags", []string{}, "List of full names (registry and tag) of the images to be deployed.")
@@ -390,6 +392,14 @@ func kubernetesDeployMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     []string{},
+					},
+					{
+						Name:        "valuesMapping",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "map[string]interface{}",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
 					},
 					{
 						Name: "image",

--- a/cmd/kubernetesDeploy_test.go
+++ b/cmd/kubernetesDeploy_test.go
@@ -799,6 +799,96 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		assert.EqualError(t, err, "number of imageNames and imageNameTags must be equal")
 	})
 
+	t.Run("test helm v3 - with multiple images and valuesMapping", func(t *testing.T) {
+		opts := kubernetesDeployOptions{
+			ContainerRegistryURL:      "https://my.registry:55555",
+			ContainerRegistryUser:     "registryUser",
+			ContainerRegistryPassword: "dummy",
+			ContainerRegistrySecret:   "testSecret",
+			ChartPath:                 "path/to/chart",
+			DeploymentName:            "deploymentName",
+			DeployTool:                "helm3",
+			ForceUpdates:              true,
+			HelmDeployWaitSeconds:     400,
+			HelmValues:                []string{"values1.yaml", "values2.yaml"},
+			ValuesMapping: map[string]interface{}{
+				"subchart.image.registry": "image.myImage.repository",
+				"subchart.image.tag":      "image.myImage.tag",
+			},
+			ImageNames:           []string{"myImage", "myImage.sub1", "myImage.sub2"},
+			ImageNameTags:        []string{"myImage:myTag", "myImage-sub1:myTag", "myImage-sub2:myTag"},
+			AdditionalParameters: []string{"--testParam", "testValue"},
+			KubeContext:          "testCluster",
+			Namespace:            "deploymentNamespace",
+			DockerConfigJSON:     ".pipeline/docker/config.json",
+		}
+
+		dockerConfigJSON := `{"kind": "Secret","data":{".dockerconfigjson": "ThisIsOurBase64EncodedSecret=="}}`
+
+		mockUtils := newKubernetesDeployMockUtils()
+		mockUtils.StdoutReturn = map[string]string{
+			`kubectl create secret generic testSecret --from-file=.dockerconfigjson=.pipeline/docker/config.json --type=kubernetes.io/dockerconfigjson --insecure-skip-tls-verify=true --dry-run=client --output=json`: dockerConfigJSON,
+		}
+
+		var stdout bytes.Buffer
+
+		require.NoError(t, runKubernetesDeploy(opts, &telemetry.CustomData{}, mockUtils, &stdout))
+
+		assert.Equal(t, "kubectl", mockUtils.Calls[0].Exec, "Wrong secret creation command")
+		assert.Equal(t, []string{
+			"create",
+			"secret",
+			"generic",
+			"testSecret",
+			"--from-file=.dockerconfigjson=.pipeline/docker/config.json",
+			"--type=kubernetes.io/dockerconfigjson",
+			"--insecure-skip-tls-verify=true",
+			"--dry-run=client",
+			"--output=json"},
+			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
+
+		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
+
+		assert.Contains(t, mockUtils.Calls[1].Params, `image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,image.myImage\.sub1.repository=my.registry:55555/myImage-sub1,image.myImage\.sub1.tag=myTag,image.myImage\.sub2.repository=my.registry:55555/myImage-sub2,image.myImage\.sub2.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,subchart.image.registry=my.registry:55555/myImage,subchart.image.tag=myTag`, "Wrong upgrade parameters")
+
+	})
+
+	t.Run("test helm v3 - with multiple images and incorrect valuesMapping", func(t *testing.T) {
+		opts := kubernetesDeployOptions{
+			ContainerRegistryURL:      "https://my.registry:55555",
+			ContainerRegistryUser:     "registryUser",
+			ContainerRegistryPassword: "dummy",
+			ContainerRegistrySecret:   "testSecret",
+			ChartPath:                 "path/to/chart",
+			DeploymentName:            "deploymentName",
+			DeployTool:                "helm3",
+			ForceUpdates:              true,
+			HelmDeployWaitSeconds:     400,
+			HelmValues:                []string{"values1.yaml", "values2.yaml"},
+			ValuesMapping: map[string]interface{}{
+				"subchart.image.registry": false,
+			},
+			ImageNames:           []string{"myImage", "myImage.sub1", "myImage.sub2"},
+			ImageNameTags:        []string{"myImage:myTag", "myImage-sub1:myTag", "myImage-sub2:myTag"},
+			AdditionalParameters: []string{"--testParam", "testValue"},
+			KubeContext:          "testCluster",
+			Namespace:            "deploymentNamespace",
+			DockerConfigJSON:     ".pipeline/docker/config.json",
+		}
+
+		dockerConfigJSON := `{"kind": "Secret","data":{".dockerconfigjson": "ThisIsOurBase64EncodedSecret=="}}`
+
+		mockUtils := newKubernetesDeployMockUtils()
+		mockUtils.StdoutReturn = map[string]string{
+			`kubectl create secret generic testSecret --from-file=.dockerconfigjson=.pipeline/docker/config.json --type=kubernetes.io/dockerconfigjson --insecure-skip-tls-verify=true --dry-run=client --output=json`: dockerConfigJSON,
+		}
+
+		var stdout bytes.Buffer
+
+		require.Error(t, runKubernetesDeploy(opts, &telemetry.CustomData{}, mockUtils, &stdout), "invalid path 'false' is used for valueMapping, only strings are supported")
+
+	})
+
 	t.Run("test helm3 - fails without image information", func(t *testing.T) {
 		opts := kubernetesDeployOptions{
 			ContainerRegistryURL:    "https://my.registry:55555",

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -225,7 +225,7 @@ spec:
           - STEPS
       - name: valuesMapping
         type: "map[string]interface{}"
-        description: |
+        longDescription: |
           Mapping of values provided by Piper onto custom paths in format `[custom-path]: [piper-value]`
 
           Example:

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -231,11 +231,9 @@ spec:
           Example:
           ```yaml
           valuesMapping:
-            subchart1.image.tag:        image.tag
-            subchart2.image.tag:        image.debug.tag
-            subchart2.image.repository: image.debug.repository
-            subchart2.image.pullsecret: secret.dockerconfigjson
-            mysidecar:                  image.sidecar.gun
+            subchart.image.tag:        image.debug.tag
+            subchart.image.repository: image.debug.repository
+            subchart.image.pullsecret: secret.dockerconfigjson
           ```
         scope:
           - PARAMETERS

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -223,6 +223,24 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: valuesMapping
+        type: "map[string]interface{}"
+        description: |
+          Mapping of values provided by Piper onto custom paths in format `[custom-path]: [piper-value]`
+
+          Example:
+          ```yaml
+          valuesMapping:
+            subchart1.image.tag:        image.tag
+            subchart2.image.tag:        image.debug.tag
+            subchart2.image.repository: image.debug.repository
+            subchart2.image.pullsecret: secret.dockerconfigjson
+            mysidecar:                  image.sidecar.gun
+          ```
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: image
         aliases:
           - name: deployImage


### PR DESCRIPTION
# Changes

Added `valuesMapping` config option, which allows to pass Piper-provided values using custom values paths, e.g.:

```groovy
kubernetesDeploy(
    script: this,
    deployTool: "helm3",
    valuesMapping: {
      "subchart.image.tag":        "image.debug.tag",
      "subchart.image.repository": "image.debug.repository",
      "subchart.image.pullsecret": "secret.dockerconfigjson",
      "mysidecar":                 "image.sidecar.gun",
    }
)
```

**Important**: should be rebased and merged after https://github.com/SAP/jenkins-library/pull/3548 is closed

- [X] Tests
- [X] Documentation
