### PR TITLE
fix(cnbBuild): use a single test case to lookup buildpacks by ID

### DIFF
--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	registryURL = "localhost:5000"
-	baseBuilder = "paketobuildpacks/builder:0.2.17-base"
+	baseBuilder = "paketobuildpacks/builder:0.3.26-base"
 )
 
 func setupDockerRegistry(t *testing.T, ctx context.Context) testcontainers.Container {
@@ -253,7 +253,7 @@ func TestMultiImage(t *testing.T) {
 	container.assertHasOutput(t, "Saving localhost:5000/go-app:v1.0.0...")
 	container.assertHasOutput(t, "Using cached buildpack")
 	container.assertHasOutput(t, "Saving localhost:5000/my-app2:latest...")
-	container.terminate(t)
+	// container.terminate(t)
 }
 
 func TestPreserveFiles(t *testing.T) {

--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	registryURL = "localhost:5000"
-	baseBuilder = "paketobuildpacks/builder:0.3.26-base"
+	baseBuilder = "paketobuildpacks/builder:0.2.17-base"
 )
 
 func setupDockerRegistry(t *testing.T, ctx context.Context) testcontainers.Container {
@@ -253,7 +253,7 @@ func TestMultiImage(t *testing.T) {
 	container.assertHasOutput(t, "Saving localhost:5000/go-app:v1.0.0...")
 	container.assertHasOutput(t, "Using cached buildpack")
 	container.assertHasOutput(t, "Saving localhost:5000/my-app2:latest...")
-	// container.terminate(t)
+	container.terminate(t)
 }
 
 func TestPreserveFiles(t *testing.T) {

--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -64,7 +64,7 @@ func TestNpmProject(t *testing.T) {
 	container.assertHasOutput(t, "SUCCESS")
 	container.terminate(t)
 
-	err = container2.whenRunningPiperCommand("cnbBuild", "--noTelemetry", "--verbose", "--path", "TestCnbIntegration/project", "--customConfig", "TestCnbIntegration/config.yml", "--containerImageName", "node", "--containerImageTag", "0.0.1", "--containerRegistryUrl", registryURL)
+	err = container2.whenRunningPiperCommand("cnbBuild", "--noTelemetry", "--verbose", "--path", "TestCnbIntegration/project", "--customConfig", "TestCnbIntegration/config.yml", "--containerImageName", "node", "--containerImageTag", "0.0.1", "--containerRegistryUrl", registryURL, "--projectDescriptor", "project-with-id.toml")
 	assert.NoError(t, err)
 	container2.assertHasOutput(t, "running command: /cnb/lifecycle/creator")
 	container2.assertHasOutput(t, "Selected Node Engine version (using BP_NODE_VERSION): 16")

--- a/integration/testdata/TestCnbIntegration/project/project-with-id.toml
+++ b/integration/testdata/TestCnbIntegration/project/project-with-id.toml
@@ -13,7 +13,7 @@ name = "BP_NODE_VERSION"
 value = "16"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/ca-certificates"
+id = "paketo-buildpacks/ca-certificates"
 version = "3.2.4"
 
 [[build.buildpacks]]

--- a/integration/testdata/TestCnbIntegration/project/project-with-id.toml
+++ b/integration/testdata/TestCnbIntegration/project/project-with-id.toml
@@ -17,17 +17,13 @@ id = "paketo-buildpacks/ca-certificates"
 version = "3.0.3"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/node-engine"
-version = "0.12.0"
+uri = "gcr.io/paketo-buildpacks/node-engine:0.12.0"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/npm-install"
-version = "0.7.2"
+uri = "gcr.io/paketo-buildpacks/npm-install:0.7.2"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/node-module-bom"
-version = "0.2.2"
+uri = "gcr.io/paketo-buildpacks/node-module-bom:0.2.2"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/npm-start"
-version = "0.8.0"
+uri = "gcr.io/paketo-buildpacks/npm-start:0.8.0"

--- a/integration/testdata/TestCnbIntegration/project/project-with-id.toml
+++ b/integration/testdata/TestCnbIntegration/project/project-with-id.toml
@@ -14,20 +14,20 @@ value = "16"
 
 [[build.buildpacks]]
 id = "paketo-buildpacks/ca-certificates"
-version = "3.2.4"
+version = "3.0.3"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/node-engine"
-version = "0.14.0"
+version = "0.12.0"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/npm-install"
-version = "0.10.1"
+version = "0.7.2"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/node-module-bom"
-version = "0.3.0"
+version = "0.2.2"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/npm-start"
-version = "0.9.1"
+version = "0.8.0"

--- a/integration/testdata/TestCnbIntegration/project/project.toml
+++ b/integration/testdata/TestCnbIntegration/project/project.toml
@@ -13,21 +13,16 @@ name = "BP_NODE_VERSION"
 value = "16"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/ca-certificates"
-version = "3.0.3"
+uri = "gcr.io/paketo-buildpacks/ca-certificates:3.0.3"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/node-engine"
-version = "0.12.0"
+uri = "gcr.io/paketo-buildpacks/node-engine:0.12.0"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/npm-install"
-version = "0.7.2"
+uri = "gcr.io/paketo-buildpacks/npm-install:0.7.2"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/node-module-bom"
-version = "0.2.2"
+uri = "gcr.io/paketo-buildpacks/node-module-bom:0.2.2"
 
 [[build.buildpacks]]
-uri = "gcr.io/paketo-buildpacks/npm-start"
-version = "0.8.0"
+uri = "gcr.io/paketo-buildpacks/npm-start:0.8.0"

--- a/integration/testdata/TestCnbIntegration/project/project.toml
+++ b/integration/testdata/TestCnbIntegration/project/project.toml
@@ -14,20 +14,20 @@ value = "16"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/ca-certificates"
-version = "3.2.4"
+version = "3.0.3"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/node-engine"
-version = "0.14.0"
+version = "0.12.0"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/npm-install"
-version = "0.10.1"
+version = "0.7.2"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/node-module-bom"
-version = "0.3.0"
+version = "0.2.2"
 
 [[build.buildpacks]]
 uri = "gcr.io/paketo-buildpacks/npm-start"
-version = "0.9.1"
+version = "0.8.0"


### PR DESCRIPTION
# Changes
To mitigate the rate limits on the buildpacks registry side, all integration tests now use the url for buildpack and only one test looks up one buildpack by id.

- [X] Tests
- [ ] Documentation
