### PR TITLE
feat(cnbBuild): Support of username/password authorization

### DIFF
--- a/pkg/cnbutils/auth.go
+++ b/pkg/cnbutils/auth.go
@@ -28,7 +28,7 @@ func GenerateCnbAuth(config string, utils BuildUtils) (string, error) {
 	auth := map[string]string{}
 	for registry, value := range dockerConfig.AuthConfigs {
 		if value.Auth == "" && value.Username == "" && value.Password == "" {
-			log.Entry().Warnf("docker confing.json contains empty credentails for registry %q. Either 'auth' or 'username' and 'password' have to be provided.", registry)
+			log.Entry().Warnf("docker config.json contains empty credentials for registry %q. Either 'auth' or 'username' and 'password' have to be provided.", registry)
 			continue
 		}
 

--- a/pkg/cnbutils/auth.go
+++ b/pkg/cnbutils/auth.go
@@ -1,6 +1,7 @@
 package cnbutils
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -26,6 +27,15 @@ func GenerateCnbAuth(config string, utils BuildUtils) (string, error) {
 
 	auth := map[string]string{}
 	for registry, value := range dockerConfig.AuthConfigs {
+		if value.Auth == "" && value.Username == "" && value.Password == "" {
+			log.Entry().Warnf("docker confing.json contains empty credentails for registry %q. Either 'auth' or 'username' and 'password' have to be provided.", registry)
+			continue
+		}
+
+		if value.Auth == "" {
+			value.Auth = encodeAuth(value.Username, value.Password)
+		}
+
 		log.Entry().Debugf("Adding credentials for: registry %q", registry)
 
 		auth[registry] = fmt.Sprintf("Basic %s", value.Auth)
@@ -37,4 +47,9 @@ func GenerateCnbAuth(config string, utils BuildUtils) (string, error) {
 	}
 
 	return string(cnbRegistryAuth), nil
+}
+
+func encodeAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
 }

--- a/pkg/cnbutils/auth_test.go
+++ b/pkg/cnbutils/auth_test.go
@@ -15,10 +15,24 @@ func TestGenerateCnbAuth(t *testing.T) {
 	}
 
 	t.Run("successfully generates cnb auth env variable", func(t *testing.T) {
-		mockUtils.AddFile("/test/valid_config.json", []byte("{\"auths\":{\"example.com\":{\"username\":\"username\",\"password\":\"password\",\"auth\":\"dXNlcm5hbWU6cGFzc3dvcmQ=\"}}}"))
+		mockUtils.AddFile("/test/valid_config.json", []byte("{\"auths\":{\"example.com\":{\"auth\":\"dXNlcm5hbWU6cGFzc3dvcmQ=\"}}}"))
 		auth, err := cnbutils.GenerateCnbAuth("/test/valid_config.json", mockUtils)
 		assert.NoError(t, err)
 		assert.Equal(t, "{\"example.com\":\"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"}", auth)
+	})
+
+	t.Run("successfully generates cnb auth env variable from username and password", func(t *testing.T) {
+		mockUtils.AddFile("/test/valid_config.json", []byte("{\"auths\":{\"example.com\":{\"username\":\"username\",\"password\":\"password\"}}}"))
+		auth, err := cnbutils.GenerateCnbAuth("/test/valid_config.json", mockUtils)
+		assert.NoError(t, err)
+		assert.Equal(t, "{\"example.com\":\"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\"}", auth)
+	})
+
+	t.Run("skips registry with empty credentials", func(t *testing.T) {
+		mockUtils.AddFile("/test/valid_config.json", []byte("{\"auths\":{\"example.com\":{}}}"))
+		auth, err := cnbutils.GenerateCnbAuth("/test/valid_config.json", mockUtils)
+		assert.NoError(t, err)
+		assert.Equal(t, "{}", auth)
 	})
 
 	t.Run("successfully generates cnb auth env variable if docker config is not present", func(t *testing.T) {


### PR DESCRIPTION
# Changes

The authorisation used in `cnbBuild` also works if only `username` and `password` are present in the `config.json`.

- [X] Tests
- [ ] Documentation
