### PR TITLE
fix(cpe): breaking change introduced with #3641

### DIFF
--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -368,8 +368,8 @@ func (m *StepData) GetResourceParameters(path, name string) map[string]interface
 			if res.Name == name {
 				if val := getParameterValue(path, res, param); val != nil {
 					resourceParams[param.Name] = val
+					break
 				}
-				break
 			}
 		}
 	}

--- a/pkg/config/stepmeta_test.go
+++ b/pkg/config/stepmeta_test.go
@@ -657,6 +657,13 @@ func TestGetResourceParameters(t *testing.T) {
 				}}}},
 			expected: map[string]interface{}{"param1": "val1"},
 		},
+		{
+			in: StepData{
+				Spec: StepSpec{Inputs: StepInputs{Parameters: []StepParameters{
+					{Name: "param1", ResourceRef: []ResourceReference{{Name: "commonPipelineEnvironment", Param: "sthwhichclearlydoesntexist"}, {Name: "commonPipelineEnvironment", Param: "envparam2"}}, Type: "string"},
+				}}}},
+			expected: map[string]interface{}{"param1": "val2"},
+		},
 	}
 
 	dir, err := ioutil.TempDir("", "")


### PR DESCRIPTION
# Changes

This PR fixes an issue which got introduced with #3641 recently. It is causing issues with retrieving/publishing artifacts from/towards a registry. RC is a missing reference in the CPE.

Affected piper steps:
* golangBuild
* malwareExecuteScan
* whitesourceExecuteScan
* helmExecute
* kubernetesDeploy
* mtaBuild
* npmExecuteScripts
* mavenBuild

- [x] Tests
- [ ] Documentation
