### PR TITLE
fix(malwareExecuteScan): Set ImageFormat to tarball

### DIFF
--- a/cmd/malwareExecuteScan.go
+++ b/cmd/malwareExecuteScan.go
@@ -150,9 +150,10 @@ func selectAndPrepareFileForMalwareScan(config *malwareExecuteScanOptions, utils
 			ContainerRegistryUser:     config.ContainerRegistryUser,
 			ContainerRegistryPassword: config.ContainerRegistryPassword,
 			DockerConfigJSON:          config.DockerConfigJSON,
+			ImageFormat:               "tarball",
 		}
 
-		dClientOptions := piperDocker.ClientOptions{ImageName: saveImageOptions.ContainerImage, RegistryURL: saveImageOptions.ContainerRegistryURL, LocalPath: ""}
+		dClientOptions := piperDocker.ClientOptions{ImageName: saveImageOptions.ContainerImage, RegistryURL: saveImageOptions.ContainerRegistryURL, LocalPath: "", ImageFormat: saveImageOptions.ImageFormat}
 		dClient := utils.newDockerClient(dClientOptions)
 
 		tarFile, err := runContainerSaveImage(&saveImageOptions, &telemetry.CustomData{}, "./cache", "", dClient, utils)


### PR DESCRIPTION
# Changes

- [x] Tests
- [x] Documentation

# Issue

The commit https://github.com/SAP/jenkins-library/commit/e6724d7f05f9f7b7a75b96904a487939efce1a91 introduced a new property called `ImageFormat` to the `containerSaveImageOptions` struct.
It also adapted steps such as `protecodeExecuteScan` and `whitesourceExecuteScan` to pass the `ImageFormat`.
However, the `malwareExecuteScan` has not been adapted.
With the latest release, the following happens in our pipelines:
```
[2022-05-19T16:03:04.983Z] + ./piper malwareExecuteScan --defaultConfig .pipeline/piper-defaults.yml,.pipeline/sapgraph-default.yml,.pipeline/sapgraph-monorepo.yml,.pipeline/sapgraph-release.yml,.pipeline/sapgraph-release-monorepo.yml --ignoreCustomDefaults
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Using stageName 'Security' from env variable
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Project config: '.pipeline/config.yml'
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Project defaults: '.pipeline/piper-defaults.yml'
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Project defaults: '.pipeline/sapgraph-default.yml'
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Project defaults: '.pipeline/sapgraph-monorepo.yml'
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Project defaults: '.pipeline/sapgraph-release.yml'
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Project defaults: '.pipeline/sapgraph-release-monorepo.yml'
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Ignoring custom defaults from pipeline config
[2022-05-19T16:03:04.983Z] info  malwareExecuteScan - Fetching secrets from Vault at https://vault.tools.sap
[2022-05-19T16:03:05.278Z] info  malwareExecuteScan - Retrieving hook configuration
[2022-05-19T16:03:05.278Z] info  malwareExecuteScan - Docker credentials configuration: ****
[2022-05-19T16:03:05.278Z] info  malwareExecuteScan - Downloading 'configurable-graphlet:1.4.7-20220519153457' to 'configurable-graphlet_1_4_7-20220519153457.tar'
[2022-05-19T16:03:05.288Z] + ./piper whitesourceExecuteScan --defaultConfig .pipeline/piper-defaults.yml,.pipeline/sapgraph-default.yml,.pipeline/sapgraph-monorepo.yml,.pipeline/sapgraph-release.yml,.pipeline/sapgraph-release-monorepo.yml --ignoreCustomDefaults
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Using stageName 'Security' from env variable
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Project config: '.pipeline/config.yml'
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Project defaults: '.pipeline/piper-defaults.yml'
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Project defaults: '.pipeline/sapgraph-default.yml'
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Project defaults: '.pipeline/sapgraph-monorepo.yml'
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Project defaults: '.pipeline/sapgraph-release.yml'
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Project defaults: '.pipeline/sapgraph-release-monorepo.yml'
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Ignoring custom defaults from pipeline config
[2022-05-19T16:03:05.288Z] info  whitesourceExecuteScan - Fetching secrets from Vault at https://vault.tools.sap
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan - Error: unexpected --format: "" (valid values are: tarball, legacy, and oci)
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan - Usage:
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan -   pull IMAGE TARBALL [flags]
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan - 
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan - Flags:
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan -   -c, --cache_path string   Path to cache image layers
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan -       --format string       Format in which to save images ("tarball", "legacy", or "oci") (default "tarball")
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan -   -h, --help                help for pull
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan - 
[2022-05-19T16:03:05.575Z] info  malwareExecuteScan - fatal error: errorDetails{"category":"undefined","correlationId":"https://graph.jaas-gcp.cloud.sap.corp/job/sapgraph-monorepo/job/configurable-graphlet/job/main/210/","error":"failed to download Docker image configurable-graphlet:1.4.7-20220519153457: failed to download docker image: unexpected --format: \"\" (valid values are: tarball, legacy, and oci)","library":"SAP/jenkins-library","message":"step execution failed","result":"failure","stepName":"malwareExecuteScan","time":"2022-05-19T16:03:05.358683202Z"}
[2022-05-19T16:03:05.575Z] fatal malwareExecuteScan - step execution failed - failed to download Docker image configurable-graphlet:1.4.7-20220519153457: failed to download docker image: unexpected --format: "" (valid values are: tarball, legacy, and oci)
```

This PR adapts `malwareExecuteScan` to always provide `ImageFormat` with `tarball` as a value when downloading the Docker image to be scanned for malware.

addition to #3774