### PR TITLE
sonarExecuteScan: fix building the URL to call sonar API

### DIFF
--- a/pkg/sonar/componentService.go
+++ b/pkg/sonar/componentService.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -43,6 +44,10 @@ type SonarLanguageDistribution struct {
 }
 
 func (service *ComponentService) Component(options *MeasuresComponentOption) (*sonargo.MeasuresComponentObject, *http.Response, error) {
+	// ***
+	fmt.Printf("\nComponentService: %+v\n", service)
+	fmt.Printf("\noptions: %+v\n", options)
+	// ***
 	if len(service.Branch) > 0 {
 		options.Branch = service.Branch
 	}

--- a/pkg/sonar/componentService.go
+++ b/pkg/sonar/componentService.go
@@ -48,12 +48,14 @@ func (service *ComponentService) Component(options *MeasuresComponentOption) (*s
 	fmt.Printf("\nComponentService: %+v\n", service)
 	fmt.Printf("\noptions: %+v\n", options)
 	// ***
-	if len(service.Branch) > 0 {
-		options.Branch = service.Branch
-	}
 	if len(service.PullRequest) > 0 {
 		options.PullRequest = service.PullRequest
+	} else if len(service.Branch) > 0 {
+		options.Branch = service.Branch
 	}
+	// ***
+	fmt.Printf("\noptions: %+v\n", options)
+	// ***
 	request, err := service.apiClient.create("GET", EndpointMeasuresComponent, options)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sonar/componentService.go
+++ b/pkg/sonar/componentService.go
@@ -1,7 +1,6 @@
 package sonar
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -44,18 +43,11 @@ type SonarLanguageDistribution struct {
 }
 
 func (service *ComponentService) Component(options *MeasuresComponentOption) (*sonargo.MeasuresComponentObject, *http.Response, error) {
-	// ***
-	fmt.Printf("\nComponentService: %+v\n", service)
-	fmt.Printf("\noptions: %+v\n", options)
-	// ***
 	if len(service.PullRequest) > 0 {
 		options.PullRequest = service.PullRequest
 	} else if len(service.Branch) > 0 {
 		options.Branch = service.Branch
 	}
-	// ***
-	fmt.Printf("\noptions: %+v\n", options)
-	// ***
 	request, err := service.apiClient.create("GET", EndpointMeasuresComponent, options)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sonar/componentService.go
+++ b/pkg/sonar/componentService.go
@@ -43,6 +43,7 @@ type SonarLanguageDistribution struct {
 }
 
 func (service *ComponentService) Component(options *MeasuresComponentOption) (*sonargo.MeasuresComponentObject, *http.Response, error) {
+	// if PR, ignore branch name and consider PR branch name. If not PR, consider branch name
 	if len(service.PullRequest) > 0 {
 		options.PullRequest = service.PullRequest
 	} else if len(service.Branch) > 0 {

--- a/pkg/sonar/issueService.go
+++ b/pkg/sonar/issueService.go
@@ -54,6 +54,7 @@ func (service *IssueService) getIssueCount(severity issueSeverity) (int, error) 
 	if len(service.Organization) > 0 {
 		options.Organization = service.Organization
 	}
+	// if PR, ignore branch name and consider PR branch name. If not PR, consider branch name
 	if len(service.PullRequest) > 0 {
 		options.PullRequest = service.PullRequest
 	} else if len(service.Branch) > 0 {

--- a/pkg/sonar/issueService.go
+++ b/pkg/sonar/issueService.go
@@ -1,7 +1,6 @@
 package sonar
 
 import (
-	"fmt"
 	"net/http"
 
 	sonargo "github.com/magicsong/sonargo/sonar"
@@ -46,18 +45,12 @@ func (service *IssueService) SearchIssues(options *IssuesSearchOption) (*sonargo
 }
 
 func (service *IssueService) getIssueCount(severity issueSeverity) (int, error) {
-	// ***
-	fmt.Printf("\nIssueService: %+v\n", service)
-	// ***
 	options := &IssuesSearchOption{
 		ComponentKeys: service.Project,
 		Severities:    severity.ToString(),
 		Resolved:      "false",
 		Ps:            "1",
 	}
-	// ***
-	fmt.Printf("\noptions: %+v\n", options)
-	// ***
 	if len(service.Organization) > 0 {
 		options.Organization = service.Organization
 	}

--- a/pkg/sonar/issueService.go
+++ b/pkg/sonar/issueService.go
@@ -1,6 +1,7 @@
 package sonar
 
 import (
+	"fmt"
 	"net/http"
 
 	sonargo "github.com/magicsong/sonargo/sonar"
@@ -21,6 +22,10 @@ type IssueService struct {
 
 // SearchIssues ...
 func (service *IssueService) SearchIssues(options *IssuesSearchOption) (*sonargo.IssuesSearchObject, *http.Response, error) {
+	// ***
+	fmt.Printf("\nIssueService: %+v\n", service)
+	fmt.Printf("\noptions: %+v\n", options)
+	// ***
 	if len(service.PullRequest) > 0 {
 		options.PullRequest = service.PullRequest
 	} else if len(service.Branch) > 0 {

--- a/pkg/sonar/issueService.go
+++ b/pkg/sonar/issueService.go
@@ -22,15 +22,6 @@ type IssueService struct {
 
 // SearchIssues ...
 func (service *IssueService) SearchIssues(options *IssuesSearchOption) (*sonargo.IssuesSearchObject, *http.Response, error) {
-	// ***
-	fmt.Printf("\nIssueService: %+v\n", service)
-	fmt.Printf("\noptions: %+v\n", options)
-	// ***
-	if len(service.PullRequest) > 0 {
-		options.PullRequest = service.PullRequest
-	} else if len(service.Branch) > 0 {
-		options.Branch = service.Branch
-	}
 	request, err := service.apiClient.create("GET", EndpointIssuesSearch, options)
 	if err != nil {
 		return nil, nil, err
@@ -55,20 +46,25 @@ func (service *IssueService) SearchIssues(options *IssuesSearchOption) (*sonargo
 }
 
 func (service *IssueService) getIssueCount(severity issueSeverity) (int, error) {
+	// ***
+	fmt.Printf("\nIssueService: %+v\n", service)
+	// ***
 	options := &IssuesSearchOption{
 		ComponentKeys: service.Project,
 		Severities:    severity.ToString(),
 		Resolved:      "false",
 		Ps:            "1",
 	}
-	if len(service.Branch) > 0 {
-		options.Branch = service.Branch
-	}
+	// ***
+	fmt.Printf("\noptions: %+v\n", options)
+	// ***
 	if len(service.Organization) > 0 {
 		options.Organization = service.Organization
 	}
 	if len(service.PullRequest) > 0 {
 		options.PullRequest = service.PullRequest
+	} else if len(service.Branch) > 0 {
+		options.Branch = service.Branch
 	}
 	result, _, err := service.SearchIssues(options)
 	if err != nil {

--- a/pkg/sonar/issueService.go
+++ b/pkg/sonar/issueService.go
@@ -21,6 +21,11 @@ type IssueService struct {
 
 // SearchIssues ...
 func (service *IssueService) SearchIssues(options *IssuesSearchOption) (*sonargo.IssuesSearchObject, *http.Response, error) {
+	if len(service.PullRequest) > 0 {
+		options.PullRequest = service.PullRequest
+	} else if len(service.Branch) > 0 {
+		options.Branch = service.Branch
+	}
 	request, err := service.apiClient.create("GET", EndpointIssuesSearch, options)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
# Changes

This PR fixes building the URL to call sonar API.

If there is a PR then `sonarExecuteScan` gets the results of the completed evaluation of the project from the PR branch, if no - from `branchName`

Issues:
fixes [#3994](https://github.com/SAP/jenkins-library/issues/3994)
#4585 (inner-souce)

- [ ] Tests
- [ ] Documentation
