### PR TITLE
fix(helmExecute): do not publish helm charts under subfolders

### DIFF
--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -426,9 +426,7 @@ func (h *HelmExecute) RunHelmPublish() (string, error) {
 
 	h.utils.SetOptions(repoClientOptions)
 
-	binary := fmt.Sprintf("%v", h.config.DeploymentName+"-"+h.config.PublishVersion+".tgz")
-
-	targetPath := fmt.Sprintf("%v/%s", h.config.DeploymentName, binary)
+	binary := fmt.Sprintf("%s-%s.tgz", h.config.DeploymentName, h.config.PublishVersion)
 
 	separator := "/"
 
@@ -436,7 +434,7 @@ func (h *HelmExecute) RunHelmPublish() (string, error) {
 		separator = ""
 	}
 
-	targetURL := fmt.Sprintf("%s%s%s", h.config.TargetRepositoryURL, separator, targetPath)
+	targetURL := fmt.Sprintf("%s%s%s", h.config.TargetRepositoryURL, separator, binary)
 
 	log.Entry().Infof("publishing artifact: %s", targetURL)
 

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -540,8 +540,8 @@ func TestRunHelmPublish(t *testing.T) {
 		targetURL, err := helmExecute.RunHelmPublish()
 		if assert.NoError(t, err) {
 			assert.Equal(t, 1, len(utils.FileUploads))
-			assert.Equal(t, "https://my.target.repository.local/test_helm_chart/test_helm_chart-1.2.3.tgz", targetURL)
-			assert.Equal(t, "https://my.target.repository.local/test_helm_chart/test_helm_chart-1.2.3.tgz", utils.FileUploads["test_helm_chart-1.2.3.tgz"])
+			assert.Equal(t, "https://my.target.repository.local/test_helm_chart-1.2.3.tgz", targetURL)
+			assert.Equal(t, "https://my.target.repository.local/test_helm_chart-1.2.3.tgz", utils.FileUploads["test_helm_chart-1.2.3.tgz"])
 		}
 	})
 }


### PR DESCRIPTION
# Changes

When publishing a helm chart under the subfolder, it's not possible to use it as a dependency in the `Chart.yaml`, since the registry's `index.yaml` doesn't include the subfolder in the url to the chart's tarball, resulting in a 404 error during a `helm dependency update`.

- [X] Tests
- [ ] Documentation
