### PR TITLE
fix(orchestrator): correct orchestrator name for Azure DevOps

### DIFF
--- a/pkg/orchestrator/azureDevOps.go
+++ b/pkg/orchestrator/azureDevOps.go
@@ -94,7 +94,7 @@ func (a *AzureDevOpsConfigProvider) OrchestratorVersion() string {
 
 // OrchestratorType returns the orchestrator name e.g. Azure/GitHubActions/Jenkins
 func (a *AzureDevOpsConfigProvider) OrchestratorType() string {
-	return "Azure"
+	return "Azure DevOps"
 }
 
 // GetBuildStatus returns status of the build. Return variables are aligned with Jenkins build statuses.

--- a/pkg/orchestrator/azureDevOps.go
+++ b/pkg/orchestrator/azureDevOps.go
@@ -94,7 +94,7 @@ func (a *AzureDevOpsConfigProvider) OrchestratorVersion() string {
 
 // OrchestratorType returns the orchestrator name e.g. Azure/GitHubActions/Jenkins
 func (a *AzureDevOpsConfigProvider) OrchestratorType() string {
-	return "Azure DevOps"
+	return "AzureDevOps"
 }
 
 // GetBuildStatus returns status of the build. Return variables are aligned with Jenkins build statuses.


### PR DESCRIPTION
# Changes

Use the full name `AzureDevOps`.
