### PR TITLE
Build stage stashing delegated to piperStageWrapper

### DIFF
--- a/resources/com.sap.piper/pipeline/stashSettings.yml
+++ b/resources/com.sap.piper/pipeline/stashSettings.yml
@@ -14,6 +14,7 @@ Build:
   unstash:
     - source
   stashes:
+    # configuration copied from pipelineStashFilesAfterBuild (default_pipeline_environment)
     - name: 'buildResult'
       includes: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original, dist/*'
       excludes: ''

--- a/resources/com.sap.piper/pipeline/stashSettings.yml
+++ b/resources/com.sap.piper/pipeline/stashSettings.yml
@@ -13,7 +13,22 @@ Init:
 Build:
   unstash:
     - source
-  stashes: []
+  stashes:
+    - name: 'buildResult'
+      includes: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original, dist/*'
+      excludes: ''
+    - name: 'checkmarx'
+      includes: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html, **/*.ts'
+      excludes: '**/*.mockserver.js, node_modules/**/*.js'
+    - name: 'checkmarxOne'
+      includes: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html, **/*.ts'
+      excludes: '**/*.mockserver.js, node_modules/**/*.js'
+    - name: 'classFiles'
+      includes: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
+      excludes: ''
+    - name: 'sonar'
+      includes: '**/jacoco*.exec, **/sonar-project.properties'
+      excludes: ''
 
 Integration:
   unstash:

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -373,6 +373,9 @@ steps:
     timeoutInSeconds: 900
     stepMessage: 'Do you want to restart?'
   pipelineStashFilesAfterBuild:
+    # Step is present due to backward compatibility
+    # Configuration has been moved to resources/com.sap.piper/pipeline/stashSettings.yml
+    # piperStageWrapper will do the stashing after the build
     stashIncludes:
       buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original, dist/**'
       checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html, **/*.ts'

--- a/test/groovy/PiperStageWrapperTest.groovy
+++ b/test/groovy/PiperStageWrapperTest.groovy
@@ -320,4 +320,47 @@ class PiperStageWrapperTest extends BasePiperTest {
         assertThat(DebugReport.instance.failedBuild.fatal, is('true'))
         assertThat(DebugReport.instance.failedBuild.reason, is(caught))
     }
+
+    @Test
+    void testStashing() {
+
+        String stageNameStashStageFiles, stageNameUnstashStageFiles
+        List stashConfigStash, stashConfigUnstash
+
+        def utilsMock =  new com.sap.piper.Utils() {
+
+            public unstashStageFiles(Script script, String stageName,  List stashes = []) {
+                stageNameUnstashStageFiles = stageName
+                stashConfigUnstash = script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.unstash ?: []
+            }
+            public stashStageFiles(Script script, String stageName)  {
+                stageNameStashStageFiles = stageName
+                stashConfigStash = script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.stash ?: []
+            }
+            public void pushToSWA(Map parameters, Map config) {
+
+            }
+        }
+
+        nullScript.commonPipelineEnvironment.configuration['stageStashes'] = [
+            foo: [
+                stash: ['foo-stash'],
+                unstash: ['foo-unstash']
+            ]
+        ]
+
+        stepRule.step.piperStageWrapper(
+            script: nullScript,
+            juStabUtils: utilsMock,
+            stageName: 'foo',
+            ordinal: 10
+        ) {
+
+        }
+
+        assertThat(stageNameStashStageFiles, is('foo'))
+        assertThat(stageNameUnstashStageFiles, is('foo'))
+        assertThat(stashConfigStash, is(['foo-stash']))
+        assertThat(stashConfigUnstash, is(['foo-unstash']))
+    }
 }

--- a/test/groovy/PiperStageWrapperTest.groovy
+++ b/test/groovy/PiperStageWrapperTest.groovy
@@ -344,7 +344,7 @@ class PiperStageWrapperTest extends BasePiperTest {
 
         nullScript.commonPipelineEnvironment.configuration['stageStashes'] = [
             foo: [
-                stash: ['foo-stash'],
+                stash: [[name: 'foo-stash']],
                 unstash: ['foo-unstash']
             ]
         ]
@@ -360,7 +360,7 @@ class PiperStageWrapperTest extends BasePiperTest {
 
         assertThat(stageNameStashStageFiles, is('foo'))
         assertThat(stageNameUnstashStageFiles, is('foo'))
-        assertThat(stashConfigStash, is(['foo-stash']))
+        assertThat(stashConfigStash, is([[name: 'foo-stash']]))
         assertThat(stashConfigUnstash, is(['foo-unstash']))
     }
 }

--- a/test/groovy/templates/PiperPipelineStageBuildTest.groovy
+++ b/test/groovy/templates/PiperPipelineStageBuildTest.groovy
@@ -48,10 +48,6 @@ class PiperPipelineStageBuildTest extends BasePiperTest {
             stepsCalled.add('buildExecute')
         })
 
-        helper.registerAllowedMethod('pipelineStashFilesAfterBuild', [Map.class], {m ->
-            stepsCalled.add('pipelineStashFilesAfterBuild')
-        })
-
         helper.registerAllowedMethod('checksPublishResults', [Map.class], {m ->
             stepsCalled.add('checksPublishResults')
         })
@@ -75,7 +71,7 @@ class PiperPipelineStageBuildTest extends BasePiperTest {
 
         jsr.step.piperPipelineStageBuild(script: nullScript, juStabUtils: utils)
 
-        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults', 'pipelineStashFilesAfterBuild', 'testsPublishResults'))
+        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults',  'testsPublishResults'))
         assertThat(stepParameters.testsPublishResults.junit.updateResults, is(true))
         assertThat(stepsCalled, not(anyOf(hasItem('mavenExecuteStaticCodeChecks'), hasItem('npmExecuteLint'))))
     }
@@ -87,7 +83,7 @@ class PiperPipelineStageBuildTest extends BasePiperTest {
 
         jsr.step.piperPipelineStageBuild(script: nullScript, juStabUtils: utils)
 
-        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults', 'pipelineStashFilesAfterBuild', 'testsPublishResults', 'npmExecuteLint'))
+        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults',  'testsPublishResults', 'npmExecuteLint'))
     }
 
     @Test
@@ -97,6 +93,6 @@ class PiperPipelineStageBuildTest extends BasePiperTest {
 
         jsr.step.piperPipelineStageBuild(script: nullScript, juStabUtils: utils)
 
-        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults', 'pipelineStashFilesAfterBuild', 'testsPublishResults', 'mavenExecuteStaticCodeChecks'))
+        assertThat(stepsCalled, hasItems('buildExecute', 'checksPublishResults', 'testsPublishResults', 'mavenExecuteStaticCodeChecks'))
     }
 }

--- a/vars/piperPipelineStageBuild.groovy
+++ b/vars/piperPipelineStageBuild.groovy
@@ -13,13 +13,6 @@ import static com.sap.piper.Prerequisites.checkScript
 @Field STAGE_STEP_KEYS = [
     /** Starts build execution. This is always being executed.*/
     'buildExecute',
-    /**
-     * Executes stashing of files after build execution.<br /
-     * Build results are stashed with stash name `buildResult`.
-     *
-     * **Note: Please make sure that your build artifacts are contained here since this stash is the foundation for subsequent tests and checks, e.g. deployment to a test landscape.**
-     **/
-    'pipelineStashFilesAfterBuild',
     /** Executes a Sonar scan.*/
     'sonarExecuteScan',
     /** Publishes test results to Jenkins. It will always be active. */
@@ -64,7 +57,6 @@ void call(Map parameters = [:]) {
         durationMeasure(script: script, measurementName: 'build_duration') {
 
             buildExecute script: script
-            pipelineStashFilesAfterBuild script: script
 
             try {
                 testsPublishResults script: script, junit: [updateResults: true]


### PR DESCRIPTION
Up to now these stashes are created inside the build stage by step `pipelineStashFilesAfterBuild `
- buildResult
- checkmarx
- checkmarxOne
- classFiles
- sonar

Step `piperStageWrapper` which is invoked inside `piperPipelineStageBuild` provides also facilities to create stashes based on [stashSettings.yml](https://github.com/SAP/jenkins-library/blob/master/resources/com.sap.piper/pipeline/stashSettings.yml).

Creating the stashes via the `piperStageWrapper` is a more generic approach and is more open for other stage-stash configs like the current approach via `pipelineStashFilesAfterBuild`.

Step  `pipelineStashFilesAfterBuild` is not used anymore inside `piperPipelineStageBuild`. But this step itself and the corresponding configuration in [default_pipeline_environment.yml](https://github.com/SAP/jenkins-library/blob/master/resources/default_pipeline_environment.yml#L375) remains unchanged in order to ensure backward-compatibility in case this step is used elsewhere.

⚠️  Before merging this we need to check carefully if the stashes created currently inside `piperPipelineStageBuild` [right after](https://github.com/SAP/jenkins-library/blob/master/vars/piperPipelineStageBuild.groovy#L67) `buildExecute` are used somewhere else inside the build stage. In this case the stashes would be created too late. We need also to check carefully if there are some significant changes wrt the stash contents of the corresponding stashes since files are modified/created after `buildExecute` and the end of the build-stage.

I expect no impact to the build-times since we do not create/update stashes twice with that approach. The stashes are just created a little build later.


# Changes

- [ ] Tests
- [ ] Documentation
