### PR TITLE
remove confusing log message

### DIFF
--- a/cmd/getDefaults.go
+++ b/cmd/getDefaults.go
@@ -43,7 +43,6 @@ func newGetDefaultsUtilsUtils() getDefaultsUtils {
 func DefaultsCommand() *cobra.Command {
 
 	defaultsOptions.openFile = config.OpenPiperFile
-	log.Entry().Info(defaultsOptions)
 	var createDefaultsCmd = &cobra.Command{
 		Use:   "getDefaults",
 		Short: "Retrieves multiple default configurations and outputs them embedded into a JSON object.",


### PR DESCRIPTION
# Changes

This PR gets rid of this confusing log message, which printed by every piper invocation, e.g.:

```diff
 14:45:50  + ./piper version
-14:45:50  time="2022-03-30T12:45:50Z" level=info msg="{  [] 0xa3eb60}" library=SAP/jenkins-library
 14:45:50  [Pipeline] echo
 14:45:50  Piper go binary version: piper-version:
 14:45:50      commit: "1f750af16da119afd9401fe596fefdeeb0c02eab"
 14:45:50      tag: "<n/a>"
```

It appears in our pipeline run 33 times.

It seams to log some pointer to a function.

- [ ] Tests
- [ ] Documentation
