### PR TITLE
avoid log message pointing to http error in case the endpoint cannot …

### DIFF
--- a/cmd/integrationArtifactGetServiceEndpoint.go
+++ b/cmd/integrationArtifactGetServiceEndpoint.go
@@ -62,11 +62,11 @@ func runIntegrationArtifactGetServiceEndpoint(config *integrationArtifactGetServ
 		return errors.Errorf("did not retrieve a HTTP response: %v", httpErr)
 	}
 
+	bodyText, readErr := ioutil.ReadAll(serviceEndpointResp.Body)
+	if readErr != nil {
+		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", serviceEndpointResp.StatusCode)
+	}
 	if serviceEndpointResp.StatusCode == 200 {
-		bodyText, readErr := ioutil.ReadAll(serviceEndpointResp.Body)
-		if readErr != nil {
-			return errors.Wrap(readErr, "HTTP response body could not be read")
-		}
 		jsonResponse, parsingErr := gabs.ParseJSON([]byte(bodyText))
 		if parsingErr != nil {
 			return errors.Wrapf(parsingErr, "HTTP response body could not be parsed as JSON: %v", string(bodyText))
@@ -81,13 +81,9 @@ func runIntegrationArtifactGetServiceEndpoint(config *integrationArtifactGetServ
 				return nil
 			}
 		}
-	}
-	responseBody, readErr := ioutil.ReadAll(serviceEndpointResp.Body)
-
-	if readErr != nil {
-		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", serviceEndpointResp.StatusCode)
+                return fmt.Errorf("Cannot retrieve integrationFlowServiceEndpoint from response: %q", bodyText)
 	}
 
-	log.Entry().Errorf("a HTTP error occurred!  Response body: %v, Response status code: %v", string(responseBody), serviceEndpointResp.StatusCode)
+	log.Entry().Errorf("a HTTP error occurred!  Response body: %v, Response status code: %v", string(bodyText), serviceEndpointResp.StatusCode)
 	return errors.Errorf("Unable to get integration flow service endpoint, Response Status code: %v", serviceEndpointResp.StatusCode)
 }


### PR DESCRIPTION
…be retrieved from a 200 response body

We have cases where the response body is empty but we still get an http-200 response code (side thread: why is that, should be investigated on the server-level).

The log message we get is confusing: `Error: Unable to get integration flow service endpoint, Response Status code: 200`.

With that change there will be a more precise message `Cannot retrieve integrationFlowServiceEndpoint from response: %q` where `q` is the quoted response.

Regarding the empty response which is currently shown with the error message I'm not sure. There are cases where a response can only be read once (depends on the http client). So maybe reading the response a second time (... as it was up to now) might be part of the problem.

# Changes

- [ ] Tests
- [ ] Documentation
