### PR TITLE
feat(cnbBuild): support Vault general purpose secrets as a binding content source

### DIFF
--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -239,6 +239,9 @@ func TestCNBIntegrationBindings(t *testing.T) {
 		User:    "cnb",
 		TestDir: []string{"testdata"},
 		Network: fmt.Sprintf("container:%s", registryContainer.GetContainerID()),
+		Environment: map[string]string{
+			"PIPER_VAULTCREDENTIAL_DYNATRACE_API_KEY": "api-key-content",
+		},
 	})
 	defer container.terminate(t)
 
@@ -250,6 +253,8 @@ func TestCNBIntegrationBindings(t *testing.T) {
 		"/tmp/platform/bindings/dummy-binding/type",
 		"/tmp/platform/bindings/dummy-binding/dummy.yml",
 	)
+	container.assertFileContentEquals(t, "/tmp/platform/bindings/maven-settings/settings.xml", "invalid xml")
+	container.assertFileContentEquals(t, "/tmp/platform/bindings/dynatrace/api-key", "api-key-content")
 }
 
 func TestCNBIntegrationMultiImage(t *testing.T) {

--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -46,6 +46,9 @@ func TestCNBIntegrationNPMProject(t *testing.T) {
 		User:    "cnb",
 		TestDir: []string{"testdata"},
 		Network: fmt.Sprintf("container:%s", registryContainer.GetContainerID()),
+		Environment: map[string]string{
+			"PIPER_VAULTCREDENTIAL_DYNATRACE_API_KEY": "api-key-content",
+		},
 	})
 	defer container.terminate(t)
 
@@ -54,6 +57,9 @@ func TestCNBIntegrationNPMProject(t *testing.T) {
 		User:    "cnb",
 		TestDir: []string{"testdata"},
 		Network: fmt.Sprintf("container:%s", registryContainer.GetContainerID()),
+		Environment: map[string]string{
+			"PIPER_VAULTCREDENTIAL_DYNATRACE_API_KEY": "api-key-content",
+		},
 	})
 	defer container2.terminate(t)
 

--- a/integration/testdata/TestCnbIntegration/config.yml
+++ b/integration/testdata/TestCnbIntegration/config.yml
@@ -13,3 +13,8 @@ steps:
         data:
         - key: dummy.yml
           file: TestCnbIntegration/config.yml
+      dynatrace:
+        type: Dynatrace
+        data:
+        - key: api-key
+          vaultCredentialKey: dynatrace-api-key

--- a/pkg/cnbutils/bindings/bindings_test.go
+++ b/pkg/cnbutils/bindings/bindings_test.go
@@ -56,37 +56,42 @@ func TestProcessBindings(t *testing.T) {
 		})
 
 		if assert.NoError(t, err) {
-			if assert.True(t, utils.HasFile("/tmp/platform/bindings/a/inline.yaml")) {
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/a/inline.yaml")) {
 				content, err := utils.FileRead("/tmp/platform/bindings/a/inline.yaml")
 				if assert.NoError(t, err) {
 					assert.Equal(t, string(content), "my inline content")
 				}
 			}
 
-			if assert.True(t, utils.HasFile("/tmp/platform/bindings/a/type")) {
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/a/type")) {
 				content, err := utils.FileRead("/tmp/platform/bindings/a/type")
 				if assert.NoError(t, err) {
 					assert.Equal(t, string(content), "inline")
 				}
 			}
 
-			assert.True(t, utils.HasCopiedFile("/tmp/somefile.yaml", "/tmp/platform/bindings/b/from-file.yaml"))
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/b/from-file.yaml")) {
+				content, err := utils.FileRead("/tmp/platform/bindings/b/from-file.yaml")
+				if assert.NoError(t, err) {
+					assert.Equal(t, string(content), "some file content")
+				}
+			}
 
-			if assert.True(t, utils.HasFile("/tmp/platform/bindings/b/type")) {
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/b/type")) {
 				content, err := utils.FileRead("/tmp/platform/bindings/b/type")
 				if assert.NoError(t, err) {
 					assert.Equal(t, string(content), "file")
 				}
 			}
 
-			if assert.True(t, utils.HasFile("/tmp/platform/bindings/c/type")) {
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/c/type")) {
 				content, err := utils.FileRead("/tmp/platform/bindings/c/type")
 				if assert.NoError(t, err) {
 					assert.Equal(t, string(content), "url")
 				}
 			}
 
-			if assert.True(t, utils.HasFile("/tmp/platform/bindings/c/from-url.yaml")) {
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/c/from-url.yaml")) {
 				content, err := utils.FileRead("/tmp/platform/bindings/c/from-url.yaml")
 				if assert.NoError(t, err) {
 					assert.Equal(t, string(content), "from url content")
@@ -96,6 +101,7 @@ func TestProcessBindings(t *testing.T) {
 	})
 
 	t.Run("writes bindings to files", func(t *testing.T) {
+		t.Setenv("PIPER_VAULTCREDENTIAL_VAULT_KEY1", "test value from vault")
 		var utils = mockUtils()
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
@@ -118,6 +124,10 @@ func TestProcessBindings(t *testing.T) {
 						"key":     "from-url.yaml",
 						"fromUrl": "http://test-url.com/binding",
 					},
+					{
+						"key":                "from-vault.yaml",
+						"vaultCredentialKey": "vault-key1",
+					},
 				},
 			},
 			"b": map[string]interface{}{
@@ -132,35 +142,48 @@ func TestProcessBindings(t *testing.T) {
 		})
 
 		if assert.NoError(t, err) {
-			if assert.True(t, utils.HasFile("/tmp/platform/bindings/a/type")) {
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/a/type")) {
 				content, err := utils.FileRead("/tmp/platform/bindings/a/type")
 				if assert.NoError(t, err) {
 					assert.Equal(t, string(content), "test")
 				}
 
-				if assert.True(t, utils.HasFile("/tmp/platform/bindings/a/inline.yaml")) {
+				if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/a/inline.yaml")) {
 					content, err = utils.FileRead("/tmp/platform/bindings/a/inline.yaml")
 					if assert.NoError(t, err) {
 						assert.Equal(t, string(content), "my inline content")
 					}
 				}
 
-				assert.True(t, utils.HasCopiedFile("/tmp/somefile.yaml", "/tmp/platform/bindings/a/from-file.yaml"))
+				if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/a/from-file.yaml")) {
+					content, err = utils.FileRead("/tmp/platform/bindings/a/from-file.yaml")
+					if assert.NoError(t, err) {
+						assert.Equal(t, string(content), "some file content")
+					}
+				}
 
-				if assert.True(t, utils.HasFile("/tmp/platform/bindings/a/from-url.yaml")) {
+				if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/a/from-url.yaml")) {
 					content, err := utils.FileRead("/tmp/platform/bindings/a/from-url.yaml")
 					if assert.NoError(t, err) {
 						assert.Equal(t, string(content), "from url content")
 					}
 				}
+
+				if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/a/from-vault.yaml")) {
+					content, err := utils.FileRead("/tmp/platform/bindings/a/from-vault.yaml")
+					if assert.NoError(t, err) {
+						assert.Equal(t, string(content), "test value from vault")
+					}
+				}
 			}
-			if assert.True(t, utils.HasFile("/tmp/platform/bindings/b/type")) {
+
+			if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/b/type")) {
 				content, err := utils.FileRead("/tmp/platform/bindings/b/type")
 				if assert.NoError(t, err) {
 					assert.Equal(t, string(content), "test2")
 				}
 
-				if assert.True(t, utils.HasFile("/tmp/platform/bindings/b/inline2.yaml")) {
+				if assert.True(t, utils.HasWrittenFile("/tmp/platform/bindings/b/inline2.yaml")) {
 					content, err = utils.FileRead("/tmp/platform/bindings/b/inline2.yaml")
 					if assert.NoError(t, err) {
 						assert.Equal(t, string(content), "my inline content2")
@@ -224,7 +247,7 @@ func TestProcessBindings(t *testing.T) {
 		})
 
 		if assert.Error(t, err) {
-			assert.Equal(t, "failed to validate binding 'my-binding': only one of 'content', 'file' or 'fromUrl' can be set", err.Error())
+			assert.Equal(t, "failed to validate binding 'my-binding': only one of 'content', 'file', 'fromUrl' or 'vaultCredentialKey' can be set", err.Error())
 		}
 	})
 
@@ -238,7 +261,7 @@ func TestProcessBindings(t *testing.T) {
 		})
 
 		if assert.Error(t, err) {
-			assert.Equal(t, "failed to validate binding 'my-binding': one of 'file', 'content' or 'fromUrl' properties must be specified", err.Error())
+			assert.Equal(t, "failed to validate binding 'my-binding': one of 'file', 'content', 'fromUrl' or 'vaultCredentialKey' properties must be specified", err.Error())
 		}
 	})
 
@@ -283,6 +306,23 @@ func TestProcessBindings(t *testing.T) {
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "error while reading bindings: could not process binding 'my-binding'", err.Error())
 			assert.Contains(t, err.Error(), "validation error", err.Error())
+		}
+	})
+
+	t.Run("fails if vault environment variable is not set", func(t *testing.T) {
+		var utils = mockUtils()
+		err := bindings.ProcessBindings(utils, &piperhttp.Client{}, "/tmp/platform", map[string]interface{}{
+			"my-binding": map[string]interface{}{
+				"type": "test",
+				"data": []map[string]interface{}{{
+					"key":                "from-vault.yaml",
+					"vaultCredentialKey": "vault-key1",
+				}},
+			},
+		})
+
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "environment variable \"PIPER_VAULTCREDENTIAL_VAULT_KEY1\" is not set (required by the \"my-binding\" binding)")
 		}
 	})
 }

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -32,7 +32,7 @@ const (
 	vaultTestCredentialEnvPrefix        = "vaultTestCredentialEnvPrefix"
 	vaultCredentialEnvPrefix            = "vaultCredentialEnvPrefix"
 	vaultTestCredentialEnvPrefixDefault = "PIPER_TESTCREDENTIAL_"
-	vaultCredentialEnvPrefixDefault     = "PIPER_VAULTCREDENTIAL_"
+	VaultCredentialEnvPrefixDefault     = "PIPER_VAULTCREDENTIAL_"
 	vaultSecretName                     = ".+VaultSecretName$"
 )
 
@@ -257,7 +257,7 @@ func populateTestCredentialsAsEnvs(config *StepConfig, secret map[string]string,
 		for _, key := range keys {
 			if secretKey == key {
 				log.RegisterSecret(secretValue)
-				envVariable := vaultTestCredentialEnvPrefix + convertEnvVar(secretKey)
+				envVariable := vaultTestCredentialEnvPrefix + ConvertEnvVar(secretKey)
 				log.Entry().Debugf("Exposing test credential '%v' as '%v'", key, envVariable)
 				os.Setenv(envVariable, secretValue)
 				matched = true
@@ -273,19 +273,19 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 	isCredentialEnvPrefixDefault := false
 
 	if !ok {
-		vaultCredentialEnvPrefix = vaultCredentialEnvPrefixDefault
+		vaultCredentialEnvPrefix = VaultCredentialEnvPrefixDefault
 		isCredentialEnvPrefixDefault = true
 	}
 	for secretKey, secretValue := range secret {
 		for _, key := range keys {
 			if secretKey == key {
 				log.RegisterSecret(secretValue)
-				envVariable := vaultCredentialEnvPrefix + convertEnvVar(secretKey)
+				envVariable := vaultCredentialEnvPrefix + ConvertEnvVar(secretKey)
 				log.Entry().Debugf("Exposing general purpose credential '%v' as '%v'", key, envVariable)
 				os.Setenv(envVariable, secretValue)
 
 				log.RegisterSecret(piperutils.EncodeString(secretValue))
-				envVariable = vaultCredentialEnvPrefix + convertEnvVar(secretKey) + "_BASE64"
+				envVariable = vaultCredentialEnvPrefix + ConvertEnvVar(secretKey) + "_BASE64"
 				log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
 				os.Setenv(envVariable, piperutils.EncodeString(secretValue))
 				matched = true
@@ -300,12 +300,12 @@ func populateCredentialsAsEnvs(config *StepConfig, secret map[string]string, key
 			for _, key := range keys {
 				if secretKey == key {
 					log.RegisterSecret(secretValue)
-					envVariable := vaultCredentialEnvPrefixDefault + convertEnvVar(secretKey)
+					envVariable := VaultCredentialEnvPrefixDefault + ConvertEnvVar(secretKey)
 					log.Entry().Debugf("Exposing general purpose credential '%v' as '%v'", key, envVariable)
 					os.Setenv(envVariable, secretValue)
 
 					log.RegisterSecret(piperutils.EncodeString(secretValue))
-					envVariable = vaultCredentialEnvPrefixDefault + convertEnvVar(secretKey) + "_BASE64"
+					envVariable = VaultCredentialEnvPrefixDefault + ConvertEnvVar(secretKey) + "_BASE64"
 					log.Entry().Debugf("Exposing general purpose base64 encoded credential '%v' as '%v'", key, envVariable)
 					os.Setenv(envVariable, piperutils.EncodeString(secretValue))
 					matched = true
@@ -351,8 +351,8 @@ func getCredentialKeys(config *StepConfig) []string {
 	return keys
 }
 
-// converts to a valid environment variable string
-func convertEnvVar(s string) string {
+// ConvertEnvVar converts to a valid environment variable string
+func ConvertEnvVar(s string) string {
 	r := strings.ToUpper(s)
 	r = strings.ReplaceAll(r, "-", "_")
 	reg, err := regexp.Compile("[^a-zA-Z0-9_]*")

--- a/pkg/config/vault_test.go
+++ b/pkg/config/vault_test.go
@@ -357,7 +357,7 @@ func Test_convertEnvVar(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := convertEnvVar(tt.args.s); got != tt.want {
+			if got := ConvertEnvVar(tt.args.s); got != tt.want {
 				t.Errorf("convertEnvironment() = %v, want %v", got, tt.want)
 			}
 		})

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -207,6 +207,18 @@ spec:
                 fromUrl: https://url-to/setting.xml
           ```
 
+          using [Vault general purpose credentials](https://www.project-piper.io/infrastructure/vault/#using-vault-for-general-purpose-and-test-credentials):
+          ```yaml
+          bindings:
+            dynatrace:
+              type: Dynatrace
+              data:
+              - key: api-token
+                vaultCredentialKey: dynatrace-api-token
+          vaultCredentialPath: cnb-bindings
+          vaultCredentialKeys: ['dynatrace-api-token']
+          ```
+
           Deprecated: A binding with a single key, could be written like this:
 
           ```yaml


### PR DESCRIPTION
# Changes

Binding content can now be provided via [Vault general purpose secrets](https://www.project-piper.io/infrastructure/vault/#using-vault-for-general-purpose-and-test-credentials)

- [X] Tests
- [X] Documentation
