### PR TITLE
feat(Splunk) Increases retry mechanism to 1 and timeout for transport to 10 seconds

### DIFF
--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -48,10 +48,10 @@ func (s *Splunk) Initialize(correlationID, dsn, token, index string, sendLogs bo
 	client := piperhttp.Client{}
 
 	client.SetOptions(piperhttp.ClientOptions{
-		MaxRequestDuration:        5 * time.Second,
+		MaxRequestDuration:        10 * time.Second,
 		Token:                     token,
 		TransportSkipVerification: true,
-		MaxRetries:                -1,
+		MaxRetries:                1,
 	})
 
 	hostName, err := os.Hostname()


### PR DESCRIPTION
# Changes
Increases retry to 1 and transport timeout to 10 seconds.
Increasing the retry mechanism to 1 makes use of the piper retry http mechanism and should avoid the nil response issues we have seen so far.

- [ ] Tests
- [ ] Documentation
