### PR TITLE
Add dist folder into build result

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -367,7 +367,7 @@ steps:
     stepMessage: 'Do you want to restart?'
   pipelineStashFilesAfterBuild:
     stashIncludes:
-      buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original'
+      buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original, dist/**'
       checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html'
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
       sonar: '**/jacoco*.exec, **/sonar-project.properties'


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation

While running the pipeline on JFR, the dist folder created during the build stage is not stashed properly and hence, not handed over to `transportRequestUploadCTS` step to perform deployment to abap system. This PR change will resolve the issue.
