### PR TITLE
artifactPrepareVersion: update documentation

### DIFF
--- a/resources/metadata/artifactPrepareVersion.yaml
+++ b/resources/metadata/artifactPrepareVersion.yaml
@@ -124,7 +124,7 @@ spec:
 
           You can use either a file name or a glob pattern like `**/package.json`.
 
-          For `helm` the default value is `**/Chart.yaml`, thus typically no adaptions are required.
+          For `helm` the default value is `**/Chart.yaml`, thus typically no adaptions are required, but if a helm chart contains nested chart(s), the parameter needs to be set explicitly.
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
# Changes

This PR updates the documentation for the `artifactPrepareVersion` step.
When a helm chart contains a nested chart(s), the `additionalTargetDescriptors` parameter needs to be set explicitly.

- [ ] Tests
- [x] Documentation
