### PR TITLE
Syft install using binary instead of shell script

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -17,7 +17,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 )
 
-const syftURL = "https://raw.githubusercontent.com/anchore/syft/main/install.sh"
+const syftURL = "https://github.com/anchore/syft/releases/download/v0.60.3/syft_0.60.3_linux_amd64.tar.gz"
 
 type kanikoHttpClient interface {
 	piperhttp.Sender
@@ -25,22 +25,15 @@ type kanikoHttpClient interface {
 }
 
 func installSyft(shellRunner command.ShellRunner, fileUtils piperutils.FileUtils, httpClient kanikoHttpClient) error {
-	installationScript := "./install.sh"
-	err := httpClient.DownloadFile(syftURL, installationScript, nil, nil)
+	//Pinning to latest version as of today , to avoid nasty surprises
+	err := httpClient.DownloadFile(syftURL, "syftBinary.tar.gz", nil, nil)
 	if err != nil {
-		return fmt.Errorf("failed to download syft: %w", err)
+		return fmt.Errorf("failed to download syft binary: %w", err)
 	}
-
-	err = fileUtils.Chmod(installationScript, 0777)
+	err = shellRunner.RunShell("/busybox/sh", "mkdir Syft & tar -zxvf syftBinary.tar.gz -C Syft")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to untar syft: %w", err)
 	}
-
-	err = shellRunner.RunShell("/busybox/sh", "cat ./install.sh | sh -s -- -b .")
-	if err != nil {
-		return fmt.Errorf("failed to install syft: %w", err)
-	}
-
 	return nil
 }
 
@@ -52,13 +45,12 @@ func generateSBOM(shellRunner command.ShellRunner, fileUtils piperutils.FileUtil
 	}
 	for index, eachImageTag := range commonPipelineEnvironment.container.imageNameTags {
 		// TrimPrefix needed as syft needs containerRegistry name only
-		syftRunErr := shellRunner.RunShell("/busybox/sh", fmt.Sprintf("./syft %s/%s -o cyclonedx-xml=bom-docker-%v.xml", strings.TrimPrefix(commonPipelineEnvironment.container.registryURL, "https://"), eachImageTag, index))
+		syftRunErr := shellRunner.RunShell("/busybox/sh", fmt.Sprintf("Syft/syft %s/%s -o cyclonedx-xml=bom-docker-%v.xml", strings.TrimPrefix(commonPipelineEnvironment.container.registryURL, "https://"), eachImageTag, index))
 		if syftRunErr != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", syftRunErr)
 		}
 	}
 	return nil
-
 }
 
 func kanikoExecute(config kanikoExecuteOptions, telemetryData *telemetry.CustomData, commonPipelineEnvironment *kanikoExecuteCommonPipelineEnvironment) {

--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -350,7 +350,7 @@ func TestRunKanikoExecute(t *testing.T) {
 		}
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("path/to/docker/config.json", []byte(`{"auths":{"custom":"test"}}`))
-		fileUtils.AddFile("install.sh", []byte(`echo syft`))
+		fileUtils.AddFile("Syft/syft", []byte(`echo syft`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, execRunner, shellRunner, certClient, fileUtils)
 
@@ -362,8 +362,8 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.Equal(t, "https://index.docker.io", commonPipelineEnvironment.container.registryURL)
 
 		//Syft install and call
-		assert.Contains(t, shellRunner.Calls[0], "cat ./install.sh | sh -s -- -b .")
-		assert.Contains(t, shellRunner.Calls[1], "./syft index.docker.io/myImage:tag -o cyclonedx-xml=bom-docker-0.xml")
+		assert.Contains(t, shellRunner.Calls[0], "mkdir Syft & tar -zxvf syftBinary.tar.gz -C Syft")
+		assert.Contains(t, shellRunner.Calls[1], "Syft/syft index.docker.io/myImage:tag -o cyclonedx-xml=bom-docker-0.xml")
 	})
 
 	t.Run("success case - multi image build with root image", func(t *testing.T) {
@@ -496,7 +496,7 @@ func TestRunKanikoExecute(t *testing.T) {
 		fileUtils.AddFile("Dockerfile", []byte("some content"))
 		fileUtils.AddFile("sub1/Dockerfile", []byte("some content"))
 		fileUtils.AddFile("sub2/Dockerfile", []byte("some content"))
-		fileUtils.AddFile("install.sh", []byte(`echo syft`))
+		fileUtils.AddFile("Syft/syft", []byte(`echo syft`))
 
 		err := runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, execRunner, shellRunner, certClient, fileUtils)
 		assert.NoError(t, err)
@@ -536,12 +536,12 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.Equal(t, "", commonPipelineEnvironment.container.imageDigest)
 		assert.Empty(t, commonPipelineEnvironment.container.imageDigests)
 
-		//Syft install and call, can we do it better without 2 for loops
+		//Syft install and call, can we do it better without 2 for loops?
 		expectedShellCalls := []string{
-			"cat ./install.sh | sh -s -- -b .",
-			"./syft my.registry.com:50000/myImage:myTag -o cyclonedx-xml=bom-docker-0.xml",
-			"./syft my.registry.com:50000/myImage-sub1:myTag -o cyclonedx-xml=bom-docker-1.xml",
-			"./syft my.registry.com:50000/myImage-sub2:myTag -o cyclonedx-xml=bom-docker-2.xml",
+			"mkdir Syft & tar -zxvf syftBinary.tar.gz -C Syft",
+			"Syft/syft my.registry.com:50000/myImage:myTag -o cyclonedx-xml=bom-docker-0.xml",
+			"Syft/syft my.registry.com:50000/myImage-sub1:myTag -o cyclonedx-xml=bom-docker-1.xml",
+			"Syft/syft my.registry.com:50000/myImage-sub2:myTag -o cyclonedx-xml=bom-docker-2.xml",
 		}
 		for _, call := range shellRunner.Calls {
 			found := false
@@ -805,7 +805,7 @@ func TestRunKanikoExecute(t *testing.T) {
 		}
 		fileUtils := &mock.FilesMock{}
 		fileUtils.AddFile("path/to/docker/config.json", []byte(`{"auths":{"custom":"test"}}`))
-		fileUtils.AddFile("install.sh", []byte(`echo syft`))
+		fileUtils.AddFile("Syft/syft", []byte(`echo syft`))
 
 		// Case 1 - Download of syft installation file failed
 		certClient.errorMessage = "Download failed"
@@ -815,14 +815,14 @@ func TestRunKanikoExecute(t *testing.T) {
 
 		// Case 2 - Installation of syft failed, using new kanikoMockClient here
 		certClient1 := &kanikoMockClient{}
-		shellRunner.ShouldFailOnCommand = map[string]error{"cat ./install.sh | sh -s -- -b .": fmt.Errorf("install failed")}
+		shellRunner.ShouldFailOnCommand = map[string]error{"mkdir Syft & tar -zxvf syftBinary.tar.gz -C Syft": fmt.Errorf("untar failed")}
 		err = runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, execRunner, shellRunner, certClient1, fileUtils)
 		assert.Error(t, err)
-		assert.Contains(t, fmt.Sprint(err), "failed to install syft")
+		assert.Contains(t, fmt.Sprint(err), "failed to untar syft")
 
 		// Case 3 syft run failed, using new ShellMockRunner here
 		shellRunner1 := &mock.ShellMockRunner{}
-		shellRunner1.ShouldFailOnCommand = map[string]error{"./syft index.docker.io/myImage:tag -o cyclonedx-xml=bom-docker-0.xml": fmt.Errorf("run failed")}
+		shellRunner1.ShouldFailOnCommand = map[string]error{"Syft/syft index.docker.io/myImage:tag -o cyclonedx-xml=bom-docker-0.xml": fmt.Errorf("run failed")}
 		err = runKanikoExecute(config, &telemetry.CustomData{}, &commonPipelineEnvironment, execRunner, shellRunner1, certClient1, fileUtils)
 		assert.Error(t, err)
 		assert.Contains(t, fmt.Sprint(err), "failed to generate SBOM")


### PR DESCRIPTION
This PR intends to change the way Syft is installed in Piper as it is better to rely on a release binary than a shell script.
As part of #4093 , syft was installed using a Shell script .

The release of syft is pinned to 60.3 which is the latest version available. Tested with this release and looks good.

- [ ] Tests
- [ ] Documentation
