### PR TITLE
fix(whitesource):add stash for checkmarxOne

### DIFF
--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -386,6 +386,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 					{Name: "buildDescriptor", Type: "stash"},
 					{Name: "opensourceConfiguration", Type: "stash"},
 					{Name: "checkmarx", Type: "stash"},
+					{Name: "checkmarxOne", Type: "stash"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/resources/metadata/whitesourceExecuteScan.yaml
+++ b/resources/metadata/whitesourceExecuteScan.yaml
@@ -604,6 +604,8 @@ spec:
         type: stash
       - name: checkmarx
         type: stash
+      - name: checkmarxOne
+        type: stash
   outputs:
     resources:
       - name: commonPipelineEnvironment


### PR DESCRIPTION
# Changes
This change aims to add checkmarxOne as stash content for whiteSourceExecuteScan step.

- [ ] Tests
- [ ] Documentation
