### PR TITLE
feat: allow OSVM scans to succeed with vulnerabilities

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -173,9 +173,13 @@ func runDetect(config detectExecuteScanOptions, utils detectUtils, influx *detec
 	if err != nil {
 		// Setting error category based on exit code
 		mapErrorCategory(utils.GetExitCode())
-
-		// Error code mapping with more human readable text
-		err = errors.Wrapf(err, exitCodeMapping(utils.GetExitCode()))
+		if log.GetErrorCategory() == log.ErrorCompliance && !config.FailOnSevereVulnerabilities {
+			err = nil
+			log.Entry().Infof("policy violation(s) found - step will only create data but not fail due to setting failOnSevereVulnerabilities: false")
+		} else {
+			// Error code mapping with more human readable text
+			err = errors.Wrapf(err, exitCodeMapping(utils.GetExitCode()))
+		}
 	}
 	// create Toolrecord file
 	toolRecordFileName, toolRecordErr := createToolRecordDetect("./", config, blackduckSystem)

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -22,37 +22,38 @@ import (
 )
 
 type detectExecuteScanOptions struct {
-	Token                      string   `json:"token,omitempty"`
-	CodeLocation               string   `json:"codeLocation,omitempty"`
-	ProjectName                string   `json:"projectName,omitempty"`
-	Scanners                   []string `json:"scanners,omitempty" validate:"possible-values=signature source"`
-	ScanPaths                  []string `json:"scanPaths,omitempty"`
-	DependencyPath             string   `json:"dependencyPath,omitempty"`
-	Unmap                      bool     `json:"unmap,omitempty"`
-	ScanProperties             []string `json:"scanProperties,omitempty"`
-	ServerURL                  string   `json:"serverUrl,omitempty"`
-	Groups                     []string `json:"groups,omitempty"`
-	FailOn                     []string `json:"failOn,omitempty" validate:"possible-values=ALL BLOCKER CRITICAL MAJOR MINOR NONE"`
-	VersioningModel            string   `json:"versioningModel,omitempty" validate:"possible-values=major major-minor semantic full"`
-	Version                    string   `json:"version,omitempty"`
-	CustomScanVersion          string   `json:"customScanVersion,omitempty"`
-	ProjectSettingsFile        string   `json:"projectSettingsFile,omitempty"`
-	GlobalSettingsFile         string   `json:"globalSettingsFile,omitempty"`
-	M2Path                     string   `json:"m2Path,omitempty"`
-	InstallArtifacts           bool     `json:"installArtifacts,omitempty"`
-	IncludedPackageManagers    []string `json:"includedPackageManagers,omitempty"`
-	ExcludedPackageManagers    []string `json:"excludedPackageManagers,omitempty"`
-	MavenExcludedScopes        []string `json:"mavenExcludedScopes,omitempty"`
-	DetectTools                []string `json:"detectTools,omitempty"`
-	ScanOnChanges              bool     `json:"scanOnChanges,omitempty"`
-	CustomEnvironmentVariables []string `json:"customEnvironmentVariables,omitempty"`
-	GithubToken                string   `json:"githubToken,omitempty"`
-	CreateResultIssue          bool     `json:"createResultIssue,omitempty"`
-	GithubAPIURL               string   `json:"githubApiUrl,omitempty"`
-	Owner                      string   `json:"owner,omitempty"`
-	Repository                 string   `json:"repository,omitempty"`
-	Assignees                  []string `json:"assignees,omitempty"`
-	CustomTLSCertificateLinks  []string `json:"customTlsCertificateLinks,omitempty"`
+	Token                       string   `json:"token,omitempty"`
+	CodeLocation                string   `json:"codeLocation,omitempty"`
+	ProjectName                 string   `json:"projectName,omitempty"`
+	Scanners                    []string `json:"scanners,omitempty" validate:"possible-values=signature source"`
+	ScanPaths                   []string `json:"scanPaths,omitempty"`
+	DependencyPath              string   `json:"dependencyPath,omitempty"`
+	Unmap                       bool     `json:"unmap,omitempty"`
+	ScanProperties              []string `json:"scanProperties,omitempty"`
+	ServerURL                   string   `json:"serverUrl,omitempty"`
+	Groups                      []string `json:"groups,omitempty"`
+	FailOn                      []string `json:"failOn,omitempty" validate:"possible-values=ALL BLOCKER CRITICAL MAJOR MINOR NONE"`
+	VersioningModel             string   `json:"versioningModel,omitempty" validate:"possible-values=major major-minor semantic full"`
+	Version                     string   `json:"version,omitempty"`
+	CustomScanVersion           string   `json:"customScanVersion,omitempty"`
+	ProjectSettingsFile         string   `json:"projectSettingsFile,omitempty"`
+	GlobalSettingsFile          string   `json:"globalSettingsFile,omitempty"`
+	M2Path                      string   `json:"m2Path,omitempty"`
+	InstallArtifacts            bool     `json:"installArtifacts,omitempty"`
+	IncludedPackageManagers     []string `json:"includedPackageManagers,omitempty"`
+	ExcludedPackageManagers     []string `json:"excludedPackageManagers,omitempty"`
+	MavenExcludedScopes         []string `json:"mavenExcludedScopes,omitempty"`
+	DetectTools                 []string `json:"detectTools,omitempty"`
+	ScanOnChanges               bool     `json:"scanOnChanges,omitempty"`
+	CustomEnvironmentVariables  []string `json:"customEnvironmentVariables,omitempty"`
+	GithubToken                 string   `json:"githubToken,omitempty"`
+	CreateResultIssue           bool     `json:"createResultIssue,omitempty"`
+	GithubAPIURL                string   `json:"githubApiUrl,omitempty"`
+	Owner                       string   `json:"owner,omitempty"`
+	Repository                  string   `json:"repository,omitempty"`
+	Assignees                   []string `json:"assignees,omitempty"`
+	CustomTLSCertificateLinks   []string `json:"customTlsCertificateLinks,omitempty"`
+	FailOnSevereVulnerabilities bool     `json:"failOnSevereVulnerabilities,omitempty"`
 }
 
 type detectExecuteScanInflux struct {
@@ -278,6 +279,7 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.Repository, "repository", os.Getenv("PIPER_repository"), "Set the GitHub repository.")
 	cmd.Flags().StringSliceVar(&stepConfig.Assignees, "assignees", []string{``}, "Defines the assignees for the Github Issue created/updated with the results of the scan as a list of login names.")
 	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List of download links to custom TLS certificates. This is required to ensure trusted connections to instances with repositories (like nexus) when publish flag is set to true.")
+	cmd.Flags().BoolVar(&stepConfig.FailOnSevereVulnerabilities, "failOnSevereVulnerabilities", true, "Whether to fail the step on severe vulnerabilties or not")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -622,6 +624,15 @@ func detectExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     []string{},
+					},
+					{
+						Name:        "failOnSevereVulnerabilities",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     true,
 					},
 				},
 			},

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -253,7 +253,7 @@ func TestRunDetect(t *testing.T) {
 		utilsMock.ShouldFailOnCommand = map[string]error{"./detect.sh --blackduck.url= --blackduck.api.token= \"--detect.project.name=''\" \"--detect.project.version.name=''\" \"--detect.code.location.name=''\" --detect.source.path='.'": fmt.Errorf("")}
 		utilsMock.ExitCode = 3
 		utilsMock.AddFile("detect.sh", []byte(""))
-		err := runDetect(detectExecuteScanOptions{}, utilsMock, &detectExecuteScanInflux{})
+		err := runDetect(detectExecuteScanOptions{FailOnSevereVulnerabilities: true}, utilsMock, &detectExecuteScanInflux{})
 		assert.Equal(t, utilsMock.ExitCode, 3)
 		assert.Contains(t, err.Error(), "FAILURE_POLICY_VIOLATION => Detect found policy violations.")
 		assert.True(t, utilsMock.HasRemovedFile("detect.sh"))

--- a/cmd/protecodeExecuteScan.go
+++ b/cmd/protecodeExecuteScan.go
@@ -279,6 +279,8 @@ func executeProtecodeScan(influx *protecodeExecuteScanInflux, client protecode.P
 	if config.FailOnSevereVulnerabilities && protecode.HasSevereVulnerabilities(result.Result, config.ExcludeCVEs) {
 		log.SetErrorCategory(log.ErrorCompliance)
 		return fmt.Errorf("the product is not compliant")
+	} else if protecode.HasSevereVulnerabilities(result.Result, config.ExcludeCVEs) {
+		log.Entry().Infof("policy violation(s) found - step will only create data but not fail due to setting failOnSevereVulnerabilities: false")
 	}
 	return nil
 }

--- a/cmd/protecodeExecuteScan_generated.go
+++ b/cmd/protecodeExecuteScan_generated.go
@@ -239,7 +239,7 @@ BDBA (Protecode) uses a combination of static binary analysis techniques to X-ra
 
 func addProtecodeExecuteScanFlags(cmd *cobra.Command, stepConfig *protecodeExecuteScanOptions) {
 	cmd.Flags().StringVar(&stepConfig.ExcludeCVEs, "excludeCVEs", ``, "DEPRECATED: Do use triaging within the Protecode UI instead")
-	cmd.Flags().BoolVar(&stepConfig.FailOnSevereVulnerabilities, "failOnSevereVulnerabilities", true, "Whether to fail the job on severe vulnerabilties or not")
+	cmd.Flags().BoolVar(&stepConfig.FailOnSevereVulnerabilities, "failOnSevereVulnerabilities", true, "Whether to fail the step on severe vulnerabilties or not")
 	cmd.Flags().StringVar(&stepConfig.ScanImage, "scanImage", os.Getenv("PIPER_scanImage"), "The reference to the docker image to scan with Protecode. Note: If possible please also check [fetchUrl](https://www.project-piper.io/steps/protecodeExecuteScan/#fetchurl) parameter, which might help you to optimize upload time.")
 	cmd.Flags().StringVar(&stepConfig.DockerRegistryURL, "dockerRegistryUrl", os.Getenv("PIPER_dockerRegistryUrl"), "The reference to the docker registry to scan with Protecode")
 	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")

--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -529,9 +529,12 @@ func checkPolicyViolations(config *ScanOptions, scan *ws.Scan, sys whitesource, 
 	// and there does not seem to be real benefit in archiving it.
 
 	if policyViolationCount > 0 {
-		log.SetErrorCategory(log.ErrorCompliance)
 		influx.whitesource_data.fields.policy_violations = policyViolationCount
-		return policyReport, fmt.Errorf("%v policy violation(s) found", policyViolationCount)
+		if config.FailOnSevereVulnerabilities {
+			log.SetErrorCategory(log.ErrorCompliance)
+			return policyReport, fmt.Errorf("%v policy violation(s) found", policyViolationCount)
+		}
+		log.Entry().Infof("%v policy violation(s) found - step will only create data but not fail due to setting failOnSevereVulnerabilities: false", policyViolationCount)
 	}
 
 	return policyReport, nil

--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -40,6 +40,7 @@ type whitesourceExecuteScanOptions struct {
 	DockerConfigJSON                     string   `json:"dockerConfigJSON,omitempty"`
 	EmailAddressesOfInitialProductAdmins []string `json:"emailAddressesOfInitialProductAdmins,omitempty"`
 	Excludes                             []string `json:"excludes,omitempty"`
+	FailOnSevereVulnerabilities          bool     `json:"failOnSevereVulnerabilities,omitempty"`
 	Includes                             []string `json:"includes,omitempty"`
 	InstallCommand                       string   `json:"installCommand,omitempty"`
 	JreDownloadURL                       string   `json:"jreDownloadUrl,omitempty"`
@@ -322,6 +323,7 @@ func addWhitesourceExecuteScanFlags(cmd *cobra.Command, stepConfig *whitesourceE
 	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")
 	cmd.Flags().StringSliceVar(&stepConfig.EmailAddressesOfInitialProductAdmins, "emailAddressesOfInitialProductAdmins", []string{}, "The list of email addresses to assign as product admins for newly created WhiteSource products.")
 	cmd.Flags().StringSliceVar(&stepConfig.Excludes, "excludes", []string{}, "List of file path patterns to exclude in the scan.")
+	cmd.Flags().BoolVar(&stepConfig.FailOnSevereVulnerabilities, "failOnSevereVulnerabilities", true, "Whether to fail the step on severe vulnerabilties or not")
 	cmd.Flags().StringSliceVar(&stepConfig.Includes, "includes", []string{}, "List of file path patterns to include in the scan.")
 	cmd.Flags().StringVar(&stepConfig.InstallCommand, "installCommand", os.Getenv("PIPER_installCommand"), "[NOT IMPLEMENTED] Install command that can be used to populate the default docker image for some scenarios.")
 	cmd.Flags().StringVar(&stepConfig.JreDownloadURL, "jreDownloadUrl", `https://github.com/SAP/SapMachine/releases/download/sapmachine-11.0.2/sapmachine-jre-11.0.2_linux-x64_bin.tar.gz`, "URL used for downloading the Java Runtime Environment (JRE) required to run the WhiteSource Unified Agent.")
@@ -584,6 +586,15 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     []string{},
+					},
+					{
+						Name:        "failOnSevereVulnerabilities",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     true,
 					},
 					{
 						Name:        "includes",

--- a/cmd/whitesourceExecuteScan_test.go
+++ b/cmd/whitesourceExecuteScan_test.go
@@ -408,7 +408,7 @@ func TestCheckPolicyViolations(t *testing.T) {
 	})
 
 	t.Run("error - policy violations", func(t *testing.T) {
-		config := ScanOptions{}
+		config := ScanOptions{FailOnSevereVulnerabilities: true}
 		scan := newWhitesourceScan(&config)
 		scan.AppendScannedProject("testProject1")
 		systemMock := ws.NewSystemMock("ignored")
@@ -615,8 +615,9 @@ func TestAggregateVersionWideLibraries(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		// init
 		config := &ScanOptions{
-			ProductToken: "mock-product-token",
-			Version:      "1",
+			FailOnSevereVulnerabilities: true,
+			ProductToken:                "mock-product-token",
+			Version:                     "1",
 		}
 		utils := newWhitesourceUtilsMock()
 		system := ws.NewSystemMock("2010-05-30 00:15:00 +0100")

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -392,6 +392,12 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: failOnSevereVulnerabilities
+        type: bool
+        description: Whether to fail the step on severe vulnerabilties or not
+        scope:
+          - PARAMETERS
+        default: true
   outputs:
     resources:
       - name: influx

--- a/resources/metadata/protecodeExecuteScan.yaml
+++ b/resources/metadata/protecodeExecuteScan.yaml
@@ -34,7 +34,7 @@ spec:
         aliases:
           - name: protecodeFailOnSevereVulnerabilities
         type: bool
-        description: Whether to fail the job on severe vulnerabilties or not
+        description: Whether to fail the step on severe vulnerabilties or not
         scope:
           - PARAMETERS
           - STAGES

--- a/resources/metadata/whitesourceExecuteScan.yaml
+++ b/resources/metadata/whitesourceExecuteScan.yaml
@@ -209,6 +209,12 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: failOnSevereVulnerabilities
+        type: bool
+        description: Whether to fail the step on severe vulnerabilties or not
+        scope:
+          - PARAMETERS
+        default: true
       - name: includes
         type: "[]string"
         description: List of file path patterns to include in the scan.


### PR DESCRIPTION
For running open source vulnerability scans in de-coupled processes
it is helpful to allow that steps only create
compliance reports to inform users/teams
but not fail the pipeline.

This can now be achieved constitently with the flag:
`failOnSevereVulnerabilities`

# Changes

- [x] Tests
- [x] Documentation
