### PR TITLE
fix(mtaBuild): Use correct file path when publishing MTAR

### DIFF
--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -288,7 +288,7 @@ func runMtaBuild(config mtaBuildOptions,
 
 				log.Entry().Infof("pushing mtar artifact to repository : %s", config.MtaDeploymentRepositoryURL)
 
-				data, err := os.Open(mtarName)
+				data, err := os.Open(getMtarFilePath(config, mtarName))
 				if err != nil {
 					return errors.Wrap(err, "failed to open mtar archive for upload")
 				}


### PR DESCRIPTION
# Changes

Use full file path when trying to publish MTAR in `mtaBuild` step.

This should fix #3734.

- [ ] Tests
- [ ] Documentation
