### PR TITLE
feat(ExecRunner): interpolate environment variables

### DIFF
--- a/pkg/command/execution.go
+++ b/pkg/command/execution.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-//errCopyStdout and errCopyStderr are filled after the command execution after Wait() terminates
+// errCopyStdout and errCopyStderr are filled after the command execution after Wait() terminates
 type execution struct {
 	cmd           *exec.Cmd
 	wg            sync.WaitGroup


### PR DESCRIPTION
# Changes

We want to pass secrets configured in [vault](https://www.project-piper.io/infrastructure/vault/#using-vault-for-general-purpose-and-test-credentials) to the kaniko build context as build-args. This PR enhances the command execution runner to support environment variable interpolation with `$ENVVAR` or `${ENVVAR}`. With that we could simply realise our scenario with:

```yaml
  kanikoExecute:
    vaultCredentialPath: 'myStepCredentials'
    vaultCredentialKeys: ['TF_USER', 'TF_PWD']
    buildOptions:
      - '--build-arg=TF_USER=$PIPER_VAULTCREDENTIAL_TF_USER'
      - '--build-arg=TF_PWD=$PIPER_VAULTCREDENTIAL_TF_PWD'
```

```Dockerfile
FROM alpine
ARG TF_USER
ARG TF_PWD
...
```

- [x] Tests
- [x] Documentation
