### PR TITLE
Add build description to Slack notification

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -444,7 +444,7 @@ steps:
       dockerWorkspace: ''
   slackSendNotification:
     color: "${['SUCCESS': '#8cc04f', 'FAILURE': '#d54c53', 'ABORTED': '#949393', 'UNSTABLE': '#f6b44b', 'PAUSED': '#24b0d5', 'UNKNOWN': '#d54cc4'].get(buildStatus, '#d54cc4')}"
-    defaultMessage: "${buildStatus}: Job ${env.JOB_NAME} <${env.BUILD_URL}|#${env.BUILD_NUMBER}>"
+    defaultMessage: "${buildStatus}: Job ${env.JOB_NAME} <${env.BUILD_URL}|#${env.BUILD_NUMBER}> ${buildDescription}"
   snykExecute:
     buildDescriptorFile: './package.json'
     dockerImage: 'node:lts-buster'

--- a/test/groovy/SlackSendNotificationTest.groovy
+++ b/test/groovy/SlackSendNotificationTest.groovy
@@ -40,7 +40,7 @@ class SlackSendNotificationTest extends BasePiperTest {
     void testNotificationBuildSuccessDefaultChannel() throws Exception {
         stepRule.step.slackSendNotification(script: [currentBuild: [result: 'SUCCESS']])
         // asserts
-        assertEquals('Message not set correctly', 'SUCCESS: Job p <http://build.url|#1>', slackCallMap.message.toString())
+        assertEquals('Message not set correctly', 'SUCCESS: Job p <http://build.url|#1> ', slackCallMap.message.toString())
         assertNull('Channel not set correctly', slackCallMap.channel)
         assertEquals('Color not set correctly', '#8cc04f', slackCallMap.color)
         assertJobStatusSuccess()
@@ -58,7 +58,7 @@ class SlackSendNotificationTest extends BasePiperTest {
     void testNotificationBuildFailed() throws Exception {
         stepRule.step.slackSendNotification(script: [currentBuild: [result: 'FAILURE']])
         // asserts
-        assertEquals('Message not set correctly', 'FAILURE: Job p <http://build.url|#1>', slackCallMap.message.toString())
+        assertEquals('Message not set correctly', 'FAILURE: Job p <http://build.url|#1> ', slackCallMap.message.toString())
         assertEquals('Color not set correctly', '#d54c53', slackCallMap.color)
     }
 

--- a/vars/slackSendNotification.groovy
+++ b/vars/slackSendNotification.groovy
@@ -41,6 +41,7 @@ import groovy.text.GStringTemplateEngine
  * Notification contains:
  *
  * * Build status
+ * * Build description
  * * Repo Owner
  * * Repo Name
  * * Branch Name

--- a/vars/slackSendNotification.groovy
+++ b/vars/slackSendNotification.groovy
@@ -73,7 +73,8 @@ void call(Map parameters = [:]) {
                 echo "[${STEP_NAME}] currentBuild.result is not set. Skipping Slack notification"
                 return
             }
-            config.message = GStringTemplateEngine.newInstance().createTemplate(config.defaultMessage).make([buildStatus: buildStatus, env: env]).toString()
+            def buildDescription = script.currentBuild.description ? script.currentBuild.description : ''
+            config.message = GStringTemplateEngine.newInstance().createTemplate(config.defaultMessage).make([buildStatus: buildStatus, buildDescription: buildDescription, env: env]).toString()
         }
         Map options = [:]
         if(config.credentialsId)


### PR DESCRIPTION
Suggest to add the build description to the Slack notification.

We update our descriptions with names, PR numbers, content summaries, and so on. It is vital having this information available at a glance to understand pipeline progress when not being on messenger only.

In case the description is not available, this will simply add an empty string, meaning nothing.

We considered using the `message` parameter to customize the message, but this is not feasible. SAP's internal extensibility design does not support injecting custom code at this late post stage of the pipeline, hence we can only set the message at a much earlier stage, meaning we'd lose important information such as the build status.