### PR TITLE
helmExecute: change permissions for downloaded dependency

### DIFF
--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -377,8 +377,16 @@ func (h *HelmExecute) RunHelmDependency() error {
 		log.Entry().WithError(err).Fatal("Helm dependency call failed")
 	}
 
-	if err := h.utils.Chmod(filepath.Join(h.config.ChartPath, "charts"), 0777); err != nil {
-		return fmt.Errorf("failed to change permissions: %v", err)
+	dependencyDir := filepath.Join(h.config.ChartPath, "charts")
+	exists, err := h.utils.DirExists(dependencyDir)
+	if err != nil {
+		return fmt.Errorf("failed to get directory information: %v", err)
+	}
+
+	if exists {
+		if err := h.utils.Chmod(dependencyDir, 0777); err != nil {
+			return fmt.Errorf("failed to change permissions: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
@@ -374,6 +375,10 @@ func (h *HelmExecute) RunHelmDependency() error {
 
 	if err := h.runHelmCommand(helmParams); err != nil {
 		log.Entry().WithError(err).Fatal("Helm dependency call failed")
+	}
+
+	if err := h.utils.Chmod(filepath.Join(h.config.ChartPath, "charts"), 0777); err != nil {
+		return fmt.Errorf("failed to change permissions: %v", err)
 	}
 
 	return nil

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -466,6 +466,9 @@ func TestRunHelmDependency(t *testing.T) {
 		t.Run(fmt.Sprintf("test case: %d", i), func(t *testing.T) {
 			utils := helmMockUtilsBundle{
 				ExecMockRunner: &mock.ExecMockRunner{},
+				FilesMock: &mock.FilesMock{
+					Separator: "/",
+				},
 			}
 			helmExecute := HelmExecute{
 				utils:   utils,


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation

This PR changes permissions for downloaded dependency. 

```helmExecute``` runs docker container (dtzar/helm-kubectl:3.8.0) with ```-u 0``` (because, for example, ```helm dependency update``` tries to read and write files to ```./root/.cache/helm/repository``` in the container).
Dependency is being downloaded to the ```charts``` folder with permissions ```drwxr-xr-x root root```.
Jenkins can’t clean up the workspace - operation not permitted.

```
Error when executing cleanup post condition:
Also:   java.nio.file.FileSystemException: /var/jenkins_home/workspace/uild-helm-with-dependency-5_main/helm/azure-demo-k8s-go/charts/nginx-13.1.6.tgz: Operation not permitted
...
Also:   java.nio.file.FileSystemException: /var/jenkins_home/workspace/uild-helm-with-dependency-5_main/helm/azure-demo-k8s-go/charts: Operation not permitted
```
