### PR TITLE
fix(golangBuild): order of arguments

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -446,10 +446,11 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 		buildOptions = append(buildOptions, "-o", binaryName)
 	}
 	buildOptions = append(buildOptions, config.BuildFlags...)
-	buildOptions = append(buildOptions, config.Packages...)
 	if len(ldflags) > 0 {
-		buildOptions = append(buildOptions, "-ldflags", ldflags)
+	   buildOptions = append(buildOptions, "-ldflags", ldflags)
 	}
+	buildOptions = append(buildOptions, config.Packages...)
+
 
 	if err := utils.RunExecutable("go", buildOptions...); err != nil {
 		log.Entry().Debugf("buildOptions: %v", buildOptions)

--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -451,7 +451,6 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 	}
 	buildOptions = append(buildOptions, config.Packages...)
 
-
 	if err := utils.RunExecutable("go", buildOptions...); err != nil {
 		log.Entry().Debugf("buildOptions: %v", buildOptions)
 		log.SetErrorCategory(log.ErrorBuild)

--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -447,7 +447,7 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 	}
 	buildOptions = append(buildOptions, config.BuildFlags...)
 	if len(ldflags) > 0 {
-	   buildOptions = append(buildOptions, "-ldflags", ldflags)
+		buildOptions = append(buildOptions, "-ldflags", ldflags)
 	}
 	buildOptions = append(buildOptions, config.Packages...)
 

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -98,6 +98,7 @@ func TestRunGolangBuild(t *testing.T) {
 		config := golangBuildOptions{
 			RunTests:            true,
 			LdflagsTemplate:     "test",
+			Packages:            []string{"package/foo"},
 			TargetArchitectures: []string{"linux,amd64"},
 		}
 		utils := newGolangBuildTestsUtils()
@@ -110,7 +111,7 @@ func TestRunGolangBuild(t *testing.T) {
 		assert.Equal(t, "gotestsum", utils.ExecMockRunner.Calls[1].Exec)
 		assert.Equal(t, []string{"--junitfile", "TEST-go.xml", "--", fmt.Sprintf("-coverprofile=%v", coverageFile), "./..."}, utils.ExecMockRunner.Calls[1].Params)
 		assert.Equal(t, "go", utils.ExecMockRunner.Calls[2].Exec)
-		assert.Equal(t, []string{"build", "-trimpath", "-ldflags", "test"}, utils.ExecMockRunner.Calls[2].Params)
+		assert.Equal(t, []string{"build", "-trimpath", "-ldflags", "test", "package/foo"}, utils.ExecMockRunner.Calls[2].Params)
 	})
 
 	t.Run("success - tests with coverage", func(t *testing.T) {


### PR DESCRIPTION
As per https://pkg.go.dev/cmd/go#hdr-Compile_packages_and_dependencies 
docs say the following order is required `go build [-o output] [build flags] [packages]`.

Currently,  `-ldflags` is put after packages and treated as a part of packages. e shall be put it before packages.

The build may fail this way
```
running command: go build -trimpath -o foo-linux.amd64 ./cmd/main.go -ldflags '-linkmode=external'
named files must be .go files: -ldflags

```

# Changes

- [x] Tests
- [ ] Documentation
