### PR TITLE
fix ci: missing needs in github action yaml

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -120,6 +120,7 @@ jobs:
     needs:
       - build_piper
       - build_integration_tests
+      - start
     strategy:
       fail-fast: true
       matrix: ${{ fromJson(needs.build_integration_tests.outputs.matrix) }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,6 +92,7 @@ jobs:
     needs:
       - build_piper
       - build_integration_tests
+      - start
     strategy:
       fail-fast: true
       matrix: ${{ fromJson(needs.build_integration_tests.outputs.matrix) }}


### PR DESCRIPTION
# Changes

The sha from the `start` step is accessed here:

https://github.com/SAP/jenkins-library/blob/b7468e81aa27e04470c736a5c9f2423abd2d2678/.github/workflows/integration-tests-pr.yml#L129-L131

I looks like github actions fail silently here: As `needs.start` does not exist, `${{ needs.start.outputs.sha }}` evaluates to an empty string and the `checkout`  action seems to default to the `master` branch in that case.

Which means during the integration tests it uses the "new" code (productive and test code) with the "old" test asset files.

- [ ] Tests
- [ ] Documentation
