### PR TITLE
feat(cnbBuild): use SHA256 hashed values for redacted telemetry properties

### DIFF
--- a/cmd/cnbBuild_test.go
+++ b/cmd/cnbBuild_test.go
@@ -518,8 +518,7 @@ uri = "some-buildpack"`))
 
 		assert.Contains(t, customData.Data[0].Buildpacks.FromConfig, "paketobuildpacks/java")
 		assert.NotContains(t, customData.Data[0].Buildpacks.FromProjectDescriptor, "paketobuildpacks/java")
-		assert.Contains(t, customData.Data[0].Buildpacks.FromProjectDescriptor, "<redacted>")
-		assert.NotContains(t, customData.Data[0].Buildpacks.Overall, "<redacted>")
+		assert.Contains(t, customData.Data[0].Buildpacks.FromProjectDescriptor, "bcc73ab1f0a0d3fb0d1bf2b6df5510a25ccd14a761dbc0f5044ea24ead30452b")
 		assert.Contains(t, customData.Data[0].Buildpacks.Overall, "paketobuildpacks/java")
 
 		assert.True(t, customData.Data[0].ProjectDescriptor.Used)
@@ -639,7 +638,7 @@ uri = "some-buildpack"
 		assert.Equal(t, "11", customData.Data[0].BuildEnv.KeyValues["BP_NODE_VERSION"])
 		assert.NotContains(t, customData.Data[0].BuildEnv.KeyValues, "PROJECT_KEY")
 
-		assert.Contains(t, customData.Data[0].Buildpacks.Overall, "<redacted>")
+		assert.Contains(t, customData.Data[0].Buildpacks.Overall, "bcc73ab1f0a0d3fb0d1bf2b6df5510a25ccd14a761dbc0f5044ea24ead30452b")
 	})
 
 	t.Run("success case (multiple images configured)", func(t *testing.T) {

--- a/pkg/cnbutils/privacy/privacy.go
+++ b/pkg/cnbutils/privacy/privacy.go
@@ -1,6 +1,8 @@
 package privacy
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"strings"
 
 	containerName "github.com/google/go-containerregistry/pkg/name"
@@ -37,6 +39,8 @@ func FilterBuilder(builder string) string {
 // FilterBuildpacks filters a list of buildpacks to redact Personally Identifiable Information (PII) like the hostname of a personal registry
 func FilterBuildpacks(buildpacks []string) []string {
 	result := make([]string, 0, len(buildpacks))
+	hash := sha256.New()
+
 	for _, buildpack := range buildpacks {
 		ref, err := containerName.ParseReference(strings.ToLower(buildpack))
 		if err != nil {
@@ -58,7 +62,9 @@ func FilterBuildpacks(buildpacks []string) []string {
 		if allowed {
 			result = append(result, buildpack)
 		} else {
-			result = append(result, "<redacted>")
+			hash.Write([]byte(buildpack))
+			result = append(result, fmt.Sprintf("%x", hash.Sum(nil)))
+			hash.Reset()
 		}
 	}
 	return result

--- a/pkg/cnbutils/privacy/privacy_test.go
+++ b/pkg/cnbutils/privacy/privacy_test.go
@@ -57,6 +57,7 @@ func TestCnbPrivacy_FilterBuildpacks(t *testing.T) {
 	t.Run("filters others", func(t *testing.T) {
 		images := []string{
 			"test/nodejs:v1",
+			"test/nodejs:v1", // SHA should be the same for multiple occurences
 			"my-mirror.de/paketobuildpacks/nodejs:v1",
 			"gcr.io/my-project/paketo-buildpacks/nodejs:v1",
 		}
@@ -66,6 +67,7 @@ func TestCnbPrivacy_FilterBuildpacks(t *testing.T) {
 		require.Len(t, filtered, len(images))
 
 		assert.ElementsMatch(t, filtered, []string{
+			"6ea013d746199ccc0e48e0b4984a6d9357105b82f936ecf18d15786805ac892f",
 			"6ea013d746199ccc0e48e0b4984a6d9357105b82f936ecf18d15786805ac892f",
 			"66131ef922cf26b1500e54a74827f051b43857bcf8d0596593c182548f7d4bd6",
 			"4fd8f0a950aacd7e428c79fce6f51bb1fbf0ab15caf4aca7accc18609acd79b1",
@@ -136,7 +138,7 @@ func TestCnbPrivacy_FilterBuilder(t *testing.T) {
 
 		filteredBuilder := privacy.FilterBuilder(builder)
 
-		assert.Equal(t, "<redacted>", filteredBuilder)
+		assert.Equal(t, "70278d9360533fa4978e5c50aa79bc35a8c0167a353e00521202feeaa09a305b", filteredBuilder)
 	})
 
 }

--- a/pkg/cnbutils/privacy/privacy_test.go
+++ b/pkg/cnbutils/privacy/privacy_test.go
@@ -64,9 +64,12 @@ func TestCnbPrivacy_FilterBuildpacks(t *testing.T) {
 		filtered := privacy.FilterBuildpacks(images)
 
 		require.Len(t, filtered, len(images))
-		for _, image := range filtered {
-			assert.Equal(t, "<redacted>", image)
-		}
+
+		assert.ElementsMatch(t, filtered, []string{
+			"6ea013d746199ccc0e48e0b4984a6d9357105b82f936ecf18d15786805ac892f",
+			"66131ef922cf26b1500e54a74827f051b43857bcf8d0596593c182548f7d4bd6",
+			"4fd8f0a950aacd7e428c79fce6f51bb1fbf0ab15caf4aca7accc18609acd79b1",
+		})
 	})
 
 	t.Run("fails gracefully on parse error", func(t *testing.T) {


### PR DESCRIPTION
# Changes

Instead of hardcoding `<redacted>` string in telemetry, use SHA256 hashed strings.

- [X] Tests
- [ ] Documentation
