### PR TITLE
`artifactPrepareVersion` doesn’t change the order of entries in the package.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/vault v1.9.9
 	github.com/hashicorp/vault/api v1.3.1
+	github.com/iancoleman/orderedmap v0.2.0
 	github.com/imdario/mergo v0.3.12
 	github.com/influxdata/influxdb-client-go/v2 v2.5.1
 	github.com/jarcoal/httpmock v1.0.8

--- a/go.sum
+++ b/go.sum
@@ -1280,6 +1280,8 @@ github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huaweicloud/golangsdk v0.0.0-20200304081349-45ec0797f2a4/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
+github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.4/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=

--- a/pkg/versioning/jsonfile.go
+++ b/pkg/versioning/jsonfile.go
@@ -6,13 +6,14 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/iancoleman/orderedmap"
 	"github.com/pkg/errors"
 )
 
 // JSONfile defines an artifact using a json file for versioning
 type JSONfile struct {
 	path         string
-	content      map[string]interface{}
+	content      *orderedmap.OrderedMap
 	versionField string
 	readFile     func(string) ([]byte, error)
 	writeFile    func(string, []byte, os.FileMode) error
@@ -50,7 +51,10 @@ func (j *JSONfile) GetVersion() (string, error) {
 		return "", errors.Wrapf(err, "failed to read json content of file '%v'", j.content)
 	}
 
-	return fmt.Sprint(j.content[j.versionField]), nil
+	version, _ := j.content.Get(j.versionField)
+
+	return fmt.Sprint(version), nil
+	// return fmt.Sprint(j.content[j.versionField]), nil
 }
 
 // SetVersion updates the version of the artifact with a JSON-based build descriptor
@@ -63,7 +67,8 @@ func (j *JSONfile) SetVersion(version string) error {
 			return err
 		}
 	}
-	j.content[j.versionField] = version
+	j.content.Set(j.versionField, version)
+	// j.content[j.versionField] = version
 
 	content, err := json.MarshalIndent(j.content, "", "  ")
 	if err != nil {
@@ -84,9 +89,10 @@ func (j *JSONfile) GetCoordinates() (Coordinates, error) {
 	if err != nil {
 		return result, err
 	}
-	projectName := j.content["name"].(string)
+	// projectName := j.content["name"].(string)
+	projectName, _ := j.content.Get("name")
 
-	result.ArtifactID = projectName
+	result.ArtifactID = fmt.Sprint(projectName)
 	result.Version = projectVersion
 
 	return result, nil

--- a/pkg/versioning/jsonfile.go
+++ b/pkg/versioning/jsonfile.go
@@ -54,7 +54,6 @@ func (j *JSONfile) GetVersion() (string, error) {
 	version, _ := j.content.Get(j.versionField)
 
 	return fmt.Sprint(version), nil
-	// return fmt.Sprint(j.content[j.versionField]), nil
 }
 
 // SetVersion updates the version of the artifact with a JSON-based build descriptor
@@ -68,7 +67,6 @@ func (j *JSONfile) SetVersion(version string) error {
 		}
 	}
 	j.content.Set(j.versionField, version)
-	// j.content[j.versionField] = version
 
 	content, err := json.MarshalIndent(j.content, "", "  ")
 	if err != nil {
@@ -89,7 +87,6 @@ func (j *JSONfile) GetCoordinates() (Coordinates, error) {
 	if err != nil {
 		return result, err
 	}
-	// projectName := j.content["name"].(string)
 	projectName, _ := j.content.Get("name")
 
 	result.ArtifactID = fmt.Sprint(projectName)


### PR DESCRIPTION
# Changes

This PR adds the possibility to work with package.json (gets/sets version field) without changing the ordering.
In some cases ordering is significant.

See inner-source issue #4657

(!!!) PR adds usage of the new `github.com/iancoleman/orderedmap` package

- [ ] Tests
- [ ] Documentation
