### PR TITLE
Cleanup of SBOM generation parameters

### DIFF
--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -359,8 +359,6 @@ func (exec *Execute) CreateBOM(packageJSONFiles []string) error {
 			params := []string{
 				"cyclonedx-bom",
 				path,
-				"--include-license-text", "false",
-				"--include-dev", "false", // Include devDependencies
 				"--output", filepath.Join(path, "bom.xml"),
 			}
 			err := execRunner.RunExecutable("npx", params...)

--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -359,9 +359,9 @@ func TestNpm(t *testing.T) {
 			if assert.Equal(t, 3, len(utils.execRunner.Calls)) {
 				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "@cyclonedx/bom", "--no-save"}}, utils.execRunner.Calls[0])
 				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", ".",
-					"--include-license-text", "false", "--include-dev", "false", "--output", "bom.xml"}}, utils.execRunner.Calls[1])
+					"--output", "bom.xml"}}, utils.execRunner.Calls[1])
 				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", "src",
-					"--include-license-text", "false", "--include-dev", "false", "--output", filepath.Join("src", "bom.xml")}}, utils.execRunner.Calls[2])
+					"--output", filepath.Join("src", "bom.xml")}}, utils.execRunner.Calls[2])
 			}
 		}
 	})


### PR DESCRIPTION
Adding `false` does not what is intended. If the parameters are added to the call, license texts and dev dependencies are included

# Changes

- [ ] Tests
- [ ] Documentation
