### PR TITLE
Orchestrator/GHActions: fix pr-number determination

### DIFF
--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -85,6 +85,7 @@ func (g *GitHubActionsConfigProvider) GetRepoURL() string {
 }
 
 func (g *GitHubActionsConfigProvider) GetPullRequestConfig() PullRequestConfig {
+        // See https://docs.github.com/en/enterprise-server@3.6/actions/learn-github-actions/variables#default-environment-variables
 	githubRef := getEnv("GITHUB_REF", "n/a")
 	prNumber := strings.TrimSuffix(strings.TrimPrefix(githubRef, "refs/pull/"), "/merge")
 	return PullRequestConfig{

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -85,7 +85,7 @@ func (g *GitHubActionsConfigProvider) GetRepoURL() string {
 }
 
 func (g *GitHubActionsConfigProvider) GetPullRequestConfig() PullRequestConfig {
-        // See https://docs.github.com/en/enterprise-server@3.6/actions/learn-github-actions/variables#default-environment-variables
+	// See https://docs.github.com/en/enterprise-server@3.6/actions/learn-github-actions/variables#default-environment-variables
 	githubRef := getEnv("GITHUB_REF", "n/a")
 	prNumber := strings.TrimSuffix(strings.TrimPrefix(githubRef, "refs/pull/"), "/merge")
 	return PullRequestConfig{

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -85,10 +85,12 @@ func (g *GitHubActionsConfigProvider) GetRepoURL() string {
 }
 
 func (g *GitHubActionsConfigProvider) GetPullRequestConfig() PullRequestConfig {
+	githubRef := getEnv("GITHUB_REF", "n/a")
+	prNumber := strings.TrimSuffix(strings.TrimPrefix(githubRef, "refs/pull/"), "/merge")
 	return PullRequestConfig{
 		Branch: getEnv("GITHUB_HEAD_REF", "n/a"),
 		Base:   getEnv("GITHUB_BASE_REF", "n/a"),
-		Key:    getEnv("GITHUB_EVENT_PULL_REQUEST_NUMBER", "n/a"),
+		Key:    prNumber,
 	}
 }
 

--- a/pkg/orchestrator/gitHubActions_test.go
+++ b/pkg/orchestrator/gitHubActions_test.go
@@ -35,7 +35,7 @@ func TestGitHubActions(t *testing.T) {
 		os.Clearenv()
 		os.Setenv("GITHUB_HEAD_REF", "feat/test-gh-actions")
 		os.Setenv("GITHUB_BASE_REF", "main")
-		os.Setenv("GITHUB_EVENT_PULL_REQUEST_NUMBER", "42")
+		os.Setenv("GITHUB_REF", "refs/pull/42/merge")
 
 		p := GitHubActionsConfigProvider{}
 		c := p.GetPullRequestConfig()


### PR DESCRIPTION
# Changes

To get the PR number the sonarExecuteScan relies on the orchestrator package. The orchestrator package reads env var GITHUB_EVENT_PULL_REQUEST_NUMBER. There is no mention of GITHUB_EVENT_PULL_REQUEST_NUMBER in the GitHub documentation anymore.
The list of default env vars: https://docs.github.com/en/enterprise-server@3.6/actions/learn-github-actions/variables#default-environment-variables.
The env var GITHUB_EVENT_PULL_REQUEST_NUMBER doesn’t exist --> the orchestrator package returns n/a, which is not good.

<img width="795" alt="Снимок экрана 2023-02-21 в 5 09 19 PM" src="https://user-images.githubusercontent.com/32613074/220333107-9f988ffe-06ae-4bf1-933b-1f379757a834.png">

<img width="1091" alt="Снимок экрана 2023-02-21 в 5 09 50 PM" src="https://user-images.githubusercontent.com/32613074/220333183-b4995a8d-4847-4fda-8a27-43671b951166.png">

The PR fixes this behavior:

<img width="663" alt="Снимок экрана 2023-02-21 в 4 54 13 PM" src="https://user-images.githubusercontent.com/32613074/220333465-dc3e0d14-9946-49f3-89b0-f6832cec95fe.png">

<img width="1094" alt="Снимок экрана 2023-02-21 в 4 53 26 PM" src="https://user-images.githubusercontent.com/32613074/220333595-7492bd90-9114-4e45-9d6d-04825ed77ab8.png">


- [x] Tests
- [ ] Documentation
