### PR TITLE
fix(fortifyExecuteScan): remove unneeded parameter (project), fix rule ID in rules

### DIFF
--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -269,7 +269,7 @@ func runFortifyScan(config fortifyExecuteScanOptions, sys fortify.System, utils 
 	if config.ConvertToSarif {
 		resultFilePath := fmt.Sprintf("%vtarget/result.fpr", config.ModulePath)
 		log.Entry().Info("Calling conversion to SARIF function.")
-		sarif, err := fortify.ConvertFprToSarif(sys, project, projectVersion, resultFilePath, filterSet)
+		sarif, err := fortify.ConvertFprToSarif(sys, projectVersion, resultFilePath, filterSet)
 		if err != nil {
 			return reports, fmt.Errorf("failed to generate SARIF")
 		}

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -498,7 +498,7 @@ type Attribute struct {
 }
 
 // ConvertFprToSarif converts the FPR file contents into SARIF format
-func ConvertFprToSarif(sys System, project *models.Project, projectVersion *models.ProjectVersion, resultFilePath string, filterSet *models.FilterSet) (format.SARIF, error) {
+func ConvertFprToSarif(sys System, projectVersion *models.ProjectVersion, resultFilePath string, filterSet *models.FilterSet) (format.SARIF, error) {
 	log.Entry().Debug("Extracting FPR.")
 	var sarif format.SARIF
 	tmpFolder, err := ioutil.TempDir(".", "temp-")
@@ -525,11 +525,11 @@ func ConvertFprToSarif(sys System, project *models.Project, projectVersion *mode
 	}
 
 	log.Entry().Debug("Calling Parse.")
-	return Parse(sys, project, projectVersion, data, filterSet)
+	return Parse(sys, projectVersion, data, filterSet)
 }
 
 // Parse parses the FPR file
-func Parse(sys System, project *models.Project, projectVersion *models.ProjectVersion, data []byte, filterSet *models.FilterSet) (format.SARIF, error) {
+func Parse(sys System, projectVersion *models.ProjectVersion, data []byte, filterSet *models.FilterSet) (format.SARIF, error) {
 	//To read XML data, Unmarshal or Decode can be used, here we use Decode to work on the stream
 	reader := bytes.NewReader(data)
 	decoder := xml.NewDecoder(reader)
@@ -796,7 +796,7 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 		prop.InstanceID = fvdl.Vulnerabilities.Vulnerability[i].InstanceInfo.InstanceID
 		prop.RuleGUID = fvdl.Vulnerabilities.Vulnerability[i].ClassInfo.ClassID
 		//Get the audit data
-		if err := integrateAuditData(prop, fvdl.Vulnerabilities.Vulnerability[i].InstanceInfo.InstanceID, sys, project, projectVersion, auditData, filterSet, oneRequestPerIssueMode, maxretries); err != nil {
+		if err := integrateAuditData(prop, fvdl.Vulnerabilities.Vulnerability[i].InstanceInfo.InstanceID, sys, projectVersion, auditData, filterSet, oneRequestPerIssueMode, maxretries); err != nil {
 			log.Entry().Debug(err)
 			maxretries = maxretries - 1
 			if maxretries >= 0 {
@@ -826,7 +826,7 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 				var nameArray []string
 				var idArray []string
 				if fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Kingdom != "" {
-					idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Kingdom)
+					//idArray = append(idArray, fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Kingdom)
 					words := strings.Split(fvdl.Vulnerabilities.Vulnerability[j].ClassInfo.Kingdom, " ")
 					for index, element := range words { // These are required to ensure that titlecase is respected in titles, part of sarif "friendly name" rules
 						words[index] = piperutils.Title(strings.ToLower(element))
@@ -960,7 +960,7 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 					rls := *new(format.Relationships)
 					rls.Target.Id = cweIds[j]
 					rls.Target.ToolComponent.Name = "CWE"
-					rls.Target.ToolComponent.Guid = "25F72D7E-8A92-459D-AD67-64853F788765"
+					rls.Target.ToolComponent.Guid = "25F72D7E-8A92-459D-AD67-64853F788765" //This might not be exact, it is taken from the Microsoft tool converter
 					rls.Kinds = append(rls.Kinds, "relevant")
 					sarifRule.Relationships = append(sarifRule.Relationships, rls)
 				}
@@ -1179,7 +1179,7 @@ func Parse(sys System, project *models.Project, projectVersion *models.ProjectVe
 	return sarif, nil
 }
 
-func integrateAuditData(ruleProp *format.SarifProperties, issueInstanceID string, sys System, project *models.Project, projectVersion *models.ProjectVersion, auditData []*models.ProjectVersionIssue, filterSet *models.FilterSet, oneRequestPerIssue bool, maxretries int) error {
+func integrateAuditData(ruleProp *format.SarifProperties, issueInstanceID string, sys System, projectVersion *models.ProjectVersion, auditData []*models.ProjectVersionIssue, filterSet *models.FilterSet, oneRequestPerIssue bool, maxretries int) error {
 	// Set default values
 	ruleProp.Audited = false
 	ruleProp.FortifyCategory = "Unknown"
@@ -1201,7 +1201,7 @@ func integrateAuditData(ruleProp *format.SarifProperties, issueInstanceID string
 		err := errors.New("no system instance, lookup impossible for " + issueInstanceID)
 		return err
 	}
-	if project == nil || projectVersion == nil {
+	if projectVersion == nil {
 		err := errors.New("project or projectVersion is undefined: lookup aborted for " + issueInstanceID)
 		return err
 	}

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -1180,6 +1180,7 @@ func Parse(sys System, projectVersion *models.ProjectVersion, data []byte, filte
 }
 
 func integrateAuditData(ruleProp *format.SarifProperties, issueInstanceID string, sys System, projectVersion *models.ProjectVersion, auditData []*models.ProjectVersionIssue, filterSet *models.FilterSet, oneRequestPerIssue bool, maxretries int) error {
+
 	// Set default values
 	ruleProp.Audited = false
 	ruleProp.FortifyCategory = "Unknown"

--- a/pkg/fortify/fpr_to_sarif_test.go
+++ b/pkg/fortify/fpr_to_sarif_test.go
@@ -360,9 +360,8 @@ If you are concerned about leaking system data via NFC on an Android device, you
 	filterSet.Folders = append(filterSet.Folders, &models.FolderDto{GUID: "aaaaaaaa-1111-aaaa-1111-1111aaaaaaaa", Name: "Audit All"})
 
 	t.Run("Valid config", func(t *testing.T) {
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
-		sarif, err := Parse(sys, &project, &projectVersion, []byte(testFvdl), filterSet)
+		sarif, err := Parse(sys, &projectVersion, []byte(testFvdl), filterSet)
 		assert.NoError(t, err, "error")
 		assert.Equal(t, len(sarif.Runs[0].Results), 2)
 		assert.Equal(t, len(sarif.Runs[0].Tool.Driver.Rules), 1)
@@ -371,16 +370,14 @@ If you are concerned about leaking system data via NFC on an Android device, you
 	})
 
 	t.Run("Missing data", func(t *testing.T) {
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
-		_, err := Parse(sys, &project, &projectVersion, []byte{}, filterSet)
+		_, err := Parse(sys, &projectVersion, []byte{}, filterSet)
 		assert.Error(t, err, "EOF")
 	})
 
 	t.Run("No system instance", func(t *testing.T) {
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
-		sarif, err := Parse(nil, &project, &projectVersion, []byte(testFvdl), filterSet)
+		sarif, err := Parse(nil, &projectVersion, []byte(testFvdl), filterSet)
 		assert.NoError(t, err, "error")
 		assert.Equal(t, len(sarif.Runs[0].Results), 2)
 		assert.Equal(t, len(sarif.Runs[0].Tool.Driver.Rules), 1)
@@ -438,10 +435,9 @@ func TestIntegrateAuditData(t *testing.T) {
 
 	t.Run("Successful lookup", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
 		auditData, _ := sys.GetAllIssueDetails(projectVersion.ID)
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &project, &projectVersion, auditData, filterSet, false, 5)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &projectVersion, auditData, filterSet, false, 5)
 		assert.NoError(t, err, "error")
 		assert.Equal(t, ruleProp.Audited, true)
 		assert.Equal(t, ruleProp.ToolState, "Exploitable")
@@ -452,53 +448,40 @@ func TestIntegrateAuditData(t *testing.T) {
 		assert.Equal(t, ruleProp.FortifyCategory, "Audit All")
 	})
 
-	t.Run("Missing project", func(t *testing.T) {
-		ruleProp := *new(format.SarifProperties)
-		projectVersion := models.ProjectVersion{ID: 11037}
-		auditData, _ := sys.GetAllIssueDetails(projectVersion.ID)
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, nil, &projectVersion, auditData, filterSet, false, 5)
-		assert.Error(t, err, "project or projectVersion is undefined: lookup aborted for 11037")
-	})
-
 	t.Run("Missing project version", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		auditData, _ := sys.GetAllIssueDetails(11037)
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &project, nil, auditData, filterSet, false, 5)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, nil, auditData, filterSet, false, 5)
 		assert.Error(t, err, "project or projectVersion is undefined: lookup aborted for 11037")
 	})
 
 	t.Run("Missing sys", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
 		auditData, _ := sys.GetAllIssueDetails(projectVersion.ID)
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", nil, &project, &projectVersion, auditData, filterSet, false, 5)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", nil, &projectVersion, auditData, filterSet, false, 5)
 		assert.Error(t, err, "no system instance, lookup impossible for DUMMYDUMMYDUMMY")
 	})
 
 	t.Run("Missing filterSet", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
 		auditData, _ := sys.GetAllIssueDetails(projectVersion.ID)
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &project, &projectVersion, auditData, nil, false, 5)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &projectVersion, auditData, nil, false, 5)
 		assert.Error(t, err, "no filter set defined, category will be missing from 11037")
 	})
 
 	t.Run("Missing Audit Data", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &project, &projectVersion, nil, filterSet, false, 5)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &projectVersion, nil, filterSet, false, 5)
 		assert.Error(t, err, "not exactly 1 issue found for instance ID 11037, found 0")
 	})
 
 	t.Run("Successful lookup in oneRequestPerInstance mode", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &project, &projectVersion, nil, filterSet, true, 5)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &projectVersion, nil, filterSet, true, 5)
 		assert.NoError(t, err, "error")
 		assert.Equal(t, ruleProp.Audited, true)
 		assert.Equal(t, ruleProp.ToolState, "Exploitable")
@@ -511,19 +494,17 @@ func TestIntegrateAuditData(t *testing.T) {
 
 	t.Run("Max retries set to 0: error raised", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
 		auditData, _ := sys.GetAllIssueDetails(11037)
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &project, &projectVersion, auditData, filterSet, false, 0)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &projectVersion, auditData, filterSet, false, 0)
 		assert.Error(t, err, "request failed: maximum number of retries reached, placeholder values will be set from now on for audit data")
 	})
 
 	t.Run("Max retries set to -1: fail silently", func(t *testing.T) {
 		ruleProp := *new(format.SarifProperties)
-		project := models.Project{}
 		projectVersion := models.ProjectVersion{ID: 11037}
 		auditData, _ := sys.GetAllIssueDetails(11037)
-		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &project, &projectVersion, auditData, filterSet, false, -1)
+		err := integrateAuditData(&ruleProp, "DUMMYDUMMYDUMMY", sys, &projectVersion, auditData, filterSet, false, -1)
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
# Changes

- "project" parameter was unneeded in the code, removed, unit tests adapted
- ruleID in rules still used kingdom, removed

- [x] Tests
- [ ] Documentation
