### PR TITLE
gradleExecuteBuild: get published artifacts names and write those to CPE

### DIFF
--- a/cmd/gradleExecuteBuild.go
+++ b/cmd/gradleExecuteBuild.go
@@ -193,7 +193,7 @@ func publishArtifacts(config *gradleExecuteBuildOptions, utils gradleExecuteBuil
 		log.Entry().WithError(err).Errorf("failed to publish artifacts: %v", err)
 		return err
 	}
-	artifacts, err := getPublishedArtifactsNames(utils)
+	artifacts, err := getPublishedArtifactsNames(pathToModuleFile, utils)
 	if err != nil {
 		return fmt.Errorf("failed to get published artifacts: %v", err)
 	}
@@ -216,23 +216,23 @@ func getPublishInitScriptContent(options *gradleExecuteBuildOptions) (string, er
 	return generatedCode.String(), nil
 }
 
-func getPublishedArtifactsNames(utils gradleExecuteBuildUtils) (piperenv.Artifacts, error) {
+func getPublishedArtifactsNames(file string, utils gradleExecuteBuildUtils) (piperenv.Artifacts, error) {
 	artifacts := piperenv.Artifacts{}
 	publishedArtifacts := PublishedArtifacts{}
-	exists, err := utils.FileExists(pathToModuleFile)
+	exists, err := utils.FileExists(file)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check existence of the file '%s': %v", pathToModuleFile, err)
+		return nil, fmt.Errorf("failed to check existence of the file '%s': %v", file, err)
 	}
 	if !exists {
-		return nil, fmt.Errorf("failed to get '%s': file does not exist", pathToModuleFile)
+		return nil, fmt.Errorf("failed to get '%s': file does not exist", file)
 	}
-	content, err := utils.ReadFile(pathToModuleFile)
+	content, err := utils.ReadFile(file)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read '%s': %v", pathToModuleFile, err)
+		return nil, fmt.Errorf("failed to read '%s': %v", file, err)
 	}
 	err = json.Unmarshal(content, &publishedArtifacts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal '%s': %v", pathToModuleFile, err)
+		return nil, fmt.Errorf("failed to unmarshal '%s': %v", file, err)
 	}
 	for _, publishedArtifact := range publishedArtifacts.Elements {
 		if publishedArtifact.Name != "apiElements" {

--- a/cmd/gradleExecuteBuild.go
+++ b/cmd/gradleExecuteBuild.go
@@ -234,11 +234,11 @@ func getPublishedArtifactsNames(file string, utils gradleExecuteBuildUtils) (pip
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal '%s': %v", file, err)
 	}
-	for _, publishedArtifact := range publishedArtifacts.Elements {
-		if publishedArtifact.Name != "apiElements" {
+	for _, element := range publishedArtifacts.Elements {
+		if element.Name != "apiElements" {
 			continue
 		}
-		for _, artifact := range publishedArtifact.Artifacts {
+		for _, artifact := range element.Artifacts {
 			artifacts = append(artifacts, piperenv.Artifact{Name: artifact.Name})
 		}
 	}

--- a/cmd/gradleExecuteBuild_test.go
+++ b/cmd/gradleExecuteBuild_test.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/SAP/jenkins-library/pkg/mock"
+	"github.com/SAP/jenkins-library/pkg/piperenv"
 )
+
+const moduleFileContent = `{"variants": [{"name": "apiElements","files": [{"name": "gradle-1.2.3-12234567890-plain.jar"}]}]}`
 
 type gradleExecuteBuildMockUtils struct {
 	*mock.ExecMockRunner
@@ -15,6 +19,7 @@ type gradleExecuteBuildMockUtils struct {
 }
 
 func TestRunGradleExecuteBuild(t *testing.T) {
+	pipelineEnv := &gradleExecuteBuildCommonPipelineEnvironment{}
 
 	t.Run("failed case - build.gradle isn't present", func(t *testing.T) {
 		utils := gradleExecuteBuildMockUtils{
@@ -27,7 +32,7 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			UseWrapper: false,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "the specified gradle build script could not be found")
 	})
@@ -44,7 +49,7 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			UseWrapper: false,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(utils.Calls))
 		assert.Equal(t, mock.ExecCall{Exec: "gradle", Params: []string{"build", "-p", "path/to"}}, utils.Calls[0])
@@ -63,7 +68,7 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			CreateBOM:  true,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(utils.Calls))
 		assert.Equal(t, mock.ExecCall{Exec: "gradle", Params: []string{"tasks", "-p", "path/to"}}, utils.Calls[0])
@@ -79,6 +84,7 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			FilesMock:      &mock.FilesMock{},
 		}
 		utils.FilesMock.AddFile("path/to/build.gradle", []byte{})
+		utils.FilesMock.AddFile("/build/publications/maven/module.json", []byte(moduleFileContent))
 		options := &gradleExecuteBuildOptions{
 			Path:       "path/to",
 			Task:       "build",
@@ -86,12 +92,13 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			Publish:    true,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(utils.Calls))
 		assert.Equal(t, mock.ExecCall{Exec: "gradle", Params: []string{"build", "-p", "path/to"}}, utils.Calls[0])
 		assert.Equal(t, mock.ExecCall{Exec: "gradle", Params: []string{"tasks", "-p", "path/to"}}, utils.Calls[1])
 		assert.Equal(t, mock.ExecCall{Execution: (*mock.Execution)(nil), Async: false, Exec: "gradle", Params: []string{"publish", "-p", "path/to", "--init-script", "initScript.gradle.tmp"}}, utils.Calls[2])
+		assert.Equal(t, "gradle-1.2.3-12234567890-plain.jar", pipelineEnv.custom.artifacts[0].Name)
 		assert.True(t, utils.HasWrittenFile("initScript.gradle.tmp"))
 		assert.True(t, utils.HasRemovedFile("initScript.gradle.tmp"))
 	})
@@ -109,7 +116,7 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			UseWrapper: true,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(utils.Calls))
 		assert.Equal(t, mock.ExecCall{Exec: "./gradlew", Params: []string{"build", "-p", "path/to"}}, utils.Calls[0])
@@ -129,7 +136,7 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			UseWrapper: false,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to build")
 	})
@@ -150,7 +157,7 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			CreateBOM:  true,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create bom")
 	})
@@ -171,8 +178,84 @@ func TestRunGradleExecuteBuild(t *testing.T) {
 			Publish:    true,
 		}
 
-		err := runGradleExecuteBuild(options, nil, utils)
+		err := runGradleExecuteBuild(options, nil, utils, pipelineEnv)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to publish artifacts")
 	})
+}
+
+func TestGetPublishedArtifactsNames(t *testing.T) {
+	tt := []struct {
+		name              string
+		utils             gradleExecuteBuildMockUtils
+		moduleFile        string
+		moduleFileContent string
+		expectedResult    piperenv.Artifacts
+		expectedErr       error
+	}{
+		{
+			name: "failed to check file existence",
+			utils: gradleExecuteBuildMockUtils{
+				ExecMockRunner: &mock.ExecMockRunner{},
+				FilesMock: &mock.FilesMock{
+					FileExistsErrors: map[string]error{"module.json": fmt.Errorf("err")},
+				},
+			},
+			moduleFile:        "module.json",
+			moduleFileContent: "",
+			expectedErr:       fmt.Errorf("failed to check existence of the file 'module.json': err"),
+		}, {
+			name: "failed to get file",
+			utils: gradleExecuteBuildMockUtils{
+				ExecMockRunner: &mock.ExecMockRunner{},
+				FilesMock:      &mock.FilesMock{},
+			},
+			moduleFile:        "",
+			moduleFileContent: "",
+			expectedErr:       fmt.Errorf("failed to get '': file does not exist"),
+		}, {
+			name: "failed to read file",
+			utils: gradleExecuteBuildMockUtils{
+				ExecMockRunner: &mock.ExecMockRunner{},
+				FilesMock: &mock.FilesMock{
+					FileReadErrors: map[string]error{"module.json": fmt.Errorf("err")},
+				},
+			},
+			moduleFile:        "module.json",
+			moduleFileContent: "",
+			expectedErr:       fmt.Errorf("failed to read 'module.json': err"),
+		}, {
+			name: "failed to unmarshal file",
+			utils: gradleExecuteBuildMockUtils{
+				ExecMockRunner: &mock.ExecMockRunner{},
+				FilesMock:      &mock.FilesMock{},
+			},
+			moduleFile:        "module.json",
+			moduleFileContent: "",
+			expectedErr:       fmt.Errorf("failed to unmarshal 'module.json': unexpected end of JSON input"),
+		}, {
+			name: "success - get name of published artifact",
+			utils: gradleExecuteBuildMockUtils{
+				ExecMockRunner: &mock.ExecMockRunner{},
+				FilesMock:      &mock.FilesMock{},
+			},
+			moduleFile:        "module.json",
+			moduleFileContent: moduleFileContent,
+			expectedResult:    piperenv.Artifacts{piperenv.Artifact{Name: "gradle-1.2.3-12234567890-plain.jar"}},
+			expectedErr:       nil,
+		},
+	}
+
+	for _, test := range tt {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if test.moduleFile != "" {
+				test.utils.FilesMock.AddFile(test.moduleFile, []byte(test.moduleFileContent))
+			}
+			artifacts, err := getPublishedArtifactsNames(test.moduleFile, test.utils)
+			assert.Equal(t, test.expectedResult, artifacts)
+			assert.Equal(t, test.expectedErr, err)
+		})
+	}
 }

--- a/resources/metadata/gradleExecuteBuild.yaml
+++ b/resources/metadata/gradleExecuteBuild.yaml
@@ -122,6 +122,11 @@ spec:
         params:
           - filePattern: "**/bom-gradle.xml"
             type: sbom
+      - name: commonPipelineEnvironment
+        type: piperEnvironment
+        params:
+          - name: custom/artifacts
+            type: "piperenv.Artifacts"
   containers:
     - name: gradle
       image: gradle:6-jdk11-alpine


### PR DESCRIPTION
# Changes

PR adds the possibility to get and write to CPE published artifacts names for later usage (for downloading artifacts).

- [x] Tests
- [x] Documentation
