### PR TITLE
Expose syft url as a parameter for kanikoExecute

### DIFF
--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -37,6 +37,7 @@ type kanikoExecuteOptions struct {
 	TargetArchitectures              []string `json:"targetArchitectures,omitempty"`
 	ReadImageDigest                  bool     `json:"readImageDigest,omitempty"`
 	CreateBOM                        bool     `json:"createBOM,omitempty"`
+	SyftDownloadURL                  string   `json:"syftDownloadUrl,omitempty"`
 }
 
 type kanikoExecuteCommonPipelineEnvironment struct {
@@ -259,6 +260,7 @@ func addKanikoExecuteFlags(cmd *cobra.Command, stepConfig *kanikoExecuteOptions)
 	cmd.Flags().StringSliceVar(&stepConfig.TargetArchitectures, "targetArchitectures", []string{``}, "Defines the target architectures for which the build should run using OS and architecture separated by a comma. (EXPERIMENTAL)")
 	cmd.Flags().BoolVar(&stepConfig.ReadImageDigest, "readImageDigest", false, "")
 	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using Syft and stored in a file of CycloneDX 1.4 format.")
+	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v0.60.3/syft_0.60.3_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
 
 }
 
@@ -482,6 +484,15 @@ func kanikoExecuteMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     false,
+					},
+					{
+						Name:        "syftDownloadUrl",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `https://github.com/anchore/syft/releases/download/v0.60.3/syft_0.60.3_linux_amd64.tar.gz`,
 					},
 				},
 			},

--- a/resources/metadata/kanikoExecute.yaml
+++ b/resources/metadata/kanikoExecute.yaml
@@ -265,6 +265,13 @@ spec:
           - STEPS
           - STAGES
           - PARAMETERS
+      - name: syftDownloadUrl
+        type: string
+        description: Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.
+        scope:
+          - PARAMETERS
+          - STEPS
+        default: "https://github.com/anchore/syft/releases/download/v0.60.3/syft_0.60.3_linux_amd64.tar.gz"
   outputs:
     resources:
       - name: commonPipelineEnvironment


### PR DESCRIPTION
# Changes
This PR introduces Syft PR as a parameter to kanikoExecute step . This was mainly required so as to ease the up gradation to a major release if needed in future.

- [ ] Tests
- [ ] Documentation
