### PR TITLE
fix(pythonBuild): Disable progress bar during twine upload

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -161,7 +161,7 @@ func publishWithTwine(config *pythonBuildOptions, utils pythonBuildUtils, pipIns
 	}
 	virutalEnvironmentPathMap["twine"] = filepath.Join(config.VirutalEnvironmentName, "bin", "twine")
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["twine"], "upload", "--username", config.TargetRepositoryUser,
-		"--password", config.TargetRepositoryPassword, "--repository-url", config.TargetRepositoryURL,
+		"--password", config.TargetRepositoryPassword, "--repository-url", config.TargetRepositoryURL, "--disable-progress-bar",
 		"dist/*"); err != nil {
 		return err
 	}

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -87,7 +87,7 @@ func TestRunPythonBuild(t *testing.T) {
 		assert.Equal(t, filepath.Join("dummy", "bin", "twine"), utils.ExecMockRunner.Calls[4].Exec)
 		assert.Equal(t, []string{"upload", "--username", config.TargetRepositoryUser,
 			"--password", config.TargetRepositoryPassword, "--repository-url", config.TargetRepositoryURL,
-			"dist/*"}, utils.ExecMockRunner.Calls[4].Params)
+			"--disable-progress-bar", "dist/*"}, utils.ExecMockRunner.Calls[4].Params)
 	})
 
 	t.Run("success - create BOM", func(t *testing.T) {


### PR DESCRIPTION
# Changes

Use `twine` in a more CI-friendly way by disabling the progress bar during the upload of a Python package.

At the moment the logs of the `pythonBuild` step look like this, the proposed changes would get rid of the progress bar clutter:
```
info  pythonBuild - Uploading distributions to https://staging.repositories.cloud.sap/stage/reposito
info  pythonBuild - ry/c31a08838081-20220627-142634877-819/
info  pythonBuild - Uploading spotlight_otr_service-1.2.0.20220627142627+493cb2332cfd7b8c8889ca4b9fd
info  pythonBuild - 2b3ac9f7d991c-py3-none-any.whl
info  pythonBuild - 25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/31.1 kB • --:-- • ?
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 31.1/31.1 kB • 00:00 • 79.3 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 31.1/31.1 kB • 00:00 • 79.3 MB/s
info  pythonBuild - 25hUploading spotlight-otr-service-1.2.0.20220627142627+493cb2332cfd7b8c8889ca4b9fd
info  pythonBuild - 2b3ac9f7d991c.tar.gz
info  pythonBuild - 25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/48.8 MB • --:-- • ?
 23% ━━━━━━━━━╺━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 11.2/48.8 MB • 00:01 • 130.6 MB/s
 49% ━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━ 24.0/48.8 MB • 00:01 • 128.1 MB/s
 76% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━ 37.1/48.8 MB • 00:01 • 132.0 MB/s
 94% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━ 45.8/48.8 MB • 00:01 • 92.0 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.8/48.8 MB • 00:00 • 54.4 MB/s
info  pythonBuild - SUCCESS
```

- [x] Tests
- [ ] Documentation
