### PR TITLE
Fix mta buildtool error

### DIFF
--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -36,7 +36,7 @@ parameters:
 
 modules:
   - name: {{.ApplicationName}}
-    type: html5
+    type: com.sap.hcp.html5
     path: .
     parameters:
       version: {{.Version}}-${timestamp}

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -39,8 +39,8 @@ modules:
     type: html5
     path: .
     parameters:
-       version: {{.Version}}-${timestamp}
-       name: {{.ApplicationName}}
+      version: {{.Version}}-${timestamp}
+      name: {{.ApplicationName}}
     build-parameters:
       builder: grunt
       build-result: dist`

--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -415,7 +415,7 @@ func getTimestamp() string {
 
 func createMtaYamlFile(mtaYamlFile, applicationName string, utils mtaBuildUtils) error {
 
-	log.Entry().Debugf("mta yaml file not found in project sources.")
+	log.Entry().Infof("\"%s\" file not found in project sources", mtaYamlFile)
 
 	if len(applicationName) == 0 {
 		return fmt.Errorf("'%[1]s' not found in project sources and 'applicationName' not provided as parameter - cannot generate '%[1]s' file", mtaYamlFile)

--- a/test/groovy/templates/PiperPipelineStageInitTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageInitTest.groovy
@@ -127,6 +127,18 @@ class PiperPipelineStageInitTest extends BasePiperTest {
         )
 
     }
+    
+    @Test
+    void testInitMtaBuildToolDoesNotThrowException() {
+
+        jsr.step.piperPipelineStageInit(
+            script: nullScript,
+            juStabUtils: utils,
+            buildTool: 'mta',
+            stashSettings: 'com.sap.piper/pipeline/stashSettings.yml'
+        )
+        assertThat(stepsCalled, hasItems('checkout', 'setupCommonPipelineEnvironment', 'piperInitRunStageConfiguration', 'artifactPrepareVersion', 'pipelineStashFilesBeforeBuild'))
+    }
 
     @Test
     void testInitDefault() {

--- a/vars/piperPipelineStageInit.groovy
+++ b/vars/piperPipelineStageInit.groovy
@@ -302,7 +302,7 @@ private String inferProjectName(Script script, String buildTool, String buildToo
 }
 
 private checkBuildTool(String buildTool, String buildDescriptorPattern) {
-    if (buildDescriptorPattern && !findFiles(glob: buildDescriptorPattern)) {
+    if (buildTool != "mta" && !findFiles(glob: buildDescriptorPattern)) {
         error "[${STEP_NAME}] buildTool configuration '${buildTool}' does not fit to your project (buildDescriptorPattern: '${buildDescriptorPattern}'), please set buildTool as general setting in your .pipeline/config.yml correctly, see also https://sap.github.io/jenkins-library/configuration/"
     }
 }


### PR DESCRIPTION
# Changes
This change utilizes the  functionality of dynamic creation of `mta.yaml` file during `mtaBuild` step  if that file does not exist beforehand. Currently,it is not possible with `buildTool` set to `mta` because of initial failure at `piperPipelineStageInit` step.

- [x] Tests
- [ ] Documentation
