### PR TITLE
fix(checkmarxExecuteScan): split and trim filterPattern

### DIFF
--- a/cmd/checkmarxExecuteScan.go
+++ b/cmd/checkmarxExecuteScan.go
@@ -226,7 +226,7 @@ func loadExistingProject(sys checkmarx.System, initialProjectName, pullRequestNa
 
 func zipWorkspaceFiles(filterPattern string, utils checkmarxExecuteScanUtils) (*os.File, error) {
 	zipFileName := filepath.Join(utils.GetWorkspace(), "workspace.zip")
-	patterns := strings.Split(strings.ReplaceAll(strings.ReplaceAll(filterPattern, ", ", ","), " ,", ","), ",")
+	patterns := piperutils.Trim(strings.Split(filterPattern, ","))
 	sort.Strings(patterns)
 	zipFile, err := os.Create(zipFileName)
 	if err != nil {


### PR DESCRIPTION
# Changes

The current implementation fails if there are too many whitespaces used in the filterPattern, like:

```YAML
  checkmarxExecuteScan:
    filterPattern: '!a        , b'
```

- [ ] Tests
- [ ] Documentation
