### PR TITLE
feat(getDefaults): add parameter for CRD-style config

### DIFF
--- a/cmd/getDefaults.go
+++ b/cmd/getDefaults.go
@@ -17,6 +17,7 @@ type defaultsCommandOptions struct {
 	output        string //output format of default configs, currently only YAML
 	outputFile    string //if set: path to file where the output should be written to
 	defaultsFiles []string
+	useV1         bool
 	openFile      func(s string, t map[string]string) (io.ReadCloser, error)
 }
 
@@ -77,15 +78,28 @@ func getDefaults() ([]map[string]string, error) {
 			return yamlDefaults, errors.Wrapf(err, "defaults: retrieving defaults file failed: '%v'", f)
 		}
 		if err == nil {
-			var c config.Config
-			c.ReadConfig(fc)
+			var yamlContent string
 
-			yaml, err := config.GetYAML(c)
-			if err != nil {
-				return yamlDefaults, errors.Wrapf(err, "defaults: could not marshal YAML default file: '%v", f)
+			if !defaultsOptions.useV1 {
+				var c config.Config
+				c.ReadConfig(fc)
+
+				yamlContent, err = config.GetYAML(c)
+				if err != nil {
+					return yamlDefaults, errors.Wrapf(err, "defaults: could not marshal YAML default file: '%v", f)
+				}
+			} else {
+				var rc config.RunConfigV1
+				rc.StageConfigFile = fc
+				rc.LoadConditionsV1()
+
+				yamlContent, err = config.GetYAML(rc.PipelineConfig)
+				if err != nil {
+					return yamlDefaults, errors.Wrapf(err, "defaults: could not marshal YAML default file: '%v", f)
+				}
 			}
 
-			yamlDefaults = append(yamlDefaults, map[string]string{"content": yaml, "filepath": f})
+			yamlDefaults = append(yamlDefaults, map[string]string{"content": yamlContent, "filepath": f})
 		}
 	}
 
@@ -128,6 +142,6 @@ func addDefaultsFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&defaultsOptions.output, "output", "yaml", "Defines the format of the configs embedded into a JSON object")
 	cmd.Flags().StringVar(&defaultsOptions.outputFile, "outputFile", "", "Defines the output filename")
 	cmd.Flags().StringArrayVar(&defaultsOptions.defaultsFiles, "defaultsFile", []string{}, "Defines the input defaults file(s)")
-
+	cmd.Flags().BoolVar(&defaultsOptions.useV1, "useV1", false, "Input files are CRD-style stage configuration")
 	cmd.MarkFlagRequired("defaultsFile")
 }

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -153,6 +153,7 @@ func (r *RunConfig) loadConditions() error {
 	return nil
 }
 
+// LoadConditionsV1 loads stage conditions into PipelineConfig
 func (r *RunConfigV1) LoadConditionsV1() error {
 	defer r.StageConfigFile.Close()
 	content, err := ioutil.ReadAll(r.StageConfigFile)

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -153,7 +153,7 @@ func (r *RunConfig) loadConditions() error {
 	return nil
 }
 
-// LoadConditionsV1 loads stage conditions into PipelineConfig
+// LoadConditionsV1 loads stage conditions (in CRD-style) into PipelineConfig
 func (r *RunConfigV1) LoadConditionsV1() error {
 	defer r.StageConfigFile.Close()
 	content, err := ioutil.ReadAll(r.StageConfigFile)

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -81,7 +81,7 @@ func (r *RunConfigV1) InitRunConfigV1(config *Config, filters map[string]StepFil
 	secrets map[string][]StepSecrets, stepAliases map[string][]Alias, utils piperutils.FileUtils, envRootPath string) error {
 
 	if len(r.PipelineConfig.Spec.Stages) == 0 {
-		if err := r.loadConditionsV1(); err != nil {
+		if err := r.LoadConditionsV1(); err != nil {
 			return fmt.Errorf("failed to load pipeline run conditions: %w", err)
 		}
 	}
@@ -153,7 +153,7 @@ func (r *RunConfig) loadConditions() error {
 	return nil
 }
 
-func (r *RunConfigV1) loadConditionsV1() error {
+func (r *RunConfigV1) LoadConditionsV1() error {
 	defer r.StageConfigFile.Close()
 	content, err := ioutil.ReadAll(r.StageConfigFile)
 	if err != nil {


### PR DESCRIPTION
To enable stage conditions to be parsed properly as well.

Does it still make sense to keep the name of this command as `getDefaults`?

# Changes

- [x] Tests
- [ ] Documentation