### PR TITLE
Npm extra parameters

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -390,7 +390,6 @@ func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectU
 	}
 
 	// npm
-	log.Entry().Infof("Checking for npm paramters: ", config.NpmDependencyTypesExcluded, config.NpmArguments)
 	if len(config.NpmDependencyTypesExcluded) > 0 {
 		args = append(args, fmt.Sprintf("--detect.npm.dependency.types.excluded=%v", strings.ToUpper(strings.Join(config.NpmDependencyTypesExcluded, ","))))
 	}

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -389,6 +389,14 @@ func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectU
 		args = append(args, fmt.Sprintf("--detect.tools=%v", strings.Join(config.DetectTools, ",")))
 	}
 
+	// npm
+	if len(config.ExcludedNpmDependencies) > 0 {
+		args = append(args, fmt.Sprintf("--detect.npm.dependency.types.excluded=%v", strings.ToUpper(strings.Join(config.ExcludedPackageManagers, ","))))
+	}
+	if len(config.NpmArguments) > 0 {
+		args = append(args, fmt.Sprintf("--detect.npm.arguments=%v", strings.ToUpper(strings.Join(config.NpmArguments, " "))))
+	}
+
 	mavenArgs, err := maven.DownloadAndGetMavenParameters(config.GlobalSettingsFile, config.ProjectSettingsFile, utils)
 	if err != nil {
 		return nil, err

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -390,8 +390,8 @@ func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectU
 	}
 
 	// npm
-	if len(config.ExcludedNpmDependencies) > 0 {
-		args = append(args, fmt.Sprintf("--detect.npm.dependency.types.excluded=%v", strings.ToUpper(strings.Join(config.ExcludedPackageManagers, ","))))
+	if len(config.NpmDependencyTypesExcluded) > 0 {
+		args = append(args, fmt.Sprintf("--detect.npm.dependency.types.excluded=%v", strings.ToUpper(strings.Join(config.NpmDependencyTypesExcluded, ","))))
 	}
 	if len(config.NpmArguments) > 0 {
 		args = append(args, fmt.Sprintf("--detect.npm.arguments=%v", strings.ToUpper(strings.Join(config.NpmArguments, " "))))

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -390,6 +390,7 @@ func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectU
 	}
 
 	// npm
+	log.Entry().Infof("Checking for npm paramters: ", config.NpmDependencyTypesExcluded, config.NpmArguments)
 	if len(config.NpmDependencyTypesExcluded) > 0 {
 		args = append(args, fmt.Sprintf("--detect.npm.dependency.types.excluded=%v", strings.ToUpper(strings.Join(config.NpmDependencyTypesExcluded, ","))))
 	}

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -57,7 +57,7 @@ type detectExecuteScanOptions struct {
 	FailOnSevereVulnerabilities bool     `json:"failOnSevereVulnerabilities,omitempty"`
 	BuildTool                   string   `json:"buildTool,omitempty"`
 	ExcludedDirectories         []string `json:"excludedDirectories,omitempty"`
-	ExcludedNpmDependencies     []string `json:"excludedNpmDependencies,omitempty" validate:"possible-values=NONE DEV PEER"`
+	NpmDependencyTypesExcluded  []string `json:"npmDependencyTypesExcluded,omitempty" validate:"possible-values=NONE DEV PEER"`
 	NpmArguments                []string `json:"npmArguments,omitempty"`
 }
 
@@ -291,7 +291,7 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().BoolVar(&stepConfig.FailOnSevereVulnerabilities, "failOnSevereVulnerabilities", true, "Whether to fail the step on severe vulnerabilties or not")
 	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", os.Getenv("PIPER_buildTool"), "Defines the tool which is used for building the artifact.")
 	cmd.Flags().StringSliceVar(&stepConfig.ExcludedDirectories, "excludedDirectories", []string{}, "List of directories which should be excluded from the scan.")
-	cmd.Flags().StringSliceVar(&stepConfig.ExcludedNpmDependencies, "excludedNpmDependencies", []string{}, "List of npm dependency types which Detect should exclude from the BOM.")
+	cmd.Flags().StringSliceVar(&stepConfig.NpmDependencyTypesExcluded, "npmDependencyTypesExcluded", []string{}, "List of npm dependency types which Detect should exclude from the BOM.")
 	cmd.Flags().StringSliceVar(&stepConfig.NpmArguments, "npmArguments", []string{}, "List of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project.")
 
 	cmd.MarkFlagRequired("token")
@@ -681,12 +681,12 @@ func detectExecuteScanMetadata() config.StepData {
 						Default:     []string{},
 					},
 					{
-						Name:        "excludedNpmDependencies",
+						Name:        "npmDependencyTypesExcluded",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "detect/excludedDirectories"}},
+						Aliases:     []config.Alias{{Name: "detect/npmDependencyTypesExcluded"}},
 						Default:     []string{},
 					},
 					{
@@ -695,7 +695,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "detect/excludedDirectories"}},
+						Aliases:     []config.Alias{{Name: "detect/npmArguments"}},
 						Default:     []string{},
 					},
 				},

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -57,6 +57,8 @@ type detectExecuteScanOptions struct {
 	FailOnSevereVulnerabilities bool     `json:"failOnSevereVulnerabilities,omitempty"`
 	BuildTool                   string   `json:"buildTool,omitempty"`
 	ExcludedDirectories         []string `json:"excludedDirectories,omitempty"`
+	ExcludedNpmDependencies     []string `json:"excludedNpmDependencies,omitempty" validate:"possible-values=NONE DEV PEER"`
+	NpmArguments                []string `json:"npmArguments,omitempty"`
 }
 
 type detectExecuteScanInflux struct {
@@ -289,6 +291,8 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().BoolVar(&stepConfig.FailOnSevereVulnerabilities, "failOnSevereVulnerabilities", true, "Whether to fail the step on severe vulnerabilties or not")
 	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", os.Getenv("PIPER_buildTool"), "Defines the tool which is used for building the artifact.")
 	cmd.Flags().StringSliceVar(&stepConfig.ExcludedDirectories, "excludedDirectories", []string{}, "List of directories which should be excluded from the scan.")
+	cmd.Flags().StringSliceVar(&stepConfig.ExcludedNpmDependencies, "excludedNpmDependencies", []string{}, "List of npm dependency types which Detect should exclude from the BOM.")
+	cmd.Flags().StringSliceVar(&stepConfig.NpmArguments, "npmArguments", []string{}, "List of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project.")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -669,6 +673,24 @@ func detectExecuteScanMetadata() config.StepData {
 					},
 					{
 						Name:        "excludedDirectories",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "[]string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "detect/excludedDirectories"}},
+						Default:     []string{},
+					},
+					{
+						Name:        "excludedNpmDependencies",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "[]string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "detect/excludedDirectories"}},
+						Default:     []string{},
+					},
+					{
+						Name:        "npmArguments",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -427,6 +427,30 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: excludedNpmDependencies
+        description:
+          "List of npm dependency types which Detect should exclude from the BOM."
+        aliases:
+          - name: detect/excludedDirectories
+        type: "[]string"
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        possibleValues:
+          - NONE
+          - DEV
+          - PEER
+      - name: npmArguments
+        description:
+          "List of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project."
+        aliases:
+          - name: detect/excludedDirectories
+        type: "[]string"
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
   outputs:
     resources:
       - name: influx

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -427,11 +427,11 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-      - name: excludedNpmDependencies
+      - name: npmDependencyTypesExcluded
         description:
           "List of npm dependency types which Detect should exclude from the BOM."
         aliases:
-          - name: detect/excludedDirectories
+          - name: detect/npmDependencyTypesExcluded
         type: "[]string"
         scope:
           - PARAMETERS
@@ -445,7 +445,7 @@ spec:
         description:
           "List of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project."
         aliases:
-          - name: detect/excludedDirectories
+          - name: detect/npmArguments
         type: "[]string"
         scope:
           - PARAMETERS


### PR DESCRIPTION
Added two new parameters for npm in blackduck step:

- _npmDependencyTypesExcluded_ : Set this value to indicate which Npm dependency types Detect should exclude from the BOM.
- _npmArguments_ : A space-separated list of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project.

[Documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties/detectors/npm.html&_LANG=enus) from synopsys 
