### PR TITLE
[checkmarxExecuteScan] Fix project name string comparison

### DIFF
--- a/cmd/checkmarxExecuteScan.go
+++ b/cmd/checkmarxExecuteScan.go
@@ -133,7 +133,7 @@ func runScan(ctx context.Context, config checkmarxExecuteScanOptions, sys checkm
 	if err != nil {
 		return errors.Wrap(err, "error when trying to load project")
 	}
-	if project.Name == projectName {
+	if strings.EqualFold(project.Name, projectName) { // case insensitive string comparison
 		err = presetExistingProject(config, sys, projectName, project)
 		if err != nil {
 			return err


### PR DESCRIPTION
Piper is using case sensitive comparison for project names, but Checkmarx project names are case insensitive.
So Piper can try to create the same Checkmarx project and it fails.
This PR is fixing this by using case insensitive string comparison for project names.
