### PR TITLE
fix (docker pull) pull image if repository name contains dots

### DIFF
--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -194,14 +195,15 @@ func (c *Client) GetRemoteImageInfo(imageSource string) (v1.Image, error) {
 
 func (c *Client) getImageRef(image string) (name.Reference, error) {
 	opts := []name.Option{}
+	registry := ""
 
 	if len(c.registryURL) > 0 {
 		re := regexp.MustCompile(`(?i)^https?://`)
-		registry := re.ReplaceAllString(c.registryURL, "")
+		registry = re.ReplaceAllString(c.registryURL, "")
 		opts = append(opts, name.WithDefaultRegistry(registry))
 	}
 
-	return name.ParseReference(image, opts...)
+	return name.ParseReference(path.Join(registry, image), opts...)
 }
 
 // ImageListWithFilePath compiles container image names based on all Dockerfiles found, considering excludes


### PR DESCRIPTION
# Changes

adjusting the go-containerregistry library to consider dots during registry url parsing by passing the parent base url as well . 

fixes #3668 
- [ ] Tests
- [ ] Documentation
