### PR TITLE
golangBuild: update golangci-lint version

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -36,7 +36,7 @@ const (
 	golangCycloneDXPackage      = "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest"
 	sbomFilename                = "bom-golang.xml"
 	golangciLintURL             = "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
-	golangciLintVersion         = "v1.46.2"
+	golangciLintVersion         = "latest"
 )
 
 type golangBuildUtils interface {


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation

We are using golangci-lint version v1.46.2 and we started getting errors:
```21:34:08  debug golangBuild - --------------------------------
21:34:08  info  golangBuild - running command: ./install.sh -b /go/bin v1.46.2
21:34:08  info  golangBuild - golangci/golangci-lint info checking GitHub for tag 'v1.46.2'
21:34:09  info  golangBuild - golangci/golangci-lint info found version: 1.46.2 for v1.46.2/linux/amd64
21:34:11  info  golangBuild - golangci/golangci-lint info installed /go/bin/golangci-lint
21:34:11  info  golangBuild - running command: /go/bin/golangci-lint run --out-format checkstyle
21:34:18  info  golangBuild - panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
21:34:18  info  golangBuild - 
21:34:18  info  golangBuild - goroutine 1 [running]:
21:34:18  info  golangBuild - github.com/go-critic/go-critic/checkers.init.22()
21:34:18  info  golangBuild - 	github.com/go-critic/go-critic@v0.6.3/checkers/embedded_rules.go:47 +0x4b4
21:34:18  info  golangBuild - fatal error: errorDetails{"category":"undefined","correlationId":"https://jenkins.piper.c.eu-de-2.cloud.sap/job/Testing/job/Vyacheslav%20Starostin/job/golang-build-piper/21/","error":"running golangci-lint failed: running command '/go/bin/golangci-lint' failed: cmd.Run() failed: exit status 2","library":"","message":"execution of golang build failed","result":"failure","stepName":"golangBuild","time":"2022-08-09T15:34:17.800365264Z"}
21:34:18  fatal golangBuild - execution of golang build failed - running golangci-lint failed: running command '/go/bin/golangci-lint' failed: cmd.Run() failed: exit status 2
```


```golangci-lint``` issues:
https://github.com/golangci/golangci-lint/issues/2374
https://github.com/go-critic/go-critic/issues/1157
https://github.com/golangci/golangci-lint/issues/2649
https://github.com/golangci/golangci-lint/issues/2414

```golangci-lint``` with the ```latest```  (v1.48.0) version works fine.

```21:30:09  info  golangBuild - running command: ./install.sh -b /go/bin latest
21:30:09  info  golangBuild - golangci/golangci-lint info checking GitHub for tag 'latest'
21:30:10  info  golangBuild - golangci/golangci-lint info found version: 1.48.0 for v1.48.0/linux/amd64
21:30:11  info  golangBuild - golangci/golangci-lint info installed /go/bin/golangci-lint
21:30:11  info  golangBuild - running command: /go/bin/golangci-lint run --out-format checkstyle
21:30:15  info  golangBuild - lint report: 
21:30:15  <?xml version="1.0" encoding="UTF-8"?>
21:30:15  
21:30:15  <checkstyle version="5.0">
21:30:15  </checkstyle>
21:30:15  
21:30:15  info  golangBuild - writing lint report to golangci-lint-report.xml
```