### PR TITLE
Classify Fortify & Checkmarx findings into audit group / Common properties  

### DIFF
--- a/pkg/checkmarx/cxxml_to_sarif.go
+++ b/pkg/checkmarx/cxxml_to_sarif.go
@@ -260,6 +260,21 @@ func Parse(sys System, data []byte, scanID int) (format.SARIF, error) {
 			props.InstanceID = cxxml.Query[i].Result[j].Path.ResultID + "-" + strconv.Itoa(cxxml.Query[i].Result[j].Path.PathID)
 			props.ToolSeverity = cxxml.Query[i].Result[j].Severity
 			props.ToolSeverityIndex = cxxml.Query[i].Result[j].SeverityIndex
+			// classify into audit groups
+			switch cxxml.Query[i].Result[j].Severity {
+			case "High", "Medium":
+				props.AuditRequirement = format.AUDIT_REQUIREMENT_GROUP_1_DESC
+				props.AuditRequirementIndex = format.AUDIT_REQUIREMENT_GROUP_1_INDEX
+				break
+			case "Low":
+				props.AuditRequirement = format.AUDIT_REQUIREMENT_GROUP_2_DESC
+				props.AuditRequirementIndex = format.AUDIT_REQUIREMENT_GROUP_2_INDEX
+				break
+			case "Information":
+				props.AuditRequirement = format.AUDIT_REQUIREMENT_GROUP_3_DESC
+				props.AuditRequirementIndex = format.AUDIT_REQUIREMENT_GROUP_3_INDEX
+				break
+			}
 			props.ToolStateIndex = cxxml.Query[i].Result[j].State
 			switch cxxml.Query[i].Result[j].State {
 			case 1:

--- a/pkg/checkmarx/cxxml_to_sarif_test.go
+++ b/pkg/checkmarx/cxxml_to_sarif_test.go
@@ -122,6 +122,11 @@ func TestParse(t *testing.T) {
 		assert.Equal(t, sarif.Runs[0].Results[2].Properties.ToolState, "Confirmed")
 		assert.Equal(t, sarif.Runs[0].Results[2].Properties.ToolAuditMessage, "Changed status to Confirmed \n Dummy comment")
 		//assert.Equal(t, "This is a dummy short description.", sarif.Runs[0].Tool.Driver.Rules[0].FullDescription.Text)
+
+		// ensure the existence of not applicable field (specific Fortify)
+		assert.Equal(t, sarif.Runs[0].Results[2].Properties.InstanceSeverity, "")
+		assert.Equal(t, sarif.Runs[0].Results[2].Properties.Confidence, "")
+		assert.Equal(t, sarif.Runs[0].Results[2].Properties.FortifyCategory, "")
 	})
 
 	t.Run("Missing sys", func(t *testing.T) {

--- a/pkg/checkmarx/cxxml_to_sarif_test.go
+++ b/pkg/checkmarx/cxxml_to_sarif_test.go
@@ -3,9 +3,9 @@ package checkmarx
 import (
 	"testing"
 
+	"github.com/SAP/jenkins-library/pkg/format"
 	piperHttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/format"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/checkmarx/cxxml_to_sarif_test.go
+++ b/pkg/checkmarx/cxxml_to_sarif_test.go
@@ -5,6 +5,7 @@ import (
 
 	piperHttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/format"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -121,6 +122,10 @@ func TestParse(t *testing.T) {
 		assert.Equal(t, len(sarif.Runs[0].Tool.Driver.Rules), 2)
 		assert.Equal(t, sarif.Runs[0].Results[2].Properties.ToolState, "Confirmed")
 		assert.Equal(t, sarif.Runs[0].Results[2].Properties.ToolAuditMessage, "Changed status to Confirmed \n Dummy comment")
+		assert.Equal(t, sarif.Runs[0].Results[2].Properties.ToolSeverityIndex, 3)
+		assert.Equal(t, sarif.Runs[0].Results[2].Properties.ToolSeverity, "High")
+		assert.Equal(t, sarif.Runs[0].Results[2].Properties.AuditRequirementIndex, format.AUDIT_REQUIREMENT_GROUP_1_INDEX)
+		assert.Equal(t, sarif.Runs[0].Results[2].Properties.AuditRequirement, format.AUDIT_REQUIREMENT_GROUP_1_DESC)
 		//assert.Equal(t, "This is a dummy short description.", sarif.Runs[0].Tool.Driver.Rules[0].FullDescription.Text)
 
 		// ensure the existence of not applicable field (specific Fortify)

--- a/pkg/format/sarif.go
+++ b/pkg/format/sarif.go
@@ -1,5 +1,12 @@
 package format
 
+const AUDIT_REQUIREMENT_GROUP_1_INDEX = 1
+const AUDIT_REQUIREMENT_GROUP_2_INDEX = 2
+const AUDIT_REQUIREMENT_GROUP_3_INDEX = 3
+const AUDIT_REQUIREMENT_GROUP_1_DESC = "Audit All"
+const AUDIT_REQUIREMENT_GROUP_2_DESC = "Spot Check"
+const AUDIT_REQUIREMENT_GROUP_3_DESC = "Optional"
+
 // SARIF format related JSON structs
 type SARIF struct {
 	Schema  string `json:"$schema" default:"https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json"`

--- a/pkg/format/sarif.go
+++ b/pkg/format/sarif.go
@@ -87,12 +87,9 @@ type PartialFingerprints struct {
 
 // SarifProperties adding additional information/context to the finding
 type SarifProperties struct {
+	// common
 	RuleGUID              string `json:"ruleGUID,omitempty"`
 	InstanceID            string `json:"instanceID,omitempty"`
-	InstanceSeverity      string `json:"instanceSeverity,omitempty"`
-	Confidence            string `json:"confidence,omitempty"`
-	FortifyCategory       string `json:"fortifyCategory,omitempty"`
-	CheckmarxSimilarityID string `json:"checkmarxSimilarityID,omitempty"`
 	Audited               bool   `json:"audited"`
 	ToolSeverity          string `json:"toolSeverity"`
 	ToolSeverityIndex     int    `json:"toolSeverityIndex"`
@@ -100,6 +97,14 @@ type SarifProperties struct {
 	ToolStateIndex        int    `json:"toolStateIndex"`
 	ToolAuditMessage      string `json:"toolAuditMessage"`
 	UnifiedAuditState     string `json:"unifiedAuditState"`
+	AuditRequirement      string `json:"auditRequirement"`
+	AuditRequirementIndex int    `json:"auditRequirementIndex"`
+
+	// specific
+	InstanceSeverity      string `json:"instanceSeverity,omitempty"`
+	Confidence            string `json:"confidence,omitempty"`
+	FortifyCategory       string `json:"fortifyCategory,omitempty"`
+	CheckmarxSimilarityID string `json:"checkmarxSimilarityID,omitempty"`
 }
 
 // Tool these structs are relevant to the Tool object

--- a/pkg/format/sarif.go
+++ b/pkg/format/sarif.go
@@ -101,10 +101,10 @@ type SarifProperties struct {
 	AuditRequirementIndex int    `json:"auditRequirementIndex"`
 
 	// specific
-	InstanceSeverity      string `json:"instanceSeverity,omitempty"`
-	Confidence            string `json:"confidence,omitempty"`
-	FortifyCategory       string `json:"fortifyCategory,omitempty"`
-	CheckmarxSimilarityID string `json:"checkmarxSimilarityID,omitempty"`
+	InstanceSeverity      string `json:"instanceSeverity"`
+	Confidence            string `json:"confidence"`
+	FortifyCategory       string `json:"fortifyCategory"`
+	CheckmarxSimilarityID string `json:"checkmarxSimilarityID"`
 }
 
 // Tool these structs are relevant to the Tool object

--- a/pkg/fortify/fortify.go
+++ b/pkg/fortify/fortify.go
@@ -637,7 +637,8 @@ func (sys *SystemInstance) GetReportDetails(id int64) (*models.SavedReport, erro
 // GetIssueDetails returns the details of an issue with its issueInstanceId and projectVersionId
 func (sys *SystemInstance) GetIssueDetails(projectVersionId int64, issueInstanceId string) ([]*models.ProjectVersionIssue, error) {
 	qmStr := "issues"
-	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Q: &issueInstanceId, Qm: &qmStr}
+	showSuppressed := true
+	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Q: &issueInstanceId, Qm: &qmStr, Showsuppressed: &showSuppressed}
 	params.WithTimeout(sys.timeout)
 	result, err := sys.client.IssueOfProjectVersionController.ListIssueOfProjectVersion(params, sys)
 	if err != nil {
@@ -650,7 +651,8 @@ func (sys *SystemInstance) GetIssueDetails(projectVersionId int64, issueInstance
 func (sys *SystemInstance) GetAllIssueDetails(projectVersionId int64) ([]*models.ProjectVersionIssue, error) {
 	var limit int32
 	limit = -1
-	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Limit: &limit}
+	showSuppressed := true
+	params := &issue_of_project_version_controller.ListIssueOfProjectVersionParams{ParentID: projectVersionId, Limit: &limit, Showsuppressed: &showSuppressed}
 	params.WithTimeout(sys.timeout)
 	result, err := sys.client.IssueOfProjectVersionController.ListIssueOfProjectVersion(params, sys)
 	if err != nil {

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -1189,6 +1189,9 @@ func integrateAuditData(ruleProp *format.SarifProperties, issueInstanceID string
 	ruleProp.ToolAuditMessage = "Error fetching audit state" // We set this as default for the error phase, then reset it to nothing
 	ruleProp.ToolSeverityIndex = 0
 	ruleProp.ToolStateIndex = 0
+	ruleProp.AuditRequirementIndex = 0
+	ruleProp.AuditRequirement = "Unknown"
+
 	// These default values allow for the property bag to be filled even if an error happens later. They all should be overwritten by a normal course of the progrma.
 	if maxretries == 0 {
 		// Max retries reached, we stop there to avoid a longer execution time
@@ -1231,6 +1234,18 @@ func integrateAuditData(ruleProp *format.SarifProperties, issueInstanceID string
 		for i := 0; i < len(filterSet.Folders); i++ {
 			if filterSet.Folders[i].GUID == *data[0].FolderGUID {
 				ruleProp.FortifyCategory = filterSet.Folders[i].Name
+				//  classify into audit groups
+				switch ruleProp.FortifyCategory {
+				case "Corporate Security Requirements", "Audit All":
+					ruleProp.AuditRequirementIndex = 1
+					ruleProp.AuditRequirement = "Audit All"
+				case "Spot Checks of Each Category":
+					ruleProp.AuditRequirementIndex = 2
+					ruleProp.AuditRequirement = "Spot Check"
+				case "Optional":
+					ruleProp.AuditRequirementIndex = 3
+					ruleProp.AuditRequirement = "Optional"
+				}
 				break
 			}
 		}

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -1237,14 +1237,14 @@ func integrateAuditData(ruleProp *format.SarifProperties, issueInstanceID string
 				//  classify into audit groups
 				switch ruleProp.FortifyCategory {
 				case "Corporate Security Requirements", "Audit All":
-					ruleProp.AuditRequirementIndex = 1
-					ruleProp.AuditRequirement = "Audit All"
+					ruleProp.AuditRequirementIndex = format.AUDIT_REQUIREMENT_GROUP_1_INDEX
+					ruleProp.AuditRequirement = format.AUDIT_REQUIREMENT_GROUP_1_DESC
 				case "Spot Checks of Each Category":
-					ruleProp.AuditRequirementIndex = 2
-					ruleProp.AuditRequirement = "Spot Check"
+					ruleProp.AuditRequirementIndex = format.AUDIT_REQUIREMENT_GROUP_2_INDEX
+					ruleProp.AuditRequirement = format.AUDIT_REQUIREMENT_GROUP_2_DESC
 				case "Optional":
-					ruleProp.AuditRequirementIndex = 3
-					ruleProp.AuditRequirement = "Optional"
+					ruleProp.AuditRequirementIndex = format.AUDIT_REQUIREMENT_GROUP_3_INDEX
+					ruleProp.AuditRequirement = format.AUDIT_REQUIREMENT_GROUP_3_DESC
 				}
 				break
 			}

--- a/pkg/fortify/fpr_to_sarif_test.go
+++ b/pkg/fortify/fpr_to_sarif_test.go
@@ -446,6 +446,8 @@ func TestIntegrateAuditData(t *testing.T) {
 		assert.Equal(t, ruleProp.ToolSeverityIndex, 3)
 		assert.Equal(t, ruleProp.ToolAuditMessage, "Dummy comment.")
 		assert.Equal(t, ruleProp.FortifyCategory, "Audit All")
+		assert.Equal(t, ruleProp.AuditRequirementIndex, 1)
+		assert.Equal(t, ruleProp.AuditRequirement, "Audit All")
 	})
 
 	t.Run("Missing project version", func(t *testing.T) {
@@ -490,6 +492,8 @@ func TestIntegrateAuditData(t *testing.T) {
 		assert.Equal(t, ruleProp.ToolSeverityIndex, 3)
 		assert.Equal(t, ruleProp.ToolAuditMessage, "Dummy comment.")
 		assert.Equal(t, ruleProp.FortifyCategory, "Audit All")
+		assert.Equal(t, ruleProp.AuditRequirementIndex, 1)
+		assert.Equal(t, ruleProp.AuditRequirement, "Audit All")
 	})
 
 	t.Run("Max retries set to 0: error raised", func(t *testing.T) {

--- a/pkg/fortify/fpr_to_sarif_test.go
+++ b/pkg/fortify/fpr_to_sarif_test.go
@@ -448,6 +448,7 @@ func TestIntegrateAuditData(t *testing.T) {
 		assert.Equal(t, ruleProp.FortifyCategory, "Audit All")
 		assert.Equal(t, ruleProp.AuditRequirementIndex, 1)
 		assert.Equal(t, ruleProp.AuditRequirement, "Audit All")
+		assert.Equal(t, ruleProp.CheckmarxSimilarityID, "") // ensure the existence of not applicable field (specific Checkmarx)
 	})
 
 	t.Run("Missing project version", func(t *testing.T) {
@@ -494,6 +495,7 @@ func TestIntegrateAuditData(t *testing.T) {
 		assert.Equal(t, ruleProp.FortifyCategory, "Audit All")
 		assert.Equal(t, ruleProp.AuditRequirementIndex, 1)
 		assert.Equal(t, ruleProp.AuditRequirement, "Audit All")
+		assert.Equal(t, ruleProp.CheckmarxSimilarityID, "") // ensure the existence of not applicable field (specific Checkmarx)
 	})
 
 	t.Run("Max retries set to 0: error raised", func(t *testing.T) {

--- a/pkg/fortify/fpr_to_sarif_test.go
+++ b/pkg/fortify/fpr_to_sarif_test.go
@@ -446,8 +446,8 @@ func TestIntegrateAuditData(t *testing.T) {
 		assert.Equal(t, ruleProp.ToolSeverityIndex, 3)
 		assert.Equal(t, ruleProp.ToolAuditMessage, "Dummy comment.")
 		assert.Equal(t, ruleProp.FortifyCategory, "Audit All")
-		assert.Equal(t, ruleProp.AuditRequirementIndex, 1)
-		assert.Equal(t, ruleProp.AuditRequirement, "Audit All")
+		assert.Equal(t, ruleProp.AuditRequirementIndex, format.AUDIT_REQUIREMENT_GROUP_1_INDEX)
+		assert.Equal(t, ruleProp.AuditRequirement, format.AUDIT_REQUIREMENT_GROUP_1_DESC)
 		assert.Equal(t, ruleProp.CheckmarxSimilarityID, "") // ensure the existence of not applicable field (specific Checkmarx)
 	})
 
@@ -493,8 +493,8 @@ func TestIntegrateAuditData(t *testing.T) {
 		assert.Equal(t, ruleProp.ToolSeverityIndex, 3)
 		assert.Equal(t, ruleProp.ToolAuditMessage, "Dummy comment.")
 		assert.Equal(t, ruleProp.FortifyCategory, "Audit All")
-		assert.Equal(t, ruleProp.AuditRequirementIndex, 1)
-		assert.Equal(t, ruleProp.AuditRequirement, "Audit All")
+		assert.Equal(t, ruleProp.AuditRequirementIndex, format.AUDIT_REQUIREMENT_GROUP_1_INDEX)
+		assert.Equal(t, ruleProp.AuditRequirement, format.AUDIT_REQUIREMENT_GROUP_1_DESC)
 		assert.Equal(t, ruleProp.CheckmarxSimilarityID, "") // ensure the existence of not applicable field (specific Checkmarx)
 	})
 


### PR DESCRIPTION
# Changes
Various changes for Fortify & Checkmarx SARIF:
- classify findings into audit requirement groups (internal policy)
- common properties bag for both tools (although accepting the fact that some will be empty, requested by internal analytical constraints)
- enhance additional tests for both tools, add some new checks for Checkmarx

- [x] Tests
- [ ] Documentation
