### PR TITLE
dockerExecuteOnKubernetes: return result of body closure

### DIFF
--- a/vars/dockerExecuteOnKubernetes.groovy
+++ b/vars/dockerExecuteOnKubernetes.groovy
@@ -331,10 +331,11 @@ void executeOnPod(Map config, utils, Closure body, Script script) {
                                 echo "invalidate stash workspace-${config.uniqueId}"
                                 stash name: "workspace-${config.uniqueId}", excludes: '**/*', allowEmpty: true
                             }
-                            body()
+                            def result = body()
                             if (config.verbose) {
                                 lsDir('Directory content after body execution')
                             }
+                            return result
                         } finally {
                             stashWorkspace(config, 'container', true, true)
                         }


### PR DESCRIPTION
# Changes

With #4293 the body closure is not the last statement which gets executed. With that the return value of the call method changed (transitively via `executeOnPod`.

This change in the behaviour is fixed with this change.

- [ ] Tests
- [ ] Documentation
