### PR TITLE
fix(checkmarx) Improve project branching process

### DIFF
--- a/pkg/checkmarx/checkmarx.go
+++ b/pkg/checkmarx/checkmarx.go
@@ -51,6 +51,26 @@ type ProjectCreateResult struct {
 	Link Link `json:"link"`
 }
 
+// ProjectBranchingResponse - ProjectBranchingResponse Structure
+type ProjectBranchingResponse struct {
+	ID   int  `json:"id"`
+	Link Link `json:"link"`
+}
+
+type BranchingStatus struct {
+	ID    int    `json:"id"`
+	Value string `json:"value"`
+}
+
+// ProjectBranchingStatusResponse - ProjectBranchingStatusResponse Structure
+type ProjectBranchingStatusResponse struct {
+	ID                int             `json:"id"`
+	OriginalProjectId int             `json:"originalProjectId"`
+	BranchedProjectId int             `json:"branchedProjectId"`
+	Status            BranchingStatus `json:"status"`
+	ErrorMessage      string          `json:"errorMessage"`
+}
+
 // Report - Report Structure
 type Report struct {
 	ReportID int   `json:"reportId"`
@@ -432,10 +452,39 @@ func (sys *SystemInstance) CreateBranch(projectID int, branchName string) int {
 		return 0
 	}
 
-	var scan Scan
+	var branchingResponse ProjectBranchingResponse
+	json.Unmarshal(data, &branchingResponse)
+	branchedProjectId := branchingResponse.ID
 
-	json.Unmarshal(data, &scan)
-	return scan.ID
+	branchingStatusId := 0 // 0 Started, 1 InProgress, 2 Completed, 3 Failed
+	i := 0
+	for branchingStatusId != 2 {
+		dataBranchingStatus, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/projects/branch/%v", branchedProjectId), nil, header)
+		if err != nil {
+			sys.logger.Warnf("Failed to poll status of branching process: %s", err)
+		} else {
+			var branchingStatusResponse ProjectBranchingStatusResponse
+			json.Unmarshal(dataBranchingStatus, &branchingStatusResponse)
+			branchingStatusId = branchingStatusResponse.Status.ID
+			branchingStatusValue := branchingStatusResponse.Status.Value
+			sys.logger.Debugf("Branching process status: %s", branchingStatusValue)
+			if branchingStatusId == 2 {
+				sys.logger.Debug("Branching process completed successfuly")
+				break
+			} else if branchingStatusId == 3 {
+				sys.logger.Errorf("Branching process failed. Error is: %s", branchingStatusResponse.ErrorMessage)
+				return 0
+			}
+		}
+		if i >= 30 {
+			// time out after 5 minutes
+			sys.logger.Errorf("Branching process timed out.")
+			return 0
+		}
+		i++
+		time.Sleep(10 * time.Second)
+	}
+	return branchedProjectId
 }
 
 // UploadProjectSourceCode zips and uploads the project sources for scanning

--- a/pkg/checkmarx/checkmarx_test.go
+++ b/pkg/checkmarx/checkmarx_test.go
@@ -557,22 +557,6 @@ func TestDownloadReport(t *testing.T) {
 	})
 }
 
-func TestCreateBranch(t *testing.T) {
-	logger := log.Entry().WithField("package", "SAP/jenkins-library/pkg/checkmarx_test")
-	opts := piperHttp.ClientOptions{}
-	t.Run("test success", func(t *testing.T) {
-		myTestClient := senderMock{responseBody: `{"id": 13, "link": {}}`, httpStatusCode: 201}
-		sys := SystemInstance{serverURL: "https://cx.server.com", client: &myTestClient, logger: logger}
-		myTestClient.SetOptions(opts)
-
-		result := sys.CreateBranch(6, "PR-17")
-		assert.Equal(t, "https://cx.server.com/cxrestapi/projects/6/branch", myTestClient.urlCalled, "Called url incorrect")
-		assert.Equal(t, "POST", myTestClient.httpMethod, "HTTP method incorrect")
-		assert.Equal(t, `{"name":"PR-17"}`, myTestClient.requestBody, "Request body incorrect")
-		assert.Equal(t, 13, result, "result incorrect")
-	})
-}
-
 func TestGetProjectByID(t *testing.T) {
 	logger := log.Entry().WithField("package", "SAP/jenkins-library/pkg/checkmarx_test")
 	opts := piperHttp.ClientOptions{}


### PR DESCRIPTION
Use new Checkmarx APIs to poll the status of the branching before scanning.
If the branching is not completed and Piper starts the scan, it will fail with an error like `The scan's project is either temporarily inactive or deleted.` or `scan canceled`