### PR TITLE
fix(orchestrator): determine if it is a pull request (GH Actions)

### DIFF
--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -1,7 +1,6 @@
 package orchestrator
 
 import (
-	"os"
 	"strings"
 	"time"
 
@@ -94,8 +93,7 @@ func (g *GitHubActionsConfigProvider) GetPullRequestConfig() PullRequestConfig {
 }
 
 func (g *GitHubActionsConfigProvider) IsPullRequest() bool {
-	_, exists := os.LookupEnv("GITHUB_HEAD_REF")
-	return exists
+	return truthy("GITHUB_HEAD_REF")
 }
 
 func isGitHubActions() bool {


### PR DESCRIPTION
# Changes

`sonarExecuteScan` in GHActions considers the non-PR branch as a pull request.
It is happening because the `isPullRequest` function checks if `GITHUB_HEAD_REF` env var exists and if yes —> it is a PR. And indeed, env var exists, but the value is ‘’, and the length is 0, and it is not a PR.

<img width="1017" alt="2023-02-05 в 5 09 04 PM" src="https://user-images.githubusercontent.com/32613074/216917242-cfc5a762-6768-49a2-b2ee-6be483e94b42.png">



This PR adds usage of the `truthy` function from the `orchestrator` package, it checks that env var exists and makes additional checks (e.g. length greater than zero).

https://github.com/SAP/jenkins-library/blob/f3c1bf6edc899a88806a4b65cefae70affae0d00/pkg/orchestrator/orchestrator.go#L100-L111


- [x] Tests
- [ ] Documentation
