### PR TITLE
fix(golangBuild) properly handle multi-package builds

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"text/template"
@@ -18,7 +19,6 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
-
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 
 	"github.com/SAP/jenkins-library/pkg/multiarch"
@@ -182,8 +182,7 @@ func runGolangBuild(config *golangBuildOptions, telemetryData *telemetry.CustomD
 		log.Entry().Infof("ldflags from template: '%v'", ldflags)
 	}
 
-	binaries := []string{}
-
+	var binaries []string
 	platforms, err := multiarch.ParsePlatformStrings(config.TargetArchitectures)
 
 	if err != nil {
@@ -191,14 +190,14 @@ func runGolangBuild(config *golangBuildOptions, telemetryData *telemetry.CustomD
 	}
 
 	for _, platform := range platforms {
-		binary, err := runGolangBuildPerArchitecture(config, utils, ldflags, platform)
+		binaryNames, err := runGolangBuildPerArchitecture(config, utils, ldflags, platform)
 
 		if err != nil {
 			return err
 		}
 
-		if len(binary) > 0 {
-			binaries = append(binaries, binary)
+		if len(binaryNames) > 0 {
+			binaries = append(binaries, binaryNames...)
 		}
 	}
 
@@ -425,8 +424,8 @@ func prepareLdflags(config *golangBuildOptions, utils golangBuildUtils, envRootP
 	return generatedLdflags.String(), nil
 }
 
-func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuildUtils, ldflags string, architecture multiarch.Platform) (string, error) {
-	var binaryName string
+func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuildUtils, ldflags string, architecture multiarch.Platform) ([]string, error) {
+	var binaryNames []string
 
 	envVars := os.Environ()
 	envVars = append(envVars, fmt.Sprintf("GOOS=%v", architecture.OS), fmt.Sprintf("GOARCH=%v", architecture.Arch))
@@ -437,13 +436,25 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 	utils.SetEnv(envVars)
 
 	buildOptions := []string{"build", "-trimpath"}
+
 	if len(config.Output) > 0 {
-		fileExtension := ""
-		if architecture.OS == "windows" {
-			fileExtension = ".exe"
+		if len(config.Packages) > 1 {
+			binaries, outputDir, err := getOutputBinaries(config.Output, config.Packages, utils, architecture)
+			if err != nil {
+				log.SetErrorCategory(log.ErrorBuild)
+				return nil, fmt.Errorf("failed to calculate output binaries or directory, error: %s", err.Error())
+			}
+			buildOptions = append(buildOptions, "-o", outputDir)
+			binaryNames = append(binaryNames, binaries...)
+		} else {
+			fileExtension := ""
+			if architecture.OS == "windows" {
+				fileExtension = ".exe"
+			}
+			binaryName := fmt.Sprintf("%s-%s.%s%s", strings.TrimRight(config.Output, string(os.PathSeparator)), architecture.OS, architecture.Arch, fileExtension)
+			buildOptions = append(buildOptions, "-o", binaryName)
+			binaryNames = append(binaryNames, binaryName)
 		}
-		binaryName = fmt.Sprintf("%v-%v.%v%v", config.Output, architecture.OS, architecture.Arch, fileExtension)
-		buildOptions = append(buildOptions, "-o", binaryName)
 	}
 	buildOptions = append(buildOptions, config.BuildFlags...)
 	if len(ldflags) > 0 {
@@ -454,9 +465,10 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, utils golangBuild
 	if err := utils.RunExecutable("go", buildOptions...); err != nil {
 		log.Entry().Debugf("buildOptions: %v", buildOptions)
 		log.SetErrorCategory(log.ErrorBuild)
-		return "", fmt.Errorf("failed to run build for %v.%v: %w", architecture.OS, architecture.Arch, err)
+		return nil, fmt.Errorf("failed to run build for %v.%v: %w", architecture.OS, architecture.Arch, err)
 	}
-	return binaryName, nil
+
+	return binaryNames, nil
 }
 
 // lookupPrivateModulesRepositories returns a slice of all modules that match the given glob pattern
@@ -511,4 +523,42 @@ func readGoModFile(utils golangBuildUtils) (*modfile.File, error) {
 	}
 
 	return modfile.Parse(modFilePath, modFileContent, nil)
+}
+
+func getOutputBinaries(out string, packages []string, utils golangBuildUtils, architecture multiarch.Platform) ([]string, string, error) {
+	var binaries []string
+	outDir := fmt.Sprintf("%s-%s-%s%c", strings.TrimRight(out, string(os.PathSeparator)), architecture.OS, architecture.Arch, os.PathSeparator)
+
+	for _, pkg := range packages {
+		ok, err := isMainPackage(utils, pkg)
+		if err != nil {
+			return nil, "", err
+		}
+
+		if ok {
+			fileExt := ""
+			if architecture.OS == "windows" {
+				fileExt = ".exe"
+			}
+			binaries = append(binaries, filepath.Join(outDir, filepath.Base(pkg)+fileExt))
+		}
+	}
+
+	return binaries, outDir, nil
+}
+
+func isMainPackage(utils golangBuildUtils, pkg string) (bool, error) {
+	outBuffer := bytes.NewBufferString("")
+	utils.Stdout(outBuffer)
+	utils.Stderr(outBuffer)
+	err := utils.RunExecutable("go", "list", "-f", "{{ .Name }}", pkg)
+	if err != nil {
+		return false, err
+	}
+
+	if outBuffer.String() != "main" {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/cmd/golangBuild_generated.go
+++ b/cmd/golangBuild_generated.go
@@ -483,8 +483,9 @@ func golangBuildMetadata() config.StepData {
 						Name: "privateModulesGitToken",
 						ResourceRef: []config.ResourceReference{
 							{
-								Name: "golangPrivateModulesGitTokenCredentialsId",
-								Type: "secret",
+								Name:  "golangPrivateModulesGitTokenCredentialsId",
+								Param: "password",
+								Type:  "secret",
 							},
 
 							{

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -72,7 +72,7 @@ func newGolangBuildTestsUtils() *golangBuildMockUtils {
 	utils := golangBuildMockUtils{
 		ExecMockRunner: &mock.ExecMockRunner{},
 		FilesMock:      &mock.FilesMock{},
-		//clientOptions:  []piperhttp.ClientOptions{},
+		// clientOptions:  []piperhttp.ClientOptions{},
 		fileUploads: map[string]string{},
 	}
 	return &utils
@@ -632,14 +632,15 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		ldflags := "-X test=test"
 		architecture, _ := multiarch.ParsePlatformString("linux,amd64")
 
-		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		binaryNames, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Contains(t, utils.Calls[0].Params, "-o")
 		assert.Contains(t, utils.Calls[0].Params, "testBin-linux.amd64")
 		assert.Contains(t, utils.Calls[0].Params, "./test/..")
 		assert.Contains(t, utils.Calls[0].Params, "-ldflags")
 		assert.Contains(t, utils.Calls[0].Params, "-X test=test")
-		assert.Equal(t, "testBin-linux.amd64", binaryName)
+		assert.Len(t, binaryNames, 1)
+		assert.Contains(t, binaryNames, "testBin-linux.amd64")
 	})
 
 	t.Run("success - windows", func(t *testing.T) {
@@ -649,11 +650,80 @@ func TestRunGolangBuildPerArchitecture(t *testing.T) {
 		ldflags := ""
 		architecture, _ := multiarch.ParsePlatformString("windows,amd64")
 
-		binaryName, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		binaryNames, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
 		assert.NoError(t, err)
 		assert.Contains(t, utils.Calls[0].Params, "-o")
 		assert.Contains(t, utils.Calls[0].Params, "testBin-windows.amd64.exe")
-		assert.Equal(t, "testBin-windows.amd64.exe", binaryName)
+		assert.Len(t, binaryNames, 1)
+		assert.Contains(t, binaryNames, "testBin-windows.amd64.exe")
+	})
+
+	t.Run("success - multiple main packages (linux)", func(t *testing.T) {
+		t.Parallel()
+		config := golangBuildOptions{Output: "test/", Packages: []string{"package/foo", "package/bar"}}
+		utils := newGolangBuildTestsUtils()
+		utils.StdoutReturn = map[string]string{
+			"go list -f {{ .Name }} package/foo": "main",
+			"go list -f {{ .Name }} package/bar": "main",
+		}
+		ldflags := ""
+		architecture, _ := multiarch.ParsePlatformString("linux,amd64")
+
+		binaryNames, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		assert.NoError(t, err)
+		assert.Contains(t, utils.Calls[0].Params, "list")
+		assert.Contains(t, utils.Calls[0].Params, "package/foo")
+		assert.Contains(t, utils.Calls[1].Params, "list")
+		assert.Contains(t, utils.Calls[1].Params, "package/bar")
+
+		assert.Len(t, binaryNames, 2)
+		assert.Contains(t, binaryNames, "test-linux-amd64/foo")
+		assert.Contains(t, binaryNames, "test-linux-amd64/bar")
+	})
+
+	t.Run("success - multiple main packages (windows)", func(t *testing.T) {
+		t.Parallel()
+		config := golangBuildOptions{Output: "test/", Packages: []string{"package/foo", "package/bar"}}
+		utils := newGolangBuildTestsUtils()
+		utils.StdoutReturn = map[string]string{
+			"go list -f {{ .Name }} package/foo": "main",
+			"go list -f {{ .Name }} package/bar": "main",
+		}
+		ldflags := ""
+		architecture, _ := multiarch.ParsePlatformString("windows,amd64")
+
+		binaryNames, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		assert.NoError(t, err)
+		assert.Contains(t, utils.Calls[0].Params, "list")
+		assert.Contains(t, utils.Calls[0].Params, "package/foo")
+		assert.Contains(t, utils.Calls[1].Params, "list")
+		assert.Contains(t, utils.Calls[1].Params, "package/bar")
+
+		assert.Len(t, binaryNames, 2)
+		assert.Contains(t, binaryNames, "test-windows-amd64/foo.exe")
+		assert.Contains(t, binaryNames, "test-windows-amd64/bar.exe")
+	})
+
+	t.Run("success - multiple mixed packages", func(t *testing.T) {
+		t.Parallel()
+		config := golangBuildOptions{Output: "test/", Packages: []string{"package/foo", "package/bar"}}
+		utils := newGolangBuildTestsUtils()
+		utils.StdoutReturn = map[string]string{
+			"go list -f {{ .Name }} package/foo": "main",
+			"go list -f {{ .Name }} package/bar": "bar",
+		}
+		ldflags := ""
+		architecture, _ := multiarch.ParsePlatformString("linux,amd64")
+
+		binaryNames, err := runGolangBuildPerArchitecture(&config, utils, ldflags, architecture)
+		assert.NoError(t, err)
+		assert.Contains(t, utils.Calls[0].Params, "list")
+		assert.Contains(t, utils.Calls[0].Params, "package/foo")
+		assert.Contains(t, utils.Calls[1].Params, "list")
+		assert.Contains(t, utils.Calls[1].Params, "package/bar")
+
+		assert.Len(t, binaryNames, 1)
+		assert.Contains(t, binaryNames, "test-linux-amd64/foo")
 	})
 
 	t.Run("execution error", func(t *testing.T) {

--- a/integration/integration_golang_test.go
+++ b/integration/integration_golang_test.go
@@ -6,157 +6,92 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/testcontainers/testcontainers-go"
 )
 
 // In this test the piper command golangBuild performs testing, BOM file creation and building a project with entry point in the cmd/server/server.go
 // The configuration for golangBuild can be found in testdata/TestGolangIntegration/golang-project1/.pipeline/config.yml
 func TestGolangBuild_Project1(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	pwd, err := os.Getwd()
-	assert.NoError(t, err, "Getting current working directory failed.")
-	pwd = filepath.Dir(pwd)
-
-	// using custom createTmpDir function to avoid issues with symlinks on Docker for Mac
-	tempDir, err := createTmpDir("")
-	defer os.RemoveAll(tempDir) // clean up
-	assert.NoError(t, err, "Error when creating temp dir")
-
-	err = copyDir(filepath.Join(pwd, "integration", "testdata", "TestGolangIntegration", "golang-project1"), tempDir)
-	if err != nil {
-		t.Fatal("Failed to copy test project.")
-	}
-
-	//workaround to use test script util it is possible to set workdir for Exec call
-	testScript := fmt.Sprintf(`#!/bin/sh
-cd /test
-/piperbin/piper golangBuild >test-log.txt 2>&1
-`)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
-
-	reqNode := testcontainers.ContainerRequest{
-		Image: "golang:1",
-		Cmd:   []string{"tail", "-f"},
-		BindMounts: map[string]string{
-			pwd:     "/piperbin",
-			tempDir: "/test",
-		},
-	}
-
-	nodeContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: reqNode,
-		Started:          true,
+	container := givenThisContainer(t, IntegrationTestDockerExecRunnerBundle{
+		Image:       "golang:1",
+		TestDir:     []string{"testdata", "TestGolangIntegration", "golang-project1"},
+		ExecNoLogin: true,
 	})
-
-	code, err := nodeContainer.Exec(ctx, []string{"sh", "/test/runPiper.sh"})
+	err := container.whenRunningPiperCommand("golangBuild")
 	assert.NoError(t, err)
-	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
-	if err != nil {
-		t.Fatal("Could not read test-log.txt.", err)
-	}
-	output := string(content)
-	assert.Contains(t, output, "info  golangBuild - running command: go install gotest.tools/gotestsum@latest")
-	assert.Contains(t, output, "info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest")
-	assert.Contains(t, output, "info  golangBuild - running command: gotestsum --junitfile TEST-go.xml -- -coverprofile=cover.out ./...")
-	assert.Contains(t, output, "info  golangBuild - DONE 8 tests")
-	assert.Contains(t, output, "info  golangBuild - running command: go tool cover -html cover.out -o coverage.html")
-	assert.Contains(t, output, "info  golangBuild - running command: gotestsum --junitfile TEST-integration.xml -- -tags=integration ./...")
-	assert.Contains(t, output, "info  golangBuild - running command: cyclonedx-gomod mod -licenses -test -output bom.xml")
-	assert.Contains(t, output, "info  golangBuild - running command: go build -trimpath -o golang-app-linux.amd64 cmd/server/server.go")
-	assert.Contains(t, output, "info  golangBuild - SUCCESS")
+	container.assertHasOutput(t, "info  golangBuild - running command: go install gotest.tools/gotestsum@latest")
+	container.assertHasOutput(t, "info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest")
+	container.assertHasOutput(t, "info  golangBuild - running command: gotestsum --junitfile TEST-go.xml -- -coverprofile=cover.out ./...")
+	container.assertHasOutput(t, "info  golangBuild - DONE 8 tests")
+	container.assertHasOutput(t, "info  golangBuild - running command: go tool cover -html cover.out -o coverage.html")
+	container.assertHasOutput(t, "info  golangBuild - running command: gotestsum --junitfile TEST-integration.xml -- -tags=integration ./...")
+	container.assertHasOutput(t, "info  golangBuild - running command: cyclonedx-gomod mod -licenses -test -output bom.xml")
+	container.assertHasOutput(t, "info  golangBuild - running command: go build -trimpath -o golang-app-linux.amd64 cmd/server/server.go")
+	container.assertHasOutput(t, "info  golangBuild - SUCCESS")
 
-	//workaround to use test script util it is possible to set workdir for Exec call
-	testScript = fmt.Sprintf(`#!/bin/sh
-cd /test
-ls -l >files-list.txt 2>&1
-`)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	container.assertHasFile(t, "/project/TEST-go.xml")
+	container.assertHasFile(t, "/project/TEST-integration.xml")
+	container.assertHasFile(t, "/project/bom.xml")
+	container.assertHasFile(t, "/project/cover.out")
+	container.assertHasFile(t, "/project/coverage.html")
+	container.assertHasFile(t, "/project/golang-app-linux.amd64")
+}
 
-	code, err = nodeContainer.Exec(ctx, []string{"sh", "/test/runPiper.sh"})
+// This test extends TestGolangBuild_Project1 with multi-package build
+func TestGolangBuild_Project1_Multipackage(t *testing.T) {
+	t.Parallel()
+
+	container := givenThisContainer(t, IntegrationTestDockerExecRunnerBundle{
+		Image:       "golang:1",
+		TestDir:     []string{"testdata", "TestGolangIntegration", "golang-project1"},
+		ExecNoLogin: true,
+	})
+	err := container.whenRunningPiperCommand("golangBuild", "--packages", "github.com/example/golang-app/cmd/server,github.com/example/golang-app/cmd/helper")
 	assert.NoError(t, err)
-	assert.Equal(t, 0, code)
 
-	content, err = ioutil.ReadFile(filepath.Join(tempDir, "/files-list.txt"))
-	if err != nil {
-		t.Fatal("Could not read files-list.txt.", err)
-	}
-	output = string(content)
-	assert.Contains(t, output, "TEST-go.xml")
-	assert.Contains(t, output, "TEST-integration.xml")
-	assert.Contains(t, output, "bom.xml")
-	assert.Contains(t, output, "cover.out")
-	assert.Contains(t, output, "coverage.html")
-	assert.Contains(t, output, "golang-app-linux.amd64")
+	container.assertHasOutput(t, "info  golangBuild - running command: go install gotest.tools/gotestsum@latest")
+	container.assertHasOutput(t, "info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest")
+	container.assertHasOutput(t, "info  golangBuild - running command: gotestsum --junitfile TEST-go.xml -- -coverprofile=cover.out ./...")
+	container.assertHasOutput(t, "info  golangBuild - DONE 8 tests")
+	container.assertHasOutput(t, "info  golangBuild - running command: go tool cover -html cover.out -o coverage.html")
+	container.assertHasOutput(t, "info  golangBuild - running command: gotestsum --junitfile TEST-integration.xml -- -tags=integration ./...")
+	container.assertHasOutput(t, "info  golangBuild - running command: cyclonedx-gomod mod -licenses -test -output bom.xml")
+	container.assertHasOutput(t, "info  golangBuild - running command: go build -trimpath -o golang-app-linux-amd64/ github.com/example/golang-app/cmd/server github.com/example/golang-app/cmd/helper")
+	container.assertHasOutput(t, "info  golangBuild - SUCCESS")
+
+	container.assertHasFile(t, "/project/TEST-go.xml")
+	container.assertHasFile(t, "/project/TEST-integration.xml")
+	container.assertHasFile(t, "/project/bom.xml")
+	container.assertHasFile(t, "/project/cover.out")
+	container.assertHasFile(t, "/project/coverage.html")
+	container.assertHasFile(t, "/project/golang-app-linux-amd64/server")
+	container.assertHasFile(t, "/project/golang-app-linux-amd64/helper")
 }
 
 // In this test, the piper golangBuild command only builds the project with the entry point at the project root.
 // The configuration for golangBuild can be found in testdata/TestGolangIntegration/golang-project2/.pipeline/config.yml
 func TestGolangBuild_Project2(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
-	pwd, err := os.Getwd()
-	assert.NoError(t, err, "Getting current working directory failed.")
-	pwd = filepath.Dir(pwd)
-
-	// using custom createTmpDir function to avoid issues with symlinks on Docker for Mac
-	tempDir, err := createTmpDir("")
-	defer os.RemoveAll(tempDir) // clean up
-	assert.NoError(t, err, "Error when creating temp dir")
-
-	err = copyDir(filepath.Join(pwd, "integration", "testdata", "TestGolangIntegration", "golang-project2"), tempDir)
-	if err != nil {
-		t.Fatal("Failed to copy test project.")
-	}
-
-	//workaround to use test script util it is possible to set workdir for Exec call
-	testScript := fmt.Sprintf(`#!/bin/sh
-cd /test
-/piperbin/piper golangBuild >test-log.txt 2>&1
-`)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
-
-	reqNode := testcontainers.ContainerRequest{
-		Image: "golang:1",
-		Cmd:   []string{"tail", "-f"},
-		BindMounts: map[string]string{
-			pwd:     "/piperbin",
-			tempDir: "/test",
-		},
-	}
-
-	nodeContainer, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: reqNode,
-		Started:          true,
+	container := givenThisContainer(t, IntegrationTestDockerExecRunnerBundle{
+		Image:       "golang:1",
+		TestDir:     []string{"testdata", "TestGolangIntegration", "golang-project2"},
+		ExecNoLogin: true,
 	})
-
-	code, err := nodeContainer.Exec(ctx, []string{"sh", "/test/runPiper.sh"})
+	err := container.whenRunningPiperCommand("golangBuild")
 	assert.NoError(t, err)
-	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
-	if err != nil {
-		t.Fatal("Could not read test-log.txt.", err)
-	}
-	output := string(content)
-	assert.NotContains(t, output, "info  golangBuild - running command: go install gotest.tools/gotestsum@latest")
-	assert.NotContains(t, output, "info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest")
-	assert.NotContains(t, output, "info  golangBuild - running command: gotestsum --junitfile TEST-go.xml -- -coverprofile=cover.out ./...")
-	assert.NotContains(t, output, "info  golangBuild - running command: go tool cover -html cover.out -o coverage.html")
-	assert.NotContains(t, output, "info  golangBuild - running command: gotestsum --junitfile TEST-integration.xml -- -tags=integration ./...")
-	assert.NotContains(t, output, "info  golangBuild - running command: cyclonedx-gomod mod -licenses -test -output bom.xml")
-	assert.Contains(t, output, "info  golangBuild - running command: go build -trimpath -o golang-app-linux.amd64")
-	assert.Contains(t, output, "info  golangBuild - SUCCESS")
+	container.assertHasNoOutput(t, "info  golangBuild - running command: go install gotest.tools/gotestsum@latest")
+	container.assertHasNoOutput(t, "info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest")
+	container.assertHasNoOutput(t, "info  golangBuild - running command: gotestsum --junitfile TEST-go.xml -- -coverprofile=cover.out ./...")
+	container.assertHasNoOutput(t, "info  golangBuild - running command: go tool cover -html cover.out -o coverage.html")
+	container.assertHasNoOutput(t, "info  golangBuild - running command: gotestsum --junitfile TEST-integration.xml -- -tags=integration ./...")
+	container.assertHasNoOutput(t, "info  golangBuild - running command: cyclonedx-gomod mod -licenses -test -output bom.xml")
+	container.assertHasOutput(t, "info  golangBuild - running command: go build -trimpath -o golang-app-linux.amd64")
+	container.assertHasOutput(t, "info  golangBuild - SUCCESS")
 }

--- a/integration/testdata/TestGolangIntegration/golang-project1/cmd/helper/helper.go
+++ b/integration/testdata/TestGolangIntegration/golang-project1/cmd/helper/helper.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+
+	"github.com/example/golang-app/pkg/http/handlers"
+	"github.com/example/golang-app/pkg/http/middlewares"
+	"github.com/gorilla/mux"
+)
+
+const (
+	defaultServerAddress = "0.0.0.0"
+	defaultServerPort    = "8080"
+)
+
+func main() {
+	serverAddress := flag.String("server.address", defaultServerAddress, "IP address of the HTTP server")
+	serverPort := flag.String("server.port", defaultServerPort, "Port of the HTTP server")
+	flag.Parse()
+
+	router := mux.NewRouter()
+
+	router.HandleFunc("/hello/{who}", middlewares.MultipleMiddleware(handlers.HelloHandler,
+		middlewares.LoggerMiddleware, middlewares.RecoverMiddleware)).Methods("GET", "POST")
+	router.HandleFunc("/panic", middlewares.MultipleMiddleware(handlers.ThrowPanicHandler,
+		middlewares.LoggerMiddleware, middlewares.RecoverMiddleware)).Methods("GET", "POST")
+	http.Handle("/", router)
+
+	fmt.Printf("Server address: %s:%s\n", *serverAddress, *serverPort)
+	fmt.Println("Server is listening...")
+	http.ListenAndServe(fmt.Sprintf("%s:%s", *serverAddress, *serverPort), nil)
+}

--- a/integration/testdata/TestGolangIntegration/golang-project1/go.mod
+++ b/integration/testdata/TestGolangIntegration/golang-project1/go.mod
@@ -1,5 +1,5 @@
 module github.com/example/golang-app
 
-go 1.15
+go 1.18
 
 require github.com/gorilla/mux v1.8.0

--- a/integration/testdata/TestGolangIntegration/golang-project2/go.mod
+++ b/integration/testdata/TestGolangIntegration/golang-project2/go.mod
@@ -1,3 +1,3 @@
 module github.com/example/golang-app
 
-go 1.15
+go 1.18

--- a/resources/metadata/golangBuild.yaml
+++ b/resources/metadata/golangBuild.yaml
@@ -219,6 +219,7 @@ spec:
         resourceRef:
           - name: golangPrivateModulesGitTokenCredentialsId
             type: secret
+            param: password
           - type: vaultSecret
             name: golangPrivateModulesGitTokenVaultSecret
             default: golang

--- a/vars/golangBuild.groovy
+++ b/vars/golangBuild.groovy
@@ -4,6 +4,8 @@ import groovy.transform.Field
 @Field String METADATA_FILE = "metadata/golangBuild.yaml"
 
 void call(Map parameters = [:]) {
-    List credentials = []
+    List credentials = [
+        [type: 'usernamePassword', id: 'golangPrivateModulesGitTokenCredentialsId', env: ['PIPER_privateModulesGitUsername', 'PIPER_privateModulesGitToken']]
+    ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes

This PR fixes several bugs in the `golangBuild` step:

* When using a single package to build, the output binary name will be incorrect, if `config.Output` ends with a `os.PathSeparator` (`/` or `\`)
* When using multiple packages to build, the `-o` flag **MUST** be a directory (`go build` will produce a binary for each `main` package in the list and put it into the output directory)
* Added missing credentials handling for the private modules.

- [X] Tests
- [ ] Documentation
