### PR TITLE
fix(whitesourceExecuteScan): accept failOnSevereVulnerabilities configuration on step and stage level

### DIFF
--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -603,7 +603,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 					{
 						Name:        "failOnSevereVulnerabilities",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS"},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},

--- a/resources/metadata/whitesourceExecuteScan.yaml
+++ b/resources/metadata/whitesourceExecuteScan.yaml
@@ -224,6 +224,8 @@ spec:
         description: Whether to fail the step on severe vulnerabilties or not
         scope:
           - PARAMETERS
+          - STAGES
+          - STEPS
         default: true
       - name: includes
         type: "[]string"


### PR DESCRIPTION
Imho `failOnSevereVulnerabilities` should be configurable on stage and step level. It's also mplemented this way in [protecodeExecuteScan](https://github.com/SAP/jenkins-library/blob/0626c7d861f33c7e0946601c32a35aa949827d69/resources/metadata/protecodeExecuteScan.yaml#L36-L45)

# Changes

- [x] Tests
- [x] Documentation
