### PR TITLE
fix(cnbBuild): allow setting empty env variables in project descriptor

### DIFF
--- a/pkg/cnbutils/project/descriptor.go
+++ b/pkg/cnbutils/project/descriptor.go
@@ -104,7 +104,7 @@ func (b *build) envToMap() map[string]interface{} {
 	envMap := map[string]interface{}{}
 
 	for _, e := range b.Env {
-		if len(e.Name) == 0 || len(e.Value) == 0 {
+		if len(e.Name) == 0 {
 			continue
 		}
 

--- a/pkg/cnbutils/project/descriptor_test.go
+++ b/pkg/cnbutils/project/descriptor_test.go
@@ -34,6 +34,10 @@ value = "VAL1"
 name = "VAR2"
 value = "VAL2"
 
+[[build.env]]
+name = "EMPTY"
+value = ""
+
 [[build.buildpacks]]
 id = "paketo-buildpacks/java"
 version = "5.9.1"
@@ -64,6 +68,7 @@ id = "paketo-buildpacks/nodejs"
 		assert.NoError(t, err)
 		assert.Equal(t, descriptor.EnvVars["VAR1"], "VAL1")
 		assert.Equal(t, descriptor.EnvVars["VAR2"], "VAL2")
+		assert.Equal(t, descriptor.EnvVars["EMPTY"], "")
 
 		assert.Equal(t, descriptor.ProjectID, "io.buildpacks.my-app")
 


### PR DESCRIPTION
Adding something like this to the `project.toml`:

```toml
[[build.env]]
name="BP_NODE_RUN_SCRIPTS"
value=""
```

is silently ignored by `cnbBuild (it works in pack).

We should fix this.

# Changes

- [x] Tests
- [ ] Documentation
