### PR TITLE
Allow transport request id from config

### DIFF
--- a/cmd/transportRequestUploadCTS_generated.go
+++ b/cmd/transportRequestUploadCTS_generated.go
@@ -281,7 +281,7 @@ func transportRequestUploadCTSMetadata() config.StepData {
 								Param: "custom/transportRequestId",
 							},
 						},
-						Scope:     []string{"PARAMETERS"},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
 						Type:      "string",
 						Mandatory: true,
 						Aliases:   []config.Alias{},

--- a/resources/metadata/transportRequestUploadCTS.yaml
+++ b/resources/metadata/transportRequestUploadCTS.yaml
@@ -116,6 +116,9 @@ spec:
         description: "ID of the transport request to which the UI5 application is uploaded"
         scope:
           - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
       - name: deployToolDependencies
         type: "[]string"
         default: ['@ui5/cli', '@sap/ux-ui5-tooling', '@ui5/logger', '@ui5/fs']


### PR DESCRIPTION
# Changes

To be able to set the transportRequestId for the `transportRequestUploadCTS` step when used in the `piperPipelineStageRelease` step we want to set it via config.yaml

- [x] Documentation
