### PR TITLE
cnbBuild: bump platform api version to 0.9 [breaking]

### DIFF
--- a/cmd/cnbBuild.go
+++ b/cmd/cnbBuild.go
@@ -584,7 +584,7 @@ func runCnbBuild(config *cnbBuildOptions, cnbTelemetry *cnbBuildTelemetry, utils
 	}
 
 	utils.AppendEnv([]string{fmt.Sprintf("CNB_REGISTRY_AUTH=%s", cnbRegistryAuth)})
-	utils.AppendEnv([]string{"CNB_PLATFORM_API=0.8"})
+	utils.AppendEnv([]string{"CNB_PLATFORM_API=0.9"})
 
 	creatorArgs := []string{
 		"-no-color",


### PR DESCRIPTION
If you have configured a [custom builder](https://www.project-piper.io/steps/cnbBuild/#dockerimage) make sure it supports the [CNB Platform API 0.9](https://github.com/buildpacks/spec/releases/tag/platform%2Fv0.9) (previously 0.8 was required). This can be done be upgrading your builder to the lifecycle 0.14.x in the [builder.toml](https://buildpacks.io/docs/reference/config/builder-config/#lifecycle-_optional_)

# Changes

- [ ] Tests
- [ ] Documentation
