### PR TITLE
fix(whitesourceExecuteScan): proper container options for golang

### DIFF
--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -948,7 +948,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 			Containers: []config.Container{
 				{Image: "buildpack-deps:stretch-curl", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "dub"}, {Name: "buildTool", Value: "docker"}}}}},
 				{Image: "devxci/mbtci-java11-node14", WorkingDir: "/home/mta", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "mta"}}}}},
-				{Image: "golang:1", WorkingDir: "/go", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "golang"}}}}},
+				{Image: "golang:1", WorkingDir: "/go", Options: []config.Option{{Name: "-u", Value: "0"}}, Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "golang"}}}}},
 				{Image: "gradle", WorkingDir: "/home/gradle", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "gradle"}}}}},
 				{Image: "hseeberger/scala-sbt:8u181_2.12.8_1.2.8", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "sbt"}}}}},
 				{Image: "maven:3.5-jdk-8", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}}}}},

--- a/resources/metadata/whitesourceExecuteScan.yaml
+++ b/resources/metadata/whitesourceExecuteScan.yaml
@@ -648,6 +648,9 @@ spec:
     - image: golang:1
       workingDir: /go
       env: []
+      options:
+        - name: -u
+          value: "0"
       conditions:
         - conditionRef: strings-equal
           params:


### PR DESCRIPTION
this fixes issues when running WhiteSource for golang in a non-Kubernetes scenario.
