### PR TITLE
chore(cnbbuild): Use builder:base instead of builder:full because `nc` is no longer needed

### DIFF
--- a/cmd/cnbBuild_generated.go
+++ b/cmd/cnbBuild_generated.go
@@ -348,7 +348,7 @@ func cnbBuildMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "paketobuildpacks/builder:full"},
+				{Image: "paketobuildpacks/builder:base"},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/cnbBuild_test.go
+++ b/cmd/cnbBuild_test.go
@@ -452,7 +452,7 @@ uri = "some-buildpack"`))
 		assert.Equal(t, "folder", string(customData.Data[0].Path))
 		assert.Contains(t, customData.Data[0].AdditionalTags, "latest")
 		assert.Contains(t, customData.Data[0].BindingKeys, "SECRET")
-		assert.Equal(t, "paketobuildpacks/builder:full", customData.Data[0].Builder)
+		assert.Equal(t, "paketobuildpacks/builder:base", customData.Data[0].Builder)
 
 		assert.Contains(t, customData.Data[0].Buildpacks.FromConfig, "paketobuildpacks/java")
 		assert.NotContains(t, customData.Data[0].Buildpacks.FromProjectDescriptor, "paketobuildpacks/java")

--- a/documentation/docs/steps/cnbBuild.md
+++ b/documentation/docs/steps/cnbBuild.md
@@ -23,7 +23,7 @@ via _Jenkins_ -> _Credentials_ -> _System_ -> _Global credentials (unrestricted)
 ### Additional hints
 
 To run the `cnbBuild` with a different builder, you can specify the `dockerImage` parameter.
-Without specifying it, the step will run with the `paketobuildpacks/builder:full` builder.
+Without specifying it, the step will run with the `paketobuildpacks/builder:base` builder.
 
 #### Default Excludes
 

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -248,4 +248,4 @@ spec:
           - name: container/imageDigests
             type: "[]string"
   containers:
-    - image: "paketobuildpacks/builder:full"
+    - image: "paketobuildpacks/builder:base"


### PR DESCRIPTION
Since `nc` is no longer used as a workaround for tcp probes, we can switch to the `builder:base` as default.