### PR TITLE
Added parameter to define availability zone for deploy/rolling-update

### DIFF
--- a/src/com/sap/piper/tools/neo/NeoCommandHelper.groovy
+++ b/src/com/sap/piper/tools/neo/NeoCommandHelper.groovy
@@ -147,6 +147,10 @@ class NeoCommandHelper {
         if (deploymentConfiguration.containsKey('vmArguments')) {
             args += " --vm-arguments ${BashUtils.quoteAndEscape(deploymentConfiguration.vmArguments)}"
         }
+        
+        if (deploymentConfiguration.containsKey('azDistribution')) {
+            args += " --az-distribution ${BashUtils.quoteAndEscape(deploymentConfiguration.azDistribution)}"
+        }
 
         return args
     }

--- a/test/groovy/com/sap/piper/tools/neo/NeoCommandHelperTest.groovy
+++ b/test/groovy/com/sap/piper/tools/neo/NeoCommandHelperTest.groovy
@@ -29,6 +29,7 @@ class NeoCommandHelperTest extends BasePiperTest {
             runtimeVersion: '2',
             size          : 'lite',
             propertiesFile: 'file.properties'
+            azDistribution: '2'
         ]
 
         String source = (deployMode == DeployMode.MTA) ? 'file.mta' : 'file.war'
@@ -75,6 +76,7 @@ class NeoCommandHelperTest extends BasePiperTest {
         Assert.assertTrue(actual.contains('--runtime \'neо-javaee6-wp\''))
         Assert.assertTrue(actual.contains(' --runtime-version \'2\''))
         Assert.assertTrue(actual.contains(' --size \'lite\''))
+        Assert.assertTrue(actual.contains(' --az-distribution \'2\''))
     }
 
     @Test
@@ -96,6 +98,7 @@ class NeoCommandHelperTest extends BasePiperTest {
         Assert.assertTrue(actual.contains(' --runtime \'neо-javaee6-wp\''))
         Assert.assertTrue(actual.contains(' --runtime-version \'2\''))
         Assert.assertTrue(actual.contains(' --size \'lite\''))
+        Assert.assertTrue(actual.contains(' --az-distribution \'2\''))
     }
 
     @Test

--- a/test/groovy/com/sap/piper/tools/neo/NeoCommandHelperTest.groovy
+++ b/test/groovy/com/sap/piper/tools/neo/NeoCommandHelperTest.groovy
@@ -28,7 +28,7 @@ class NeoCommandHelperTest extends BasePiperTest {
             runtime       : 'neо-javaee6-wp',
             runtimeVersion: '2',
             size          : 'lite',
-            propertiesFile: 'file.properties'
+            propertiesFile: 'file.properties',
             azDistribution: '2'
         ]
 

--- a/vars/neoDeploy.groovy
+++ b/vars/neoDeploy.groovy
@@ -96,7 +96,13 @@ import static com.sap.piper.Prerequisites.checkScript
      * Site ID of the SAP Fiori Launchpad containing the SAP Fiori app. If not set, the cache of the default site, as defined in the Portal service, is invalidated.
      * @parentConfigKey neo
      */
-    'siteId'
+    'siteId',
+    /**
+     * Availability zone of BTP NEO into which the application is deployed.
+     * @possibleValues 1, 2
+     * @parentConfigKey neo
+     */
+    'azDistribution'
 ]
 
 @Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS.plus([


### PR DESCRIPTION
Dear colleagues,

the NEO cli supports the undocumented parameter `--az-distribution` which allows to control into which availability zone an application is deployed. This parameter is currently not usable with `neoDeploy` step of Piper but would be required for users of BTP NEO that want/need to run their applications on the longer-term available BTP NEO infrastructure.

This parameter is implicitly set by `neo deploy` and `neo rolling-update` commands to value `1` which is the original BTP NEO infrastructure on GMP. In order to switch to the longer-term available infrastructure in CC, the value would need to explicitly set to `2`. Also subsequent calls to `neo deploy` and `neo rolling-update` do make use of this defaulting and do not use the same availability zone assignment as the previous call.

Hence, I propose to add this parameter to the `neoDeploy` step.

# Changes

- Enhanced `NeoCommandHelper` with `--az-distribution` parameter for deploy modes `warParams` and `warPropertiesFile`
- [X] Tests
    - Enhanced `NeoCommandHelperTest` with setting of the parameter and checking that it is available
- [X] Documentation
    - Added documentation of the new parameter under `neo` parameter to `neoDeploy.groovy`

BR, Stefan