### PR TITLE
helm add repo with several repos

### DIFF
--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -89,44 +89,51 @@ func (h *HelmExecute) runHelmInit() error {
 
 // runHelmAdd is used to add a chart repository
 func (h *HelmExecute) runHelmAdd() error {
-	helmParams := []string{
-		"repo",
-		"add",
-	}
 
 	repoNames := strings.Split(h.config.TargetRepositoryName, ",")
 	repoUrls := strings.Split(h.config.TargetRepositoryURL, ",")
 	repoUsers := strings.Split(h.config.TargetRepositoryUser, ",")
 	repoPasswords := strings.Split(h.config.TargetRepositoryPassword, ",")
 
-	fmt.Printf("%s, %s, %s, %s", repoNames, repoUrls, repoUsers, repoPasswords)
+	fmt.Printf("[MH] : names: %s, urls: %s, user: %s, passwd: %s\n", repoNames, repoUrls, repoUsers, repoPasswords)
 
-	// the slices should have the same number of entries
+	// the slices should have the same number of entries TODO: we need to check that
+	// that is only POC: should be done with some kind of map for each repo entry.
 
-	for index, name := range repoNames {
-		fmt.Printf("%d/%s", index, name)
-	}
+	for index, _ := range repoNames {
+		repoName := repoNames[index]
+		repoUrl := repoUrls[index]
+		repoUser := repoUsers[index]
+		repoPassword := repoPasswords[index]
+		fmt.Printf("[MH : ] index: %d : repo: %s, url: %s, user: %s, password: %s\n", index, repoName, repoUrl, repoUser, repoPassword)
 
-	if len(h.config.TargetRepositoryName) == 0 {
-		return fmt.Errorf("there is no TargetRepositoryName value. 'helm repo add' command requires 2 arguments")
-	}
-	if len(h.config.TargetRepositoryURL) == 0 {
-		return fmt.Errorf("there is no TargetRepositoryURL value. 'helm repo add' command requires 2 arguments")
-	}
-	if len(h.config.TargetRepositoryUser) != 0 {
-		helmParams = append(helmParams, "--username", h.config.TargetRepositoryUser)
-	}
-	if len(h.config.TargetRepositoryPassword) != 0 {
-		helmParams = append(helmParams, "--password", h.config.TargetRepositoryPassword)
-	}
-	helmParams = append(helmParams, h.config.TargetRepositoryName)
-	helmParams = append(helmParams, h.config.TargetRepositoryURL)
-	if h.verbose {
-		helmParams = append(helmParams, "--debug")
-	}
+		helmParams := []string{
+			"repo",
+			"add",
+		}
 
-	if err := h.runHelmCommand(helmParams); err != nil {
-		log.Entry().WithError(err).Fatal("Helm add call failed")
+		if len(repoName) == 0 {
+			return fmt.Errorf("there is no TargetRepositoryName value. 'helm repo add' command requires 2 arguments")
+		}
+		if len(repoUrl) == 0 {
+			return fmt.Errorf("there is no TargetRepositoryURL value. 'helm repo add' command requires 2 arguments")
+		}
+		if len(repoUser) != 0 {
+			helmParams = append(helmParams, "--username", repoUser)
+		}
+		if len(repoPassword) != 0 {
+			helmParams = append(helmParams, "--password", repoPassword)
+		}
+		helmParams = append(helmParams, repoName)
+		helmParams = append(helmParams, repoUrl)
+		if h.verbose {
+			helmParams = append(helmParams, "--debug")
+		}
+
+		fmt.Printf("[MH]: helm call: %s", strings.Join(helmParams, ","))
+		if err := h.runHelmCommand(helmParams); err != nil {
+			log.Entry().WithError(err).Fatal("Helm add call failed")
+		}
 	}
 
 	return nil

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -95,8 +95,6 @@ func (h *HelmExecute) runHelmAdd() error {
 	repoUsers := strings.Split(h.config.TargetRepositoryUser, ",")
 	repoPasswords := strings.Split(h.config.TargetRepositoryPassword, ",")
 
-	fmt.Printf("[MH] : names: %s, urls: %s, user: %s, passwd: %s\n", repoNames, repoUrls, repoUsers, repoPasswords)
-
 	// the slices should have the same number of entries TODO: we need to check that
 	// that is only POC: should be done with some kind of map for each repo entry.
 
@@ -105,7 +103,6 @@ func (h *HelmExecute) runHelmAdd() error {
 		repoUrl := repoUrls[index]
 		repoUser := repoUsers[index]
 		repoPassword := repoPasswords[index]
-		fmt.Printf("[MH : ] index: %d : repo: %s, url: %s, user: %s, password: %s\n", index, repoName, repoUrl, repoUser, repoPassword)
 
 		helmParams := []string{
 			"repo",
@@ -130,7 +127,6 @@ func (h *HelmExecute) runHelmAdd() error {
 			helmParams = append(helmParams, "--debug")
 		}
 
-		fmt.Printf("[MH]: helm call: %s", strings.Join(helmParams, ","))
 		if err := h.runHelmCommand(helmParams); err != nil {
 			log.Entry().WithError(err).Fatal("Helm add call failed")
 		}

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -87,6 +87,8 @@ func (h *HelmExecute) runHelmInit() error {
 	return nil
 }
 
+// this can be removed finally since it is replaced by
+// runHelmAddSingleRepo
 // runHelmAdd is used to add a chart repository
 func (h *HelmExecute) runHelmAdd() error {
 

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -158,8 +158,6 @@ func (h *HelmExecute) RunHelmUpgrade() error {
 	chartPaths := strings.Split(h.config.ChartPath, ",")
 	namespaces := strings.Split(h.config.Namespace, ",")
 
-	fmt.Printf("[MH] before loop: %s\n", strings.Join(deploymentNames, ","))
-
 	for index, _ := range deploymentNames {
 
 		deploymentName := deploymentNames[index]
@@ -212,7 +210,6 @@ func (h *HelmExecute) RunHelmUpgrade() error {
 			helmParams = append(helmParams, h.config.AdditionalParameters...)
 		}
 
-		fmt.Printf("[MH] before runHelmCommand: " + strings.Join(helmParams, ","))
 		if err := h.runHelmCommand(helmParams); err != nil {
 			log.Entry().WithError(err).Fatal("Helm upgrade call failed")
 		}

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -93,6 +93,20 @@ func (h *HelmExecute) runHelmAdd() error {
 		"repo",
 		"add",
 	}
+
+	repoNames := strings.Split(h.config.TargetRepositoryName, ",")
+	repoUrls := strings.Split(h.config.TargetRepositoryURL, ",")
+	repoUsers := strings.Split(h.config.TargetRepositoryUser, ",")
+	repoPasswords := strings.Split(h.config.TargetRepositoryPassword, ",")
+
+	fmt.Printf("%s, %s, %s, %s", repoNames, repoUrls, repoUsers, repoPasswords)
+
+	// the slices should have the same number of entries
+
+	for index, name := range repoNames {
+		fmt.Printf("%d/%s", index, name)
+	}
+
 	if len(h.config.TargetRepositoryName) == 0 {
 		return fmt.Errorf("there is no TargetRepositoryName value. 'helm repo add' command requires 2 arguments")
 	}

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -120,39 +120,44 @@ func TestRunHelmUpgrade(t *testing.T) {
 	}{
 		{
 			config: HelmExecuteOptions{
-				DeploymentName:        "test_deployment",
-				ChartPath:             "",
-				Namespace:             "test_namespace",
-				ForceUpdates:          true,
-				HelmDeployWaitSeconds: 3456,
-				AdditionalParameters:  []string{"additional parameter"},
-				Image:                 "dtzar/helm-kubectl:3.4.1",
-				TargetRepositoryName:  "test",
-				TargetRepositoryURL:   "https://charts.helm.sh/stable",
+				DeploymentName:           "test_deployment,test_deployment2",
+				ChartPath:                ",",
+				Namespace:                "test_namespace,test_namespace2",
+				ForceUpdates:             true,
+				HelmDeployWaitSeconds:    3456,
+				AdditionalParameters:     []string{"additional parameter"},
+				Image:                    "dtzar/helm-kubectl:3.4.1,dtzar/helm-kubectl:3.4.2",
+				TargetRepositoryName:     "test,test2",
+				TargetRepositoryURL:      "https://charts.helm.sh/stable,https://charts.helm.sh/stable2",
+				TargetRepositoryUser:     ",",
+				TargetRepositoryPassword: ",",
 			},
 			generalVerbose: true,
 			expectedExecCalls: []mock.ExecCall{
 				{Exec: "helm", Params: []string{"repo", "add", "test", "https://charts.helm.sh/stable", "--debug"}},
 				{Exec: "helm", Params: []string{"upgrade", "test_deployment", "test", "--debug", "--install", "--namespace", "test_namespace", "--force", "--wait", "--timeout", "3456s", "--atomic", "additional parameter"}},
+				{Exec: "helm", Params: []string{"repo", "add", "test2", "https://charts.helm.sh/stable2", "--debug"}},
+				{Exec: "helm", Params: []string{"upgrade", "test_deployment2", "test2", "--debug", "--install", "--namespace", "test_namespace2", "--force", "--wait", "--timeout", "3456s", "--atomic", "additional parameter"}},
 			},
-		},
-		{
-			config: HelmExecuteOptions{
-				DeploymentName:        "test_deployment",
-				ChartPath:             ".",
-				Namespace:             "test_namespace",
-				ForceUpdates:          true,
-				HelmDeployWaitSeconds: 3456,
-				AdditionalParameters:  []string{"additional parameter"},
-				Image:                 "dtzar/helm-kubectl:3.4.1",
-				TargetRepositoryName:  "test",
-				TargetRepositoryURL:   "https://charts.helm.sh/stable",
+		}, /*
+			{
+				config: HelmExecuteOptions{
+					DeploymentName:        "test_deployment",
+					ChartPath:             ".",
+					Namespace:             "test_namespace",
+					ForceUpdates:          true,
+					HelmDeployWaitSeconds: 3456,
+					AdditionalParameters:  []string{"additional parameter"},
+					Image:                 "dtzar/helm-kubectl:3.4.1",
+					TargetRepositoryName:  "test",
+					TargetRepositoryURL:   "https://charts.helm.sh/stable",
+				},
+				generalVerbose: true,
+				expectedExecCalls: []mock.ExecCall{
+					{Exec: "helm", Params: []string{"upgrade", "test_deployment", ".", "--debug", "--install", "--namespace", "test_namespace", "--force", "--wait", "--timeout", "3456s", "--atomic", "additional parameter"}},
+				},
 			},
-			generalVerbose: true,
-			expectedExecCalls: []mock.ExecCall{
-				{Exec: "helm", Params: []string{"upgrade", "test_deployment", ".", "--debug", "--install", "--namespace", "test_namespace", "--force", "--wait", "--timeout", "3456s", "--atomic", "additional parameter"}},
-			},
-		},
+		*/
 	}
 
 	for i, testCase := range testTable {

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -223,9 +223,9 @@ func TestRunHelmInstall(t *testing.T) {
 	}{
 		{
 			config: HelmExecuteOptions{
-				ChartPath:                "",
-				DeploymentName:           "testPackage",
-				Namespace:                "test-namespace",
+				ChartPath:                ",",
+				DeploymentName:           "testPackage,testPackage2",
+				Namespace:                "test-namespace,test-namespace2",
 				HelmDeployWaitSeconds:    525,
 				TargetRepositoryURL:      "https://charts.helm.sh/stable,https://charts.helm.sh/stable2",
 				TargetRepositoryName:     "test,test2",
@@ -235,10 +235,12 @@ func TestRunHelmInstall(t *testing.T) {
 			generalVerbose: false,
 			expectedExecCalls: []mock.ExecCall{
 				{Exec: "helm", Params: []string{"repo", "add", "test", "https://charts.helm.sh/stable"}},
+				{Exec: "helm", Params: []string{"install", "testPackage", "test", "--namespace", "test-namespace", "--create-namespace", "--atomic", "--wait", "--timeout", "525s"}},
 				{Exec: "helm", Params: []string{"repo", "add", "test2", "https://charts.helm.sh/stable2"}},
-				{Exec: "helm", Params: []string{"install", "testPackage", "test,test2", "--namespace", "test-namespace", "--create-namespace", "--atomic", "--wait", "--timeout", "525s"}},
+				{Exec: "helm", Params: []string{"install", "testPackage2", "test2", "--namespace", "test-namespace2", "--create-namespace", "--atomic", "--wait", "--timeout", "525s"}},
 			},
 		},
+
 		{
 			config: HelmExecuteOptions{
 				ChartPath:             ".",

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -290,10 +290,6 @@ func TestRunHelmInstall(t *testing.T) {
 	}
 }
 
-func TestMH(t *testing.T) {
-	fmt.Printf("Hello Marcus")
-}
-
 func TestRunHelmUninstall(t *testing.T) {
 	testTable := []struct {
 		config            HelmExecuteOptions

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -65,13 +65,14 @@ func TestRunHelmAdd(t *testing.T) {
 	}{
 		{
 			config: HelmExecuteOptions{
-				TargetRepositoryURL:      "https://charts.helm.sh/stable",
-				TargetRepositoryName:     "stable",
-				TargetRepositoryUser:     "userAccount",
-				TargetRepositoryPassword: "pwdAccount",
+				TargetRepositoryURL:      "https://charts.helm.sh/stable,https://charts.helm.sh/stable2",
+				TargetRepositoryName:     "stable,stable2",
+				TargetRepositoryUser:     "userAccount,userAccount2",
+				TargetRepositoryPassword: "pwdAccount,pwdAccount2",
 			},
 			expectedExecCalls: []mock.ExecCall{
 				{Exec: "helm", Params: []string{"repo", "add", "--username", "userAccount", "--password", "pwdAccount", "stable", "https://charts.helm.sh/stable"}},
+				{Exec: "helm", Params: []string{"repo", "add", "--username", "userAccount2", "--password", "pwdAccount2", "stable2", "https://charts.helm.sh/stable2"}},
 			},
 			generalVerbose: false,
 			expectedError:  nil,
@@ -222,17 +223,20 @@ func TestRunHelmInstall(t *testing.T) {
 	}{
 		{
 			config: HelmExecuteOptions{
-				ChartPath:             "",
-				DeploymentName:        "testPackage",
-				Namespace:             "test-namespace",
-				HelmDeployWaitSeconds: 525,
-				TargetRepositoryURL:   "https://charts.helm.sh/stable",
-				TargetRepositoryName:  "test",
+				ChartPath:                "",
+				DeploymentName:           "testPackage",
+				Namespace:                "test-namespace",
+				HelmDeployWaitSeconds:    525,
+				TargetRepositoryURL:      "https://charts.helm.sh/stable,https://charts.helm.sh/stable2",
+				TargetRepositoryName:     "test,test2",
+				TargetRepositoryUser:     ",",
+				TargetRepositoryPassword: ",",
 			},
 			generalVerbose: false,
 			expectedExecCalls: []mock.ExecCall{
 				{Exec: "helm", Params: []string{"repo", "add", "test", "https://charts.helm.sh/stable"}},
-				{Exec: "helm", Params: []string{"install", "testPackage", "test", "--namespace", "test-namespace", "--create-namespace", "--atomic", "--wait", "--timeout", "525s"}},
+				{Exec: "helm", Params: []string{"repo", "add", "test2", "https://charts.helm.sh/stable2"}},
+				{Exec: "helm", Params: []string{"install", "testPackage", "test,test2", "--namespace", "test-namespace", "--create-namespace", "--atomic", "--wait", "--timeout", "525s"}},
 			},
 		},
 		{
@@ -284,6 +288,10 @@ func TestRunHelmInstall(t *testing.T) {
 			assert.Equal(t, testCase.expectedExecCalls, utils.Calls)
 		})
 	}
+}
+
+func TestMH(t *testing.T) {
+	fmt.Printf("Hello Marcus")
 }
 
 func TestRunHelmUninstall(t *testing.T) {


### PR DESCRIPTION
⚠️  This is just an early draft for approaching the topic. No intention to merge that soon.

Currently the commands for `helm upgrade` and `helm install` can only work with one repo. But we need to be able to add several repos.

Finally we should not do this via comma separated list. At least string slices should be used. Would be even better to have some map which collects all the properties for a repo. Maybe at the moment there is no clear separation between repo releated properties (name, url, user, pw) and the other parameters.