### PR TITLE
log the first two level of the file system in verbose mode

### DIFF
--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -324,11 +324,17 @@ void executeOnPod(Map config, utils, Closure body, Script script) {
                     container(containerParams) {
                         try {
                             utils.unstashAll(stashContent)
+                            if (config.verbose) {
+                                lsDir('Directory content before body execution')
+                            }
                             if (defaultStashCreated) {
                                 echo "invalidate stash workspace-${config.uniqueId}"
                                 stash name: "workspace-${config.uniqueId}", excludes: '**/*', allowEmpty: true
                             }
                             body()
+                            if (config.verbose) {
+                                lsDir('Directory content after body execution')
+                            }
                         } finally {
                             stashWorkspace(config, 'container', true, true)
                         }
@@ -342,6 +348,16 @@ void executeOnPod(Map config, utils, Closure body, Script script) {
         if (config.containerName)
             unstashWorkspace(config, 'container')
     }
+}
+
+private void lsDir(String message) {
+  echo "[DEBUG] Begin of ${message}"
+  // some images might not contain the find command. In that case the build must not be aborted.
+  catchError (message: 'Cannot list directory content', buildResult: 'SUCCESS', stageResult: 'SUCCESS') {
+    // no -ls option since this is not available for some images
+    sh  'find . -mindepth 1 -maxdepth 2'
+  }
+  echo "[DEBUG] End of ${message}"
 }
 
 private String generatePodSpec(Map config) {


### PR DESCRIPTION
# Changes

Sometimes it is beneficial to know which file are available in a pod.

When verbose mode is enable we list the first two levels of the current dir.
In case the `find` command is not present in the container, the build status and the stage status will remain unchanged (e.g. build does not fail in that case).

- [ ] Tests
- [ ] Documentation
