### PR TITLE
fix(codeqlExecuteScan): fixed duplication of '--language' flag

### DIFF
--- a/cmd/codeqlExecuteScan.go
+++ b/cmd/codeqlExecuteScan.go
@@ -183,8 +183,9 @@ func runCodeqlExecuteScan(config *codeqlExecuteScanOptions, telemetryData *telem
 		}
 	}
 
-	cmd = append(cmd, "--language="+language)
-	if len(config.Language) > 0 {
+	if len(language) > 0 {
+		cmd = append(cmd, "--language="+language)
+	} else if len(config.Language) > 0 {
 		cmd = append(cmd, "--language="+config.Language)
 	}
 


### PR DESCRIPTION
# Changes

When language is set in config.yml there will be two --language flags in 'codeql database create' command. For example, .pipeline/config.yml:
```
codeqlExecuteStep: 
    language: 'java' 
    ...
```

running command:
`codeql database create codeqlDB --overwrite --source-root ./ --language=java --language=java`


- [ ] Tests
- [ ] Documentation
