### PR TITLE
fix: avoid post stage deadlock

### DIFF
--- a/vars/influxWriteData.groovy
+++ b/vars/influxWriteData.groovy
@@ -119,6 +119,7 @@ InfluxDB data map tags: ${config.customDataMapTags}
 [${STEP_NAME}]----------------------------------------------------------"""
 
         if(config.wrapInNode){
+            echo "[${STEP_NAME}] running step in separate node"
             node('influx'){
                 try{
                     writeToInflux(config, jenkinsUtils, script)

--- a/vars/influxWriteData.groovy
+++ b/vars/influxWriteData.groovy
@@ -119,7 +119,7 @@ InfluxDB data map tags: ${config.customDataMapTags}
 [${STEP_NAME}]----------------------------------------------------------"""
 
         if(config.wrapInNode){
-            node(''){
+            node('influx'){
                 try{
                     writeToInflux(config, jenkinsUtils, script)
                 }finally{

--- a/vars/mailSendNotification.groovy
+++ b/vars/mailSendNotification.groovy
@@ -170,6 +170,7 @@ def getCulpritCommitters(config, currentBuild) {
     }
     def numberOfCommits = getNumberOfCommits(buildList)
     if(config.wrapInNode){
+        echo "[${STEP_NAME}] running step in separate node"
         node('mail'){
             try{
                 recipients = getCulprits(config, env.BRANCH_NAME, numberOfCommits)

--- a/vars/mailSendNotification.groovy
+++ b/vars/mailSendNotification.groovy
@@ -170,7 +170,7 @@ def getCulpritCommitters(config, currentBuild) {
     }
     def numberOfCommits = getNumberOfCommits(buildList)
     if(config.wrapInNode){
-        node(){
+        node('mail'){
             try{
                 recipients = getCulprits(config, env.BRANCH_NAME, numberOfCommits)
             }finally{

--- a/vars/piperPipelineStagePost.groovy
+++ b/vars/piperPipelineStagePost.groovy
@@ -49,14 +49,14 @@ void call(Map parameters = [:]) {
         // telemetry reporting
         utils.pushToSWA([step: STEP_NAME], config)
 
-        influxWriteData script: script //, wrapInNode: false
+        influxWriteData script: script, wrapInNode: false
         if(env.BRANCH_NAME == parameters.script.commonPipelineEnvironment.getStepConfiguration('', '').productiveBranch) {
             if(parameters.script.commonPipelineEnvironment.configuration.runStep?.get('Post Actions')?.slackSendNotification) {
                 slackSendNotification script: parameters.script
             }
         }
 
-        mailSendNotification script: script //, wrapInNode: false
+        mailSendNotification script: script, wrapInNode: false
         debugReportArchive script: script
         piperPublishWarnings script: script
     }

--- a/vars/piperPipelineStagePost.groovy
+++ b/vars/piperPipelineStagePost.groovy
@@ -49,14 +49,14 @@ void call(Map parameters = [:]) {
         // telemetry reporting
         utils.pushToSWA([step: STEP_NAME], config)
 
-        influxWriteData script: script
+        influxWriteData script: script //, wrapInNode: false
         if(env.BRANCH_NAME == parameters.script.commonPipelineEnvironment.getStepConfiguration('', '').productiveBranch) {
             if(parameters.script.commonPipelineEnvironment.configuration.runStep?.get('Post Actions')?.slackSendNotification) {
                 slackSendNotification script: parameters.script
             }
         }
 
-        mailSendNotification script: script
+        mailSendNotification script: script //, wrapInNode: false
         debugReportArchive script: script
         piperPublishWarnings script: script
     }


### PR DESCRIPTION
# Changes

Under some circumstances the Jenkins gets into a deadlock where a stage that uses an executor waits for another executor to continue but all are already blocked.