### PR TITLE
feat: Support custom sonar-project.properties location

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -108,6 +108,10 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 	// Set config based on orchestrator-specific environment variables
 	detectParametersFromCI(&config)
 
+	if len(config.Settings) > 0 {
+		sonar.addOption("project.settings=" + config.Settings)
+	}
+
 	if len(config.ServerURL) > 0 {
 		sonar.addEnvironment("SONAR_HOST_URL=" + config.ServerURL)
 	}

--- a/cmd/sonarExecuteScan_generated.go
+++ b/cmd/sonarExecuteScan_generated.go
@@ -22,6 +22,7 @@ import (
 )
 
 type sonarExecuteScanOptions struct {
+	Settings                  string   `json:"settings,omitempty"`
 	Instance                  string   `json:"instance,omitempty"`
 	ServerURL                 string   `json:"serverUrl,omitempty"`
 	Token                     string   `json:"token,omitempty"`
@@ -236,6 +237,7 @@ func SonarExecuteScanCommand() *cobra.Command {
 }
 
 func addSonarExecuteScanFlags(cmd *cobra.Command, stepConfig *sonarExecuteScanOptions) {
+	cmd.Flags().StringVar(&stepConfig.Settings, "settings", os.Getenv("PIPER_settings"), "Custom path or filename for the sonar-project.properties file. See sonar-scanner parameter `project.settings`")
 	cmd.Flags().StringVar(&stepConfig.Instance, "instance", os.Getenv("PIPER_instance"), "Jenkins only: The name of the SonarQube instance defined in the Jenkins settings. DEPRECATED: use serverUrl parameter instead")
 	cmd.Flags().StringVar(&stepConfig.ServerURL, "serverUrl", os.Getenv("PIPER_serverUrl"), "The URL to the Sonar backend.")
 	cmd.Flags().StringVar(&stepConfig.Token, "token", os.Getenv("PIPER_token"), "Token used to authenticate with the Sonar Server.")
@@ -281,6 +283,15 @@ func sonarExecuteScanMetadata() config.StepData {
 					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing the token used to authenticate with the Github Server.", Type: "jenkins"},
 				},
 				Parameters: []config.StepParameters{
+					{
+						Name:        "settings",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_settings"),
+					},
 					{
 						Name:        "instance",
 						ResourceRef: []config.ResourceReference{},

--- a/cmd/sonarExecuteScan_test.go
+++ b/cmd/sonarExecuteScan_test.go
@@ -289,7 +289,7 @@ func TestRunSonar(t *testing.T) {
 			filepath.Join("target", "classes")))
 		assert.Contains(t, sonar.options, "-Dsonar.java.binaries=user/provided")
 	})
-	t.Run("projectKey, coverageExclusions, m2Path, verbose", func(t *testing.T) {
+	t.Run("custom settings, projectKey, coverageExclusions, m2Path, verbose", func(t *testing.T) {
 		// init
 		tmpFolder := t.TempDir()
 		createTaskReportFile(t, tmpFolder)
@@ -301,6 +301,7 @@ func TestRunSonar(t *testing.T) {
 			options:     []string{},
 		}
 		options := sonarExecuteScanOptions{
+			Settings:            "foo/custom-sonar.properties",
 			ProjectKey:          "mock-project-key",
 			M2Path:              "my/custom/m2", // assumed to be resolved via alias from mavenExecute
 			InferJavaLibraries:  true,
@@ -317,6 +318,7 @@ func TestRunSonar(t *testing.T) {
 		err := runSonar(options, &mockDownloadClient, &mockRunner, apiClient, &mock.FilesMock{}, &sonarExecuteScanInflux{})
 		// assert
 		assert.NoError(t, err)
+		assert.Contains(t, sonar.options, "-Dproject.settings=foo/custom-sonar.properties")
 		assert.Contains(t, sonar.options, "-Dsonar.projectKey=mock-project-key")
 		assert.Contains(t, sonar.options, fmt.Sprintf("-Dsonar.java.libraries=%s",
 			filepath.Join("my/custom/m2", "**")))

--- a/resources/metadata/sonarExecuteScan.yaml
+++ b/resources/metadata/sonarExecuteScan.yaml
@@ -15,6 +15,13 @@ spec:
         description: "Jenkins 'Secret text' credentials ID containing the token used to authenticate
           with the Github Server."
     params:
+      - name: settings
+        type: string
+        description: "Custom path or filename for the sonar-project.properties file. See sonar-scanner parameter `project.settings`"
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: instance
         type: string
         description: "Jenkins only: The name of the SonarQube instance defined in the Jenkins settings.


### PR DESCRIPTION
# Changes
Exposes the sonar-scanner parameter `project.settings` to allow different locations and file names for instead of /sonar-project.properties ([link to sonar docs](https://docs.sonarqube.org/latest/analyzing-source-code/scanners/sonarscanner/#sonar-project-properties)).

- [x] Tests
- [x] Documentation
