### PR TITLE
rename actual to current commit

### DIFF
--- a/cmd/abapEnvironmentAssemblePackages.go
+++ b/cmd/abapEnvironmentAssemblePackages.go
@@ -180,8 +180,13 @@ func (br *buildWithRepository) start() error {
 				Value: br.repo.PredecessorCommitID})
 	}
 	if br.repo.CommitID != "" {
+		// old value to be used until 2302 [can be deleted latest with 2308]
 		valuesInput.Values = append(valuesInput.Values,
 			abapbuild.Value{ValueID: "ACTUAL_DELIVERY_COMMIT",
+				Value: br.repo.CommitID})
+		// new value used as of 2302
+		valuesInput.Values = append(valuesInput.Values,
+			abapbuild.Value{ValueID: "CURRENT_DELIVERY_COMMIT",
 				Value: br.repo.CommitID})
 	}
 	if len(br.repo.Languages) > 0 {


### PR DESCRIPTION
# Changes
to streamline naming across the process chain the wording has been changed in the ABAP backend for 2302 release. Thus the previous named ACTUAL_DELIVERY_COMMIT was renamed to CURRENT_DELIVERY_COMMIT. For some time we will supply both values to the ABAP backend as the other one will be ignored. Proposal for deletion for the outdated ACTUAL_DELIVERY_COMMIT would be 2308 release.
