### PR TITLE
feat(checkIfStepActive): allow check if CPE variable exists

### DIFF
--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -164,13 +164,7 @@ func (s *StepCondition) evaluateV1(config StepConfig, utils piperutils.FileUtils
 
 		var metadata StepData
 		for param, value := range s.CommonPipelineEnvironment {
-			dataType := "interface"
-			_, ok := value.(string)
-			if ok {
-				dataType = "string"
-			}
-			dataTypes := []string{dataType}
-			cpeEntry := getCPEEntry(param, value, dataTypes, &metadata, stepName, envRootPath)
+			cpeEntry := getCPEEntry(param, value, &metadata, stepName, envRootPath)
 			if cpeEntry[stepName] == value {
 				return true, nil
 			}
@@ -183,8 +177,12 @@ func (s *StepCondition) evaluateV1(config StepConfig, utils piperutils.FileUtils
 		var metadata StepData
 		for _, param := range s.CommonPipelineEnvironmentVariableExists {
 
-			dataTypes := []string{"string", "interface"}
-			cpeEntry := getCPEEntry(param, "", dataTypes, &metadata, stepName, envRootPath)
+			// check CPE for both a string and non-string value
+			cpeEntry := getCPEEntry(param, "", &metadata, stepName, envRootPath)
+			if len(cpeEntry) == 0 {
+				cpeEntry = getCPEEntry(param, nil, &metadata, stepName, envRootPath)
+			}
+
 			if _, ok := cpeEntry[stepName]; ok {
 				return true, nil
 			}
@@ -201,14 +199,17 @@ func (s *StepCondition) evaluateV1(config StepConfig, utils piperutils.FileUtils
 	}
 }
 
-func getCPEEntry(param string, value interface{}, dataTypes []string, metadata *StepData, stepName string, envRootPath string) map[string]interface{} {
-
-	for _, dataType := range dataTypes {
-		stepParam := StepParameters{Name: stepName,
+func getCPEEntry(param string, value interface{}, metadata *StepData, stepName string, envRootPath string) map[string]interface{} {
+	dataType := "interface"
+	_, ok := value.(string)
+	if ok {
+		dataType = "string"
+	}
+	metadata.Spec.Inputs.Parameters = []StepParameters{
+		{Name: stepName,
 			Type:        dataType,
 			ResourceRef: []ResourceReference{{Name: "commonPipelineEnvironment", Param: param}},
-		}
-		metadata.Spec.Inputs.Parameters = append(metadata.Spec.Inputs.Parameters, stepParam)
+		},
 	}
 	return metadata.GetResourceParameters(envRootPath, "commonPipelineEnvironment")
 }

--- a/pkg/config/evaluation_test.go
+++ b/pkg/config/evaluation_test.go
@@ -385,6 +385,18 @@ func TestEvaluateV1(t *testing.T) {
 			expected:      false,
 		},
 		{
+			name:          "CommonPipelineEnvironmentVariableExists - true",
+			config:        StepConfig{Config: map[string]interface{}{}},
+			stepCondition: StepCondition{CommonPipelineEnvironmentVariableExists: []string{"custom/myCpeTrueFile"}},
+			expected:      true,
+		},
+		{
+			name:          "CommonPipelineEnvironmentVariableExists - false",
+			config:        StepConfig{Config: map[string]interface{}{}},
+			stepCondition: StepCondition{CommonPipelineEnvironmentVariableExists: []string{"custom/notMyCpeTrueFile"}},
+			expected:      false,
+		},
+		{
 			name:     "No condition - true",
 			config:   StepConfig{Config: map[string]interface{}{}},
 			expected: true,
@@ -405,11 +417,12 @@ func TestEvaluateV1(t *testing.T) {
 	dir := t.TempDir()
 
 	cpeDir := filepath.Join(dir, "commonPipelineEnvironment")
-	err := os.MkdirAll(cpeDir, 0700)
+	err := os.MkdirAll(filepath.Join(cpeDir, "custom"), 0700)
 	if err != nil {
-		t.Fatal("Failed to create sub directory")
+		t.Fatal("Failed to create sub directories")
 	}
 	ioutil.WriteFile(filepath.Join(cpeDir, "myCpeTrueFile"), []byte("myTrueValue"), 0700)
+	ioutil.WriteFile(filepath.Join(cpeDir, "custom", "myCpeTrueFile"), []byte("myTrueValue"), 0700)
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -68,13 +68,14 @@ type Step struct {
 }
 
 type StepCondition struct {
-	Config                    map[string][]interface{} `json:"config,omitempty"`
-	ConfigKey                 string                   `json:"configKey,omitempty"`
-	FilePattern               string                   `json:"filePattern,omitempty"`
-	FilePatternFromConfig     string                   `json:"filePatternFromConfig,omitempty"`
-	Inactive                  bool                     `json:"inactive,omitempty"`
-	NpmScript                 string                   `json:"npmScript,omitempty"`
-	CommonPipelineEnvironment map[string]interface{}   `json:"commonPipelineEnvironment,omitempty"`
+	Config                                  map[string][]interface{} `json:"config,omitempty"`
+	ConfigKey                               string                   `json:"configKey,omitempty"`
+	FilePattern                             string                   `json:"filePattern,omitempty"`
+	FilePatternFromConfig                   string                   `json:"filePatternFromConfig,omitempty"`
+	Inactive                                bool                     `json:"inactive,omitempty"`
+	NpmScript                               string                   `json:"npmScript,omitempty"`
+	CommonPipelineEnvironment               map[string]interface{}   `json:"commonPipelineEnvironment,omitempty"`
+	CommonPipelineEnvironmentVariableExists []string                 `json:"commonPipelineEnvironmentVariableExists,omitempty"`
 }
 
 func (r *RunConfigV1) InitRunConfigV1(config *Config, filters map[string]StepFilters, parameters map[string][]StepParameters,


### PR DESCRIPTION
# Changes

Allows setting variable names under a new `commonPipelineEnvironmentVariableExists` condition in a stage conditions file (V1 only). These are to be checked purely on presence, instead of the `commonPipelineEnvironment` condition, where the variable needs to have a specific value. This is useful for #3965, which outputs a `custom/remoteHelmChartPath` variable, with unpredictable values.

- [x] Tests
~~[ ] Documentation~~

