### PR TITLE
Change pipeline prefix to pipeline

### DIFF
--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -102,9 +102,9 @@ log entry content as follows:
     event template)
   - `ans:sourceEventId`: also set to the "Piper" correlation ID (can also be
     overwritten with the event template)
-  - `pipeline:stepName`: the "Piper" step name
-  - `pipeline:logLevel`: the "Piper" log level
-  - `pipeline:errorCategory`: the "Piper" error category, if available
+  - `cicd:stepName`: the "Piper" step name
+  - `cicd:logLevel`: the "Piper" log level
+  - `cicd:errorCategory`: the "Piper" error category, if available
 
 - `resource`: the following default properties are set by "Piper":
 

--- a/pkg/log/ansHook.go
+++ b/pkg/log/ansHook.go
@@ -45,9 +45,9 @@ func (ansHook *ANSHook) Fire(entry *logrus.Entry) (err error) {
 	} else {
 		stepName = "n/a"
 	}
-	event.Tags["pipeline:stepName"] = stepName
+	event.Tags["cicd:stepName"] = stepName
 	if errorCategory := GetErrorCategory().String(); errorCategory != "undefined" {
-		event.Tags["pipeline:errorCategory"] = errorCategory
+		event.Tags["cicd:errorCategory"] = errorCategory
 	}
 
 	event.EventTimestamp = entry.Time.Unix()
@@ -55,7 +55,7 @@ func (ansHook *ANSHook) Fire(entry *logrus.Entry) (err error) {
 		event.Subject = fmt.Sprintf("Pipeline step '%s' sends '%s'", stepName, event.Severity)
 	}
 	event.Body = entry.Message
-	event.Tags["pipeline:logLevel"] = logLevel.String()
+	event.Tags["cicd:logLevel"] = logLevel.String()
 
 	return ansHook.client.Send(event)
 }

--- a/pkg/log/ansHook_test.go
+++ b/pkg/log/ansHook_test.go
@@ -141,7 +141,7 @@ func TestANSHook_Fire(t *testing.T) {
 		SetErrorCategory(ErrorTest)
 		ansHook.eventTemplate = defaultEvent()
 		require.NoError(t, ansHook.Fire(defaultLogrusEntry()), "error is not nil")
-		assert.Equal(t, "test", registrationUtil.Event.Tags["pipeline:errorCategory"], "error category tag is not as expected")
+		assert.Equal(t, "test", registrationUtil.Event.Tags["cicd:errorCategory"], "error category tag is not as expected")
 		SetErrorCategory(ErrorUndefined)
 		registrationUtil.clearEventTemplate()
 	})
@@ -156,10 +156,10 @@ func TestANSHook_Fire(t *testing.T) {
 		ansHook.eventTemplate = defaultEvent()
 		SetErrorCategory(ErrorTest)
 		require.NoError(t, ansHook.Fire(defaultLogrusEntry()), "error is not nil")
-		assert.Equal(t, "test", registrationUtil.Event.Tags["pipeline:errorCategory"], "error category tag is not as expected")
+		assert.Equal(t, "test", registrationUtil.Event.Tags["cicd:errorCategory"], "error category tag is not as expected")
 		SetErrorCategory(ErrorUndefined)
 		require.NoError(t, ansHook.Fire(defaultLogrusEntry()), "error is not nil")
-		assert.Nil(t, registrationUtil.Event.Tags["pipeline:errorCategory"], "error category tag is not nil")
+		assert.Nil(t, registrationUtil.Event.Tags["cicd:errorCategory"], "error category tag is not nil")
 		registrationUtil.clearEventTemplate()
 	})
 	t.Run("White space messages should not send", func(t *testing.T) {
@@ -180,7 +180,7 @@ func TestANSHook_Fire(t *testing.T) {
 		logrusEntryWithoutStepName := defaultLogrusEntry()
 		logrusEntryWithoutStepName.Data = map[string]interface{}{}
 		require.NoError(t, ansHook.Fire(logrusEntryWithoutStepName), "error is not nil")
-		assert.Equal(t, "n/a", registrationUtil.Event.Tags["pipeline:stepName"], "event step name tag is not as expected.")
+		assert.Equal(t, "n/a", registrationUtil.Event.Tags["cicd:stepName"], "event step name tag is not as expected.")
 		assert.Equal(t, "Pipeline step 'n/a' sends 'WARNING'", registrationUtil.Event.Subject, "event subject is not as expected")
 		registrationUtil.clearEventTemplate()
 	})
@@ -404,8 +404,8 @@ func defaultResultingEvent() ans.Event {
 		"Tags": map[string]interface{}{
 			"ans:correlationId": "1234",
 			"ans:sourceEventId": "1234",
-			"pipeline:stepName": "testStep",
-			"pipeline:logLevel": "warning",
+			"cicd:stepName":     "testStep",
+			"cicd:logLevel":     "warning",
 		},
 	})
 }


### PR DESCRIPTION
# Changes

Changes the ANS (SAP Alert Notification Service) tag prefixes to _cicd_ instead of  the current _pipeline_.

- [x] Tests
- [x] Documentation
