### PR TITLE
feat(containerPushToRegistry): add new --multi-arch=all flag to skopeo

### DIFF
--- a/src/com/sap/piper/DockerUtils.groovy
+++ b/src/com/sap/piper/DockerUtils.groovy
@@ -58,11 +58,9 @@ class DockerUtils implements Serializable {
 
     private void skopeoMoveImage(sourceImageFullName, sourceUserId, sourcePassword, targetImageFullName, targetUserId, targetPassword) {
         if (sourceUserId && sourcePassword) {
-            script.sh "skopeo copy --src-tls-verify=false --src-creds=${BashUtils.quoteAndEscape(sourceUserId)}:${BashUtils.quoteAndEscape(sourcePassword)} --dest-tls-verify=false --dest-creds=${BashUtils.quoteAndEscape(targetUserId)}:${BashUtils.quoteAndEscape(targetPassword)} docker://${sourceImageFullName} docker://${targetImageFullName}"
+            script.sh "skopeo copy --src-tls-verify=false --src-creds=${BashUtils.quoteAndEscape(sourceUserId)}:${BashUtils.quoteAndEscape(sourcePassword)} --dest-tls-verify=false --dest-creds=${BashUtils.quoteAndEscape(targetUserId)}:${BashUtils.quoteAndEscape(targetPassword)} docker://${sourceImageFullName} docker://${targetImageFullName} --multi-arch=all"
         } else {
-            script.sh "skopeo copy --src-tls-verify=false --dest-tls-verify=false --dest-creds=${BashUtils.quoteAndEscape(targetUserId)}:${BashUtils.quoteAndEscape(targetPassword)} docker://${sourceImageFullName} docker://${targetImageFullName}"
+            script.sh "skopeo copy --src-tls-verify=false --dest-tls-verify=false --dest-creds=${BashUtils.quoteAndEscape(targetUserId)}:${BashUtils.quoteAndEscape(targetPassword)} docker://${sourceImageFullName} docker://${targetImageFullName} --multi-arch=all"
         }
     }
-
-
 }

--- a/test/groovy/ContainerPushToRegistryTest.groovy
+++ b/test/groovy/ContainerPushToRegistryTest.groovy
@@ -296,7 +296,7 @@ class ContainerPushToRegistryTest extends BasePiperTest {
             sourceRegistryUrl: 'https://my.source.registry:44444',
         )
 
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag --multi-arch=all'))
         assertThat(dockerRule.dockerParams.dockerImage, is('skopeo:latest'))
     }
 
@@ -316,8 +316,8 @@ class ContainerPushToRegistryTest extends BasePiperTest {
             tagLatest: true
         )
 
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag'))
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:latest'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag --multi-arch=all'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:latest --multi-arch=all'))
     }
 
     @Test
@@ -337,8 +337,8 @@ class ContainerPushToRegistryTest extends BasePiperTest {
             tagArtifactVersion: true
         )
 
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag'))
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:1.0.0'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag --multi-arch=all'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:1.0.0 --multi-arch=all'))
     }
 
     @Test
@@ -359,9 +359,9 @@ class ContainerPushToRegistryTest extends BasePiperTest {
             tagArtifactVersion: true
         )
 
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag'))
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:latest'))
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:1.0.0'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag --multi-arch=all'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:latest --multi-arch=all'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:1.0.0 --multi-arch=all'))
     }
 
     @Test
@@ -377,7 +377,7 @@ class ContainerPushToRegistryTest extends BasePiperTest {
             sourceRegistryUrl: 'https://my.source.registry:44444',
         )
 
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/sourceImage:sourceTag'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/sourceImage:sourceTag --multi-arch=all'))
     }
 
     @Test
@@ -396,7 +396,7 @@ class ContainerPushToRegistryTest extends BasePiperTest {
             sourceCredentialsId: 'testCredentialsId'
         )
 
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/sourceImage:sourceTag'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/sourceImage:sourceTag --multi-arch=all'))
     }
 
     @Test

--- a/test/groovy/com/sap/piper/DockerUtilsTest.groovy
+++ b/test/groovy/com/sap/piper/DockerUtilsTest.groovy
@@ -78,7 +78,7 @@ class DockerUtilsTest extends BasePiperTest {
             ]
         )
 
-        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag'))
+        assertThat(shellCallRule.shell, hasItem('skopeo copy --src-tls-verify=false --src-creds=\'registryUser\':\'********\' --dest-tls-verify=false --dest-creds=\'registryUser\':\'********\' docker://my.source.registry:44444/sourceImage:sourceTag docker://my.registry:55555/testImage:tag --multi-arch=all'))
     }
 
     @Test


### PR DESCRIPTION
# Changes

This PR solves the #4857 inner-source issue.
The PR adds --multi-arch=all to the skopeo copy command.
--multi-arch=all: copy the full multi-architecture image

- [x] Tests
- [ ] Documentation

