### PR TITLE
fixes retry when sending telemetry to Splunk

### DIFF
--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -177,7 +177,9 @@ func (s *Splunk) postTelemetry(telemetryData map[string]interface{}) error {
 	}
 
 	payload, err := json.Marshal(details)
-
+	if err != nil {
+		return errors.Wrap(err, "error while marshalling Splunk message details")
+	}
 	prettyPayload, err := json.MarshalIndent(details, "", "    ")
 	if err != nil {
 		log.Entry().WithError(err).Warn("Failed to generate pretty payload json")

--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -51,7 +51,7 @@ func (s *Splunk) Initialize(correlationID, dsn, token, index string, sendLogs bo
 		MaxRequestDuration:        5 * time.Second,
 		Token:                     token,
 		TransportSkipVerification: true,
-		MaxRetries:                5,
+		MaxRetries:                -1,
 	})
 
 	hostName, err := os.Hostname()
@@ -170,7 +170,7 @@ func (s *Splunk) postTelemetry(telemetryData map[string]interface{}) error {
 		telemetryData = map[string]interface{}{"Empty": "No telemetry available."}
 	}
 	details := DetailsTelemetry{
-		Host:       s.correlationID,
+		Host:       s.hostName,
 		SourceType: "piper:pipeline:telemetry",
 		Index:      s.splunkIndex,
 		Event:      telemetryData,
@@ -275,7 +275,7 @@ func (s *Splunk) tryPostMessages(telemetryData MonitoringData, messages []log.Me
 		Telemetry: telemetryData,
 	}
 	details := Details{
-		Host:       s.correlationID,
+		Host:       s.hostName,
 		SourceType: "_json",
 		Index:      s.splunkIndex,
 		Event:      event,


### PR DESCRIPTION
# Changes
- Reduces the retries, sending telemetry information to Splunk to 1
- Uses correct hostName
- [ ] Tests
- [ ] Documentation
