### PR TITLE
unstashStageFiles: avoid duplicate unstash, use defensive copy

### DIFF
--- a/src/com/sap/piper/Utils.groovy
+++ b/src/com/sap/piper/Utils.groovy
@@ -65,12 +65,14 @@ def stashStageFiles(Script script, String stageName) {
 }
 
 def unstashStageFiles(Script script, String stageName, List stashContent = []) {
-    stashContent += script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.unstash ?: []
+    def stashes = [] as Set
+    stashes += stashContent
+    stashes += script.commonPipelineEnvironment.configuration.stageStashes?.get(stageName)?.unstash ?: []
 
     script.deleteDir()
-    unstashAll(stashContent)
+    unstashAll(stashes)
 
-    return stashContent
+    return stashes
 }
 
 boolean isInsidePod(Script script) {


### PR DESCRIPTION
In case some stashes are the same in stashContent and configured in the environment we get these stashes unstashed twice.

There is also no defensive copy for stashContent. That means after invoking the unstash method here that list might contain unexpected entries.

There is also this related pr: #4372 

# Changes

- [ ] Tests
- [ ] Documentation
