### PR TITLE
replace depreacted strings.Title function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/xuri/excelize/v2 v2.4.1
 	golang.org/x/mod v0.5.1
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
+	golang.org/x/text v0.3.7
 	google.golang.org/api v0.67.0
 	gopkg.in/ini.v1 v1.66.2
 	gopkg.in/yaml.v2 v2.4.0
@@ -285,7 +286,6 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pkg/checkmarx/cxxml_to_sarif.go
+++ b/pkg/checkmarx/cxxml_to_sarif.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/SAP/jenkins-library/pkg/format"
 	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/pkg/errors"
 )
 
@@ -285,7 +286,7 @@ func Parse(data []byte) (format.SARIF, error) {
 		rule.ID = "checkmarx-" + cxxml.Query[i].ID
 		words := strings.Split(cxxml.Query[i].Name, "_")
 		for w := 0; w < len(words); w++ {
-			words[w] = strings.Title(strings.ToLower(words[w]))
+			words[w] = piperutils.Title(strings.ToLower(words[w]))
 		}
 		rule.Name = strings.Join(words, "")
 		rule.HelpURI = baseURL + "queryID=" + cxxml.Query[i].ID + "&queryVersionCode=" + cxxml.Query[i].QueryVersionCode + "&queryTitle=" + cxxml.Query[i].Name

--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -359,7 +359,7 @@ func createPipelineStageDocumentation(stageRunConfig *config.RunConfigV1, stageT
 }
 
 func getBadge(orchestrator string) string {
-	orchestratorOnly := strings.Title(strings.ToLower(orchestrator)) + " only"
+	orchestratorOnly := piperutils.Title(strings.ToLower(orchestrator)) + " only"
 	urlPath := &url.URL{Path: orchestratorOnly}
 	orchestratorOnlyString := urlPath.String()
 

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -15,7 +15,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/format"
 
 	"github.com/SAP/jenkins-library/pkg/log"
-	FileUtils "github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
 )
 
 // FVDL This struct encapsulates everyting in the FVDL document
@@ -505,7 +505,7 @@ func ConvertFprToSarif(sys System, project *models.Project, projectVersion *mode
 		return sarif, err
 	}
 
-	_, err = FileUtils.Unzip(resultFilePath, tmpFolder)
+	_, err = piperutils.Unzip(resultFilePath, tmpFolder)
 	if err != nil {
 		return sarif, err
 	}
@@ -812,7 +812,7 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 					idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Kingdom)
 					words := strings.Split(fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Kingdom, " ")
 					for index, element := range words { // These are required to ensure that titlecase is respected in titles, part of sarif "friendly name" rules
-						words[index] = strings.Title(strings.ToLower(element))
+						words[index] = piperutils.Title(strings.ToLower(element))
 					}
 					nameArray = append(nameArray, words...)
 				}
@@ -820,7 +820,7 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 					idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Type)
 					words := strings.Split(fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Type, " ")
 					for index, element := range words {
-						words[index] = strings.Title(strings.ToLower(element))
+						words[index] = piperutils.Title(strings.ToLower(element))
 					}
 					nameArray = append(nameArray, words...)
 				}
@@ -828,7 +828,7 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 					idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Subtype)
 					words := strings.Split(fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Subtype, " ")
 					for index, element := range words {
-						words[index] = strings.Title(strings.ToLower(element))
+						words[index] = piperutils.Title(strings.ToLower(element))
 					}
 					nameArray = append(nameArray, words...)
 				}

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -640,13 +640,13 @@ func getStepInfo(stepData *config.StepData, osImport bool, exportPrefix string) 
 
 	return stepInfo{
 			StepName:         stepData.Metadata.Name,
-			CobraCmdFuncName: fmt.Sprintf("%vCommand", strings.Title(stepData.Metadata.Name)),
-			CreateCmdVar:     fmt.Sprintf("create%vCmd", strings.Title(stepData.Metadata.Name)),
+			CobraCmdFuncName: fmt.Sprintf("%vCommand", piperutils.Title(stepData.Metadata.Name)),
+			CreateCmdVar:     fmt.Sprintf("create%vCmd", piperutils.Title(stepData.Metadata.Name)),
 			Short:            stepData.Metadata.Description,
 			Long:             stepData.Metadata.LongDescription,
 			StepParameters:   stepData.Spec.Inputs.Parameters,
 			StepAliases:      stepData.Metadata.Aliases,
-			FlagsFunc:        fmt.Sprintf("add%vFlags", strings.Title(stepData.Metadata.Name)),
+			FlagsFunc:        fmt.Sprintf("add%vFlags", piperutils.Title(stepData.Metadata.Name)),
 			OSImport:         osImport,
 			OutputResources:  oRes,
 			ExportPrefix:     exportPrefix,
@@ -787,7 +787,7 @@ func stepTemplate(myStepInfo stepInfo, templateName, goTemplate string) []byte {
 	funcMap := sprig.HermeticTxtFuncMap()
 	funcMap["flagType"] = flagType
 	funcMap["golangName"] = GolangNameTitle
-	funcMap["title"] = strings.Title
+	funcMap["title"] = piperutils.Title
 	funcMap["longName"] = longName
 	funcMap["uniqueName"] = mustUniqName
 	funcMap["isCLIParam"] = isCLIParam
@@ -797,7 +797,7 @@ func stepTemplate(myStepInfo stepInfo, templateName, goTemplate string) []byte {
 
 func stepImplementation(myStepInfo stepInfo, templateName, goTemplate string) []byte {
 	funcMap := sprig.HermeticTxtFuncMap()
-	funcMap["title"] = strings.Title
+	funcMap["title"] = piperutils.Title
 	funcMap["uniqueName"] = mustUniqName
 
 	return generateCode(myStepInfo, templateName, goTemplate, funcMap)
@@ -841,7 +841,7 @@ func golangName(name string) string {
 
 // GolangNameTitle returns name in title case with abbriviations in capital (API, URL, ID, JSON, TLS)
 func GolangNameTitle(name string) string {
-	return strings.Title(golangName(name))
+	return piperutils.Title(golangName(name))
 }
 
 func flagType(paramType string) string {

--- a/pkg/generator/helper/resources.go
+++ b/pkg/generator/helper/resources.go
@@ -3,8 +3,9 @@ package helper
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"text/template"
+
+	"github.com/SAP/jenkins-library/pkg/piperutils"
 )
 
 // PiperEnvironmentResource defines a piper environement resource which stores data across multiple pipeline steps
@@ -69,13 +70,13 @@ func (p *{{ .StepName }}{{ .Name | title}}) persist(path, resourceName string) {
 
 // StructName returns the name of the environment resource struct
 func (p *PiperEnvironmentResource) StructName() string {
-	return fmt.Sprintf("%v%v", p.StepName, strings.Title(p.Name))
+	return fmt.Sprintf("%v%v", p.StepName, piperutils.Title(p.Name))
 }
 
 // StructString returns the golang coding for the struct definition of the environment resource
 func (p *PiperEnvironmentResource) StructString() (string, error) {
 	funcMap := template.FuncMap{
-		"title":             strings.Title,
+		"title":             piperutils.Title,
 		"golangName":        golangName,
 		"resourceFieldType": resourceFieldType,
 	}
@@ -172,7 +173,7 @@ func (i *{{ .StepName }}{{ .Name | title}}) persist(path, resourceName string) {
 // StructString returns the golang coding for the struct definition of the InfluxResource
 func (i *InfluxResource) StructString() (string, error) {
 	funcMap := template.FuncMap{
-		"title":             strings.Title,
+		"title":             piperutils.Title,
 		"golangName":        golangName,
 		"resourceFieldType": resourceFieldType,
 	}
@@ -193,7 +194,7 @@ func (i *InfluxResource) StructString() (string, error) {
 
 // StructName returns the name of the influx resource struct
 func (i *InfluxResource) StructName() string {
-	return fmt.Sprintf("%v%v", i.StepName, strings.Title(i.Name))
+	return fmt.Sprintf("%v%v", i.StepName, piperutils.Title(i.Name))
 }
 
 // PiperEnvironmentResource defines a piper environement resource which stores data across multiple pipeline steps
@@ -250,13 +251,13 @@ func (p *{{ .StepName }}{{ .Name | title}}) persist(stepConfig {{ .StepName }}Op
 
 // StructName returns the name of the environment resource struct
 func (p *ReportsResource) StructName() string {
-	return fmt.Sprintf("%v%v", p.StepName, strings.Title(p.Name))
+	return fmt.Sprintf("%v%v", p.StepName, piperutils.Title(p.Name))
 }
 
 // StructString returns the golang coding for the struct definition of the environment resource
 func (p *ReportsResource) StructString() (string, error) {
 	funcMap := template.FuncMap{
-		"title":             strings.Title,
+		"title":             piperutils.Title,
 		"golangName":        golangName,
 		"resourceFieldType": resourceFieldType,
 	}

--- a/pkg/piperutils/strings.go
+++ b/pkg/piperutils/strings.go
@@ -1,0 +1,10 @@
+package piperutils
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func Title(in string) string {
+	return cases.Title(language.English, cases.NoLower).String(in)
+}

--- a/pkg/piperutils/strings_test.go
+++ b/pkg/piperutils/strings_test.go
@@ -1,0 +1,15 @@
+package piperutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTitle(t *testing.T) {
+	assert.Equal(t, "TEST", Title("tEST"))
+	assert.Equal(t, "Test", Title("test"))
+	assert.Equal(t, "TEST", Title("TEST"))
+	assert.Equal(t, "Test", Title("Test"))
+	assert.Equal(t, "TEST1 Test2 TEsT3 Test4", Title("TEST1 test2 tEsT3 Test4"))
+}


### PR DESCRIPTION
# Changes

Replace [`strings.Title`](https://pkg.go.dev/strings#Title) which is deprecated starting with go 1.18 with [`golang.org/x/text/cases.Title`](https://pkg.go.dev/golang.org/x/text@v0.3.7/cases#Title) as suggested by the go authors.

- [x] Tests
- [ ] Documentation
