### PR TITLE
chore(GitHub actions): update deprecated output syntax

### DIFF
--- a/.github/workflows/consumer-tests-pr.yml
+++ b/.github/workflows/consumer-tests-pr.yml
@@ -25,21 +25,21 @@ jobs:
       - name: Get pull request URL
         id: pull_request
         run: |
-          echo "::set-output name=pull_request::$(curl ${{ github.event.comment.issue_url }} |
+          echo "pull_request=$(curl ${{ github.event.comment.issue_url }} |
           jq '.pull_request.url' |
-          sed 's/\"//g')"
+          sed 's/\"//g')" >> "$GITHUB_OUTPUT"
       - name: Get repository
         id: repository
         run: |
-          echo "::set-output name=repository::$(curl ${{ steps.pull_request.outputs.pull_request }} |
+          echo "repository=$(curl ${{ steps.pull_request.outputs.pull_request }} |
           jq '.head.repo.full_name' |
-          sed 's/\"//g')"
+          sed 's/\"//g')" >> "$GITHUB_OUTPUT"
       - name: Get branch name
         id: branch_name
         run: |
-          echo "::set-output name=branch_name::$(curl ${{ steps.pull_request.outputs.pull_request }} |
+          echo "branch_name=$(curl ${{ steps.pull_request.outputs.pull_request }} |
           jq '.head.ref' |
-          sed 's/\"//g')"
+          sed 's/\"//g')" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v3
         with:
           repository: ${{ steps.repository.outputs.repository }}

--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -27,21 +27,21 @@ jobs:
       - name: Get pull request URL
         id: pull_request
         run: |
-          echo "::set-output name=pull_request::$(curl ${{ github.event.comment.issue_url }} |
+          echo "pull_request=$(curl ${{ github.event.comment.issue_url }} |
           jq '.pull_request.url' |
-          sed 's/\"//g')"
+          sed 's/\"//g')" >> "$GITHUB_OUTPUT"
       - name: Get repository
         id: repository
         run: |
-          echo "::set-output name=repository::$(curl ${{ steps.pull_request.outputs.pull_request }} |
+          echo "repository=$(curl ${{ steps.pull_request.outputs.pull_request }} |
           jq '.head.repo.full_name' |
-          sed 's/\"//g')"
+          sed 's/\"//g')" >> "$GITHUB_OUTPUT"
       - name: Get branch name
         id: branch_name
         run: |
-          echo "::set-output name=branch_name::$(curl ${{ steps.pull_request.outputs.pull_request }} |
+          echo "branch_name=$(curl ${{ steps.pull_request.outputs.pull_request }} |
           jq '.head.ref' |
-          sed 's/\"//g')"
+          sed 's/\"//g')" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v3
         with:
           repository: ${{ steps.repository.outputs.repository }}
@@ -49,11 +49,11 @@ jobs:
       - name: Get GO version
         id: go_version
         run: |
-          echo "::set-output name=go_version::$(cat go.mod | grep go | head -1 | awk '{print $2}')"
+          echo "go_version=$(cat go.mod | grep go | head -1 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - name: Get commit SHA
         id: sha
         run: |
-          echo "::set-output name=sha::$(git log --format=%H -n 1)"
+          echo "sha=$(git log --format=%H -n 1)" >> "$GITHUB_OUTPUT"
       - name: Update status
         run: |
           curl \
@@ -107,7 +107,7 @@ jobs:
         if: success()
         id: matrix
         run: |
-          echo "::set-output name=matrix::$(go run .github/workflows/parse_integration_test_list.go -file ./integration/github_actions_integration_test_list.yml)"
+          echo "matrix=$(go run .github/workflows/parse_integration_test_list.go -file ./integration/github_actions_integration_test_list.yml)" >> "$GITHUB_OUTPUT"
       - name: Upload integration tests binary
         if: success()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Get GO version
         id: go_version
         run: |
-          echo "::set-output name=go_version::$(cat go.mod | grep go | head -1 | awk '{print $2}')"
+          echo "go_version=$(cat go.mod | grep go | head -1 | awk '{print $2}')" >> "$GITHUB_OUTPUT"
       - name: Get commit SHA
         id: sha
         run: |
-          echo "::set-output name=sha::$(git log --format=%H -n 1)"
+          echo "sha=$(git log --format=%H -n 1)" >> "$GITHUB_OUTPUT"
       - name: Update status
         run: |
           curl \
@@ -79,7 +79,7 @@ jobs:
         if: success()
         id: matrix
         run: |
-          echo "::set-output name=matrix::$(go run .github/workflows/parse_integration_test_list.go -file ./integration/github_actions_integration_test_list.yml)"
+          echo "matrix=$(go run .github/workflows/parse_integration_test_list.go -file ./integration/github_actions_integration_test_list.yml)" >> "$GITHUB_OUTPUT"
       - name: Upload integration tests binary
         if: success()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# Changes

Use the new way of producing outputs in a GitHub action as the old way is deprecated and will be removed (on 31st May 2023).

See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- [ ] Tests
- [ ] Documentation
