### PR TITLE
do not return names of non-unstashed stashes from unstashStageFiles

### DIFF
--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -68,9 +68,7 @@ def unstashStageFiles(Script script, String stageName, List stashContent = []) {
     stashContent += script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.unstash ?: []
 
     script.deleteDir()
-    unstashAll(stashContent)
-
-    return stashContent
+    return unstashAll(stashContent)
 }
 
 boolean isInsidePod(Script script) {


### PR DESCRIPTION
similar to `unstashAll` we should only return the names of the stashes which has been unstashed from `unstashStageFiles`.

Or: what is the reason why we return the names of all configured stashes rather than the stashes which has been unstashes - similar to `unstashAll`?

Another question is: why do we not fail when we find a stash which should be unstashed, but does not exist?

# Changes

- [ ] Tests
- [ ] Documentation
