### PR TITLE
fix(JenkinsConfigProvider): panic in GetBuildReason

### DIFF
--- a/pkg/orchestrator/jenkins.go
+++ b/pkg/orchestrator/jenkins.go
@@ -191,7 +191,7 @@ func (j *JenkinsConfigProvider) GetStageName() string {
 	return getEnv("STAGE_NAME", "n/a")
 }
 
-//GetBuildReason returns the build reason of the current build
+// GetBuildReason returns the build reason of the current build
 func (j *JenkinsConfigProvider) GetBuildReason() string {
 	// BuildReasons are unified with AzureDevOps build reasons,see
 	// https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
@@ -210,6 +210,9 @@ func (j *JenkinsConfigProvider) GetBuildReason() string {
 
 	for _, child := range jsonParsed.Path("actions").Children() {
 		class := child.S("_class")
+		if class == nil {
+			continue
+		}
 		if class.Data().(string) == "hudson.model.CauseAction" {
 			for _, val := range child.Path("causes").Children() {
 				subclass := val.S("_class")

--- a/pkg/orchestrator/jenkins_test.go
+++ b/pkg/orchestrator/jenkins_test.go
@@ -348,6 +348,13 @@ func TestJenkinsConfigProvider_GetBuildReason(t *testing.T) {
 			apiInformation: []byte(`{}`),
 			want:           "Unknown",
 		},
+		{
+			name: "Empty action api",
+			apiInformation: []byte(`{
+				"actions": [{}]
+			}`),
+			want: "Unknown",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The `_class` field of the objects in the actions array is not always populated, like in this example (notice the `CauseAction` is only the 2nd entry):

```json
{
  "_class": "org.jenkinsci.plugins.workflow.job.WorkflowRun",
  "actions": [
    {},
    {
      "_class": "hudson.model.CauseAction",
      "causes": [
        {
          "_class": "hudson.model.Cause$UserIdCause",
          "shortDescription": "Started by user John Doe",
          "userId": "d012345",
          "userName": "John Doe"
        },
        {
          "_class": "org.jenkinsci.plugins.workflow.cps.replay.ReplayCause",
          "shortDescription": "Replayed #1"
        }
      ]
    },
    {
      "_class": "jenkins.scm.api.SCMRevisionAction"
    }
  ]
}
```

I have no idea why this happens, but it causes the `GetBuildReason` method to panic. This PR fixes this by ignoring any actions without class.

Log:

```
14:58:12  panic: interface conversion: interface {} is nil, not string
14:58:12  
14:58:12  goroutine 1 [running]:
14:58:12  github.com/SAP/jenkins-library/pkg/orchestrator.(*JenkinsConfigProvider).GetBuildReason(0xc00072ea00)
14:58:12  	github.com/SAP/jenkins-library@v1.243.0/pkg/orchestrator/jenkins.go:213 +0x685
14:58:12  github.wdf.sap.corp/ContinuousDelivery/piper-library/cmd.runSapReportPipelineStatus(0xc00124bb90, 0x0?, {0x1?, 0x0?})
14:58:12  	github.wdf.sap.corp/ContinuousDelivery/piper-library/cmd/sapReportPipelineStatus.go:112 +0x50f
14:58:12  github.wdf.sap.corp/ContinuousDelivery/piper-library/cmd.sapReportPipelineStatus({0x1, {0xc00051e4b0, 0x42}, {0xc0009f6720, 0x24}, {0xc0012ad7b0, 0x5}, 0x1, {0xc0008c82c0, 0x4, ...}, ...}, ...)
```

# Changes

- [x] Tests
- [ ] Documentation
