### PR TITLE
Checkmarx/CheckmarxOne: update include/exclude stash file patterns

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -375,8 +375,8 @@ steps:
   pipelineStashFilesAfterBuild:
     stashIncludes:
       buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original, dist/**'
-      checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html'
-      checkmarxOne: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html'
+      checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html, **/*.ts'
+      checkmarxOne: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html, **/*.ts'
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
       sonar: '**/jacoco*.exec, **/sonar-project.properties'
     stashExcludes:


### PR DESCRIPTION
# Changes
This PR contains two changes:
- for the existing CxSAST step: fix the missing include/exclude stash file patterns in _pipelineStashFilesBeforeBuild_ step
- for the new CxOne step: add the stash file patterns for both _pipelineStashFilesBeforeBuild_  and _pipelineStashFilesAfterBuild_ steps

- [ ] Tests
- [ ] Documentation
