### PR TITLE
feat(fortifyExecuteScan): SARIF generation improvements

### DIFF
--- a/pkg/format/sarif.go
+++ b/pkg/format/sarif.go
@@ -22,15 +22,16 @@ type Runs struct {
 
 // Results these structs are relevant to the Results object
 type Results struct {
-	RuleID           string            `json:"ruleId"`
-	RuleIndex        int               `json:"ruleIndex"`
-	Level            string            `json:"level,omitempty"`
-	Message          *Message          `json:"message,omitempty"`
-	AnalysisTarget   *ArtifactLocation `json:"analysisTarget,omitempty"`
-	Locations        []Location        `json:"locations,omitempty"`
-	CodeFlows        []CodeFlow        `json:"codeFlows,omitempty"`
-	RelatedLocations []RelatedLocation `json:"relatedLocations,omitempty"`
-	Properties       *SarifProperties  `json:"properties"`
+	RuleID              string              `json:"ruleId"`
+	RuleIndex           int                 `json:"ruleIndex"`
+	Level               string              `json:"level,omitempty"`
+	Message             *Message            `json:"message,omitempty"`
+	AnalysisTarget      *ArtifactLocation   `json:"analysisTarget,omitempty"`
+	Locations           []Location          `json:"locations,omitempty"`
+	CodeFlows           []CodeFlow          `json:"codeFlows,omitempty"`
+	RelatedLocations    []RelatedLocation   `json:"relatedLocations,omitempty"`
+	PartialFingerprints PartialFingerprints `json:"partialFingerprints"`
+	Properties          *SarifProperties    `json:"properties"`
 }
 
 // Message to detail the finding
@@ -54,8 +55,9 @@ type PhysicalLocation struct {
 
 // ArtifactLocation describing the path of the artifact
 type ArtifactLocation struct {
-	URI   string `json:"uri"`
-	Index int    `json:"index"`
+	URI       string `json:"uri"`
+	URIBaseId string `json:"uriBaseId"`
+	Index     int    `json:"index"`
 }
 
 // Region where the finding was detected
@@ -72,6 +74,13 @@ type Region struct {
 // LogicalLocation of the finding
 type LogicalLocation struct {
 	FullyQualifiedName string `json:"fullyQualifiedName"`
+}
+
+// PartialFingerprints
+type PartialFingerprints struct {
+	FortifyInstanceID       string `json:"fortifyInstanceID,omitempty"`
+	CheckmarxSimilarityID   string `json:"checkmarxSimilarityID,omitempty"`
+	PrimaryLocationLineHash string `json:"primaryLocationLineHash,omitempty"`
 }
 
 // SarifProperties adding additional information/context to the finding
@@ -167,7 +176,7 @@ type RelatedPhysicalLocation struct {
 
 // RelatedRegion
 type RelatedRegion struct {
-	StartLine   int `json:"startLine"`
+	StartLine   int `json:"startLine,omitempty"`
 	StartColumn int `json:"startColumn,omitempty"`
 }
 

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -567,11 +567,24 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 	log.Entry().Debug("[SARIF] Now handling results.")
 	for i := 0; i < len(fvdl.Vulnerabilities.Vulnerability); i++ {
 		result := *new(format.Results)
-		result.RuleID = fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.ClassID
+		//result.RuleID = fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.ClassID
+		// Handle ruleID the same way than in Rule
+		idArray := []string{}
+		if fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.Kingdom != "" {
+			idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.Kingdom)
+		}
+		if fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.Type != "" {
+			idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.Type)
+		}
+		if fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.Subtype != "" {
+			idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.Subtype)
+		}
+		result.RuleID = "fortify-" + strings.Join(idArray, "/")
+		// end handle result
 		result.Level = "none" //TODO
 		//get message
 		for j := 0; j < len(fvdl.Description); j++ {
-			if fvdl.Description[j].ClassID == result.RuleID {
+			if fvdl.Description[j].ClassID == fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.ClassID {
 				result.RuleIndex = j
 				rawMessage := unescapeXML(fvdl.Description[j].Abstract.Text)
 				// Replacement defintions in message


### PR DESCRIPTION
# Changes

In the eventuality that SARIF files may be used in GitHub Advanced Security, several improvements have been made to ensure upload could be done without any issues, and to generally increase the quality of files.

- Added and populated the partialFingerprint field (with Fortify InstanceID in both fields)
- Changed indexation origin to 1 (0s must be omitted from SARIF files)
- Rule names now respect the "friendlyName" convention (TitleCase, human-readable)
- Rule IDs are now more human readable, GUID is only passed in the rule GUID field
- Correction to URI paths in case a file on local drive is given
- PhysicalLocation now has more info (column data)
- Several useless comments or legacy code removed, readability improved
- Escaped XML characters in message/short & full descriptions now un-escaped
- threadFlowLocations array removed (see next)
- In each result's threadFlow array, threadflowlocations that were referred to by an index are now passed directly
- If a threadflowlocation had sub-nodes, these are also appended to the threadflow array by a recursive process

- [ ] Tests
- [ ] Documentation
