### PR TITLE
do not supress AbortExceptions or IOExceptions when dealing with stashes

### DIFF
--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -10,7 +10,6 @@ import com.sap.piper.k8s.SystemEnv
 import com.sap.piper.JsonUtils
 
 import groovy.transform.Field
-import hudson.AbortException
 
 @Field def STEP_NAME = getClass().getName()
 @Field def PLUGIN_ID_KUBERNETES = 'kubernetes'
@@ -407,8 +406,6 @@ chown -R ${runAsUser}:${fsGroup} ."""
             allowEmpty: true
         )
         return stashName
-    } catch (AbortException | IOException e) {
-        echo "${e.getMessage()}"
     } catch (Throwable e) {
         echo "Unstash workspace failed with throwable ${e.getMessage()}"
         throw e
@@ -437,8 +434,6 @@ private Map getSecurityContext(Map config) {
 private void unstashWorkspace(config, prefix) {
     try {
         unstash "${prefix}-${config.uniqueId}"
-    } catch (AbortException | IOException e) {
-        echo "${e.getMessage()}\n${e.getCause()}"
     } catch (Throwable e) {
         echo "Unstash workspace failed with throwable ${e.getMessage()}"
         throw e


### PR DESCRIPTION
# Changes

More a question than a ready-to-merge pull request. 

What is the reason for supressing `AbortException`s and `IOException`s?

When an AbortException is triggered it should bubble up in order to stop the build.
When an IOException happened during stashing/unstashing it looks like it would be better not to continue.

Does anybody remember the reason why the code is like it is?

- [ ] Tests
- [ ] Documentation
