### PR TITLE
feat(helmExecute): Allow custom delimiter

### DIFF
--- a/cmd/helmExecute.go
+++ b/cmd/helmExecute.go
@@ -175,7 +175,7 @@ func parseAndRenderCPETemplate(config helmExecuteOptions, rootPath string, utils
 		if err != nil {
 			return fmt.Errorf("failed to read file: %v", err)
 		}
-		generated, err := cpe.ParseTemplate(string(cpeTemplate))
+		generated, err := cpe.ParseTemplateWithDelimiter(string(cpeTemplate), config.TemplateStartDelimiter, config.TemplateEndDelimiter)
 		if err != nil {
 			return fmt.Errorf("failed to parse template: %v", err)
 		}

--- a/cmd/helmExecute_generated.go
+++ b/cmd/helmExecute_generated.go
@@ -46,6 +46,8 @@ type helmExecuteOptions struct {
 	Publish                   bool     `json:"publish,omitempty"`
 	Version                   string   `json:"version,omitempty"`
 	RenderSubchartNotes       bool     `json:"renderSubchartNotes,omitempty"`
+	TemplateStartDelimiter    string   `json:"templateStartDelimiter,omitempty"`
+	TemplateEndDelimiter      string   `json:"templateEndDelimiter,omitempty"`
 }
 
 type helmExecuteCommonPipelineEnvironment struct {
@@ -226,6 +228,8 @@ func addHelmExecuteFlags(cmd *cobra.Command, stepConfig *helmExecuteOptions) {
 	cmd.Flags().BoolVar(&stepConfig.Publish, "publish", false, "Configures helm to run the deploy command to publish artifacts to a repository.")
 	cmd.Flags().StringVar(&stepConfig.Version, "version", os.Getenv("PIPER_version"), "Defines the artifact version to use from helm package/publish commands.")
 	cmd.Flags().BoolVar(&stepConfig.RenderSubchartNotes, "renderSubchartNotes", true, "If set, render subchart notes along with the parent.")
+	cmd.Flags().StringVar(&stepConfig.TemplateStartDelimiter, "templateStartDelimiter", `{{`, "When templating value files, use this start delimiter.")
+	cmd.Flags().StringVar(&stepConfig.TemplateEndDelimiter, "templateEndDelimiter", `}}`, "When templating value files, use this end delimiter.")
 
 	cmd.MarkFlagRequired("image")
 }
@@ -605,6 +609,24 @@ func helmExecuteMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     true,
+					},
+					{
+						Name:        "templateStartDelimiter",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `{{`,
+					},
+					{
+						Name:        "templateEndDelimiter",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `}}`,
 					},
 				},
 			},

--- a/cmd/helmExecute_generated.go
+++ b/cmd/helmExecute_generated.go
@@ -613,7 +613,7 @@ func helmExecuteMetadata() config.StepData {
 					{
 						Name:        "templateStartDelimiter",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"STEPS"},
+						Scope:       []string{"STEPS", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
@@ -622,7 +622,7 @@ func helmExecuteMetadata() config.StepData {
 					{
 						Name:        "templateEndDelimiter",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"STEPS"},
+						Scope:       []string{"STEPS", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},

--- a/pkg/piperenv/templating.go
+++ b/pkg/piperenv/templating.go
@@ -7,9 +7,16 @@ import (
 	"text/template"
 )
 
+const DEFAULT_START_DELIMITER = "{{"
+const DEFAULT_END_DELIMITER = "}}"
+
 // ParseTemplate allows to parse a template which contains references to the CPE
 // Utility functions make it simple to access specific parts of the CPE
 func (c *CPEMap) ParseTemplate(cpeTemplate string) (*bytes.Buffer, error) {
+	return c.ParseTemplateWithDelimiter(cpeTemplate, DEFAULT_START_DELIMITER, DEFAULT_END_DELIMITER)
+}
+
+func (c *CPEMap) ParseTemplateWithDelimiter(cpeTemplate string, startDelimiter string, endDelimiter string) (*bytes.Buffer, error) {
 	funcMap := template.FuncMap{
 		"cpe":         c.cpe,
 		"cpecustom":   c.custom,
@@ -21,7 +28,7 @@ func (c *CPEMap) ParseTemplate(cpeTemplate string) (*bytes.Buffer, error) {
 		// This requires alignment on artifact handling before, though
 	}
 
-	tmpl, err := template.New("cpetemplate").Funcs(funcMap).Parse(cpeTemplate)
+	tmpl, err := template.New("cpetemplate").Delims(startDelimiter, endDelimiter).Funcs(funcMap).Parse(cpeTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse cpe template '%v': %w", cpeTemplate, err)
 	}

--- a/resources/metadata/helmExecute.yaml
+++ b/resources/metadata/helmExecute.yaml
@@ -351,12 +351,14 @@ spec:
         default: "{{"
         scope:
           - STEPS
+          - PARAMETERS
       - name: templateEndDelimiter
         type: string
         description: When templating value files, use this end delimiter.
         default: "}}"
         scope:
           - STEPS
+          - PARAMETERS
   containers:
     - image: dtzar/helm-kubectl:3
       workingDir: /config

--- a/resources/metadata/helmExecute.yaml
+++ b/resources/metadata/helmExecute.yaml
@@ -345,6 +345,18 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: templateStartDelimiter
+        type: string
+        description: When templating value files, use this start delimiter.
+        default: "{{"
+        scope:
+          - STEPS
+      - name: templateEndDelimiter
+        type: string
+        description: When templating value files, use this end delimiter.
+        default: "}}"
+        scope:
+          - STEPS
   containers:
     - image: dtzar/helm-kubectl:3
       workingDir: /config


### PR DESCRIPTION
Allow custom delimiter for go templating in case the values.yaml file already contain templates that are meant to be resolved by `helm` and not piper (see unit test for an example). 

# Changes

- [x] Tests
- [x] Documentation
