### PR TITLE
feat(kubernetes): invalidate default stash only if it has been created

### DIFF
--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -305,8 +305,10 @@ void executeOnPod(Map config, utils, Closure body, Script script) {
     try {
         SidecarUtils sidecarUtils = new SidecarUtils(script)
         def stashContent = config.stashContent
+        boolean defaultStashCreated = false
         if (config.containerName && stashContent.isEmpty()) {
             stashContent = [stashWorkspace(config, 'workspace')]
+            defaultStashCreated = true
         }
         podTemplate(getOptions(config)) {
             node(config.uniqueId) {
@@ -322,8 +324,10 @@ void executeOnPod(Map config, utils, Closure body, Script script) {
                     container(containerParams) {
                         try {
                             utils.unstashAll(stashContent)
-                            echo "invalidate stash workspace-${config.uniqueId}"
-                            stash name: "workspace-${config.uniqueId}", excludes: '**/*', allowEmpty: true
+                            if (defaultStashCreated) {
+                                echo "invalidate stash workspace-${config.uniqueId}"
+                                stash name: "workspace-${config.uniqueId}", excludes: '**/*', allowEmpty: true
+                            }
                             body()
                         } finally {
                             stashWorkspace(config, 'container', true, true)


### PR DESCRIPTION
# Changes

Inside `dockerExecuteOnKubernetes` there is a default stash created for stashing the workspace into a pod. This default stash is only provided in case no stashes are explicitly provided. But also when there is no default stash use (... since we have explicit stashes), the default stash is invalidated.

- [ ] Tests
- [ ] Documentation
