### PR TITLE
cnbBuild: add alias for imageNames for easier valueMapping in helmDeploy

### DIFF
--- a/cmd/cnbBuild.go
+++ b/cmd/cnbBuild.go
@@ -467,7 +467,11 @@ func runCnbBuild(config *cnbBuildOptions, cnbTelemetry *cnbBuildTelemetry, utils
 		commonPipelineEnvironment.container.imageNameTag = fmt.Sprintf("%v:%v", targetImage.ContainerImageName, targetImage.ContainerImageTag)
 	}
 	commonPipelineEnvironment.container.imageNameTags = append(commonPipelineEnvironment.container.imageNameTags, fmt.Sprintf("%v:%v", targetImage.ContainerImageName, targetImage.ContainerImageTag))
-	commonPipelineEnvironment.container.imageNames = append(commonPipelineEnvironment.container.imageNames, targetImage.ContainerImageName)
+	imageNameAlias := targetImage.ContainerImageName
+	if config.Alias != "" {
+		imageNameAlias = config.Alias
+	}
+	commonPipelineEnvironment.container.imageNames = append(commonPipelineEnvironment.container.imageNames, imageNameAlias)
 
 	if config.BuildEnvVars != nil && len(config.BuildEnvVars) > 0 {
 		log.Entry().Infof("Setting custom environment variables: '%v'", config.BuildEnvVars)

--- a/cmd/cnbBuild.go
+++ b/cmd/cnbBuild.go
@@ -468,8 +468,8 @@ func runCnbBuild(config *cnbBuildOptions, cnbTelemetry *cnbBuildTelemetry, utils
 	}
 	commonPipelineEnvironment.container.imageNameTags = append(commonPipelineEnvironment.container.imageNameTags, fmt.Sprintf("%v:%v", targetImage.ContainerImageName, targetImage.ContainerImageTag))
 	imageNameAlias := targetImage.ContainerImageName
-	if config.Alias != "" {
-		imageNameAlias = config.Alias
+	if config.ContainerImageAlias != "" {
+		imageNameAlias = config.ContainerImageAlias
 	}
 	commonPipelineEnvironment.container.imageNames = append(commonPipelineEnvironment.container.imageNames, imageNameAlias)
 

--- a/cmd/cnbBuild_generated.go
+++ b/cmd/cnbBuild_generated.go
@@ -19,6 +19,7 @@ import (
 
 type cnbBuildOptions struct {
 	ContainerImageName        string                   `json:"containerImageName,omitempty"`
+	Alias                     string                   `json:"alias,omitempty"`
 	ContainerImageTag         string                   `json:"containerImageTag,omitempty"`
 	ContainerRegistryURL      string                   `json:"containerRegistryUrl,omitempty"`
 	Buildpacks                []string                 `json:"buildpacks,omitempty"`
@@ -170,6 +171,7 @@ func CnbBuildCommand() *cobra.Command {
 
 func addCnbBuildFlags(cmd *cobra.Command, stepConfig *cnbBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.ContainerImageName, "containerImageName", os.Getenv("PIPER_containerImageName"), "Name of the container which will be built\n`cnbBuild` step will try to identify a containerImageName using the following precedence:\n  1. `containerImageName` parameter.\n  2. `project.id` field of a `project.toml` file.\n  3. `git/repository` parameter of the `commonPipelineEnvironment`.\n  4. `github/repository` parameter of the `commonPipelineEnvironment`.\nIf none of the above was found - an error will be raised.\n")
+	cmd.Flags().StringVar(&stepConfig.Alias, "alias", os.Getenv("PIPER_alias"), "Logical name used for this image.\n")
 	cmd.Flags().StringVar(&stepConfig.ContainerImageTag, "containerImageTag", os.Getenv("PIPER_containerImageTag"), "Tag of the container which will be built")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryURL, "containerRegistryUrl", os.Getenv("PIPER_containerRegistryUrl"), "Container registry where the image should be pushed to")
 	cmd.Flags().StringSliceVar(&stepConfig.Buildpacks, "buildpacks", []string{}, "List of custom buildpacks to use in the form of '$HOSTNAME/$REPO[:$TAG]'.")
@@ -209,6 +211,15 @@ func cnbBuildMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "dockerImageName"}},
 						Default:     os.Getenv("PIPER_containerImageName"),
+					},
+					{
+						Name:        "alias",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_alias"),
 					},
 					{
 						Name: "containerImageTag",

--- a/cmd/cnbBuild_generated.go
+++ b/cmd/cnbBuild_generated.go
@@ -19,7 +19,7 @@ import (
 
 type cnbBuildOptions struct {
 	ContainerImageName        string                   `json:"containerImageName,omitempty"`
-	Alias                     string                   `json:"alias,omitempty"`
+	ContainerImageAlias       string                   `json:"containerImageAlias,omitempty"`
 	ContainerImageTag         string                   `json:"containerImageTag,omitempty"`
 	ContainerRegistryURL      string                   `json:"containerRegistryUrl,omitempty"`
 	Buildpacks                []string                 `json:"buildpacks,omitempty"`
@@ -171,7 +171,7 @@ func CnbBuildCommand() *cobra.Command {
 
 func addCnbBuildFlags(cmd *cobra.Command, stepConfig *cnbBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.ContainerImageName, "containerImageName", os.Getenv("PIPER_containerImageName"), "Name of the container which will be built\n`cnbBuild` step will try to identify a containerImageName using the following precedence:\n  1. `containerImageName` parameter.\n  2. `project.id` field of a `project.toml` file.\n  3. `git/repository` parameter of the `commonPipelineEnvironment`.\n  4. `github/repository` parameter of the `commonPipelineEnvironment`.\nIf none of the above was found - an error will be raised.\n")
-	cmd.Flags().StringVar(&stepConfig.Alias, "alias", os.Getenv("PIPER_alias"), "Logical name used for this image.\n")
+	cmd.Flags().StringVar(&stepConfig.ContainerImageAlias, "containerImageAlias", os.Getenv("PIPER_containerImageAlias"), "Logical name used for this image.\n")
 	cmd.Flags().StringVar(&stepConfig.ContainerImageTag, "containerImageTag", os.Getenv("PIPER_containerImageTag"), "Tag of the container which will be built")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryURL, "containerRegistryUrl", os.Getenv("PIPER_containerRegistryUrl"), "Container registry where the image should be pushed to")
 	cmd.Flags().StringSliceVar(&stepConfig.Buildpacks, "buildpacks", []string{}, "List of custom buildpacks to use in the form of '$HOSTNAME/$REPO[:$TAG]'.")
@@ -213,13 +213,13 @@ func cnbBuildMetadata() config.StepData {
 						Default:     os.Getenv("PIPER_containerImageName"),
 					},
 					{
-						Name:        "alias",
+						Name:        "containerImageAlias",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_alias"),
+						Default:     os.Getenv("PIPER_containerImageAlias"),
 					},
 					{
 						Name: "containerImageTag",

--- a/cmd/cnbBuild_test.go
+++ b/cmd/cnbBuild_test.go
@@ -580,7 +580,7 @@ uri = "some-buildpack"
 			ContainerRegistryURL: imageRegistry,
 			DockerConfigJSON:     "/path/to/my-config.json",
 			AdditionalTags:       []string{"3", "3.1", "3.1", "3.1.5"},
-			MultipleImages:       []map[string]interface{}{{"ContainerImageName": "my-image-0", "Alias": "simple"}, {"ContainerImageName": "my-image-1"}},
+			MultipleImages:       []map[string]interface{}{{"ContainerImageName": "my-image-0", "ContainerImageAlias": "simple"}, {"ContainerImageName": "my-image-1"}},
 		}
 
 		expectedImageCount := len(config.MultipleImages)

--- a/cmd/cnbBuild_test.go
+++ b/cmd/cnbBuild_test.go
@@ -580,7 +580,7 @@ uri = "some-buildpack"
 			ContainerRegistryURL: imageRegistry,
 			DockerConfigJSON:     "/path/to/my-config.json",
 			AdditionalTags:       []string{"3", "3.1", "3.1", "3.1.5"},
-			MultipleImages:       []map[string]interface{}{{"ContainerImageName": "my-image-0"}, {"ContainerImageName": "my-image-1"}},
+			MultipleImages:       []map[string]interface{}{{"ContainerImageName": "my-image-0", "Alias": "simple"}, {"ContainerImageName": "my-image-1"}},
 		}
 
 		expectedImageCount := len(config.MultipleImages)
@@ -612,5 +612,6 @@ uri = "some-buildpack"
 		}
 
 		assert.Equal(t, "my-image-0:3.1.5", commonPipelineEnvironment.container.imageNameTag)
+		assert.Equal(t, []string{"simple", "my-image-1"}, commonPipelineEnvironment.container.imageNames)
 	})
 }

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -51,6 +51,15 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: alias
+        type: string
+        description: |
+          Logical name used for this image.
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: containerImageTag
         aliases:
           - name: artifactVersion
@@ -210,10 +219,12 @@ spec:
           dockerConfigJsonCredentialsId: CREDENTIALS
           multipleImages:
           - containerImageName: java-app
+            alias: java
             buildpacks:
             - "java"
             path: "source/java"
           - containerImageName: nodejs-app
+            alias: nodejs
             containerImageTag: v1.0.0
             buildpacks:
             - "nodejs"

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -51,7 +51,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-      - name: alias
+      - name: containerImageAlias
         type: string
         description: |
           Logical name used for this image.


### PR DESCRIPTION
# Changes

Currently the values for `helmDeploy` are derived from the content of `imageNames`. So an image named "my-image" would get the property `image.my_image.repository` when deploying. This might lead to some confusing situations because the name of the property has to be "guessed (s/-/_/g ...).
Also it is strange that the helm chart would have to be dependent on the name of the actual image.

Introducing this `alias` uncouples the names of the property and the actual image. If no `alias` is provided, the imageName is used.

- [X] Tests
- [X] Documentation
