### PR TITLE
chore(actions): update action to use node16

### DIFF
--- a/.github/workflows/consumer-tests-pr.yml
+++ b/.github/workflows/consumer-tests-pr.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - name: Get pull request URL
         id: pull_request
         run: |

--- a/.github/workflows/consumer-tests.yml
+++ b/.github/workflows/consumer-tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v1
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,7 +12,7 @@ jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -23,7 +23,7 @@ jobs:
       sha: ${{ steps.sha.outputs.sha }}
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - name: Get pull request URL
         id: pull_request
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
       sha: ${{ steps.sha.outputs.sha }}
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v3
       - name: Get GO version
         id: go_version

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Format'
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v2
       - name: Markdown Linting
         uses: nosborn/github-action-markdown-cli@v1.1.1

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -11,7 +11,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v1
       # Workaround for https://github.com/SAP/jenkins-library/issues/1723, build only works with jdk8 currently
       - uses: actions/setup-java@v1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/stale@v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-go-dependencies.yml
+++ b/.github/workflows/update-go-dependencies.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/upload-go-master.yml
+++ b/.github/workflows/upload-go-master.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v1
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -12,7 +12,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/setup-go@v1
         with:
           go-version: '1.18.x'

--- a/.github/workflows/verify-groovy.yml
+++ b/.github/workflows/verify-groovy.yml
@@ -12,7 +12,7 @@ jobs:
   unit:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/verify-yaml.yml
+++ b/.github/workflows/verify-yaml.yml
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.10.0
+      - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@master
 
       - uses: actions/setup-python@v2


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation

> [Start](https://github.com/SAP/jenkins-library/actions/runs/4618661268/jobs/8166391793)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: styfle/cancel-workflow-action@0.10.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

<img width="1307" alt="Bildschirm­foto 2023-04-05 um 15 04 38" src="https://user-images.githubusercontent.com/26137398/230089094-179dcbd2-e2af-4d18-9921-a129adf5c965.png">

