### PR TITLE
feat(npmExecuteScripts): config@2 support

### DIFF
--- a/pkg/mock/fileUtils.go
+++ b/pkg/mock/fileUtils.go
@@ -228,6 +228,21 @@ func (f *FilesMock) Copy(src, dst string) (int64, error) {
 	return int64(len(*props.content)), nil
 }
 
+// Move moves a file to the given destination
+func (f *FilesMock) Move(src, dst string) error {
+	if exists, err := f.FileExists(src); err != nil {
+		return err
+	} else if !exists {
+		return fmt.Errorf("file doesn't exist: %s", src)
+	}
+
+	if _, err := f.Copy(src, dst); err != nil {
+		return err
+	}
+
+	return f.FileRemove(src)
+}
+
 // FileRead returns the content previously associated with the given path via AddFile(), or an error if no
 // content has been associated.
 func (f *FilesMock) FileRead(path string) ([]byte, error) {

--- a/pkg/npm/config_test.go
+++ b/pkg/npm/config_test.go
@@ -2,58 +2,163 @@ package npm
 
 import (
 	"path/filepath"
-	"reflect"
 	"testing"
 
-	"github.com/magiconair/properties"
+	filesmock "github.com/SAP/jenkins-library/pkg/mock"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewNPMRC(t *testing.T) {
 	type args struct {
 		path string
 	}
+	type want struct {
+		path     string
+		errLoad  string
+		errWrite string
+		files    map[string]string
+	}
+
 	tests := []struct {
-		name string
-		args args
-		want string
+		name  string
+		args  args
+		files map[string]string
+		want  want
 	}{
-		{name: "current dir", args: args{""}, want: defaultConfigFilename},
-		{name: "sub dir", args: args{mock.Anything}, want: filepath.Join(mock.Anything, ".piperNpmrc")},
-		{name: "file path in current dir", args: args{".piperNpmrc"}, want: ".piperNpmrc"},
-		{name: "file path in sub dir", args: args{filepath.Join(mock.Anything, ".piperNpmrc")}, want: filepath.Join(mock.Anything, ".piperNpmrc")},
+		{
+			name: "success - path pointing to no dir - no content",
+			args: args{""},
+			files: map[string]string{
+				defaultConfigFilename: "",
+			},
+			want: want{
+				path: defaultConfigFilename,
+				files: map[string]string{
+					defaultConfigFilename: "",
+				},
+			},
+		},
+		{
+			name: "success - path pointing to cwd - no content",
+			args: args{"."},
+			files: map[string]string{
+				defaultConfigFilename: "",
+			},
+			want: want{
+				path: defaultConfigFilename,
+				files: map[string]string{
+					defaultConfigFilename: "",
+				},
+			},
+		},
+		{
+			name: "success - path pointing to sub dir - no content",
+			args: args{mock.Anything},
+			files: map[string]string{
+				filepath.Join(mock.Anything, ".piperNpmrc"): "",
+			},
+			want: want{
+				path: filepath.Join(mock.Anything, ".piperNpmrc"),
+				files: map[string]string{
+					filepath.Join(mock.Anything, ".piperNpmrc"): "",
+				},
+			},
+		},
+		{
+			name: "success - path pointing to file in current folder - no content",
+			args: args{".piperNpmrc"},
+			files: map[string]string{
+				".piperNpmrc": "",
+			},
+			want: want{
+				path: ".piperNpmrc",
+				files: map[string]string{
+					".piperNpmrc": "",
+				},
+			},
+		},
+		{
+			name: "success - path pointing to file in sub folder - no content",
+			args: args{filepath.Join(mock.Anything, ".piperNpmrc")},
+			files: map[string]string{
+				filepath.Join(mock.Anything, ".piperNpmrc"): "",
+			},
+			want: want{
+				path: filepath.Join(mock.Anything, ".piperNpmrc"),
+				files: map[string]string{
+					filepath.Join(mock.Anything, ".piperNpmrc"): "",
+				},
+			},
+		},
+		{
+			name: "success - doesn't modify existing content",
+			args: args{filepath.Join(mock.Anything, ".piperNpmrc")},
+			files: map[string]string{
+				filepath.Join(mock.Anything, ".piperNpmrc"): `
+_auth=dGVzdDp0ZXN0
+registry=https://my.private.registry/
+@piper:registry=https://my.scoped.private.registry/
+//my.private.registry/:_auth=dGVzdDp0ZXN0
+//my.scoped.private.registry/:_auth=dGVzdDp0ZXN0
+`,
+			},
+			want: want{
+				path: filepath.Join(mock.Anything, ".piperNpmrc"),
+				files: map[string]string{
+					filepath.Join(mock.Anything, ".piperNpmrc"): `
+_auth=dGVzdDp0ZXN0
+registry=https://my.private.registry/
+@piper:registry=https://my.scoped.private.registry/
+//my.private.registry/:_auth=dGVzdDp0ZXN0
+//my.scoped.private.registry/:_auth=dGVzdDp0ZXN0
+`,
+				},
+			},
+		},
+		{
+			name:  "failure - path pointing to sth which doesnt exist",
+			args:  args{"./this/path/doesnt/exist/.piperNpmrc"},
+			files: map[string]string{},
+			want: want{
+				path:    "./this/path/doesnt/exist/.piperNpmrc",
+				errLoad: "could not read './this/path/doesnt/exist/.piperNpmrc'",
+			},
+		},
 	}
 	for _, tt := range tests {
+		files := filesmock.FilesMock{}
+
+		for path, content := range tt.files {
+			files.AddFile(path, []byte(content))
+		}
+
+		propertiesLoadFile = files.FileRead
+		propertiesWriteFile = files.FileWrite
+
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewNPMRC(tt.args.path); !reflect.DeepEqual(got.filepath, tt.want) {
-				t.Errorf("NewNPMRC().filepath = %v, want %v", got.filepath, tt.want)
+			uut := NewNPMRC(tt.args.path)
+
+			assert.Equal(t, tt.want.path, uut.filepath)
+
+			if err := uut.Load(); len(tt.want.errLoad) == 0 {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.want.errLoad)
+			}
+
+			if err := uut.Write(); len(tt.want.errWrite) == 0 {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.want.errWrite)
+			}
+
+			for wantFile, wantContent := range tt.want.files {
+				if actualContent, err := files.FileRead(wantFile); assert.NoError(t, err) {
+					assert.Equal(t, wantContent, string(actualContent))
+				}
 			}
 		})
 	}
-}
-
-func mockLoadProperties(t *testing.T, result *properties.Properties, err error) func(filename string, enc properties.Encoding) (*properties.Properties, error) {
-	return func(filename string, enc properties.Encoding) (*properties.Properties, error) {
-		return result, err
-	}
-}
-
-func TestLoad(t *testing.T) {
-	// init
-	config := NewNPMRC("")
-
-	new := properties.NewProperties()
-	new.Set("test", "anything")
-	propertiesLoadFile = mockLoadProperties(t, new, nil)
-	require.NotEmpty(t, new.Keys())
-
-	require.Empty(t, config.values.Keys())
-	// test
-	err := config.Load()
-	// assert
-	assert.NoError(t, err)
-	assert.NotEmpty(t, config.values.Keys())
-
 }

--- a/pkg/piperutils/FileUtils.go
+++ b/pkg/piperutils/FileUtils.go
@@ -22,6 +22,7 @@ type FileUtils interface {
 	DirExists(path string) (bool, error)
 	FileExists(filename string) (bool, error)
 	Copy(src, dest string) (int64, error)
+	Move(src, dest string) error
 	FileRead(path string) ([]byte, error)
 	FileWrite(path string, content []byte, perm os.FileMode) error
 	FileRemove(path string) error
@@ -111,6 +112,20 @@ func (f Files) Copy(src, dst string) (int64, error) {
 	defer func() { _ = destination.Close() }()
 	nBytes, err := CopyData(destination, source)
 	return nBytes, err
+}
+
+func (f Files) Move(src, dst string) error {
+	if exists, err := f.FileExists(src); err != nil {
+		return err
+	} else if !exists {
+		return fmt.Errorf("file doesn't exist: %s", src)
+	}
+
+	if _, err := f.Copy(src, dst); err != nil {
+		return err
+	}
+
+	return f.FileRemove(src)
 }
 
 //Chmod is a wrapper for os.Chmod().


### PR DESCRIPTION
# Changes

Let's piper properly handle the new npmrc format (v2) and adds even more tests.

- [x] Tests
- [ ] Documentation
