### PR TITLE
fix(mailSendNotification): do not send recovery notifications on first build

### DIFF
--- a/vars/mailSendNotification.groovy
+++ b/vars/mailSendNotification.groovy
@@ -252,5 +252,11 @@ def getDistinctRecipients(recipients){
 }
 
 def hasRecovered(buildResult, currentBuild){
-    return buildResult == 'SUCCESS' && currentBuild.getPreviousBuild()?.result != 'SUCCESS'
+    def previousBuild = currentBuild.getPreviousBuild()
+
+    if (previousBuild) {
+        return buildResult == 'SUCCESS' && previousBuild.result != 'SUCCESS'
+    }
+
+    return false
 }


### PR DESCRIPTION
# Changes

Added check if previous build exists, before verifying recovery status

- [x] Tests
- [ ] Documentation
