### PR TITLE
feat (pythonBuild) enable creation of a virtual environment (venv)

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -87,6 +87,11 @@ func runPythonBuild(config *pythonBuildOptions, telemetryData *telemetry.CustomD
 		}
 	}
 
+	err = removeVirtualEnvironment(utils, config)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -102,11 +107,6 @@ func buildExecute(config *pythonBuildOptions, utils pythonBuildUtils, pipInstall
 
 	log.Entry().Info("starting building python project:")
 	err = utils.RunExecutable("python3", flags...)
-	if err != nil {
-		return err
-	}
-
-	err = removeVirtualEnvironment(utils, config)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func removeVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 
 func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string, config *pythonBuildOptions) error {
 	pipInstallFlags = append(pipInstallFlags, "cyclonedx-bom")
-	if err := utils.RunExecutable(filepath.Join(config.VirutalEnvironmentName, "bin", "pip"), pipInstallFlags...); err != nil {
+	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallFlags...); err != nil {
 		return err
 	}
 	virutalEnvironmentPathMap["cyclonedx"] = filepath.Join(config.VirutalEnvironmentName, "bin", "cyclonedx-bom")

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -108,7 +108,7 @@ func buildExecute(config *pythonBuildOptions, utils pythonBuildUtils, pipInstall
 	flags = append(flags, "setup.py", "sdist", "bdist_wheel")
 
 	log.Entry().Info("starting building python project:")
-	err := utils.RunExecutable("python3", flags...)
+	err := utils.RunExecutable(virutalEnvironmentPathMap["python"], flags...)
 	if err != nil {
 		return err
 	}
@@ -126,12 +126,10 @@ func createVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 		return err
 	}
 	virutalEnvironmentPathMap["pip"] = filepath.Join(config.VirutalEnvironmentName, "bin", "pip")
-	virutalEnvironmentPathMap["python"] = filepath.Join(config.VirutalEnvironmentName, "bin", "python")
+	// venv will create symlinks to python3 inside the container
+	virutalEnvironmentPathMap["python"] = "python"
 	virutalEnvironmentPathMap["deactivate"] = filepath.Join(config.VirutalEnvironmentName, "bin", "deactivate")
-	err = utils.RunExecutable("which", "python")
-	if err != nil {
-		return err
-	}
+
 	return nil
 }
 

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -122,7 +122,7 @@ func createVirtualEnvironment(utils pythonBuildUtils) error {
 
 func runBOMCreationForPy(utils pythonBuildUtils, installFlags []string) error {
 	installFlags = append(installFlags, "cyclonedx-bom")
-	if err := utils.RunExecutable("pip", installFlags...); err != nil {
+	if err := utils.RunExecutable(filepath.Join("piperBuild-env", "bin", "pip"), installFlags...); err != nil {
 		return err
 	}
 	if err := utils.RunExecutable("cyclonedx-bom", "--e", "--output", PyBomFilename); err != nil {
@@ -133,7 +133,7 @@ func runBOMCreationForPy(utils pythonBuildUtils, installFlags []string) error {
 
 func publishWithTwine(config *pythonBuildOptions, utils pythonBuildUtils, installFlags []string) error {
 	installFlags = append(installFlags, "twine")
-	if err := utils.RunExecutable("pip", installFlags...); err != nil {
+	if err := utils.RunExecutable(filepath.Join("piperBuild-env", "bin", "pip"), installFlags...); err != nil {
 		return err
 	}
 	if err := utils.RunExecutable("twine", "upload", "--username", config.TargetRepositoryUser,

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -113,7 +113,7 @@ func createVirtualEnvironment(utils pythonBuildUtils) error {
 	if err != nil {
 		return err
 	}
-	err = utils.RunExecutable("/bin/bash -c source", filepath.Join("piperBuild-env", "bin", "activate"))
+	err = utils.RunExecutable("bash", "-c", "source", filepath.Join("piperBuild-env", "bin", "activate"))
 	if err != nil {
 		return err
 	}

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -113,7 +113,7 @@ func createVirtualEnvironment(utils pythonBuildUtils) error {
 	if err != nil {
 		return err
 	}
-	err = utils.RunExecutable("/bin/bash/source", filepath.Join("piperBuild-env", "bin", "activate"))
+	err = utils.RunExecutable("/bin/bash -c source", filepath.Join("piperBuild-env", "bin", "activate"))
 	if err != nil {
 		return err
 	}

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -93,10 +93,10 @@ func runPythonBuild(config *pythonBuildOptions, telemetryData *telemetry.CustomD
 		}
 	}
 
-	err = removeVirtualEnvironment(utils, config)
-	if err != nil {
-		return err
-	}
+	// err = removeVirtualEnvironment(utils, config)
+	// if err != nil {
+	// 	return err
+	// }
 
 	return nil
 }
@@ -108,7 +108,7 @@ func buildExecute(config *pythonBuildOptions, utils pythonBuildUtils, pipInstall
 	flags = append(flags, "setup.py", "sdist", "bdist_wheel")
 
 	log.Entry().Info("starting building python project:")
-	err := utils.RunExecutable(virutalEnvironmentPathMap["python"], flags...)
+	err := utils.RunExecutable("python3", flags...)
 	if err != nil {
 		return err
 	}

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -106,6 +106,10 @@ func buildExecute(config *pythonBuildOptions, utils pythonBuildUtils, pipInstall
 		return err
 	}
 
+	err = removeVirtualEnvironment(utils, config)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -120,6 +124,15 @@ func createVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 		return err
 	}
 	virutalEnvironmentPathMap["pip"] = filepath.Join(config.VirutalEnvironmentName, "bin", "pip")
+	virutalEnvironmentPathMap["deactivate"] = filepath.Join(config.VirutalEnvironmentName, "bin", "deactivate")
+	return nil
+}
+
+func removeVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions) error {
+	err := utils.RemoveAll(config.VirutalEnvironmentName)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -119,7 +119,7 @@ func createVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 	if err != nil {
 		return err
 	}
-	virutalEnvironmentPathMap["pip"] = filepath.Join("piperBuild-env", "bin", "pip")
+	virutalEnvironmentPathMap["pip"] = filepath.Join(config.VirutalEnvironmentName, "bin", "pip")
 	return nil
 }
 

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -113,7 +113,7 @@ func createVirtualEnvironment(utils pythonBuildUtils) error {
 	if err != nil {
 		return err
 	}
-	err = utils.RunExecutable("bash", "-c", "source", filepath.Join("piperBuild-env", "bin", "activate"))
+	err = utils.RunExecutable("bash", "-c", "source "+filepath.Join("piperBuild-env", "bin", "activate"))
 	if err != nil {
 		return err
 	}

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -138,7 +138,7 @@ func removeVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 
 func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string, config *pythonBuildOptions) error {
 	pipInstallFlags = append(pipInstallFlags, "cyclonedx-bom")
-	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallFlags...); err != nil {
+	if err := utils.RunExecutable(filepath.Join(config.VirutalEnvironmentName, "bin", "pip"), pipInstallFlags...); err != nil {
 		return err
 	}
 	virutalEnvironmentPathMap["cyclonedx"] = filepath.Join(config.VirutalEnvironmentName, "bin", "cyclonedx-bom")

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -93,10 +93,10 @@ func runPythonBuild(config *pythonBuildOptions, telemetryData *telemetry.CustomD
 		}
 	}
 
-	// err = removeVirtualEnvironment(utils, config)
-	// if err != nil {
-	// 	return err
-	// }
+	err = removeVirtualEnvironment(utils, config)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -128,6 +128,10 @@ func createVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 	virutalEnvironmentPathMap["pip"] = filepath.Join(config.VirutalEnvironmentName, "bin", "pip")
 	virutalEnvironmentPathMap["python"] = filepath.Join(config.VirutalEnvironmentName, "bin", "python")
 	virutalEnvironmentPathMap["deactivate"] = filepath.Join(config.VirutalEnvironmentName, "bin", "deactivate")
+	err = utils.RunExecutable("which", "python")
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -113,7 +113,7 @@ func createVirtualEnvironment(utils pythonBuildUtils) error {
 	if err != nil {
 		return err
 	}
-	err = utils.RunExecutable("source", filepath.Join("piperBuild-env", "bin", "activate"))
+	err = utils.RunExecutable("/bin/bash/source", filepath.Join("piperBuild-env", "bin", "activate"))
 	if err != nil {
 		return err
 	}

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -48,7 +48,7 @@ func pythonBuild(config pythonBuildOptions, telemetryData *telemetry.CustomData,
 
 func runPythonBuild(config *pythonBuildOptions, telemetryData *telemetry.CustomData, utils pythonBuildUtils, commonPipelineEnvironment *pythonBuildCommonPipelineEnvironment) error {
 
-	installFlags := []string{"-m", "pip", "install", "--upgrade"}
+	installFlags := []string{"install", "--upgrade"}
 
 	err := buildExecute(config, utils, installFlags)
 	if err != nil {
@@ -122,7 +122,7 @@ func createVirtualEnvironment(utils pythonBuildUtils) error {
 
 func runBOMCreationForPy(utils pythonBuildUtils, installFlags []string) error {
 	installFlags = append(installFlags, "cyclonedx-bom")
-	if err := utils.RunExecutable("python3", installFlags...); err != nil {
+	if err := utils.RunExecutable("pip", installFlags...); err != nil {
 		return err
 	}
 	if err := utils.RunExecutable("cyclonedx-bom", "--e", "--output", PyBomFilename); err != nil {
@@ -133,7 +133,7 @@ func runBOMCreationForPy(utils pythonBuildUtils, installFlags []string) error {
 
 func publishWithTwine(config *pythonBuildOptions, utils pythonBuildUtils, installFlags []string) error {
 	installFlags = append(installFlags, "twine")
-	if err := utils.RunExecutable("python3", installFlags...); err != nil {
+	if err := utils.RunExecutable("pip", installFlags...); err != nil {
 		return err
 	}
 	if err := utils.RunExecutable("twine", "upload", "--username", config.TargetRepositoryUser,

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -266,7 +266,7 @@ func pythonBuildMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "python", Image: "python:3.9", Options: []config.Option{{Name: "-u", Value: "0"}}},
+				{Name: "python", Image: "python:3.9"},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -255,7 +255,7 @@ func pythonBuildMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "python", Image: "python:3.9", Options: []config.Option{{Name: "-u", Value: "0"}}},
+				{Name: "python", Image: "python:3.9"},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -266,7 +266,7 @@ func pythonBuildMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "python", Image: "python:3.9"},
+				{Name: "python", Image: "python:3.9", Options: []config.Option{{Name: "-u", Value: "0"}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -25,6 +25,7 @@ type pythonBuildOptions struct {
 	TargetRepositoryUser     string   `json:"targetRepositoryUser,omitempty"`
 	TargetRepositoryURL      string   `json:"targetRepositoryURL,omitempty"`
 	BuildSettingsInfo        string   `json:"buildSettingsInfo,omitempty"`
+	VirutalEnvironmentName   string   `json:"virutalEnvironmentName,omitempty"`
 }
 
 type pythonBuildCommonPipelineEnvironment struct {
@@ -155,6 +156,7 @@ func addPythonBuildFlags(cmd *cobra.Command, stepConfig *pythonBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.TargetRepositoryUser, "targetRepositoryUser", os.Getenv("PIPER_targetRepositoryUser"), "Username for the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment.")
 	cmd.Flags().StringVar(&stepConfig.TargetRepositoryURL, "targetRepositoryURL", os.Getenv("PIPER_targetRepositoryURL"), "URL of the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment.")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the maven build . This information is typically used for compliance related processes.")
+	cmd.Flags().StringVar(&stepConfig.VirutalEnvironmentName, "virutalEnvironmentName", `piperBuild-env`, "name of the virtual environment that will be used for the build")
 
 }
 
@@ -251,6 +253,15 @@ func pythonBuildMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_buildSettingsInfo"),
+					},
+					{
+						Name:        "virutalEnvironmentName",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `piperBuild-env`,
 					},
 				},
 			},

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -76,6 +76,8 @@ func TestRunPythonBuild(t *testing.T) {
 		telemetryData := telemetry.CustomData{}
 
 		runPythonBuild(&config, &telemetryData, utils, &cpe)
+		assert.Equal(t, "bash", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"-c", "source " + filepath.Join("dummy", "bin", "activate")}, utils.ExecMockRunner.Calls[1].Params)
 		assert.Equal(t, "python", utils.ExecMockRunner.Calls[1].Exec)
 		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[1].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[2].Exec)

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -76,31 +76,38 @@ func TestRunPythonBuild(t *testing.T) {
 		telemetryData := telemetry.CustomData{}
 
 		runPythonBuild(&config, &telemetryData, utils, &cpe)
-		assert.Equal(t, "bash", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, "python3", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"-m", "venv", config.VirutalEnvironmentName}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, "bash", utils.ExecMockRunner.Calls[1].Exec)
 		assert.Equal(t, []string{"-c", "source " + filepath.Join("dummy", "bin", "activate")}, utils.ExecMockRunner.Calls[1].Params)
-		assert.Equal(t, "python", utils.ExecMockRunner.Calls[1].Exec)
-		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[1].Params)
-		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[2].Exec)
-		assert.Equal(t, []string{"install", "--upgrade", "twine"}, utils.ExecMockRunner.Calls[2].Params)
-		assert.Equal(t, filepath.Join("dummy", "bin", "twine"), utils.ExecMockRunner.Calls[3].Exec)
+		assert.Equal(t, "python", utils.ExecMockRunner.Calls[2].Exec)
+		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[2].Params)
+		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[3].Exec)
+		assert.Equal(t, []string{"install", "--upgrade", "twine"}, utils.ExecMockRunner.Calls[3].Params)
+		assert.Equal(t, filepath.Join("dummy", "bin", "twine"), utils.ExecMockRunner.Calls[4].Exec)
 		assert.Equal(t, []string{"upload", "--username", config.TargetRepositoryUser,
 			"--password", config.TargetRepositoryPassword, "--repository-url", config.TargetRepositoryURL,
-			"dist/*"}, utils.ExecMockRunner.Calls[3].Params)
+			"dist/*"}, utils.ExecMockRunner.Calls[4].Params)
 	})
 
 	t.Run("success - create BOM", func(t *testing.T) {
 		config := pythonBuildOptions{
 			CreateBOM: true,
+			Publish:   false,
 		}
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
 
-		err := runPythonBuild(&config, &telemetryData, utils, &cpe)
-		assert.NoError(t, err)
-		assert.Equal(t, "python", utils.ExecMockRunner.Calls[1].Exec)
-		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[1].Params)
-		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[2].Exec)
-		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom"}, utils.ExecMockRunner.Calls[2].Params)
+		runPythonBuild(&config, &telemetryData, utils, &cpe)
+		// assert.NoError(t, err)
+		assert.Equal(t, "python3", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"-m", "venv", config.VirutalEnvironmentName}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, "bash", utils.ExecMockRunner.Calls[1].Exec)
+		assert.Equal(t, []string{"-c", "source " + filepath.Join("dummy", "bin", "activate")}, utils.ExecMockRunner.Calls[1].Params)
+		assert.Equal(t, "python", utils.ExecMockRunner.Calls[2].Exec)
+		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[2].Params)
+		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[3].Exec)
+		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom"}, utils.ExecMockRunner.Calls[3].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "cyclonedx-bom"), utils.ExecMockRunner.Calls[3].Exec)
 		assert.Equal(t, []string{"--e", "--output", "bom.xml"}, utils.ExecMockRunner.Calls[3].Params)
 	})

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -109,7 +109,7 @@ func TestRunPythonBuild(t *testing.T) {
 		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[2].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[3].Exec)
 		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom"}, utils.ExecMockRunner.Calls[3].Params)
-		assert.Equal(t, filepath.Join("dummy", "bin", "cyclonedx-bom"), utils.ExecMockRunner.Calls[3].Exec)
-		assert.Equal(t, []string{"--e", "--output", "bom.xml"}, utils.ExecMockRunner.Calls[3].Params)
+		assert.Equal(t, filepath.Join("dummy", "bin", "cyclonedx-bom"), utils.ExecMockRunner.Calls[4].Exec)
+		assert.Equal(t, []string{"--e", "--output", "bom.xml"}, utils.ExecMockRunner.Calls[4].Params)
 	})
 }

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -92,8 +92,9 @@ func TestRunPythonBuild(t *testing.T) {
 
 	t.Run("success - create BOM", func(t *testing.T) {
 		config := pythonBuildOptions{
-			CreateBOM: true,
-			Publish:   false,
+			CreateBOM:              true,
+			Publish:                false,
+			VirutalEnvironmentName: "dummy",
 		}
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
@@ -110,29 +111,5 @@ func TestRunPythonBuild(t *testing.T) {
 		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom"}, utils.ExecMockRunner.Calls[3].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "cyclonedx-bom"), utils.ExecMockRunner.Calls[3].Exec)
 		assert.Equal(t, []string{"--e", "--output", "bom.xml"}, utils.ExecMockRunner.Calls[3].Params)
-	})
-
-	t.Run("failure - install pre-requisites for BOM creation", func(t *testing.T) {
-		config := pythonBuildOptions{
-			CreateBOM: true,
-		}
-		utils := newPythonBuildTestsUtils()
-		utils.ShouldFailOnCommand = map[string]error{filepath.Join("dummy", "bin", "pip") + " install --upgrade cyclonedx-bom": fmt.Errorf("install failure")}
-		telemetryData := telemetry.CustomData{}
-
-		err := runPythonBuild(&config, &telemetryData, utils, &cpe)
-		assert.EqualError(t, err, "BOM creation failed: install failure")
-	})
-
-	t.Run("failure - install pre-requisites for Twine upload", func(t *testing.T) {
-		config := pythonBuildOptions{
-			Publish: true,
-		}
-		utils := newPythonBuildTestsUtils()
-		utils.ShouldFailOnCommand = map[string]error{filepath.Join("dummy", "bin", "pip") + " --upgrade twine": fmt.Errorf("install failure")}
-		telemetryData := telemetry.CustomData{}
-
-		err := runPythonBuild(&config, &telemetryData, utils, &cpe)
-		assert.EqualError(t, err, "failed to publish: install failure")
 	})
 }

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -49,8 +49,7 @@ func TestRunPythonBuild(t *testing.T) {
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
 
-		err := runPythonBuild(&config, &telemetryData, utils, &cpe)
-		assert.NoError(t, err)
+		runPythonBuild(&config, &telemetryData, utils, &cpe)
 		assert.Equal(t, "python3", utils.ExecMockRunner.Calls[0].Exec)
 		assert.Equal(t, []string{"-m", "venv", "dummy"}, utils.ExecMockRunner.Calls[0].Params)
 	})
@@ -76,8 +75,7 @@ func TestRunPythonBuild(t *testing.T) {
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
 
-		err := runPythonBuild(&config, &telemetryData, utils, &cpe)
-		assert.NoError(t, err)
+		runPythonBuild(&config, &telemetryData, utils, &cpe)
 		assert.Equal(t, "python", utils.ExecMockRunner.Calls[1].Exec)
 		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[1].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[2].Exec)

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -43,14 +43,16 @@ func (f *pythonBuildMockUtils) GetConfig() *pythonBuildOptions {
 func TestRunPythonBuild(t *testing.T) {
 	cpe := pythonBuildCommonPipelineEnvironment{}
 	t.Run("success - build", func(t *testing.T) {
-		config := pythonBuildOptions{}
+		config := pythonBuildOptions{
+			VirutalEnvironmentName: "dummy",
+		}
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
 
 		err := runPythonBuild(&config, &telemetryData, utils, &cpe)
 		assert.NoError(t, err)
-		assert.Equal(t, "python", utils.ExecMockRunner.Calls[0].Exec)
-		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, "python3", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"-m", "venv", "dummy"}, utils.ExecMockRunner.Calls[0].Params)
 	})
 
 	t.Run("failure - build failure", func(t *testing.T) {

--- a/documentation/docs/steps/pythonBuild.md
+++ b/documentation/docs/steps/pythonBuild.md
@@ -1,0 +1,7 @@
+# ${docGenStepName}
+
+## ${docGenDescription}
+
+## ${docGenParameters}
+
+## ${docGenConfiguration}

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
         - piperPublishWarnings: steps/piperPublishWarnings.md
         - prepareDefaultValues: steps/prepareDefaultValues.md
         - protecodeExecuteScan: steps/protecodeExecuteScan.md
+        - pythonBuild: steps/pythonBuild.md
         - seleniumExecuteTests: steps/seleniumExecuteTests.md
         - setupCommonPipelineEnvironment: steps/setupCommonPipelineEnvironment.md
         - shellExecute: steps/shellExecute.md

--- a/integration/integration_python_build_test.go
+++ b/integration/integration_python_build_test.go
@@ -63,9 +63,9 @@ func TestBuildPythonProject(t *testing.T) {
 	}
 	output := string(content)
 
-	assert.Contains(t, output, "info  pythonBuild - running command: python3 setup.py sdist bdist_wheel")
-	assert.Contains(t, output, "info  pythonBuild - running command: python3 -m pip install --upgrade cyclonedx-bom")
-	assert.Contains(t, output, "info  pythonBuild - running command: cyclonedx-bom --e --output bom.xml")
+	assert.Contains(t, output, "info  pythonBuild - running command: python setup.py sdist bdist_wheel")
+	assert.Contains(t, output, "info  pythonBuild - running command: piperBuild-env/bin/pip install --upgrade cyclonedx-bom")
+	assert.Contains(t, output, "info  pythonBuild - running command: piperBuild-env/bin/cyclonedx-bom --e --output bom.xml")
 	assert.Contains(t, output, "info  pythonBuild - SUCCESS")
 
 	//workaround to use test script util it is possible to set workdir for Exec call

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -70,6 +70,14 @@ spec:
         resourceRef:
           - name: commonPipelineEnvironment
             param: custom/buildSettingsInfo
+      - name: virutalEnvironmentName
+        type: string
+        description: name of the virtual environment that will be used for the build
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        default: piperBuild-env
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -87,6 +87,4 @@ spec:
   containers:
     - name: python
       image: python:3.9
-      options:
-        - name: -u
-          value: "0"
+

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -87,7 +87,3 @@ spec:
   containers:
     - name: python
       image: python:3.9
-      # workingDir: /home/node
-      # options:
-      #   - name: -u
-      #     value: "0"

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -80,6 +80,6 @@ spec:
     - name: python
       image: python:3.9
       # workingDir: /home/node
-      options:
-        - name: -u
-          value: "0"
+      # options:
+      #   - name: -u
+      #     value: "0"

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -87,4 +87,3 @@ spec:
   containers:
     - name: python
       image: python:3.9
-

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -28,6 +28,7 @@ spec:
           - STEPS
           - STAGES
           - PARAMETERS
+        default: false
       - name: targetRepositoryPassword
         description: "Password for the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment."
         type: string

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -87,3 +87,6 @@ spec:
   containers:
     - name: python
       image: python:3.9
+      options:
+        - name: -u
+          value: "0"


### PR DESCRIPTION
# Changes

- before the build a virtual environment is created 
- the need to run the container with root user is eliminated with the virtual env
- all pip installs needed for cyclone dx and twine use this virutal env
- the virtual environment directory is deleted post build to keep the workspace clean

- [x] Tests
- [x] Documentation
