### PR TITLE
use versioningScheme for custom json/yaml

### DIFF
--- a/pkg/versioning/jsonfile.go
+++ b/pkg/versioning/jsonfile.go
@@ -12,11 +12,12 @@ import (
 
 // JSONfile defines an artifact using a json file for versioning
 type JSONfile struct {
-	path         string
-	content      *orderedmap.OrderedMap
-	versionField string
-	readFile     func(string) ([]byte, error)
-	writeFile    func(string, []byte, os.FileMode) error
+	path             string
+	content          *orderedmap.OrderedMap
+	versioningScheme string
+	versionField     string
+	readFile         func(string) ([]byte, error)
+	writeFile        func(string, []byte, os.FileMode) error
 }
 
 func (j *JSONfile) init() {
@@ -34,7 +35,7 @@ func (j *JSONfile) init() {
 
 // VersioningScheme returns the relevant versioning scheme
 func (j *JSONfile) VersioningScheme() string {
-	return "semver2"
+	return j.versioningScheme
 }
 
 // GetVersion returns the current version of the artifact with a JSON-based build descriptor

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -218,13 +218,15 @@ func customArtifact(buildDescriptorFilePath, field, section, scheme string) (Art
 		}, nil
 	case ".json":
 		return &JSONfile{
-			path:         buildDescriptorFilePath,
-			versionField: field,
+			path:             buildDescriptorFilePath,
+			versionField:     field,
+			versioningScheme: scheme,
 		}, nil
 	case ".yaml", ".yml":
 		return &YAMLfile{
-			path:         buildDescriptorFilePath,
-			versionField: field,
+			path:             buildDescriptorFilePath,
+			versionField:     field,
+			versioningScheme: scheme,
 		}, nil
 	case ".txt", "":
 		return &Versionfile{

--- a/pkg/versioning/yamlfile.go
+++ b/pkg/versioning/yamlfile.go
@@ -19,12 +19,13 @@ type YAMLDescriptor struct {
 
 // YAMLfile defines an artifact using a yaml file for versioning
 type YAMLfile struct {
-	path            string
-	content         map[string]interface{}
-	versionField    string
-	artifactIDField string
-	readFile        func(string) ([]byte, error)
-	writeFile       func(string, []byte, os.FileMode) error
+	path             string
+	content          map[string]interface{}
+	versioningScheme string
+	versionField     string
+	artifactIDField  string
+	readFile         func(string) ([]byte, error)
+	writeFile        func(string, []byte, os.FileMode) error
 }
 
 func (y *YAMLfile) init() {
@@ -68,7 +69,7 @@ func (y *YAMLfile) readField(key string) (string, error) {
 
 // VersioningScheme returns the relevant versioning scheme
 func (y *YAMLfile) VersioningScheme() string {
-	return "semver2"
+	return y.versioningScheme
 }
 
 // GetArtifactID returns the current ID of the artifact


### PR DESCRIPTION
# Changes

For some specific updates to yaml files we need to define the versioningScheme also for custom yaml processing. This way the configured scheme will be use the same way as it is in INI and TXT files.