### PR TITLE
fix(kaniko): backwards compatibility with kaniko 1.3.0

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 	"os"
+	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/buildsettings"
 	"github.com/SAP/jenkins-library/pkg/certutils"
@@ -217,7 +217,6 @@ func runKaniko(dockerFilepath string, buildOptions []string, execRunner command.
 	if !strings.Contains(pathEnv, "/busybox:/kaniko") {
 		os.Setenv("PATH", fmt.Sprintf("/busybox:/kaniko:%s", pathEnv))
 	}
-
 
 	cwd, err := fileUtils.Getwd()
 	if err != nil {

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"strings"
+	"os"
 
 	"github.com/SAP/jenkins-library/pkg/buildsettings"
 	"github.com/SAP/jenkins-library/pkg/certutils"
@@ -210,6 +211,14 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 }
 
 func runKaniko(dockerFilepath string, buildOptions []string, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, commonPipelineEnvironment *kanikoExecuteCommonPipelineEnvironment) error {
+	// https://github.com/GoogleContainerTools/kaniko/issues/1212#issuecomment-971623379
+	pathEnv := os.Getenv("PATH")
+
+	if !strings.Contains(pathEnv, "/busybox:/kaniko") {
+		os.Setenv("PATH", fmt.Sprintf("/busybox:/kaniko:%s", pathEnv))
+	}
+
+
 	cwd, err := fileUtils.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)

--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -32,6 +32,7 @@ type kanikoExecuteOptions struct {
 	DockerConfigJSON                 string   `json:"dockerConfigJSON,omitempty"`
 	DockerfilePath                   string   `json:"dockerfilePath,omitempty"`
 	TargetArchitectures              []string `json:"targetArchitectures,omitempty"`
+	ReadImageDigest                  bool     `json:"readImageDigest,omitempty"`
 }
 
 type kanikoExecuteCommonPipelineEnvironment struct {
@@ -182,7 +183,7 @@ You can activate multiple builds using the parameters
 }
 
 func addKanikoExecuteFlags(cmd *cobra.Command, stepConfig *kanikoExecuteOptions) {
-	cmd.Flags().StringSliceVar(&stepConfig.BuildOptions, "buildOptions", []string{`--skip-tls-verify-pull`}, "Defines a list of build options for the [kaniko](https://github.com/GoogleContainerTools/kaniko) build.")
+	cmd.Flags().StringSliceVar(&stepConfig.BuildOptions, "buildOptions", []string{`--skip-tls-verify-pull`, `--ignore-path=/busybox`}, "Defines a list of build options for the [kaniko](https://github.com/GoogleContainerTools/kaniko) build.")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "Build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build. This information is typically used for compliance related processes.")
 	cmd.Flags().BoolVar(&stepConfig.ContainerMultiImageBuild, "containerMultiImageBuild", false, "Defines if multiple containers should be build. Dockerfiles are used using the pattern **/Dockerfile*. Excludes can be defined via [`containerMultiImageBuildExcludes`](#containermultiimagebuildexscludes).")
 	cmd.Flags().StringSliceVar(&stepConfig.ContainerMultiImageBuildExcludes, "containerMultiImageBuildExcludes", []string{}, "Defines a list of Dockerfile paths to exclude from the build when using [`containerMultiImageBuild`](#containermultiimagebuild).")
@@ -196,6 +197,7 @@ func addKanikoExecuteFlags(cmd *cobra.Command, stepConfig *kanikoExecuteOptions)
 	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")
 	cmd.Flags().StringVar(&stepConfig.DockerfilePath, "dockerfilePath", `Dockerfile`, "Defines the location of the Dockerfile relative to the Jenkins workspace.")
 	cmd.Flags().StringSliceVar(&stepConfig.TargetArchitectures, "targetArchitectures", []string{``}, "Defines the target architectures for which the build should run using OS and architecture separated by a comma. (EXPERIMENTAL)")
+	cmd.Flags().BoolVar(&stepConfig.ReadImageDigest, "readImageDigest", false, "")
 
 }
 
@@ -220,7 +222,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     []string{`--skip-tls-verify-pull`},
+						Default:     []string{`--skip-tls-verify-pull`, `--ignore-path=/busybox`},
 					},
 					{
 						Name: "buildSettingsInfo",
@@ -369,6 +371,15 @@ func kanikoExecuteMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     []string{``},
+					},
+					{
+						Name:        "readImageDigest",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
 					},
 				},
 			},

--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -182,7 +182,7 @@ You can activate multiple builds using the parameters
 }
 
 func addKanikoExecuteFlags(cmd *cobra.Command, stepConfig *kanikoExecuteOptions) {
-	cmd.Flags().StringSliceVar(&stepConfig.BuildOptions, "buildOptions", []string{`--skip-tls-verify-pull`, `--ignore-path=/`}, "Defines a list of build options for the [kaniko](https://github.com/GoogleContainerTools/kaniko) build.")
+	cmd.Flags().StringSliceVar(&stepConfig.BuildOptions, "buildOptions", []string{`--skip-tls-verify-pull`}, "Defines a list of build options for the [kaniko](https://github.com/GoogleContainerTools/kaniko) build.")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "Build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build. This information is typically used for compliance related processes.")
 	cmd.Flags().BoolVar(&stepConfig.ContainerMultiImageBuild, "containerMultiImageBuild", false, "Defines if multiple containers should be build. Dockerfiles are used using the pattern **/Dockerfile*. Excludes can be defined via [`containerMultiImageBuildExcludes`](#containermultiimagebuildexscludes).")
 	cmd.Flags().StringSliceVar(&stepConfig.ContainerMultiImageBuildExcludes, "containerMultiImageBuildExcludes", []string{}, "Defines a list of Dockerfile paths to exclude from the build when using [`containerMultiImageBuild`](#containermultiimagebuild).")
@@ -220,7 +220,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Type:        "[]string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     []string{`--skip-tls-verify-pull`, `--ignore-path=/`},
+						Default:     []string{`--skip-tls-verify-pull`},
 					},
 					{
 						Name: "buildSettingsInfo",

--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -68,6 +68,56 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("path/to/docker/config.json", []byte(`{"auths":{"custom":"test"}}`))
 		fileUtils.AddFile("/kaniko/ssl/certs/ca-certificates.crt", []byte(``))
+
+		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, certClient, fileUtils)
+
+		assert.NoError(t, err)
+
+		assert.Equal(t, "rm", runner.Calls[0].Exec)
+		assert.Equal(t, []string{"-f", "/kaniko/.docker/config.json"}, runner.Calls[0].Params)
+
+		assert.Equal(t, config.CustomTLSCertificateLinks, certClient.urlsCalled)
+		c, err := fileUtils.FileRead("/kaniko/.docker/config.json")
+		assert.NoError(t, err)
+		assert.Equal(t, `{"auths":{"custom":"test"}}`, string(c))
+
+		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
+		cwd, _ := fileUtils.Getwd()
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
+
+		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"mavenExecuteBuild":[{"dockerImage":"maven"}]`)
+		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"kanikoExecute":[{"dockerImage":"gcr.io/kaniko-project/executor:debug"}]`)
+
+		assert.Equal(t, "myImage:tag", commonPipelineEnvironment.container.imageNameTag)
+		assert.Equal(t, "https://index.docker.io", commonPipelineEnvironment.container.registryURL)
+		assert.Equal(t, []string{"myImage"}, commonPipelineEnvironment.container.imageNames)
+		assert.Equal(t, []string{"myImage:tag"}, commonPipelineEnvironment.container.imageNameTags)
+
+		assert.Equal(t, "", commonPipelineEnvironment.container.imageDigest)
+		assert.Empty(t, commonPipelineEnvironment.container.imageDigests)
+	})
+
+	t.Run("success case - pass image digest to cpe if activated", func(t *testing.T) {
+		config := &kanikoExecuteOptions{
+			BuildOptions:                []string{"--skip-tls-verify-pull"},
+			ContainerImage:              "myImage:tag",
+			ContainerPreparationCommand: "rm -f /kaniko/.docker/config.json",
+			CustomTLSCertificateLinks:   []string{"https://test.url/cert.crt"},
+			DockerfilePath:              "Dockerfile",
+			DockerConfigJSON:            "path/to/docker/config.json",
+			BuildSettingsInfo:           `{"mavenExecuteBuild":[{"dockerImage":"maven"}]}`,
+			ReadImageDigest:             true,
+		}
+
+		runner := &mock.ExecMockRunner{}
+		commonPipelineEnvironment := kanikoExecuteCommonPipelineEnvironment{}
+
+		certClient := &kanikoMockClient{
+			responseBody: "testCert",
+		}
+		fileUtils := &mock.FilesMock{}
+		fileUtils.AddFile("path/to/docker/config.json", []byte(`{"auths":{"custom":"test"}}`))
+		fileUtils.AddFile("/kaniko/ssl/certs/ca-certificates.crt", []byte(``))
 		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, certClient, fileUtils)
@@ -84,7 +134,7 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "myImage:tag", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt"}, runner.Calls[1].Params)
 
 		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"mavenExecuteBuild":[{"dockerImage":"maven"}]`)
 		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"kanikoExecute":[{"dockerImage":"gcr.io/kaniko-project/executor:debug"}]`)
@@ -119,7 +169,6 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("path/to/docker/config.json", []byte(`{"auths":{"custom":"test"}}`))
 		fileUtils.AddFile("/kaniko/ssl/certs/ca-certificates.crt", []byte(``))
-		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, certClient, fileUtils)
 
@@ -135,15 +184,15 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--skip-tls-verify-pull", "--destination", "my.registry.com:50000/myImage:1.2.3-a-x"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "my.registry.com:50000/myImage:1.2.3-a-x"}, runner.Calls[1].Params)
 
 		assert.Equal(t, "myImage:1.2.3-a-x", commonPipelineEnvironment.container.imageNameTag)
 		assert.Equal(t, "https://my.registry.com:50000", commonPipelineEnvironment.container.registryURL)
 		assert.Equal(t, []string{"myImage"}, commonPipelineEnvironment.container.imageNames)
 		assert.Equal(t, []string{"myImage:1.2.3-a-x"}, commonPipelineEnvironment.container.imageNameTags)
 
-		assert.Equal(t, "sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0", commonPipelineEnvironment.container.imageDigest)
-		assert.Equal(t, []string{"sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0"}, commonPipelineEnvironment.container.imageDigests)
+		assert.Equal(t, "", commonPipelineEnvironment.container.imageDigest)
+		assert.Empty(t, commonPipelineEnvironment.container.imageDigests)
 	})
 
 	t.Run("success case - image params with custom destination", func(t *testing.T) {
@@ -164,7 +213,6 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("path/to/docker/config.json", []byte(`{"auths":{"custom":"test"}}`))
 		fileUtils.AddFile("/kaniko/ssl/certs/ca-certificates.crt", []byte(``))
-		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, certClient, fileUtils)
 
@@ -180,15 +228,15 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--skip-tls-verify-pull", "--destination", "my.other.registry.com:50000/myImage:3.2.1-a-x"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "my.other.registry.com:50000/myImage:3.2.1-a-x"}, runner.Calls[1].Params)
 
 		assert.Equal(t, "myImage:3.2.1-a-x", commonPipelineEnvironment.container.imageNameTag)
 		assert.Equal(t, "https://my.other.registry.com:50000", commonPipelineEnvironment.container.registryURL)
 		assert.Equal(t, []string{"myImage"}, commonPipelineEnvironment.container.imageNames)
 		assert.Equal(t, []string{"myImage:3.2.1-a-x"}, commonPipelineEnvironment.container.imageNameTags)
 
-		assert.Equal(t, "sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0", commonPipelineEnvironment.container.imageDigest)
-		assert.Equal(t, []string{"sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0"}, commonPipelineEnvironment.container.imageDigests)
+		assert.Equal(t, "", commonPipelineEnvironment.container.imageDigest)
+		assert.Empty(t, []string{}, commonPipelineEnvironment.container.imageDigests)
 	})
 
 	t.Run("no error case - when cert update skipped", func(t *testing.T) {
@@ -210,7 +258,6 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("path/to/docker/config.json", []byte(``))
 		fileUtils.FileReadErrors = map[string]error{"/kaniko/ssl/certs/ca-certificates.crt": fmt.Errorf("read error")}
-		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, certClient, fileUtils)
 
@@ -233,7 +280,6 @@ func TestRunKanikoExecute(t *testing.T) {
 		}
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("/kaniko/ssl/certs/ca-certificates.crt", []byte(``))
-		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, certClient, fileUtils)
 
@@ -244,7 +290,7 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.Equal(t, `{"auths":{}}`, string(c))
 
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--skip-tls-verify-pull", "--no-push"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--no-push"}, runner.Calls[1].Params)
 	})
 
 	t.Run("success case - backward compatibility", func(t *testing.T) {
@@ -266,13 +312,12 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("path/to/docker/config.json", []byte(`{"auths":{"custom":"test"}}`))
 		fileUtils.AddFile("/kaniko/ssl/certs/ca-certificates.crt", []byte(``))
-		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, certClient, fileUtils)
 
 		assert.NoError(t, err)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
 	})
 
 	t.Run("success case - multi image build with root image", func(t *testing.T) {
@@ -290,7 +335,6 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils.AddFile("Dockerfile", []byte("some content"))
 		fileUtils.AddFile("sub1/Dockerfile", []byte("some content"))
 		fileUtils.AddFile("sub2/Dockerfile", []byte("some content"))
-		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, nil, fileUtils)
 
@@ -303,9 +347,9 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		cwd, _ := fileUtils.Getwd()
 		expectedParams := [][]string{
-			{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--destination", "my.registry.com:50000/myImage:myTag"},
-			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
-			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
+			{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage:myTag"},
+			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
+			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
 		}
 		// need to go this way since we cannot count on the correct order
 		for _, call := range runner.Calls {
@@ -328,8 +372,8 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.Contains(t, commonPipelineEnvironment.container.imageNameTags, "myImage-sub1:myTag")
 		assert.Contains(t, commonPipelineEnvironment.container.imageNameTags, "myImage-sub2:myTag")
 
-		assert.Equal(t, commonPipelineEnvironment.container.imageDigest, "sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0")
-		assert.Equal(t, commonPipelineEnvironment.container.imageDigests, []string{"sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0", "sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0", "sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0"})
+		assert.Equal(t, "", commonPipelineEnvironment.container.imageDigest)
+		assert.Empty(t, commonPipelineEnvironment.container.imageDigests)
 	})
 
 	t.Run("success case - multi image build excluding root image", func(t *testing.T) {
@@ -348,7 +392,6 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils.AddFile("Dockerfile", []byte("some content"))
 		fileUtils.AddFile("sub1/Dockerfile", []byte("some content"))
 		fileUtils.AddFile("sub2/Dockerfile", []byte("some content"))
-		fileUtils.AddFile("/tmp/*-kanikoExecutetest/digest.txt", []byte(`sha256:468dd1253cc9f498fc600454bb8af96d880fec3f9f737e7057692adfe9f7d5b0`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, runner, nil, fileUtils)
 
@@ -360,8 +403,8 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		cwd, _ := fileUtils.Getwd()
 		expectedParams := [][]string{
-			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
-			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--reproducible", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt", "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
+			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
+			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
 		}
 		// need to go this way since we cannot count on the correct order
 		for _, call := range runner.Calls {

--- a/resources/metadata/kanikoExecute.yaml
+++ b/resources/metadata/kanikoExecute.yaml
@@ -34,6 +34,9 @@ spec:
           - STEPS
         default:
           - --skip-tls-verify-pull
+          # fixing Kaniko issue https://github.com/GoogleContainerTools/kaniko/issues/1586
+          # as per comment https://github.com/GoogleContainerTools/kaniko/issues/1586#issuecomment-945718536
+          - --ignore-path=/busybox
       - name: buildSettingsInfo
         type: string
         description: Build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build. This information is typically used for compliance related processes.
@@ -160,6 +163,13 @@ spec:
         default: []
         scope:
           - GENERAL
+          - STEPS
+          - STAGES
+          - PARAMETERS
+      - name: readImageDigest
+        type: bool
+        default: false
+        scope:
           - STEPS
           - STAGES
           - PARAMETERS

--- a/resources/metadata/kanikoExecute.yaml
+++ b/resources/metadata/kanikoExecute.yaml
@@ -34,9 +34,6 @@ spec:
           - STEPS
         default:
           - --skip-tls-verify-pull
-          # fixing Kaniko issue https://github.com/GoogleContainerTools/kaniko/issues/1586
-          # as per comment https://github.com/GoogleContainerTools/kaniko/issues/1586#issuecomment-945718536
-          - --ignore-path=/
       - name: buildSettingsInfo
         type: string
         description: Build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build. This information is typically used for compliance related processes.


### PR DESCRIPTION
# Changes

Since we can't quickly fix the issues some users have on jenkins/jnlp, this PR deactivates the recently introduced docker digest feature by default and makes piper again compatible with kaniko 1.3.0

- [x] Tests
- [ ] Documentation
