### PR TITLE
feat(piperExecuteBin): support running images from private docker reg…

### DIFF
--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -221,7 +221,7 @@ func (m *StepData) GetContextParameterFilters() StepFilters {
 		}
 	}
 	if len(m.Spec.Containers) > 0 {
-		parameterKeys := []string{"containerCommand", "containerShell", "dockerEnvVars", "dockerImage", "dockerName", "dockerOptions", "dockerPullImage", "dockerVolumeBind", "dockerWorkspace"}
+		parameterKeys := []string{"containerCommand", "containerShell", "dockerEnvVars", "dockerImage", "dockerName", "dockerOptions", "dockerPullImage", "dockerVolumeBind", "dockerWorkspace", "dockerRegistryUrl", "dockerRegistryCredentialsId"}
 		for _, container := range m.Spec.Containers {
 			for _, condition := range container.Conditions {
 				for _, dependentParam := range condition.Params {

--- a/pkg/config/stepmeta_test.go
+++ b/pkg/config/stepmeta_test.go
@@ -291,7 +291,7 @@ func TestGetContextParameterFilters(t *testing.T) {
 
 	t.Run("Containers", func(t *testing.T) {
 		filters := metadata2.GetContextParameterFilters()
-		params := defaultParams("containerCommand", "containerShell", "dockerEnvVars", "dockerImage", "dockerName", "dockerOptions", "dockerPullImage", "dockerVolumeBind", "dockerWorkspace", "pip", "scanType")
+		params := defaultParams("containerCommand", "containerShell", "dockerEnvVars", "dockerImage", "dockerName", "dockerOptions", "dockerPullImage", "dockerVolumeBind", "dockerWorkspace", "dockerRegistryUrl", "dockerRegistryCredentialsId", "pip", "scanType")
 
 		assert.Equal(t, params, filters.All, "incorrect filter All")
 		assert.Equal(t, params, filters.General, "incorrect filter General")


### PR DESCRIPTION
Once this PR is merged `piperExecuteBin` can execute piper in a private docker image like follows:

```yaml
  whitesourceExecuteScan:
    dockerImage: 'whitesource:22.2.2.1'
    dockerRegistryUrl: 'https://my.private.docker.registry'
    dockerRegistryCredentialsId: 'my-docker-credentials-id'
```


# Changes

- [x] Tests
- [ ] Documentation
