### PR TITLE
fix(kaniko): deactivate reproducible flag

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -215,7 +215,7 @@ func runKaniko(dockerFilepath string, buildOptions []string, readDigest bool, ex
 		return fmt.Errorf("failed to get current working directory: %w", err)
 	}
 
-	kanikoOpts := []string{"--dockerfile", dockerFilepath, "--context", cwd, "--reproducible"}
+	kanikoOpts := []string{"--dockerfile", dockerFilepath, "--context", cwd}
 	kanikoOpts = append(kanikoOpts, buildOptions...)
 
 	tmpDir, err := fileUtils.TempDir("", "*-kanikoExecute")

--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -83,7 +83,7 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
 
 		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"mavenExecuteBuild":[{"dockerImage":"maven"}]`)
 		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"kanikoExecute":[{"dockerImage":"gcr.io/kaniko-project/executor:debug"}]`)
@@ -134,7 +134,7 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "myImage:tag", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--destination", "myImage:tag", "--digest-file", "/tmp/*-kanikoExecutetest/digest.txt"}, runner.Calls[1].Params)
 
 		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"mavenExecuteBuild":[{"dockerImage":"maven"}]`)
 		assert.Contains(t, commonPipelineEnvironment.custom.buildSettingsInfo, `"kanikoExecute":[{"dockerImage":"gcr.io/kaniko-project/executor:debug"}]`)
@@ -184,7 +184,7 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "my.registry.com:50000/myImage:1.2.3-a-x"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--destination", "my.registry.com:50000/myImage:1.2.3-a-x"}, runner.Calls[1].Params)
 
 		assert.Equal(t, "myImage:1.2.3-a-x", commonPipelineEnvironment.container.imageNameTag)
 		assert.Equal(t, "https://my.registry.com:50000", commonPipelineEnvironment.container.registryURL)
@@ -228,7 +228,7 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.Equal(t, "/kaniko/executor", runner.Calls[1].Exec)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "my.other.registry.com:50000/myImage:3.2.1-a-x"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--destination", "my.other.registry.com:50000/myImage:3.2.1-a-x"}, runner.Calls[1].Params)
 
 		assert.Equal(t, "myImage:3.2.1-a-x", commonPipelineEnvironment.container.imageNameTag)
 		assert.Equal(t, "https://my.other.registry.com:50000", commonPipelineEnvironment.container.registryURL)
@@ -290,7 +290,7 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.Equal(t, `{"auths":{}}`, string(c))
 
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--no-push"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--no-push"}, runner.Calls[1].Params)
 	})
 
 	t.Run("success case - backward compatibility", func(t *testing.T) {
@@ -317,7 +317,7 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		assert.NoError(t, err)
 		cwd, _ := fileUtils.Getwd()
-		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
+		assert.Equal(t, []string{"--dockerfile", "Dockerfile", "--context", cwd, "--skip-tls-verify-pull", "--destination", "myImage:tag"}, runner.Calls[1].Params)
 	})
 
 	t.Run("success case - multi image build with root image", func(t *testing.T) {
@@ -347,9 +347,9 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		cwd, _ := fileUtils.Getwd()
 		expectedParams := [][]string{
-			{"--dockerfile", "Dockerfile", "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage:myTag"},
-			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
-			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
+			{"--dockerfile", "Dockerfile", "--context", cwd, "--destination", "my.registry.com:50000/myImage:myTag"},
+			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
+			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
 		}
 		// need to go this way since we cannot count on the correct order
 		for _, call := range runner.Calls {
@@ -403,8 +403,8 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		cwd, _ := fileUtils.Getwd()
 		expectedParams := [][]string{
-			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
-			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--reproducible", "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
+			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", cwd, "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
+			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", cwd, "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
 		}
 		// need to go this way since we cannot count on the correct order
 		for _, call := range runner.Calls {


### PR DESCRIPTION
# Changes

After hours and hours of testing I figured out the root cause of the issue mentioned in #3652.

Some docker implementations don't like images produced with the `--reproducible` flag of kaniko, thus I'm deactivating it with this PR. Afaik empty layers (like CMD, ENV, etc) shouldn't appear in the manifest. But if the `--reproducible` flag is set, they do. 

This is how the `container-diff` tooling responded when I tried to pull an image with it.

```bash
failed to download Docker image alpine-base:3.15.1: failed to tar container image: image config had layer history which did not match the number of layers, got len(history)=3, len(layers)=4, want len(history)=len(layers)
```

Artifactory did just end with a weird error when I tried to push the image into a registry and did not provide any further information:

```bash
manifest invalid: manifest invalid
```

Interestingly there are quite a lot tools which don't make troubles, like docker-desktop, crane, skopeo, etc. But artifactory is kind of a showstopper here. 

- [x] Tests
- [ ] Documentation
