### PR TITLE
Temporary fix for pythonBuild integration tests

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -144,7 +144,7 @@ func removeVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 }
 
 func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string, config *pythonBuildOptions) error {
-	pipInstallFlags = append(pipInstallFlags, "cyclonedx-bom")
+	pipInstallFlags = append(pipInstallFlags, "cyclonedx-bom", "packaging==21.3")
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallFlags...); err != nil {
 		return err
 	}

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -97,7 +97,7 @@ func TestRunPythonBuild(t *testing.T) {
 		assert.Equal(t, "python", utils.ExecMockRunner.Calls[2].Exec)
 		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[2].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[3].Exec)
-		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom"}, utils.ExecMockRunner.Calls[3].Params)
+		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom", "packaging==21.3"}, utils.ExecMockRunner.Calls[3].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "cyclonedx-bom"), utils.ExecMockRunner.Calls[4].Exec)
 		assert.Equal(t, []string{"--e", "--output", "bom-pip.xml"}, utils.ExecMockRunner.Calls[4].Params)
 	})


### PR DESCRIPTION
# Changes

[A recent release of the python library `packaging` ](https://github.com/pypa/packaging/releases/tag/22.0) removed some class. This seems to be used in `cyclonedx-bom` (automatically the latest version). This causes the `pythonBuild` integration tests to fail and therefore any other PR can't be merged.

I guess it will also affect anyone using `pythonBuild` productively.

As a quick fix, I pinned the version of `packaging` to the one before the breaking change. As soon as `cyclonedx-bom` and it's dependencies are updated, this can be removed again.

To prevent similar problems in the future `pythonBuild` should use fixed versions for its dependencies (and transitive dependencies)

- [x] Tests
- [ ] Documentation
