### PR TITLE
fix(fortifyExecuteScan): fix project versions api call

### DIFF
--- a/pkg/fortify/fortify.go
+++ b/pkg/fortify/fortify.go
@@ -197,7 +197,7 @@ func (sys *SystemInstance) GetProjectByName(projectName string, autoCreate bool,
 // GetProjectVersionDetailsByProjectIDAndVersionName returns the project version details of the project version identified by the id and project versionname
 // projectName parameter is only used if autoCreate=true
 func (sys *SystemInstance) GetProjectVersionDetailsByProjectIDAndVersionName(id int64, versionName string, autoCreate bool, projectName string) (*models.ProjectVersion, error) {
-	nameParam := fmt.Sprintf("name:%v", versionName)
+	nameParam := fmt.Sprintf(`name:"%v"`, versionName)
 	params := &project_version_of_project_controller.ListProjectVersionOfProjectParams{ParentID: id, Q: &nameParam}
 	params.WithTimeout(sys.timeout)
 	result, err := sys.client.ProjectVersionOfProjectController.ListProjectVersionOfProject(params, sys)

--- a/pkg/fortify/fortify_test.go
+++ b/pkg/fortify/fortify_test.go
@@ -259,7 +259,7 @@ func TestGetProjectVersionDetailsByProjectIDAndVersionName(t *testing.T) {
 				"first":{"href":"https://fortify/ssc/api/v1/projects/815/versions?start=0"}}}`))
 			return
 		}
-		if req.URL.Path == "/projects/8888/versions" && req.URL.RawQuery == "q=name%3A1" {
+		if req.URL.Path == "/projects/8888/versions" && req.URL.RawQuery == "q=name%3A%221%22" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
 			rw.Write([]byte(`{"data":[{"id":9910,"project":{"id":8888,"name":"test","description":"Created by Go script","creationDate":"2022-06-24T04:44:12.344+0000",


### PR DESCRIPTION
# Changes
The fix will solve the issue of getting the project version.  
**Example**:  the query _name:1.60_ does not work, but _name:"1.60"_ works.

As the version name is of type string we should consider it as a string in the query.

- [X] Tests
- [ ] Documentation
