### PR TITLE
fix(fortifyExecuteScan-SARIF): suppressed issues got "Unknown" category and state

### DIFF
--- a/pkg/fortify/fortify.go
+++ b/pkg/fortify/fortify.go
@@ -637,7 +637,8 @@ func (sys *SystemInstance) GetReportDetails(id int64) (*models.SavedReport, erro
 // GetIssueDetails returns the details of an issue with its issueInstanceId and projectVersionId
 func (sys *SystemInstance) GetIssueDetails(projectVersionId int64, issueInstanceId string) ([]*models.ProjectVersionIssue, error) {
 	qmStr := "issues"
-	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Q: &issueInstanceId, Qm: &qmStr}
+	showSuppressed := true
+	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Q: &issueInstanceId, Qm: &qmStr, Showsuppressed: &showSuppressed}
 	params.WithTimeout(sys.timeout)
 	result, err := sys.client.IssueOfProjectVersionController.ListIssueOfProjectVersion(params, sys)
 	if err != nil {
@@ -650,7 +651,8 @@ func (sys *SystemInstance) GetIssueDetails(projectVersionId int64, issueInstance
 func (sys *SystemInstance) GetAllIssueDetails(projectVersionId int64) ([]*models.ProjectVersionIssue, error) {
 	var limit int32
 	limit = -1
-	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Limit: &limit}
+	showSuppressed := true
+	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Limit: &limit, Showsuppressed: &showSuppressed}
 	params.WithTimeout(sys.timeout)
 	result, err := sys.client.IssueOfProjectVersionController.ListIssueOfProjectVersion(params, sys)
 	if err != nil {


### PR DESCRIPTION
# Changes
- Fixed "Suppressed" issues being returned as "Unknown" category and state. The reason is, "Showsuppressed" flag is default to False whereas in other requests (e.g., _getIssuesOfProjectVersion()_), it is explicitly set to True.

[ x ] Tests
[ ] Documentation
