### PR TITLE
Fix race condition in kanikoExecute

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -30,7 +30,7 @@ func installSyft(shellRunner command.ShellRunner, fileUtils piperutils.FileUtils
 	if err != nil {
 		return fmt.Errorf("failed to download syft binary: %w", err)
 	}
-	err = shellRunner.RunShell("/busybox/sh", "mkdir Syft & tar -zxvf syftBinary.tar.gz -C Syft")
+	err = shellRunner.RunShell("/busybox/sh", "mkdir Syft && tar -zxvf syftBinary.tar.gz -C Syft")
 	if err != nil {
 		return fmt.Errorf("failed to untar syft: %w", err)
 	}

--- a/documentation/docs/steps/cnbBuild.md
+++ b/documentation/docs/steps/cnbBuild.md
@@ -45,7 +45,7 @@ This behavior can be overwritten by using the respective sections in [`project.t
 
 ```groovy
 cnbBuild(
-    script: script,
+    script: this,
     dockerConfigJsonCredentialsId: 'DOCKER_REGISTRY_CREDS',
     containerImageName: 'images/example',
     containerImageTag: 'v0.0.1',
@@ -57,7 +57,7 @@ cnbBuild(
 
 ```groovy
 cnbBuild(
-    script: script,
+    script: this,
     dockerConfigJsonCredentialsId: 'DOCKER_REGISTRY_CREDS',
     dockerImage: 'paketobuildpacks/builder:base',
     containerImageName: 'images/example',
@@ -70,7 +70,7 @@ cnbBuild(
 
 ```groovy
 cnbBuild(
-    script: script,
+    script: this,
     dockerConfigJsonCredentialsId: 'DOCKER_REGISTRY_CREDS',
     containerImageName: 'images/example',
     containerImageTag: 'v0.0.1',
@@ -83,7 +83,7 @@ cnbBuild(
 
 ```groovy
 cnbBuild(
-    script: script,
+    script: this,
     dockerConfigJsonCredentialsId: 'DOCKER_REGISTRY_CREDS',
     containerImageName: 'images/example',
     containerImageTag: 'v0.0.1',


### PR DESCRIPTION
#4116 installs Syft by shell script. Instead of `&&`, `&` (execute in parallel) is used, introducing a race condition. In pipelines, the step will sometimes fail:
```
info  kanikoExecute - running shell script: /busybox/sh mkdir Syft & tar -zxvf syftBinary.tar.gz -C Syft
info  kanikoExecute - tar: can't change directory to 'Syft': No such file or directory
```

# Changes

- [X] Tests
- [ ] Documentation
