### PR TITLE
fix(ssh auth) downgrade x/crypto to allow ssh auth with all git instances 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/SAP/jenkins-library
 go 1.18
 
 //downgraded for :https://cs.opensource.google/go/x/crypto/+/5d542ad81a58c89581d596f49d0ba5d435481bcf : or else will break for some github instances
-// no downgraded using go get since it breaks other dependencies.
+// not downgraded using go get since it breaks other dependencies.
 replace golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d => golang.org/x/crypto v0.0.0-20220314234716-a5774263c1e0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/SAP/jenkins-library
 
 go 1.18
 
+replace golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d => golang.org/x/crypto v0.0.0-20220314234716-a5774263c1e0
+
 require (
 	cloud.google.com/go/storage v1.22.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/SAP/jenkins-library
 
 go 1.18
 
+//downgraded for :https://cs.opensource.google/go/x/crypto/+/5d542ad81a58c89581d596f49d0ba5d435481bcf : or else will break for some github instances
+// no downgraded using go get since it breaks other dependencies.
 replace golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d => golang.org/x/crypto v0.0.0-20220314234716-a5774263c1e0
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2384,8 +2384,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
-golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220314234716-a5774263c1e0 h1:VX5DDcOISmzJbt7ej5lyL1TxQc9dHTtNcTABzu1UsTw=
+golang.org/x/crypto v0.0.0-20220314234716-a5774263c1e0/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=


### PR DESCRIPTION
# Changes

PR #3959 upgraded x/crypto version however: 

https://cs.opensource.google/go/x/crypto/+/5d542ad81a58c89581d596f49d0ba5d435481bcf 

with the newer version of x/crypto there seems to a algorithm mismatch with what x/crypto/ssh uses and what some github instances support 

most like recent version of openSSH removed support for SHA1 key signing , but some github instances may still expect SHA1 (till the time such instances don't remove SHA1 support), the mistmatch can cause handshake failure during authentication, so downgrading the x/crypto version .

- [x] Tests
- [ ] Documentation
