### PR TITLE
feat(vault): Support custom general purpose vault credentials without prefix

### DIFF
--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -272,7 +272,7 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 	vaultCredentialEnvPrefix, ok := config.Config["vaultCredentialEnvPrefix"].(string)
 	isCredentialEnvPrefixDefault := false
 
-	if !ok || len(vaultCredentialEnvPrefix) == 0 {
+	if !ok {
 		vaultCredentialEnvPrefix = vaultCredentialEnvPrefixDefault
 		isCredentialEnvPrefixDefault = true
 	}


### PR DESCRIPTION
# Changes

The proposed changes would allow setting custom general purpose Vault credentials in a step without the corresponding environment variables having a prefix, i.e., injecting them into the step "as is" (w.r.t. to the existing conversion rules).

This would be helpful for use cases where a command called by a piper step allows configuration directly via environment variables. For example in some of our acceptance tests we download test fixtures from AWS S3 and want to inject the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` via Vault.

- [x] Tests
- [ ] Documentation
