### PR TITLE
[ANS] Add servicekey credential to environment

### DIFF
--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -27,8 +27,6 @@ type GeneralConfigOptions struct {
 	DefaultConfig            []string //ordered list of Piper default configurations. Can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
 	IgnoreCustomDefaults     bool
 	ParametersJSON           string
-	ANSServiceKey            string
-	ANSEventTemplateFilePath string
 	EnvRootPath              string
 	NoTelemetry              bool
 	StageName                string

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -20,33 +20,35 @@ import (
 
 // GeneralConfigOptions contains all global configuration options for piper binary
 type GeneralConfigOptions struct {
-	GitHubAccessTokens   map[string]string // map of tokens with url as key in order to maintain url-specific tokens
-	CorrelationID        string
-	CustomConfig         string
-	GitHubTokens         []string // list of entries in form of <server>:<token> to allow token authentication for downloading config / defaults
-	DefaultConfig        []string //ordered list of Piper default configurations. Can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
-	IgnoreCustomDefaults bool
-	ParametersJSON       string
-	EnvRootPath          string
-	NoTelemetry          bool
-	StageName            string
-	StepConfigJSON       string
-	StepMetadata         string //metadata to be considered, can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
-	StepName             string
-	Verbose              bool
-	LogFormat            string
-	VaultRoleID          string
-	VaultRoleSecretID    string
-	VaultToken           string
-	VaultServerURL       string
-	VaultNamespace       string
-	VaultPath            string
-	HookConfig           HookConfiguration
-	MetaDataResolver     func() map[string]config.StepData
-	GCPJsonKeyFilePath   string
-	GCSFolderPath        string
-	GCSBucketId          string
-	GCSSubFolder         string
+	GitHubAccessTokens       map[string]string // map of tokens with url as key in order to maintain url-specific tokens
+	CorrelationID            string
+	CustomConfig             string
+	GitHubTokens             []string // list of entries in form of <server>:<token> to allow token authentication for downloading config / defaults
+	DefaultConfig            []string //ordered list of Piper default configurations. Can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
+	IgnoreCustomDefaults     bool
+	ParametersJSON           string
+	ANSServiceKey            string
+	ANSEventTemplateFilePath string
+	EnvRootPath              string
+	NoTelemetry              bool
+	StageName                string
+	StepConfigJSON           string
+	StepMetadata             string //metadata to be considered, can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
+	StepName                 string
+	Verbose                  bool
+	LogFormat                string
+	VaultRoleID              string
+	VaultRoleSecretID        string
+	VaultToken               string
+	VaultServerURL           string
+	VaultNamespace           string
+	VaultPath                string
+	HookConfig               HookConfiguration
+	MetaDataResolver         func() map[string]config.StepData
+	GCPJsonKeyFilePath       string
+	GCSFolderPath            string
+	GCSBucketId              string
+	GCSSubFolder             string
 }
 
 // HookConfiguration contains the configuration for supported hooks, so far Sentry and Splunk are supported.

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -20,33 +20,33 @@ import (
 
 // GeneralConfigOptions contains all global configuration options for piper binary
 type GeneralConfigOptions struct {
-	GitHubAccessTokens       map[string]string // map of tokens with url as key in order to maintain url-specific tokens
-	CorrelationID            string
-	CustomConfig             string
-	GitHubTokens             []string // list of entries in form of <server>:<token> to allow token authentication for downloading config / defaults
-	DefaultConfig            []string //ordered list of Piper default configurations. Can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
-	IgnoreCustomDefaults     bool
-	ParametersJSON           string
-	EnvRootPath              string
-	NoTelemetry              bool
-	StageName                string
-	StepConfigJSON           string
-	StepMetadata             string //metadata to be considered, can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
-	StepName                 string
-	Verbose                  bool
-	LogFormat                string
-	VaultRoleID              string
-	VaultRoleSecretID        string
-	VaultToken               string
-	VaultServerURL           string
-	VaultNamespace           string
-	VaultPath                string
-	HookConfig               HookConfiguration
-	MetaDataResolver         func() map[string]config.StepData
-	GCPJsonKeyFilePath       string
-	GCSFolderPath            string
-	GCSBucketId              string
-	GCSSubFolder             string
+	GitHubAccessTokens   map[string]string // map of tokens with url as key in order to maintain url-specific tokens
+	CorrelationID        string
+	CustomConfig         string
+	GitHubTokens         []string // list of entries in form of <server>:<token> to allow token authentication for downloading config / defaults
+	DefaultConfig        []string //ordered list of Piper default configurations. Can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
+	IgnoreCustomDefaults bool
+	ParametersJSON       string
+	EnvRootPath          string
+	NoTelemetry          bool
+	StageName            string
+	StepConfigJSON       string
+	StepMetadata         string //metadata to be considered, can be filePath or ENV containing JSON in format 'ENV:MY_ENV_VAR'
+	StepName             string
+	Verbose              bool
+	LogFormat            string
+	VaultRoleID          string
+	VaultRoleSecretID    string
+	VaultToken           string
+	VaultServerURL       string
+	VaultNamespace       string
+	VaultPath            string
+	HookConfig           HookConfiguration
+	MetaDataResolver     func() map[string]config.StepData
+	GCPJsonKeyFilePath   string
+	GCSFolderPath        string
+	GCSBucketId          string
+	GCSSubFolder         string
 }
 
 // HookConfiguration contains the configuration for supported hooks, so far Sentry and Splunk are supported.

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -62,6 +62,107 @@ steps:
     newmanGlobals: 'myNewmanGlobals'
 ```
 
+## Sending log data to the SAP Alert Notification service for SAP BTP
+
+The SAP Alert Notification service for SAP BTP allows users to define
+certain delivery channels, for example, e-mail or triggering of HTTP
+requests, to receive notifications from pipeline events. If the alert
+notification service service-key is properly configured in "Piper", any "Piper"
+step implemented in golang will send log data to the alert notification
+service backend for log levels higher than warnings, i.e. warnings, error,
+fatal and panic.
+
+The SAP Alert Notification service event properties are defined depending on the
+log entry content as follows:
+
+- `eventType`: the type of event type (defaults to 'Piper', but can be
+  overwritten with the event template)
+- `eventTimestamp`: the time of the log entry
+- `severity` and `category`: the event severity and the event category
+  depends on the log level:
+
+  | log level | severity | category |
+  |-----------|----------|----------|
+  | info | INFO | NOTICE |
+  | debug | INFO | NOTICE |
+  | warn | WARNING | ALERT |
+  | error | ERROR | EXCEPTION |
+  | fatal | FATAL | EXCEPTION |
+  | panic | FATAL | EXCEPTION |
+
+- `subject`: short description of the event (defaults to the step name, but
+  can be overwritten with the event template)
+- `body`: the log message
+- `priority`: (optional) an integer number in the range [1:1000] (not set by
+  "Piper", but can be set with the event template)
+- `tags`: optional key-value pairs. The following are set by "Piper":
+    - `ans:correlationId`: a unique correlation ID of the pipeline run
+      (defaults to the URL of that pipeline run, but can be overwritten with the
+      event template)
+    - `ans:sourceEventId`: also set to the "Piper" correlation ID (can also be
+      overwritten with the event template)
+    - `pipeline:stepName`: the "Piper" step name
+    - `pipeline:logLevel`: the "Piper" log level
+    - `pipeline:errorCategory`: the "Piper" error category, if available
+- `resource`: the following default properties are set by "Piper":
+    - `resourceType`: resource type identifier (defaults to 'Pipeline', but
+      can be overwritten with the event template)
+    - `resourceName`: unique resource name (defaults to 'Pipeline', can be
+      overwritten with the event template)
+    - `resourceInstance`: (optional) resource instance identifier (not set by
+      "Piper", can be set with the event template)
+    - `tags`: optional key-value pairs.
+
+The following event properties cannot be set and are instead set by the SAP
+Alert Notification service:
+`region`, `regionType`, `resource.globalAccount`, `resource.subAccount` and
+`resource.resourceGroup`
+
+For more information and an example of the structure of an alert
+notification service event, see
+[SAP Alert Notification Service Events](https://help.sap.com/viewer/5967a369d4b74f7a9c2b91f5df8e6ab6/Cloud/en-US/eaaa37e6ff62486ebb849507dc33abc6.html)
+in the SAP Help Portal.
+
+### SAP Alert Notification service configuration
+
+There are two options that can be configured: the mandatory service-key and
+the optional event template.
+
+#### Service-Key
+
+The SAP Alert Notification service service-key needs to be present in the
+environment, where the "Piper" binary is run. See the
+[Credential Management guide](https://help.sap.com/docs/ALERT_NOTIFICATION/5967a369d4b74f7a9c2b91f5df8e6ab6/80fe24f86bde4e3aac2903ac05511835.html?locale=en-US)
+in the SAP Help Portal on how to retrieve an alert notification service
+service-key. The environment variable used is: `PIPER_ansHookServiceKey`.
+
+If Jenkins is used to run "Piper", you can use the Jenkins credential store
+to store the alert notification service service-key as a "Secret Text"
+credential. Provide the credential id in the configuration file in the `hooks`
+section as follows:
+
+```yaml
+hooks:
+  ans:
+    serviceKeyCredentialsId: 'my_ANS_Service_Key'
+```
+
+#### Event template
+
+You can also create an event template in JSON format to overwrite
+or add event details to the default. To do this, provide the JSON string
+directly in the environment where the "Piper" binary is run. The environment
+variable used in this case is: `PIPER_ansEventTemplate`.
+
+For example in unix:
+
+```bash
+export PIPER_ansEventTemplate='{"priority": 999}'
+```
+
+The event body, timestamp, severity and category cannot be set via the
+template. They are always set from the log entry.
+
 ## Collecting telemetry and logging data for Splunk
 
 Splunk gives the ability to analyze any kind of logging information and to visualize the retrieved information in dashboards.

--- a/test/groovy/PiperExecuteBinTest.groovy
+++ b/test/groovy/PiperExecuteBinTest.groovy
@@ -155,6 +155,41 @@ class PiperExecuteBinTest extends BasePiperTest {
     }
 
     @Test
+    void testPiperExecuteBinANSCredentials() {
+        shellCallRule.setReturnValue('./piper getConfig --contextConfig --stepMetadata \'.pipeline/tmp/metadata/test.yaml\'', '{"fileCredentialsId":"credFile", "tokenCredentialsId":"credToken", "credentialsId":"credUsernamePassword", "dockerImage":"my.Registry/my/image:latest"}')
+
+        def newScript = nullScript
+        newScript.commonPipelineEnvironment.configuration.hooks?.ans?.serviceKeyCredentialsId
+
+        List stepCredentials = [
+        ]
+        stepRule.step.piperExecuteBin(
+                [
+                        juStabUtils: utils,
+                        jenkinsUtilsStub: jenkinsUtils,
+                        testParam: "This is test content",
+                        script: newScript
+                ],
+                'testStep',
+                'metadata/test.yaml',
+                stepCredentials
+        )
+        // asserts
+        assertThat(writeFileRule.files['.pipeline/tmp/metadata/test.yaml'], containsString('name: testStep'))
+        assertThat(withEnvArgs[0], allOf(startsWith('PIPER_parametersJSON'), containsString('"testParam":"This is test content"')))
+        assertThat(shellCallRule.shell[1], is('./piper testStep'))
+        assertThat(credentials.size(), is(3))
+        assertThat(credentials[0], allOf(hasEntry('credentialsId', 'credFile'), hasEntry('variable', 'PIPER_credFile')))
+        assertThat(credentials[1], allOf(hasEntry('credentialsId', 'credToken'), hasEntry('variable', 'PIPER_credToken')))
+        assertThat(credentials[2], allOf(hasEntry('credentialsId', 'credUsernamePassword'), hasEntry('usernameVariable', 'PIPER_user') , hasEntry('passwordVariable', 'PIPER_password')))
+
+        assertThat(dockerExecuteRule.dockerParams.dockerImage, is('my.Registry/my/image:latest'))
+        assertThat(dockerExecuteRule.dockerParams.stashContent, is([]))
+
+        assertThat(artifacts[0], allOf(hasEntry('artifacts', '1234.pdf'), hasEntry('allowEmptyArchive', false)))
+    }
+
+    @Test
     void testPiperExecuteBinDontResolveCredentialsAndNoCredId() {
 
         // In case we have a credential entry without Id we drop that silenty.

--- a/test/groovy/PiperExecuteBinTest.groovy
+++ b/test/groovy/PiperExecuteBinTest.groovy
@@ -161,8 +161,7 @@ class PiperExecuteBinTest extends BasePiperTest {
         def newScript = nullScript
         newScript.commonPipelineEnvironment.configuration.hooks = [ans: [serviceKeyCredentialsId: "ansServiceKeyID"]]
 
-        List stepCredentials = [
-        ]
+        List stepCredentials = []
         stepRule.step.piperExecuteBin(
                 [
                         juStabUtils: utils,
@@ -176,7 +175,7 @@ class PiperExecuteBinTest extends BasePiperTest {
         )
         // asserts
         assertThat(credentials.size(), is(1))
-        assertThat(credentials[0], allOf(hasEntry('credentialsId', 'ansServiceKeyID'), hasEntry('variable', 'PIPER_ansServiceKey')))
+        assertThat(credentials[0], allOf(hasEntry('credentialsId', 'ansServiceKeyID'), hasEntry('variable', 'PIPER_ansHookServiceKey')))
     }
 
     @Test

--- a/test/groovy/PiperExecuteBinTest.groovy
+++ b/test/groovy/PiperExecuteBinTest.groovy
@@ -159,7 +159,7 @@ class PiperExecuteBinTest extends BasePiperTest {
         shellCallRule.setReturnValue('./piper getConfig --contextConfig --stepMetadata \'.pipeline/tmp/metadata/test.yaml\'', '{"fileCredentialsId":"credFile", "tokenCredentialsId":"credToken", "credentialsId":"credUsernamePassword", "dockerImage":"my.Registry/my/image:latest"}')
 
         def newScript = nullScript
-        newScript.commonPipelineEnvironment.configuration.hooks?.ans?.serviceKeyCredentialsId
+        newScript.commonPipelineEnvironment.configuration.hooks = [ans: [serviceKeyCredentialsId: "ansServiceKeyID"]]
 
         List stepCredentials = [
         ]
@@ -175,18 +175,8 @@ class PiperExecuteBinTest extends BasePiperTest {
                 stepCredentials
         )
         // asserts
-        assertThat(writeFileRule.files['.pipeline/tmp/metadata/test.yaml'], containsString('name: testStep'))
-        assertThat(withEnvArgs[0], allOf(startsWith('PIPER_parametersJSON'), containsString('"testParam":"This is test content"')))
-        assertThat(shellCallRule.shell[1], is('./piper testStep'))
-        assertThat(credentials.size(), is(3))
-        assertThat(credentials[0], allOf(hasEntry('credentialsId', 'credFile'), hasEntry('variable', 'PIPER_credFile')))
-        assertThat(credentials[1], allOf(hasEntry('credentialsId', 'credToken'), hasEntry('variable', 'PIPER_credToken')))
-        assertThat(credentials[2], allOf(hasEntry('credentialsId', 'credUsernamePassword'), hasEntry('usernameVariable', 'PIPER_user') , hasEntry('passwordVariable', 'PIPER_password')))
-
-        assertThat(dockerExecuteRule.dockerParams.dockerImage, is('my.Registry/my/image:latest'))
-        assertThat(dockerExecuteRule.dockerParams.stashContent, is([]))
-
-        assertThat(artifacts[0], allOf(hasEntry('artifacts', '1234.pdf'), hasEntry('allowEmptyArchive', false)))
+        assertThat(credentials.size(), is(1))
+        assertThat(credentials[0], allOf(hasEntry('credentialsId', 'ansServiceKeyID'), hasEntry('variable', 'PIPER_ansServiceKey')))
     }
 
     @Test

--- a/test/groovy/PiperExecuteBinTest.groovy
+++ b/test/groovy/PiperExecuteBinTest.groovy
@@ -1,4 +1,5 @@
 import com.sap.piper.DebugReport
+import com.sap.piper.DefaultValueCache
 import com.sap.piper.JenkinsUtils
 import groovy.json.JsonSlurper
 import hudson.AbortException
@@ -159,7 +160,7 @@ class PiperExecuteBinTest extends BasePiperTest {
         shellCallRule.setReturnValue('./piper getConfig --contextConfig --stepMetadata \'.pipeline/tmp/metadata/test.yaml\'', '{"fileCredentialsId":"credFile", "tokenCredentialsId":"credToken", "credentialsId":"credUsernamePassword", "dockerImage":"my.Registry/my/image:latest"}')
 
         def newScript = nullScript
-        newScript.commonPipelineEnvironment.configuration.hooks = [ans: [serviceKeyCredentialsId: "ansServiceKeyID"]]
+        DefaultValueCache.createInstance([hooks: [ans: [serviceKeyCredentialsId: "ansServiceKeyID"]]])
 
         List stepCredentials = []
         stepRule.step.piperExecuteBin(
@@ -176,30 +177,7 @@ class PiperExecuteBinTest extends BasePiperTest {
         // asserts
         assertThat(credentials.size(), is(1))
         assertThat(credentials[0], allOf(hasEntry('credentialsId', 'ansServiceKeyID'), hasEntry('variable', 'PIPER_ansHookServiceKey')))
-    }
-
-    @Test
-    void testPiperExecuteBinANSCredentialsFromGeneralSection() {
-        shellCallRule.setReturnValue('./piper getConfig --contextConfig --stepMetadata \'.pipeline/tmp/metadata/test.yaml\'', '{"fileCredentialsId":"credFile", "tokenCredentialsId":"credToken", "credentialsId":"credUsernamePassword", "dockerImage":"my.Registry/my/image:latest"}')
-
-        def newScript = nullScript
-        newScript.commonPipelineEnvironment.configuration.general = [ansServiceKeyCredentialsId: "ansServiceKeyID"]
-
-        List stepCredentials = []
-        stepRule.step.piperExecuteBin(
-                [
-                        juStabUtils: utils,
-                        jenkinsUtilsStub: jenkinsUtils,
-                        testParam: "This is test content",
-                        script: newScript
-                ],
-                'testStep',
-                'metadata/test.yaml',
-                stepCredentials
-        )
-        // asserts
-        assertThat(credentials.size(), is(1))
-        assertThat(credentials[0], allOf(hasEntry('credentialsId', 'ansServiceKeyID'), hasEntry('variable', 'PIPER_ansHookServiceKey')))
+        DefaultValueCache.reset()
     }
 
     @Test

--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -31,8 +31,6 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
         Map stepParameters = prepareStepParameters(parameters)
         echo "Step params $stepParameters"
 
-        //generalConfig = script.commonPipelineEnvironment.configuration.general
-
         withEnv([
             "PIPER_parametersJSON=${groovy.json.JsonOutput.toJson(stepParameters)}",
             "PIPER_correlationID=${env.BUILD_URL}",
@@ -51,7 +49,7 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
             }
 
             //Add ANS credential information to the config
-            config += ["ansServiceKeyCredentialsId": script.commonPipelineEnvironment.configuration.general.ansServiceKeyCredentialsId]
+            config += ["ansServiceKeyCredentialsId": script.commonPipelineEnvironment.configuration.hooks.ansServiceKeyCredentialsId]
 
             // prepare stashes
             // first eliminate empty stashes
@@ -257,10 +255,6 @@ List handleVaultCredentials(config, List credentialInfo) {
     if (config.containsKey('vaultTokenCredentialsId')) {
         credentialInfo += [[type: 'token', id: 'vaultTokenCredentialsId', env: ['PIPER_vaultToken']]]
     }
-
-//    if (config.containsKey('ansServiceKeyCredentialsId')) {
-//        credentialInfo += [[type: 'token', id: 'ansServiceKeyCredentialsId', env: ['PIPER_ansServiceKey']]]
-//    }
 
     return credentialInfo
 }

--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -49,7 +49,10 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
             }
 
             //Add ANS credential information to the config
-            config += ["ansServiceKeyCredentialsId": script.commonPipelineEnvironment.configuration.hooks?.ans?.serviceKeyCredentialsId]
+            ansHookServiceKeyCredentialsId =
+                script.commonPipelineEnvironment.configuration.hooks?.ans?.serviceKeyCredentialsId ?:
+                    script.commonPipelineEnvironment.configuration.general?.ansServiceKeyCredentialsId
+            config += ["ansHookServiceKeyCredentialsId": ansHookServiceKeyCredentialsId]
 
             // prepare stashes
             // first eliminate empty stashes
@@ -260,8 +263,8 @@ List handleVaultCredentials(config, List credentialInfo) {
 }
 
 List handleANSCredentials(config, List credentialInfo){
-    if (config.containsKey('ansServiceKeyCredentialsId')) {
-        credentialInfo += [[type: 'token', id: 'ansServiceKeyCredentialsId', env: ['PIPER_ansServiceKey']]]
+    if (config.containsKey('ansHookServiceKeyCredentialsId')) {
+        credentialInfo += [[type: 'token', id: 'ansHookServiceKeyCredentialsId', env: ['PIPER_ansHookServiceKey']]]
     }
 
     return credentialInfo

--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -49,7 +49,7 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
             }
 
             //Add ANS credential information to the config
-            config += ["ansServiceKeyCredentialsId": script.commonPipelineEnvironment.configuration.hooks.ansServiceKeyCredentialsId]
+            config += ["ansServiceKeyCredentialsId": script.commonPipelineEnvironment.configuration.hooks?.ans?.serviceKeyCredentialsId]
 
             // prepare stashes
             // first eliminate empty stashes

--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -50,6 +50,7 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
 
             //Add ANS credential information to the config
             ansHookServiceKeyCredentialsId =
+                // Allow the user to set the ANS credential ID both in the hooks and the general section
                 script.commonPipelineEnvironment.configuration.hooks?.ans?.serviceKeyCredentialsId ?:
                     script.commonPipelineEnvironment.configuration.general?.ansServiceKeyCredentialsId
             config += ["ansHookServiceKeyCredentialsId": ansHookServiceKeyCredentialsId]

--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -50,9 +50,7 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
 
             //Add ANS credential information to the config
             ansHookServiceKeyCredentialsId =
-                // Allow the user to set the ANS credential ID both in the hooks and the general section
-                script.commonPipelineEnvironment.configuration.hooks?.ans?.serviceKeyCredentialsId ?:
-                    script.commonPipelineEnvironment.configuration.general?.ansServiceKeyCredentialsId
+                DefaultValueCache.getInstance().getDefaultValues().hooks?.ans?.serviceKeyCredentialsId
             config += ["ansHookServiceKeyCredentialsId": ansHookServiceKeyCredentialsId]
 
             // prepare stashes


### PR DESCRIPTION
# Changes
Change piperExecuteBin so that the parameter `ansServiceKeyCredentialsId `set in the hooks section will put that secret information into the environment variable `PIPER_ansServiceKey` for use in the steps.

- [ ] Tests
- [ ] Documentation
