### PR TITLE
fix wrong log message in dockerExecOnK8s in stashWorkspace

### DIFF
--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -410,7 +410,7 @@ chown -R ${runAsUser}:${fsGroup} ."""
     } catch (AbortException | IOException e) {
         echo "${e.getMessage()}"
     } catch (Throwable e) {
-        echo "Unstash workspace failed with throwable ${e.getMessage()}"
+        echo "Stash workspace failed with throwable ${e.getMessage()}"
         throw e
     }
     return null


### PR DESCRIPTION
# Changes

Update log message in case stashing a workspace fails.
Seems to be a copy-and-paste mistake from unstashing a workspace.
