### PR TITLE
fix(Python): Pin version of cyclonedx package for python builds

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	PyBomFilename = "bom-pip.xml"
-	stepName      = "pythonBuild"
+	PyBomFilename           = "bom-pip.xml"
+	stepName                = "pythonBuild"
+	cycloneDxPackageVersion = "cyclonedx-bom==3.11.0"
+	cycloneDxSchemaVersion  = "1.4"
 )
 
 type pythonBuildUtils interface {
@@ -144,13 +146,13 @@ func removeVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 }
 
 func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string, config *pythonBuildOptions) error {
-	pipInstallFlags = append(pipInstallFlags, "cyclonedx-bom")
+	pipInstallFlags = append(pipInstallFlags, cycloneDxPackageVersion)
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallFlags...); err != nil {
 		return err
 	}
-	virutalEnvironmentPathMap["cyclonedx"] = filepath.Join(config.VirutalEnvironmentName, "bin", "cyclonedx-bom")
+	virutalEnvironmentPathMap["cyclonedx"] = filepath.Join(config.VirutalEnvironmentName, "bin", "cyclonedx-py")
 
-	if err := utils.RunExecutable(virutalEnvironmentPathMap["cyclonedx"], "--e", "--output", PyBomFilename); err != nil {
+	if err := utils.RunExecutable(virutalEnvironmentPathMap["cyclonedx"], "--e", "--output", PyBomFilename, "--format", "xml", "--schema-version", cycloneDxSchemaVersion); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -100,8 +100,8 @@ func TestRunPythonBuild(t *testing.T) {
 		assert.Equal(t, "python", utils.ExecMockRunner.Calls[2].Exec)
 		assert.Equal(t, []string{"setup.py", "sdist", "bdist_wheel"}, utils.ExecMockRunner.Calls[2].Params)
 		assert.Equal(t, filepath.Join("dummy", "bin", "pip"), utils.ExecMockRunner.Calls[3].Exec)
-		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom"}, utils.ExecMockRunner.Calls[3].Params)
-		assert.Equal(t, filepath.Join("dummy", "bin", "cyclonedx-bom"), utils.ExecMockRunner.Calls[4].Exec)
-		assert.Equal(t, []string{"--e", "--output", "bom-pip.xml"}, utils.ExecMockRunner.Calls[4].Params)
+		assert.Equal(t, []string{"install", "--upgrade", "cyclonedx-bom==3.11.0"}, utils.ExecMockRunner.Calls[3].Params)
+		assert.Equal(t, filepath.Join("dummy", "bin", "cyclonedx-py"), utils.ExecMockRunner.Calls[4].Exec)
+		assert.Equal(t, []string{"--e", "--output", "bom-pip.xml", "--format", "xml", "--schema-version", "1.4"}, utils.ExecMockRunner.Calls[4].Params)
 	})
 }

--- a/integration/integration_python_test.go
+++ b/integration/integration_python_test.go
@@ -65,7 +65,7 @@ func TestPythonIntegrationBuildProject(t *testing.T) {
 
 	assert.Contains(t, output, "info  pythonBuild - running command: python setup.py sdist bdist_wheel")
 	assert.Contains(t, output, "info  pythonBuild - running command: piperBuild-env/bin/pip install --upgrade cyclonedx-bom")
-	assert.Contains(t, output, "info  pythonBuild - running command: piperBuild-env/bin/cyclonedx-bom --e --output bom-pip.xml")
+	assert.Contains(t, output, "info  pythonBuild - running command: piperBuild-env/bin/cyclonedx-py --e --output bom-pip.xml")
 	assert.Contains(t, output, "info  pythonBuild - SUCCESS")
 
 	//workaround to use test script util it is possible to set workdir for Exec call


### PR DESCRIPTION
# Changes

1. Pin Python package for cyclonedx 
2. Replace cyclonedx-bom with [cyclonedx-py](https://github.com/CycloneDX/cyclonedx-python#installation) as it is deprecated
`info  pythonBuild - 
warn  pythonBuild - !!! DEPRECATION WARNING !!!
info  pythonBuild - ! The used call method "cyclonedx-bom" is deprecated.
info  pythonBuild - ! Use "cyclonedx-py" instead.`

- [x] Tests
- [x] Documentation
