### PR TITLE
chore: improve Influx performance

### DIFF
--- a/cmd/readInfluxData.go
+++ b/cmd/readInfluxData.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	influxDataPath = ".pipeline/influx/"
+)
+
+// ReadPipelineEnv reads the commonPipelineEnvironment from disk and outputs it as JSON
+func ReadInfluxData() *cobra.Command {
+	return &cobra.Command{
+		Use:   "readInfluxData",
+		Short: "Reads the Influx data written by the steps from disk and outputs it as JSON",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			path, _ := os.Getwd()
+			fatalHook := &log.FatalHook{CorrelationID: GeneralConfig.CorrelationID, Path: path}
+			log.RegisterHook(fatalHook)
+		},
+
+		Run: func(cmd *cobra.Command, args []string) {
+			fileUtils := piperutils.Files{}
+			err := runReadInfluxData(&fileUtils, os.Stdout)
+			if err != nil {
+				log.Entry().Fatalf("error when reading Influx data: %v", err)
+			}
+		},
+	}
+}
+
+func runReadInfluxData(fileUtils piperutils.FileUtils, out io.Writer) error {
+	files, err := fileUtils.Glob(fmt.Sprintf("%v**", influxDataPath))
+	if err != nil {
+		return fmt.Errorf("failed to find Influx data files: %w", err)
+	}
+
+	influxData := struct {
+		Fields map[string]map[string]interface{} `json:"fields,omitempty"`
+		Tags   map[string]map[string]interface{} `json:"tags,omitempty"`
+	}{
+		Fields: map[string]map[string]interface{}{},
+		Tags:   map[string]map[string]interface{}{},
+	}
+
+	for _, fileName := range files {
+		parts := strings.Split(strings.TrimPrefix(fileName, influxDataPath), "/")
+		if len(parts) != 3 {
+			return fmt.Errorf("invalid influx file path: %v", fileName)
+		}
+		theMeasurement := parts[0]
+		theType := parts[1]
+		theName := parts[2]
+		var theValue interface{}
+
+		fileContent, err := fileUtils.FileRead(fileName)
+		if err != nil {
+			return fmt.Errorf("failed to read file: %w", err)
+		}
+
+		ext := filepath.Ext(fileName)
+		if ext == ".json" {
+			theName = strings.TrimSuffix(theName, ".json")
+			if err := json.Unmarshal(fileContent, &theValue); err != nil {
+				return fmt.Errorf("failed to unmarshal json content of influx data file %v: %w", fileName, err)
+			}
+		} else {
+			switch string(fileContent) {
+			case "true":
+				theValue = true
+			case "false":
+				theValue = false
+			default:
+				theValue = string(fileContent)
+			}
+		}
+
+		if theType == "fields" {
+			if influxData.Fields[theMeasurement] == nil {
+				influxData.Fields[theMeasurement] = map[string]interface{}{}
+			}
+			influxData.Fields[theMeasurement][theName] = theValue
+		} else if theType == "tags" {
+			if influxData.Tags[theMeasurement] == nil {
+				influxData.Tags[theMeasurement] = map[string]interface{}{}
+			}
+			influxData.Tags[theMeasurement][theName] = theValue
+		}
+	}
+
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "\t")
+	if err := encoder.Encode(influxData); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/readInfluxData_test.go
+++ b/cmd/readInfluxData_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/SAP/jenkins-library/pkg/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunReadInfluxData(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success - no data", func(t *testing.T){
+		fileUtils := mock.FilesMock{}
+		var b bytes.Buffer
+		err := runReadInfluxData(&fileUtils, &b)
+	
+		assert.NoError(t, err)
+		assert.Equal(t, "{}\n", b.String())
+	})
+
+	t.Run("success - with data", func(t *testing.T){
+		fileUtils := mock.FilesMock{}
+		fileUtils.AddFile(".pipeline/influx/step_data/fields/field1", []byte("value1"))
+		fileUtils.AddFile(".pipeline/influx/step_data/fields/field2", []byte("true"))
+		fileUtils.AddFile(".pipeline/influx/step_data/fields/field3", []byte("false"))
+		fileUtils.AddFile(".pipeline/influx/step_data/fields/field4.json", []byte("25"))
+		fileUtils.AddFile(".pipeline/influx/custom_data/tags/tag1", []byte("tagValue1"))
+		fileUtils.AddFile(".pipeline/influx/custom_data/tags/tag2", []byte("tagValue2"))
+		var b bytes.Buffer
+		err := runReadInfluxData(&fileUtils, &b)
+
+		expectedJSON := `{
+	"fields": {
+		"step_data": {
+			"field1": "value1",
+			"field2": true,
+			"field3": false,
+			"field4": 25
+		}
+	},
+	"tags": {
+		"custom_data": {
+			"tag1": "tagValue1",
+			"tag2": "tagValue2"
+		}
+	}
+}
+`
+		assert.NoError(t, err)
+		assert.Equal(t, expectedJSON, b.String())
+	})
+
+	t.Run("failure - invalid file path", func(t *testing.T){
+		fileUtils := mock.FilesMock{}
+		fileUtils.AddFile(".pipeline/influx/step_data/field1", []byte("value1"))
+		var b bytes.Buffer
+		err := runReadInfluxData(&fileUtils, &b)
+	
+		assert.EqualError(t, err, "invalid influx file path: .pipeline/influx/step_data/field1")
+	})
+
+	t.Run("failure - readFile", func(t *testing.T){
+		fileUtils := mock.FilesMock{}
+		fileUtils.AddFile(".pipeline/influx/step_data/fields/field1", []byte("value1"))
+		fileUtils.FileReadErrors = map[string]error{".pipeline/influx/step_data/fields/field1": fmt.Errorf("read error")}
+		var b bytes.Buffer
+		err := runReadInfluxData(&fileUtils, &b)
+	
+		assert.EqualError(t, err, "failed to read file: read error")
+	})
+
+	t.Run("failure - unmarshal value", func(t *testing.T){
+		fileUtils := mock.FilesMock{}
+		fileUtils.AddFile(".pipeline/influx/step_data/fields/field1.json", []byte("{value1"))
+		var b bytes.Buffer
+		err := runReadInfluxData(&fileUtils, &b)
+	
+		assert.Contains(t, fmt.Sprint(err), "failed to unmarshal json content of influx data file .pipeline/influx/step_data/fields/field1.json: ")
+	})
+}

--- a/cmd/readPipelineEnv.go
+++ b/cmd/readPipelineEnv.go
@@ -23,7 +23,7 @@ func ReadPipelineEnv() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runReadPipelineEnv()
 			if err != nil {
-				log.Entry().Fatalf("error when writing reading Pipeline environment: %v", err)
+				log.Entry().Fatalf("error when reading Pipeline environment: %v", err)
 			}
 		},
 	}

--- a/src/com/sap/piper/analytics/InfluxData.groovy
+++ b/src/com/sap/piper/analytics/InfluxData.groovy
@@ -39,6 +39,21 @@ class InfluxData implements Serializable{
         instance = null
     }
 
+    public static void readFromJson(script, theJson) {
+        influxData = script.readJSON(text: theJson)
+
+        influxData.fields?.each({measurement, mValue ->
+            mValue?.each({field, value ->
+                addField(measurement, field, value)
+            })
+        })
+        influxData.tags?.each({measurement, mValue ->
+            mValue?.each({tag, value ->
+                addTag(measurement, tag, value)
+            })
+        })
+    }
+
     public static void readFromDisk(script) {
         script.echo "Transfer Influx data"
         def pathPrefix = '.pipeline/influx/'

--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -86,7 +86,11 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
                            readPipelineEnv(script: script, piperGoPath: piperGoPath)
                         }
                     } finally {
-                        InfluxData.readFromDisk(script)
+                        try {
+                            readInfluxData(script: script, piperGoPath: piperGoPath)
+                        } catch err {
+                            InfluxData.readFromJson(script, theJson)
+                        }
                         stash name: 'pipelineStepReports', includes: '.pipeline/stepReports/**', allowEmpty: true
                     }
                 }

--- a/vars/readInfluxData.groovy
+++ b/vars/readInfluxData.groovy
@@ -1,0 +1,14 @@
+import static com.sap.piper.Prerequisites.checkScript
+import com.sap.piper.analytics.InfluxData
+
+import groovy.transform.Field
+
+@Field def STEP_NAME = getClass().getName()
+
+void call(Map parameters = [:]) {
+    final script = checkScript(this, parameters) ?: this
+    String piperGoPath = parameters?.piperGoPath ?: './piper'
+    def output = script.sh(returnStdout: true, script: "${piperGoPath} readInfluxData")
+
+    InfluxData.readFromJson(script, output)
+}


### PR DESCRIPTION
# Changes

read Influx data files via golang binary and no longer via groovy.
This improves read performance significantly.

So far fallback is kept.
This is for example required when non-standard `piper` binary is in use via `piperExecuteBin`. This custom binary would also need to contain the new step.

- [x] Tests
- ~[ ] Documentation~
