### PR TITLE
helmExecute: helm lint command takes into account value files provided via helmValues parameter 

### DIFF
--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -186,6 +186,10 @@ func (h *HelmExecute) RunHelmLint() error {
 		h.config.ChartPath,
 	}
 
+	for _, v := range h.config.HelmValues {
+		helmParams = append(helmParams, "--values", v)
+	}
+
 	if h.verbose {
 		helmParams = append(helmParams, "--debug")
 	}

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -185,6 +185,15 @@ func TestRunHelmLint(t *testing.T) {
 				{Exec: "helm", Params: []string{"lint", "."}},
 			},
 		},
+		{
+			config: HelmExecuteOptions{
+				ChartPath:  ".",
+				HelmValues: []string{"./values_1.yaml", "./values_2.yaml"},
+			},
+			expectedExecCalls: []mock.ExecCall{
+				{Exec: "helm", Params: []string{"lint", ".", "--values", "./values_1.yaml", "--values", "./values_2.yaml"}},
+			},
+		},
 	}
 
 	for i, testCase := range testTable {


### PR DESCRIPTION
# Changes

helm lint command takes into account value files provided via ```helmValues``` parameter 

- [x] Tests
- [ ] Documentation
