### PR TITLE
fix (gitOpsUpdateDeployment) adding vault references for username and password

### DIFF
--- a/cmd/gitopsUpdateDeployment_generated.go
+++ b/cmd/gitopsUpdateDeployment_generated.go
@@ -206,6 +206,12 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 								Param: "username",
 								Type:  "secret",
 							},
+
+							{
+								Name:    "gitHttpsCredentialVaultSecretName",
+								Type:    "vaultSecret",
+								Default: "gitHttpsCredential",
+							},
 						},
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:      "string",
@@ -220,6 +226,12 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 								Name:  "gitHttpsCredentialsId",
 								Param: "password",
 								Type:  "secret",
+							},
+
+							{
+								Name:    "gitHttpsCredentialVaultSecretName",
+								Type:    "vaultSecret",
+								Default: "gitHttpsCredential",
 							},
 						},
 						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},

--- a/resources/metadata/gitopsUpdateDeployment.yaml
+++ b/resources/metadata/gitopsUpdateDeployment.yaml
@@ -65,6 +65,9 @@ spec:
           - name: gitHttpsCredentialsId
             type: secret
             param: username
+          - type: vaultSecret
+            name: gitHttpsCredentialVaultSecretName
+            default: gitHttpsCredential
       - name: password
         type: string
         description: Password/token for git authentication.
@@ -78,6 +81,9 @@ spec:
           - name: gitHttpsCredentialsId
             type: secret
             param: password
+          - type: vaultSecret
+            name: gitHttpsCredentialVaultSecretName
+            default: gitHttpsCredential
       - name: filePath
         description: |
           Relative path in the git repository to the deployment descriptor file that shall be updated. For different tools this has different semantics:


### PR DESCRIPTION
# Changes

currently the step gitOpsUpdateDeployment only has jenkins references, extending `username` and `password ` for vault 
- [ ] Tests
- [ ] Documentation
