### PR TITLE
fix: resolve lint files

### DIFF
--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -167,7 +167,7 @@ func runDefaultLint(npmExecutor npm.Executor, utils lintUtils, failOnError bool)
 }
 
 func findEslintConfigs(utils lintUtils) []string {
-	unfilteredListOfEslintConfigs, _ := utils.Glob("**/.eslintrc.*")
+	unfilteredListOfEslintConfigs, _ := utils.Glob("**/.eslintrc*")
 
 	var eslintConfigs []string
 

--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -167,7 +167,7 @@ func runDefaultLint(npmExecutor npm.Executor, utils lintUtils, failOnError bool)
 }
 
 func findEslintConfigs(utils lintUtils) []string {
-	unfilteredListOfEslintConfigs, _ := utils.Glob("**/.eslintrc*")
+	unfilteredListOfEslintConfigs, err := utils.Glob("**/.eslintrc*")
 
 	var eslintConfigs []string
 

--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -168,7 +168,9 @@ func runDefaultLint(npmExecutor npm.Executor, utils lintUtils, failOnError bool)
 
 func findEslintConfigs(utils lintUtils) []string {
 	unfilteredListOfEslintConfigs, err := utils.Glob("**/.eslintrc*")
-
+        if err != nil {
+                log.Entry().Warnf("Error during resolving lint config files: %v", err)
+        }
 	var eslintConfigs []string
 
 	for _, config := range unfilteredListOfEslintConfigs {


### PR DESCRIPTION
The pattern used for resolving the lint files seems to be wrong. The glob implementation does not support `.*` for "any chars", this is simply `*`.

Beside that we should log an error which we might get from resolving the eslint config files.

# Changes

- [ ] Tests
- [ ] Documentation
