### PR TITLE
chore: cleanup linting issues in abap steps

### DIFF
--- a/cmd/abapAddonAssemblyKitCheckCVs_test.go
+++ b/cmd/abapAddonAssemblyKitCheckCVs_test.go
@@ -24,7 +24,8 @@ func TestCheckCVsStep(t *testing.T) {
 		err := runAbapAddonAssemblyKitCheckCVs(&config, nil, &utils, &cpe)
 		assert.NoError(t, err, "Did not expect error")
 		var addonDescriptorFinal abaputils.AddonDescriptor
-		json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		err = json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		assert.NoError(t, err)
 		assert.Equal(t, "0001", addonDescriptorFinal.Repositories[0].Version)
 		assert.Equal(t, "0002", addonDescriptorFinal.Repositories[0].SpLevel)
 		assert.Equal(t, "0003", addonDescriptorFinal.Repositories[0].PatchLevel)

--- a/cmd/abapAddonAssemblyKitCheckPV_test.go
+++ b/cmd/abapAddonAssemblyKitCheckPV_test.go
@@ -24,7 +24,8 @@ func TestCheckPVStep(t *testing.T) {
 		err := runAbapAddonAssemblyKitCheckPV(&config, nil, &utils, &cpe)
 		assert.NoError(t, err, "Did not expect error")
 		var addonDescriptorFinal abaputils.AddonDescriptor
-		json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		err = json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		assert.NoError(t, err)
 		assert.Equal(t, "0003", addonDescriptorFinal.AddonVersion)
 		assert.Equal(t, "0002", addonDescriptorFinal.AddonSpsLevel)
 		assert.Equal(t, "0001", addonDescriptorFinal.AddonPatchLevel)

--- a/cmd/abapAddonAssemblyKitCreateTargetVector_test.go
+++ b/cmd/abapAddonAssemblyKitCreateTargetVector_test.go
@@ -47,7 +47,8 @@ func TestCreateTargetVectorStep(t *testing.T) {
 		assert.NoError(t, err, "Did not expect error")
 
 		resultAddonDescriptor := abaputils.AddonDescriptor{}
-		json.Unmarshal([]byte(cpe.abap.addonDescriptor), &resultAddonDescriptor)
+		err = json.Unmarshal([]byte(cpe.abap.addonDescriptor), &resultAddonDescriptor)
+		assert.NoError(t, err)
 		assert.Equal(t, "W7Q00207512600000262", resultAddonDescriptor.TargetVectorID)
 	})
 

--- a/cmd/abapAddonAssemblyKitRegisterPackages.go
+++ b/cmd/abapAddonAssemblyKitRegisterPackages.go
@@ -35,7 +35,9 @@ func runAbapAddonAssemblyKitRegisterPackages(config *abapAddonAssemblyKitRegiste
 	cpe *abapAddonAssemblyKitRegisterPackagesCommonPipelineEnvironment, fileReader readFile) error {
 
 	var addonDescriptor abaputils.AddonDescriptor
-	json.Unmarshal([]byte(config.AddonDescriptor), &addonDescriptor)
+	if err := json.Unmarshal([]byte(config.AddonDescriptor), &addonDescriptor); err != nil {
+		return err
+	}
 
 	conn := new(abapbuild.Connector)
 	if err := conn.InitAAKaaS(config.AbapAddonAssemblyKitEndpoint, config.Username, config.Password, client); err != nil {

--- a/cmd/abapAddonAssemblyKitRegisterPackages_test.go
+++ b/cmd/abapAddonAssemblyKitRegisterPackages_test.go
@@ -48,7 +48,8 @@ func TestRegisterPackagesStep(t *testing.T) {
 
 		assert.NoError(t, err, "Did not expect error")
 		var addonDescriptorFinal abaputils.AddonDescriptor
-		json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		err = json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		assert.NoError(t, err)
 		assert.Equal(t, "L", addonDescriptorFinal.Repositories[0].Status)
 	})
 	t.Run("step error - null file", func(t *testing.T) {

--- a/cmd/abapAddonAssemblyKitReleasePackages.go
+++ b/cmd/abapAddonAssemblyKitReleasePackages.go
@@ -28,7 +28,9 @@ func runAbapAddonAssemblyKitReleasePackages(config *abapAddonAssemblyKitReleaseP
 		return err
 	}
 	var addonDescriptor abaputils.AddonDescriptor
-	json.Unmarshal([]byte(config.AddonDescriptor), &addonDescriptor)
+	if err := json.Unmarshal([]byte(config.AddonDescriptor), &addonDescriptor); err != nil {
+		return err
+	}
 
 	err := checkInput(addonDescriptor.Repositories)
 	if err != nil {

--- a/cmd/abapAddonAssemblyKitReleasePackages_test.go
+++ b/cmd/abapAddonAssemblyKitReleasePackages_test.go
@@ -40,7 +40,8 @@ func TestReleasePackagesStep(t *testing.T) {
 		//assert
 		assert.NoError(t, err, "Did not expect error")
 		var addonDescriptorFinal abaputils.AddonDescriptor
-		json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		err = json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		assert.NoError(t, err)
 		assert.Equal(t, "R", addonDescriptorFinal.Repositories[0].Status)
 	})
 

--- a/cmd/abapAddonAssemblyKitReserveNextPackages_test.go
+++ b/cmd/abapAddonAssemblyKitReserveNextPackages_test.go
@@ -41,7 +41,8 @@ func TestReserveNextPackagesStep(t *testing.T) {
 		err := runAbapAddonAssemblyKitReserveNextPackages(&config, nil, &utils, &cpe)
 		assert.NoError(t, err, "Did not expect error")
 		var addonDescriptorFinal abaputils.AddonDescriptor
-		json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		err = json.Unmarshal([]byte(cpe.abap.addonDescriptor), &addonDescriptorFinal)
+		assert.NoError(t, err)
 		assert.Equal(t, "P", addonDescriptorFinal.Repositories[0].Status)
 		assert.Equal(t, "R", addonDescriptorFinal.Repositories[1].Status)
 	})

--- a/cmd/abapEnvironmentAssembleConfirm.go
+++ b/cmd/abapEnvironmentAssembleConfirm.go
@@ -109,7 +109,9 @@ func polling(builds []buildWithRepository, maxRuntimeInMinutes time.Duration, po
 		case <-ticker:
 			var allFinished bool = true
 			for i := range builds {
-				builds[i].build.Get()
+				if err := builds[i].build.Get(); err != nil {
+					return err
+				} 
 				if !builds[i].build.IsFinished() {
 					log.Entry().Infof("Assembly of %s is not yet finished, check again in %s", builds[i].repo.PackageName, pollInterval)
 					allFinished = false

--- a/cmd/abapEnvironmentAssembleConfirm.go
+++ b/cmd/abapEnvironmentAssembleConfirm.go
@@ -111,7 +111,7 @@ func polling(builds []buildWithRepository, maxRuntimeInMinutes time.Duration, po
 			for i := range builds {
 				if err := builds[i].build.Get(); err != nil {
 					return err
-				} 
+				}
 				if !builds[i].build.IsFinished() {
 					log.Entry().Infof("Assembly of %s is not yet finished, check again in %s", builds[i].repo.PackageName, pollInterval)
 					allFinished = false

--- a/cmd/abapEnvironmentAssemblePackages.go
+++ b/cmd/abapEnvironmentAssemblePackages.go
@@ -127,7 +127,9 @@ func (br *buildWithRepository) waitToBeFinished(maxRuntimeInMinutes time.Duratio
 		case <-timeout:
 			return errors.Errorf("Timed out: (max Runtime %v reached)", maxRuntimeInMinutes)
 		case <-ticker:
-			br.build.Get()
+			if err := br.build.Get(); err != nil {
+				return err
+			}
 			if !br.build.IsFinished() {
 				log.Entry().Infof("Assembly of %s is not yet finished, check again in %s", br.repo.PackageName, pollInterval)
 			} else {
@@ -239,7 +241,9 @@ func checkIfFailedAndPrintLogs(builds []buildWithRepository) error {
 			buildFailed = true
 		}
 		if builds[i].build.BuildID != "" {
-			builds[i].build.PrintLogs()
+			if err := builds[i].build.PrintLogs(); err != nil {
+				return err
+			}
 		}
 	}
 	if buildFailed {

--- a/cmd/abapEnvironmentBuild.go
+++ b/cmd/abapEnvironmentBuild.go
@@ -156,7 +156,9 @@ func runBuilds(conn *abapbuild.Connector, config *abapEnvironmentBuildOptions, u
 			}
 			finalValuesForOneBuild = removeAddonDescriptorValues(finalValuesForOneBuild, values)
 			//This means: probably values are duplicated, but the first one wins -> perhaps change this in the future if needed
-			vE.appendValuesIfNotPresent(finalValuesForOneBuild, false)
+			if err := vE.appendValuesIfNotPresent(finalValuesForOneBuild, false); err != nil {
+				errstrings = append(errstrings, err.Error())
+			}
 		}
 		finalValues = vE.generateValueSlice()
 		if len(errstrings) > 0 {
@@ -383,7 +385,7 @@ func (vE *valuesEvaluator) appendStringValuesIfNotPresent(stringValues string, t
 	var values []abapbuild.Value
 	values, err := generateValuesFromString(stringValues)
 	if err != nil {
-		errors.Wrapf(err, "Error converting the vales from the commonPipelineEnvironment")
+		return errors.Wrapf(err, "Error converting the vales from the commonPipelineEnvironment")
 	}
 	if err := vE.appendValuesIfNotPresent(values, throwErrorIfPresent); err != nil {
 		return err

--- a/cmd/abapEnvironmentBuild_test.go
+++ b/cmd/abapEnvironmentBuild_test.go
@@ -101,8 +101,10 @@ func TestRunAbapEnvironmentBuild(t *testing.T) {
 		err := runAbapEnvironmentBuild(&config, nil, &utils, &cpe)
 		// assert
 		finalValues := `[{"value_id":"PACKAGES","value":"/BUILD/AUNIT_DUMMY_TESTS"},{"value_id":"BUILD_FRAMEWORK_MODE","value":"P"}]`
-		json.Unmarshal([]byte(finalValues), expectedValueList)
-		json.Unmarshal([]byte(cpe.abap.buildValues), recordedValueList)
+		err = json.Unmarshal([]byte(finalValues), &expectedValueList)
+		assert.NoError(t, err)
+		err = json.Unmarshal([]byte(cpe.abap.buildValues), &recordedValueList)
+		assert.NoError(t, err)
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, expectedValueList, recordedValueList)
 	})

--- a/cmd/abapEnvironmentCheckoutBranch.go
+++ b/cmd/abapEnvironmentCheckoutBranch.go
@@ -131,8 +131,12 @@ func triggerCheckout(repositoryName string, branchName string, checkoutConnectio
 	if errRead != nil {
 		return uriConnectionDetails, err
 	}
-	json.Unmarshal(bodyText, &abapResp)
-	json.Unmarshal(*abapResp["d"], &body)
+	if err := json.Unmarshal(bodyText, &abapResp); err != nil {
+		return uriConnectionDetails, err
+	}
+	if err := json.Unmarshal(*abapResp["d"], &body); err != nil {
+		return uriConnectionDetails, err
+	}
 
 	if reflect.DeepEqual(abaputils.PullEntity{}, body) {
 		log.Entry().WithField("StatusCode", resp.Status).WithField("branchName", branchName).Error("Could not switch to specified branch")

--- a/cmd/abapEnvironmentCheckoutBranch_test.go
+++ b/cmd/abapEnvironmentCheckoutBranch_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -53,7 +52,7 @@ func TestCheckoutBranchStep(t *testing.T) {
 			BranchName:        "testBranch",
 		}
 
-		logResultSuccess := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultSuccess := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringCheckout + `}`,
@@ -82,7 +81,7 @@ func TestCheckoutBranchStep(t *testing.T) {
 
 		config := abapEnvironmentCheckoutBranchOptions{}
 
-		logResultError := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultError := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringCheckout + `}`,
@@ -121,7 +120,7 @@ func TestCheckoutBranchStep(t *testing.T) {
 			BranchName:        "testBranch",
 		}
 
-		logResultError := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultError := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringCheckout + `}`,

--- a/cmd/abapEnvironmentCloneGitRepo.go
+++ b/cmd/abapEnvironmentCloneGitRepo.go
@@ -154,8 +154,12 @@ func triggerClone(repo abaputils.Repository, cloneConnectionDetails abaputils.Co
 	if errRead != nil {
 		return uriConnectionDetails, err, false
 	}
-	json.Unmarshal(bodyText, &abapResp)
-	json.Unmarshal(*abapResp["d"], &body)
+	if err := json.Unmarshal(bodyText, &abapResp); err != nil {
+		return uriConnectionDetails, err, false
+	}
+	if err := json.Unmarshal(*abapResp["d"], &body); err != nil {
+		return uriConnectionDetails, err, false
+	}
 	if reflect.DeepEqual(abaputils.CloneEntity{}, body) {
 		log.Entry().WithField("StatusCode", resp.Status).WithField("repositoryName", repo.Name).WithField("branchName", repo.Branch).WithField("commitID", repo.CommitID).WithField("Tag", repo.Tag).Error("Could not Clone the Repository / Software Component")
 		err := errors.New("Request to ABAP System not successful")
@@ -212,7 +216,7 @@ func handleCloneError(resp *http.Response, err error, cloneConnectionDetails aba
 		}
 		log.Entry().Infof("-------------------------")
 		log.Entry().Infof("-------------------------")
-		pullOptions := *&abapEnvironmentPullGitRepoOptions{
+		pullOptions := abapEnvironmentPullGitRepoOptions{
 			Username:       cloneConnectionDetails.User,
 			Password:       cloneConnectionDetails.Password,
 			Host:           cloneConnectionDetails.Host,

--- a/cmd/abapEnvironmentCloneGitRepo_test.go
+++ b/cmd/abapEnvironmentCloneGitRepo_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -66,7 +65,8 @@ repositories:
   version: 2.1.1
 `
 		file, _ := os.Create("filename.yaml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 
 		config := abapEnvironmentCloneGitRepoOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -79,7 +79,7 @@ repositories:
 			Repositories:      "filename.yaml",
 		}
 
-		logResultSuccess := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultSuccess := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringClone + `}`,
@@ -100,7 +100,7 @@ repositories:
 			Token: "myToken",
 		}
 
-		err := runAbapEnvironmentCloneGitRepo(&config, &autils, client)
+		err = runAbapEnvironmentCloneGitRepo(&config, &autils, client)
 		assert.NoError(t, err, "Did not expect error")
 		assert.Equal(t, 0, len(client.BodyList), "Not all requests were done")
 	})
@@ -125,7 +125,7 @@ repositories:
 			BranchName:        "testBranch1",
 		}
 
-		logResultSuccess := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultSuccess := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringClone + `}`,
@@ -211,7 +211,8 @@ repositories:
   commitID: ABCD1234
 `
 		file, _ := os.Create("filename.yaml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 
 		config := abapEnvironmentCloneGitRepoOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -224,7 +225,7 @@ repositories:
 			Repositories:      "filename.yaml",
 		}
 
-		logResultError := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultError := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringClone + `}`,
@@ -238,7 +239,7 @@ repositories:
 			StatusCode: 200,
 		}
 
-		err := runAbapEnvironmentCloneGitRepo(&config, &autils, client)
+		err = runAbapEnvironmentCloneGitRepo(&config, &autils, client)
 		if assert.Error(t, err, "Expected error") {
 			assert.Equal(t, "Clone of repository / software component '/DMO/REPO_A', branch 'branchA', commit 'ABCD1234' failed on the ABAP System", err.Error(), "Expected different error message")
 		}
@@ -371,7 +372,7 @@ repositories:
 			BranchName:        "Branch",
 		}
 
-		logResultError := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultError := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				logResultError,
@@ -401,7 +402,7 @@ func TestALreadyCloned(t *testing.T) {
 		autils.ReturnedConnectionDetailsHTTP.URL = "https://example.com"
 		autils.ReturnedConnectionDetailsHTTP.Host = "example.com"
 		autils.ReturnedConnectionDetailsHTTP.XCsrfToken = "xcsrftoken"
-		logResultSuccess := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultSuccess := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringClone + `}`,
@@ -449,7 +450,7 @@ func TestALreadyCloned(t *testing.T) {
 		autils.ReturnedConnectionDetailsHTTP.URL = "https://example.com"
 		autils.ReturnedConnectionDetailsHTTP.Host = "example.com"
 		autils.ReturnedConnectionDetailsHTTP.XCsrfToken = "xcsrftoken"
-		logResultSuccess := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultSuccess := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringClone + `}`,
@@ -499,7 +500,7 @@ func TestALreadyCloned(t *testing.T) {
 		autils.ReturnedConnectionDetailsHTTP.URL = "https://example.com"
 		autils.ReturnedConnectionDetailsHTTP.Host = "example.com"
 		autils.ReturnedConnectionDetailsHTTP.XCsrfToken = "xcsrftoken"
-		logResultSuccess := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultSuccess := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				logResultSuccess,

--- a/cmd/abapEnvironmentCreateSystem.go
+++ b/cmd/abapEnvironmentCreateSystem.go
@@ -43,6 +43,9 @@ func runAbapEnvironmentCreateSystem(config *abapEnvironmentCreateSystemOptions, 
 	}
 	// if no manifest file is provided, it is created with the provided config values
 	manifestYAML, err := generateManifestYAML(config)
+	if err != nil {
+		return err
+	}
 
 	// writing the yaml into a temporary file
 	path, _ := os.Getwd()

--- a/cmd/abapEnvironmentCreateTag.go
+++ b/cmd/abapEnvironmentCreateTag.go
@@ -151,7 +151,7 @@ func createSingleTag(item CreateTagBacklog, index int, telemetryData *telemetry.
 }
 
 func checkStatus(con abaputils.ConnectionDetailsHTTP, client piperhttp.Sender, com abaputils.Communication) (err error) {
-	status := "R"
+	var status string
 	pollIntervall := com.GetPollIntervall()
 	count := 0
 	for {

--- a/cmd/abapEnvironmentCreateTag_test.go
+++ b/cmd/abapEnvironmentCreateTag_test.go
@@ -7,23 +7,9 @@ import (
 
 	"github.com/SAP/jenkins-library/pkg/abaputils"
 	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
-
-type abapEnvironmentCreateTagMockUtils struct {
-	*mock.ExecMockRunner
-	*mock.FilesMock
-}
-
-func newAbapEnvironmentCreateTagTestsUtils() abapEnvironmentCreateTagMockUtils {
-	utils := abapEnvironmentCreateTagMockUtils{
-		ExecMockRunner: &mock.ExecMockRunner{},
-		FilesMock:      &mock.FilesMock{},
-	}
-	return utils
-}
 
 func TestRunAbapEnvironmentCreateTag(t *testing.T) {
 
@@ -58,7 +44,8 @@ repositories:
     version: "4.5.6"
 `
 		file, _ := os.Create("repo.yml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 		config := &abapEnvironmentCreateTagOptions{
 			Username:                            "dummy",
 			Password:                            "dummy",
@@ -86,7 +73,7 @@ repositories:
 		_, hook := test.NewNullLogger()
 		log.RegisterHook(hook)
 
-		err := runAbapEnvironmentCreateTag(config, nil, autils, client)
+		err = runAbapEnvironmentCreateTag(config, nil, autils, client)
 
 		assert.NoError(t, err, "Did not expect error")
 		assert.Equal(t, 3, len(hook.Entries), "Expected a different number of entries")
@@ -127,7 +114,8 @@ repositories:
     version: "4.5.6"
 `
 		file, _ := os.Create("repo.yml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 		config := &abapEnvironmentCreateTagOptions{
 			Username:                            "dummy",
 			Password:                            "dummy",
@@ -155,7 +143,7 @@ repositories:
 		_, hook := test.NewNullLogger()
 		log.RegisterHook(hook)
 
-		err := runAbapEnvironmentCreateTag(config, nil, autils, client)
+		err = runAbapEnvironmentCreateTag(config, nil, autils, client)
 
 		assert.Error(t, err, "Did expect error")
 		assert.Equal(t, 4, len(hook.Entries), "Expected a different number of entries")
@@ -243,7 +231,8 @@ repositories:
     version: "4.5.6"
 `
 		file, _ := os.Create("repo.yml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 		config := &abapEnvironmentCreateTagOptions{
 			Username:                            "dummy",
 			Password:                            "dummy",
@@ -274,7 +263,7 @@ repositories:
 			StatusCode: 200,
 		}
 
-		err := runAbapEnvironmentCreateTag(config, nil, autils, client)
+		err = runAbapEnvironmentCreateTag(config, nil, autils, client)
 
 		assert.Error(t, err, "Did expect error")
 		assert.Equal(t, "Something failed during the tag creation: Configuring the parameter repositories and the parameter repositoryName at the same time is not allowed", err.Error(), "Expected different error message")
@@ -312,7 +301,8 @@ repositories:
     version: "4.5.6"
 `
 		file, _ := os.Create("repo.yml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 		config := &abapEnvironmentCreateTagOptions{
 			Username:                            "dummy",
 			Password:                            "dummy",
@@ -338,7 +328,7 @@ repositories:
 		_, hook := test.NewNullLogger()
 		log.RegisterHook(hook)
 
-		err := runAbapEnvironmentCreateTag(config, nil, autils, client)
+		err = runAbapEnvironmentCreateTag(config, nil, autils, client)
 
 		assert.NoError(t, err, "Did not expect error")
 		assert.Equal(t, 1, len(hook.Entries), "Expected a different number of entries")

--- a/cmd/abapEnvironmentPullGitRepo.go
+++ b/cmd/abapEnvironmentPullGitRepo.go
@@ -60,7 +60,7 @@ func runAbapEnvironmentPullGitRepo(options *abapEnvironmentPullGitRepoOptions, c
 	client.SetOptions(clientOptions)
 	pollIntervall := com.GetPollIntervall()
 
-	repositories := []abaputils.Repository{}
+	var repositories []abaputils.Repository
 	err = checkPullRepositoryConfiguration(*options)
 	if err != nil {
 		return err
@@ -155,8 +155,12 @@ func triggerPull(repo abaputils.Repository, pullConnectionDetails abaputils.Conn
 	if errRead != nil {
 		return uriConnectionDetails, err
 	}
-	json.Unmarshal(bodyText, &abapResp)
-	json.Unmarshal(*abapResp["d"], &body)
+	if err := json.Unmarshal(bodyText, &abapResp); err != nil {
+		return uriConnectionDetails, err
+	}
+	if err := json.Unmarshal(*abapResp["d"], &body); err != nil {
+		return uriConnectionDetails, err
+	}
 	if reflect.DeepEqual(abaputils.PullEntity{}, body) {
 		log.Entry().WithField("StatusCode", resp.Status).WithField("repositoryName", repo.Name).WithField("commitID", repo.CommitID).WithField("Tag", repo.Tag).Error("Could not pull the repository / software component")
 		err := errors.New("Request to ABAP System not successful")

--- a/cmd/abapEnvironmentPullGitRepo_test.go
+++ b/cmd/abapEnvironmentPullGitRepo_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -31,7 +30,7 @@ func init() {
 	}
 	executionLogResponse, _ := json.Marshal(executionLog)
 	executionLogStringPull = string(executionLogResponse)
-	logResultErrorPull = fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+	logResultErrorPull = `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Error", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 }
 
 func TestPullStep(t *testing.T) {
@@ -55,7 +54,7 @@ func TestPullStep(t *testing.T) {
 			RepositoryNames:   []string{"testRepo1"},
 		}
 
-		logResultSuccess := fmt.Sprintf(`{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`)
+		logResultSuccess := `{"d": { "sc_name": "/DMO/SWC", "status": "S", "to_Log_Overview": { "results": [ { "log_index": 1, "log_name": "Main Import", "type_of_found_issues": "Success", "timestamp": "/Date(1644332299000+0000)/", "to_Log_Protocol": { "results": [ { "log_index": 1, "index_no": "1", "log_name": "", "type": "Info", "descr": "Main import", "timestamp": null, "criticality": 0 } ] } } ] } } }`
 		client := &abaputils.ClientMock{
 			BodyList: []string{
 				`{"d" : ` + executionLogStringPull + `}`,
@@ -181,7 +180,8 @@ repositories:
   commitID: ABCD1234
 `
 		file, _ := os.Create("filename.yaml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 
 		config := abapEnvironmentPullGitRepoOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -206,7 +206,7 @@ repositories:
 			StatusCode: 200,
 		}
 
-		err := runAbapEnvironmentPullGitRepo(&config, &autils, client)
+		err = runAbapEnvironmentPullGitRepo(&config, &autils, client)
 		if assert.Error(t, err, "Expected error") {
 			assert.Equal(t, "Pull of the repository / software component '/DMO/REPO_A', commit 'ABCD1234' failed on the ABAP system", err.Error(), "Expected different error message")
 		}
@@ -241,7 +241,8 @@ repositories:
   commitID: ABCD1234
 `
 		file, _ := os.Create("filename.yaml")
-		file.Write([]byte(body))
+		_, err := file.Write([]byte(body))
+		assert.NoError(t, err)
 
 		config := abapEnvironmentPullGitRepoOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -267,7 +268,7 @@ repositories:
 			StatusCode: 200,
 		}
 
-		err := runAbapEnvironmentPullGitRepo(&config, &autils, client)
+		err = runAbapEnvironmentPullGitRepo(&config, &autils, client)
 		if assert.Error(t, err, "Expected error") {
 			assert.Equal(t, "Pull of the repository / software component '/DMO/REPO_A', tag 'v-1.0.1-build-0001' failed on the ABAP system", err.Error(), "Expected different error message")
 		}

--- a/cmd/abapEnvironmentPushATCSystemConfig.go
+++ b/cmd/abapEnvironmentPushATCSystemConfig.go
@@ -466,7 +466,9 @@ func getErrorDetailsFromBody(resp *http.Response, bodyText []byte) (errorString 
 			return errorString, errUnmarshal
 		}
 		if _, ok := abapResp["error"]; ok {
-			json.Unmarshal(*abapResp["error"], &abapErrorResponse)
+			if err := json.Unmarshal(*abapResp["error"], &abapErrorResponse); err != nil {
+				return errorString, err
+			}
 			if (AbapError{}) != abapErrorResponse {
 				log.Entry().WithField("ErrorCode", abapErrorResponse.Code).Error(abapErrorResponse.Message.Value)
 				errorString = fmt.Sprintf("%s - %s", abapErrorResponse.Code, abapErrorResponse.Message.Value)

--- a/cmd/abapEnvironmentRunATCCheck_test.go
+++ b/cmd/abapEnvironmentRunATCCheck_test.go
@@ -57,11 +57,7 @@ func TestHostConfig(t *testing.T) {
 
 		_, err := autils.GetAbapCommunicationArrangementInfo(options.AbapEnvOptions, "")
 		assert.EqualError(t, err, "Parameters missing. Please provide EITHER the Host of the ABAP server OR the Cloud Foundry ApiEndpoint, Organization, Space, Service Instance and a corresponding Service Key for the Communication Scenario SAP_COM_0510")
-		//Testing without ABAP Host
-		config = abaputils.AbapEnvironmentOptions{
-			Username: "testUser",
-			Password: "testPassword",
-		}
+
 		_, err = autils.GetAbapCommunicationArrangementInfo(options.AbapEnvOptions, "")
 		assert.EqualError(t, err, "Parameters missing. Please provide EITHER the Host of the ABAP server OR the Cloud Foundry ApiEndpoint, Organization, Space, Service Instance and a corresponding Service Key for the Communication Scenario SAP_COM_0510")
 	})
@@ -191,6 +187,7 @@ func TestGetHTTPResponseATCRun(t *testing.T) {
 			URL:      "https://api.endpoint.com/Entity/",
 		}
 		resp, err := getHTTPResponseATCRun("GET", con, []byte(client.Body), client)
+		assert.NoError(t, err)
 		defer resp.Body.Close()
 		if err == nil {
 			assert.Equal(t, int64(0), resp.ContentLength)
@@ -213,6 +210,7 @@ func TestGetResultATCRun(t *testing.T) {
 			URL:      "https://api.endpoint.com/Entity/",
 		}
 		resp, err := getResultATCRun("GET", con, []byte(client.Body), client)
+		assert.NoError(t, err)
 		defer resp.Body.Close()
 		if err == nil {
 			assert.Equal(t, int64(0), resp.ContentLength)

--- a/cmd/abapEnvironmentRunAUnitTest.go
+++ b/cmd/abapEnvironmentRunAUnitTest.go
@@ -136,8 +136,7 @@ func convertAUnitOptions(options *abapEnvironmentRunAUnitTestOptions) abaputils.
 
 func fetchAndPersistAUnitResults(resp *http.Response, details abaputils.ConnectionDetailsHTTP, client piperhttp.Sender, aunitResultFileName string, generateHTML bool) error {
 	var err error
-	var abapEndpoint string
-	abapEndpoint = details.URL
+	abapEndpoint := details.URL
 	location := resp.Header.Get("Location")
 	details.URL = abapEndpoint + location
 	location, err = pollAUnitRun(details, nil, client)
@@ -298,7 +297,9 @@ func pollAUnitRun(details abaputils.ConnectionDetailsHTTP, body []byte, client p
 			return "", fmt.Errorf("Reading response body failed: %w", err)
 		}
 		x := new(AUnitRun)
-		xml.Unmarshal(bodyText, &x)
+		if err := xml.Unmarshal(bodyText, &x); err != nil {
+			return "", err
+		}
 
 		log.Entry().Infof("Current polling status: %s", x.Progress.Status)
 		if x.Progress.Status == "Not Created" {
@@ -353,7 +354,9 @@ func persistAUnitResult(body []byte, aunitResultFileName string, generateHTML bo
 
 	//Optional checks before writing the Results
 	parsedXML := new(AUnitResult)
-	xml.Unmarshal([]byte(body), &parsedXML)
+	if err := xml.Unmarshal([]byte(body), &parsedXML); err != nil {
+		return err
+	}
 
 	//Write Results
 	err = ioutil.WriteFile(aunitResultFileName, body, 0644)
@@ -379,7 +382,7 @@ func persistAUnitResult(body []byte, aunitResultFileName string, generateHTML bo
 				log.Entry().Debugf("The following test has been skipped: %s: %s", skipped.Message, skipped.Text)
 			}
 		}
-		if generateHTML == true {
+		if generateHTML {
 			htmlString := generateHTMLDocumentAUnit(parsedXML)
 			htmlStringByte := []byte(htmlString)
 			aUnitResultHTMLFileName := strings.Trim(aunitResultFileName, ".xml") + ".html"

--- a/cmd/abapEnvironmentRunAUnitTest.go
+++ b/cmd/abapEnvironmentRunAUnitTest.go
@@ -355,7 +355,7 @@ func persistAUnitResult(body []byte, aunitResultFileName string, generateHTML bo
 	//Optional checks before writing the Results
 	parsedXML := new(AUnitResult)
 	if err := xml.Unmarshal([]byte(body), &parsedXML); err != nil {
-		log.Entry().WithError(err).Warning("failed to unmarschal xml response")
+		log.Entry().WithError(err).Warning("failed to unmarshal xml response")
 	}
 
 	//Write Results

--- a/cmd/abapEnvironmentRunAUnitTest.go
+++ b/cmd/abapEnvironmentRunAUnitTest.go
@@ -355,7 +355,7 @@ func persistAUnitResult(body []byte, aunitResultFileName string, generateHTML bo
 	//Optional checks before writing the Results
 	parsedXML := new(AUnitResult)
 	if err := xml.Unmarshal([]byte(body), &parsedXML); err != nil {
-		return err
+		log.Entry().WithError(err).Warning("failed to unmarschal xml response")
 	}
 
 	//Write Results

--- a/cmd/abapEnvironmentRunAUnitTest_test.go
+++ b/cmd/abapEnvironmentRunAUnitTest_test.go
@@ -10,22 +10,8 @@ import (
 	"testing"
 
 	"github.com/SAP/jenkins-library/pkg/abaputils"
-	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"
 )
-
-type abapEnvironmentRunAUnitTestMockUtils struct {
-	*mock.ExecMockRunner
-	*mock.FilesMock
-}
-
-func newAbapEnvironmentRunAUnitTestTestsUtils() abapEnvironmentRunAUnitTestMockUtils {
-	utils := abapEnvironmentRunAUnitTestMockUtils{
-		ExecMockRunner: &mock.ExecMockRunner{},
-		FilesMock:      &mock.FilesMock{},
-	}
-	return utils
-}
 
 func TestBuildAUnitRequestBody(t *testing.T) {
 	t.Parallel()
@@ -582,10 +568,12 @@ func TestGetResultAUnitRun(t *testing.T) {
 			URL:      "https://api.endpoint.com/Entity/",
 		}
 		resp, err := getAUnitResults("GET", con, []byte(client.Body), client)
+		assert.NoError(t, err)
 		defer resp.Body.Close()
 		if assert.Equal(t, nil, err) {
 			buf := new(bytes.Buffer)
-			buf.ReadFrom(resp.Body)
+			_, err = buf.ReadFrom(resp.Body)
+			assert.NoError(t, err)
 			newStr := buf.String()
 			assert.Equal(t, "AUnit test result body", newStr)
 			assert.Equal(t, int64(0), resp.ContentLength)
@@ -609,10 +597,12 @@ func TestGetResultAUnitRun(t *testing.T) {
 			URL:      "https://api.endpoint.com/Entity/",
 		}
 		resp, err := getAUnitResults("GET", con, []byte(client.Body), client)
+		assert.NoError(t, err)
 		defer resp.Body.Close()
 		if assert.EqualError(t, err, "Getting AUnit run results failed: Test fail") {
 			buf := new(bytes.Buffer)
-			buf.ReadFrom(resp.Body)
+			_, err = buf.ReadFrom(resp.Body)
+			assert.NoError(t, err)
 			newStr := buf.String()
 			assert.Equal(t, "AUnit test result body", newStr)
 			assert.Equal(t, int64(0), resp.ContentLength)
@@ -725,10 +715,12 @@ func TestRunAbapEnvironmentRunAUnitTest(t *testing.T) {
 		}
 		fmt.Println("Body:" + string([]byte(client.Body)))
 		resp, err := getHTTPResponseAUnitRun("GET", con, []byte(client.Body), client)
+		assert.NoError(t, err)
 		defer resp.Body.Close()
 		if assert.Equal(t, nil, err) {
 			buf := new(bytes.Buffer)
-			buf.ReadFrom(resp.Body)
+			_, err = buf.ReadFrom(resp.Body)
+			assert.NoError(t, err)
 			newStr := buf.String()
 			assert.Equal(t, "HTTP response test", newStr)
 			assert.Equal(t, int64(0), resp.ContentLength)

--- a/cmd/abapEnvironmentRunAUnitTest_test.go
+++ b/cmd/abapEnvironmentRunAUnitTest_test.go
@@ -597,18 +597,17 @@ func TestGetResultAUnitRun(t *testing.T) {
 			URL:      "https://api.endpoint.com/Entity/",
 		}
 		resp, err := getAUnitResults("GET", con, []byte(client.Body), client)
-		assert.NoError(t, err)
+		assert.EqualError(t, err, "Getting AUnit run results failed: Test fail")
 		defer resp.Body.Close()
-		if assert.EqualError(t, err, "Getting AUnit run results failed: Test fail") {
-			buf := new(bytes.Buffer)
-			_, err = buf.ReadFrom(resp.Body)
-			assert.NoError(t, err)
-			newStr := buf.String()
-			assert.Equal(t, "AUnit test result body", newStr)
-			assert.Equal(t, int64(0), resp.ContentLength)
-			assert.Equal(t, 400, resp.StatusCode)
-			assert.Equal(t, []string([]string(nil)), resp.Header["X-Crsf-Token"])
-		}
+
+		buf := new(bytes.Buffer)
+		_, err = buf.ReadFrom(resp.Body)
+		assert.NoError(t, err)
+		newStr := buf.String()
+		assert.Equal(t, "AUnit test result body", newStr)
+		assert.Equal(t, int64(0), resp.ContentLength)
+		assert.Equal(t, 400, resp.StatusCode)
+		assert.Equal(t, []string([]string(nil)), resp.Header["X-Crsf-Token"])
 	})
 }
 


### PR DESCRIPTION
I cleaned up issues found by golangci-lint

When looking through the code it seems like there are physical files created during tests. In some places it seems like even outside of a temporary file system.

Maybe this could be cleaned up by using the virtual filesystem we are using in many other steps.

The file creation outside of a temporary directory should in all cases be fixed in my opinion.