### PR TITLE
fix (npmExecuteScripts) pinning @cyclonedx/bom to major version 3

### DIFF
--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -355,7 +355,7 @@ func (exec *Execute) checkIfLockFilesExist() (bool, bool, error) {
 func (exec *Execute) CreateBOM(packageJSONFiles []string) error {
 	execRunner := exec.Utils.GetExecRunner()
 	// Install CycloneDX Node.js module locally without saving in package.json
-	err := execRunner.RunExecutable("npm", "install", "@cyclonedx/bom", "--no-save")
+	err := execRunner.RunExecutable("npm", "install", "@cyclonedx/bom@^3.10.6", "--no-save")
 	if err != nil {
 		return err
 	}

--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -357,7 +357,7 @@ func TestNpm(t *testing.T) {
 
 		if assert.NoError(t, err) {
 			if assert.Equal(t, 3, len(utils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "@cyclonedx/bom", "--no-save"}}, utils.execRunner.Calls[0])
+				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "@cyclonedx/bom@^3.10.6", "--no-save"}}, utils.execRunner.Calls[0])
 				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", ".",
 					"--output", "bom-npm.xml"}}, utils.execRunner.Calls[1])
 				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"cyclonedx-bom", "src",


### PR DESCRIPTION
# Changes

@cyclonedx/bom removed the executable from major version 4 which does not allow a bom creation from version 4. this is a breaking change see : https://github.com/CycloneDX/cyclonedx-node-module/issues/343

currently pinning the version to @cyclonedx/bom@^3.10.6 ,

in the long run we must think about moving to https://www.npmjs.com/package/@cyclonedx/cyclonedx-npm instead

- [ ] Tests
- [ ] Documentation
