### PR TITLE
feat(checkmarx) Launch full scan if the last incremental scan failed

### DIFF
--- a/cmd/checkmarxExecuteScan.go
+++ b/cmd/checkmarxExecuteScan.go
@@ -316,11 +316,27 @@ func uploadAndScan(ctx context.Context, config checkmarxExecuteScanOptions, sys 
 			incremental = false
 		} else if incremental && config.FullScansScheduled && fullScanCycle > 0 && (getNumCoherentIncrementalScans(previousScans)+1)%fullScanCycle == 0 {
 			incremental = false
+		} else if incremental && isLastScanFailedIncremental(previousScans) { // if the last incremental scan failed, trigger a full scan instead
+			incremental = false
+			log.Entry().Infof("Last incremental scan for project %v failed, triggering full scan instead", project.Name)
 		}
 
 		return triggerScan(ctx, config, sys, project, incremental, influx, utils)
 	}
 	return nil
+}
+
+func isLastScanFailedIncremental(scans []checkmarx.ScanStatus) bool {
+	if len(scans) == 0 {
+		return false
+	}
+
+	scan := scans[0]
+	if scan.IsIncremental && scan.Status.Name == "Failed" {
+		return true
+	} else {
+		return false
+	}
 }
 
 func triggerScan(ctx context.Context, config checkmarxExecuteScanOptions, sys checkmarx.System, project checkmarx.Project, incremental bool, influx *checkmarxExecuteScanInflux, utils checkmarxExecuteScanUtils) error {


### PR DESCRIPTION
Sometimes, the incremental scans in Checkmarx will fail because the last full scan is not consistent.
This PR is adding an auto-healing feature that is triggering a full scan if the last incremental scan failed.
