### PR TITLE
feat (protecodeExecuteScan) enhancing protecode step with registry credentials

### DIFF
--- a/resources/metadata/protecodeExecuteScan.yaml
+++ b/resources/metadata/protecodeExecuteScan.yaml
@@ -67,6 +67,32 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: containerRegistryPassword
+        description: "For `buildTool: docker`: Password for container registry access - typically provided by the CI/CD environment."
+        type: string
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        secret: true
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/repositoryPassword
+          - name: commonPipelineEnvironment
+            param: custom/repositoryPassword
+      - name: containerRegistryUser
+        description: "For `buildTool: docker`: Username for container registry access - typically provided by the CI/CD environment."
+        type: string
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        secret: true
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/repositoryUsername
+          - name: commonPipelineEnvironment
+            param: custom/repositoryUsername
       - name: dockerConfigJSON
         type: string
         description: Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).


### PR DESCRIPTION
# Changes

protecode step when running after the build stage is unaware of the docker credentials that are created during the build stage.
with these changes the registry username and password are new parameters for the step which get the values from the build stage.

these credentials are then updated in the docker config json file. if a user provided docker config json exists then the step will respect the file and enhance with the new credentials

- [ ] Tests
- [x] Documentation
