### PR TITLE
feat(mavenBuild): publish artifacts info to CPE

### DIFF
--- a/cmd/mavenBuild.go
+++ b/cmd/mavenBuild.go
@@ -110,6 +110,15 @@ func runMavenBuild(config *mavenBuildOptions, telemetryData *telemetry.CustomDat
 		log.Entry().Warnf("failed to create build settings info: %v", err)
 	}
 	commonPipelineEnvironment.custom.buildSettingsInfo = buildSettingsInfo
+	commonPipelineEnvironment.artifacts, err = maven.FindArtifacts(&maven.EvaluateOptions{
+		GlobalSettingsFile:  config.GlobalSettingsFile,
+		M2Path:              config.M2Path,
+		Defines:             defines,
+		ProjectSettingsFile: config.ProjectSettingsFile,
+	}, utils)
+	if err != nil {
+		return errors.Wrap(err, "failed to populate commonPipelineEnvironment.artifacts")
+	}
 
 	if err == nil {
 		if config.Publish && !config.Verify {

--- a/cmd/mavenBuild.go
+++ b/cmd/mavenBuild.go
@@ -110,7 +110,7 @@ func runMavenBuild(config *mavenBuildOptions, telemetryData *telemetry.CustomDat
 		log.Entry().Warnf("failed to create build settings info: %v", err)
 	}
 	commonPipelineEnvironment.custom.buildSettingsInfo = buildSettingsInfo
-	commonPipelineEnvironment.artifacts, err = maven.FindArtifacts(&maven.EvaluateOptions{
+	commonPipelineEnvironment.custom.artifacts, err = maven.FindArtifacts(&maven.EvaluateOptions{
 		GlobalSettingsFile:  config.GlobalSettingsFile,
 		M2Path:              config.M2Path,
 		Defines:             defines,

--- a/cmd/mavenBuild_generated.go
+++ b/cmd/mavenBuild_generated.go
@@ -42,7 +42,8 @@ type mavenBuildOptions struct {
 }
 
 type mavenBuildCommonPipelineEnvironment struct {
-	custom struct {
+	artifacts piperenv.Artifacts
+	custom    struct {
 		buildSettingsInfo string
 	}
 }
@@ -54,6 +55,7 @@ func (p *mavenBuildCommonPipelineEnvironment) persist(path, resourceName string)
 		value    interface{}
 	}{
 		{category: "custom", name: "buildSettingsInfo", value: p.custom.buildSettingsInfo},
+		{category: "", name: "artifacts", value: p.artifacts},
 	}
 
 	errCount := 0
@@ -495,6 +497,7 @@ func mavenBuildMetadata() config.StepData {
 						Type: "piperEnvironment",
 						Parameters: []map[string]interface{}{
 							{"name": "custom/buildSettingsInfo"},
+							{"name": "artifacts", "type": "piperenv.Artifacts"},
 						},
 					},
 					{

--- a/cmd/mavenBuild_generated.go
+++ b/cmd/mavenBuild_generated.go
@@ -42,9 +42,9 @@ type mavenBuildOptions struct {
 }
 
 type mavenBuildCommonPipelineEnvironment struct {
-	artifacts piperenv.Artifacts
-	custom    struct {
+	custom struct {
 		buildSettingsInfo string
+		artifacts         piperenv.Artifacts
 	}
 }
 
@@ -55,7 +55,7 @@ func (p *mavenBuildCommonPipelineEnvironment) persist(path, resourceName string)
 		value    interface{}
 	}{
 		{category: "custom", name: "buildSettingsInfo", value: p.custom.buildSettingsInfo},
-		{category: "", name: "artifacts", value: p.artifacts},
+		{category: "custom", name: "artifacts", value: p.custom.artifacts},
 	}
 
 	errCount := 0
@@ -497,7 +497,7 @@ func mavenBuildMetadata() config.StepData {
 						Type: "piperEnvironment",
 						Parameters: []map[string]interface{}{
 							{"name": "custom/buildSettingsInfo"},
-							{"name": "artifacts", "type": "piperenv.Artifacts"},
+							{"name": "custom/artifacts", "type": "piperenv.Artifacts"},
 						},
 					},
 					{

--- a/cmd/mavenBuild_test.go
+++ b/cmd/mavenBuild_test.go
@@ -42,7 +42,7 @@ func TestMavenBuild(t *testing.T) {
 		err := runMavenBuild(&config, nil, &mockedUtils, &cpe)
 
 		assert.Nil(t, err)
-		assert.ElementsMatch(t, cpe.artifacts, []piperenv.Artifact{{
+		assert.ElementsMatch(t, cpe.custom.artifacts, []piperenv.Artifact{{
 			Path: "target/artifacts-test.jar",
 		}, {
 			Path: "target/artifacts-test.war",

--- a/cmd/mavenBuild_test.go
+++ b/cmd/mavenBuild_test.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"testing"
 
+	piperconf "github.com/SAP/jenkins-library/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestMavenBuild(t *testing.T) {
+	configOptions.openFile = piperconf.OpenPiperFile
 
 	cpe := mavenBuildCommonPipelineEnvironment{}
 

--- a/cmd/mavenBuild_test.go
+++ b/cmd/mavenBuild_test.go
@@ -34,6 +34,7 @@ func TestMavenBuild(t *testing.T) {
 
 		mockedUtils.StdoutReturn = map[string]string{
 			"mvn .*project.build.finalName": "artifacts-test",
+			"mvn .*project.packaging":       "jar",
 		}
 
 		config := mavenBuildOptions{}
@@ -43,11 +44,8 @@ func TestMavenBuild(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.ElementsMatch(t, cpe.custom.artifacts, []piperenv.Artifact{{
+			Name: "artifacts-test.jar",
 			Path: "target/artifacts-test.jar",
-		}, {
-			Path: "target/artifacts-test.war",
-		}, {
-			Path: "target/artifacts-test-classes.jar",
 		}})
 	})
 

--- a/cmd/mavenBuild_test.go
+++ b/cmd/mavenBuild_test.go
@@ -43,13 +43,10 @@ func TestMavenBuild(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.ElementsMatch(t, cpe.artifacts, []piperenv.Artifact{{
-			Kind: "java:jar",
 			Path: "target/artifacts-test.jar",
 		}, {
-			Kind: "java:war",
 			Path: "target/artifacts-test.war",
 		}, {
-			Kind: "java:classes-jar",
 			Path: "target/artifacts-test-classes.jar",
 		}})
 	})

--- a/pkg/piperenv/artifact.go
+++ b/pkg/piperenv/artifact.go
@@ -2,6 +2,8 @@ package piperenv
 
 type Artifact struct {
 	Name string `json:"name,omitempty"`
+	Kind string `json:"kind"`
+	Path string `json:"path"`
 }
 
 type Artifacts []Artifact
@@ -14,5 +16,17 @@ func (a Artifacts) FindByName(name string) Artifacts {
 			filtered = append(filtered, artifact)
 		}
 	}
+	return filtered
+}
+
+func (a Artifacts) FindByKind(kind string) Artifacts {
+	var filtered Artifacts
+
+	for _, artifact := range a {
+		if artifact.Kind == kind {
+			filtered = append(filtered, artifact)
+		}
+	}
+
 	return filtered
 }

--- a/pkg/piperenv/artifact.go
+++ b/pkg/piperenv/artifact.go
@@ -2,7 +2,6 @@ package piperenv
 
 type Artifact struct {
 	Name string `json:"name,omitempty"`
-	Kind string `json:"kind"`
 	Path string `json:"path"`
 }
 
@@ -16,17 +15,5 @@ func (a Artifacts) FindByName(name string) Artifacts {
 			filtered = append(filtered, artifact)
 		}
 	}
-	return filtered
-}
-
-func (a Artifacts) FindByKind(kind string) Artifacts {
-	var filtered Artifacts
-
-	for _, artifact := range a {
-		if artifact.Kind == kind {
-			filtered = append(filtered, artifact)
-		}
-	}
-
 	return filtered
 }

--- a/pkg/piperenv/artifact_test.go
+++ b/pkg/piperenv/artifact_test.go
@@ -17,19 +17,3 @@ func Test_Artifacts_FindByName(t *testing.T) {
 	require.Len(t, filtered, 1)
 	assert.Equal(t, "a.jar", filtered[0].Name)
 }
-
-func Test_Artifacts_FindByKind(t *testing.T) {
-	artifacts := Artifacts([]Artifact{{
-		Path: "a.jar",
-		Kind: "jar",
-	}, {
-		Path: "b",
-		Kind: "elf",
-	}})
-
-	assert.Len(t, artifacts.FindByKind("garbage"), 0)
-
-	filtered := artifacts.FindByKind("jar")
-	require.Len(t, filtered, 1)
-	assert.Equal(t, "a.jar", filtered[0].Path)
-}

--- a/pkg/piperenv/artifact_test.go
+++ b/pkg/piperenv/artifact_test.go
@@ -17,3 +17,19 @@ func Test_Artifacts_FindByName(t *testing.T) {
 	require.Len(t, filtered, 1)
 	assert.Equal(t, "a.jar", filtered[0].Name)
 }
+
+func Test_Artifacts_FindByKind(t *testing.T) {
+	artifacts := Artifacts([]Artifact{{
+		Path: "a.jar",
+		Kind: "jar",
+	}, {
+		Path: "b",
+		Kind: "elf",
+	}})
+
+	assert.Len(t, artifacts.FindByKind("garbage"), 0)
+
+	filtered := artifacts.FindByKind("jar")
+	require.Len(t, filtered, 1)
+	assert.Equal(t, "a.jar", filtered[0].Path)
+}

--- a/resources/metadata/mavenBuild.yaml
+++ b/resources/metadata/mavenBuild.yaml
@@ -236,6 +236,8 @@ spec:
         type: piperEnvironment
         params:
           - name: custom/buildSettingsInfo
+          - name: artifacts
+            type: "piperenv.Artifacts"
       - name: reports
         type: reports
         params:

--- a/resources/metadata/mavenBuild.yaml
+++ b/resources/metadata/mavenBuild.yaml
@@ -236,7 +236,7 @@ spec:
         type: piperEnvironment
         params:
           - name: custom/buildSettingsInfo
-          - name: artifacts
+          - name: custom/artifacts
             type: "piperenv.Artifacts"
       - name: reports
         type: reports


### PR DESCRIPTION
# Changes
This change would introduce a new concept to the Piper called 'Artifacts' which contains the information on which artifacts are generated by the Maven step. The same concept can be followed through other steps in future. 

- [x] Tests
- [ ] Documentation
