### PR TITLE
[newmanExecute] Allow env vars in the runOptions

### DIFF
--- a/cmd/newmanExecute.go
+++ b/cmd/newmanExecute.go
@@ -163,7 +163,11 @@ func resolveTemplate(config *newmanExecuteOptions, collection string) ([]string,
 	}
 
 	for _, runOption := range config.RunOptions {
-		templ, err := template.New("template").Parse(runOption)
+		templ, err := template.New("template").Funcs(template.FuncMap{
+			"getenv": func(varName string) string {
+				return os.Getenv(varName)
+			},
+		}).Parse(runOption)
 		if err != nil {
 			log.SetErrorCategory(log.ErrorConfiguration)
 			return nil, errors.Wrap(err, "could not parse newman command template")

--- a/cmd/newmanExecute_test.go
+++ b/cmd/newmanExecute_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/google/uuid"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -228,6 +230,19 @@ func TestResolveTemplate(t *testing.T) {
 		cmd, err := resolveTemplate(&config, "theDisplayName")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"this", "is", "my", "fancy", "command", "theDisplayName"}, cmd)
+	})
+
+	t.Run("get environment variable", func(t *testing.T) {
+		t.Parallel()
+
+		temporaryEnvVarName := uuid.New().String()
+		os.Setenv(temporaryEnvVarName, "myEnvVar")
+		defer os.Unsetenv(temporaryEnvVarName)
+		config := newmanExecuteOptions{RunOptions: []string{"this", "is", "my", "fancy", "command", "with", "--env-var", "{{getenv \"" + temporaryEnvVarName + "\"}}"}}
+
+		cmd, err := resolveTemplate(&config, "collectionsDisplayName")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"this", "is", "my", "fancy", "command", "with", "--env-var", "myEnvVar"}, cmd)
 	})
 
 	t.Run("error when parameter cannot be resolved", func(t *testing.T) {


### PR DESCRIPTION
# Changes

With this change a template function is added to the runOptions that will retrieve a variable from the environment. This solves issue #3440 

- [x] Tests
- [ ] Documentation
