### PR TITLE
fix(fortifyExecuteScan): do not return if SARIF generation failed

### DIFF
--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -253,12 +253,12 @@ func runFortifyScan(config fortifyExecuteScanOptions, sys fortify.System, utils 
 		log.Entry().Info("Calling conversion to SARIF function.")
 		sarif, err := fortify.ConvertFprToSarif(sys, project, projectVersion, resultFilePath, filterSet)
 		if err != nil {
-			return reports, fmt.Errorf("failed to generate SARIF")
+			log.Entry().WithError(err).Error("failed to generate SARIF")
 		}
 		log.Entry().Debug("Writing sarif file to disk.")
 		paths, err := fortify.WriteSarif(sarif)
 		if err != nil {
-			return reports, fmt.Errorf("failed to write sarif")
+			log.Entry().WithError(err).Error("failed to write sarif")
 		}
 		reports = append(reports, paths...)
 	}


### PR DESCRIPTION
# Changes

Exactly what it says on the tin: replace two return instructions by just logging with errors.

- [ ] Tests
- [ ] Documentation
