### PR TITLE
DESS-1841 Fix exception handling in sapXmakeExecuteBuild

### DIFF
--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -139,6 +139,7 @@ private String formatErrorMessage(Map config, error){
 }
 
 private void writeErrorToInfluxData(Map config, error){
+    echo "--- Writing error: ${error} to influx ---"
     InfluxData.addTag('pipeline_data', 'build_error_step', config.stepName)
     InfluxData.addTag('pipeline_data', 'build_error_stage', config.stepParameters.script?.env?.STAGE_NAME)
     InfluxData.addField('pipeline_data', 'build_error_message', error.getMessage())

--- a/vars/handlePipelineStepErrors.groovy
+++ b/vars/handlePipelineStepErrors.groovy
@@ -139,9 +139,7 @@ private String formatErrorMessage(Map config, error){
 }
 
 private void writeErrorToInfluxData(Map config, error){
-    if(InfluxData.getInstance().getFields().pipeline_data?.build_error_message == null){
-        InfluxData.addTag('pipeline_data', 'build_error_step', config.stepName)
-        InfluxData.addTag('pipeline_data', 'build_error_stage', config.stepParameters.script?.env?.STAGE_NAME)
-        InfluxData.addField('pipeline_data', 'build_error_message', error.getMessage())
-    }
+    InfluxData.addTag('pipeline_data', 'build_error_step', config.stepName)
+    InfluxData.addTag('pipeline_data', 'build_error_stage', config.stepParameters.script?.env?.STAGE_NAME)
+    InfluxData.addField('pipeline_data', 'build_error_message', error.getMessage())
 }


### PR DESCRIPTION
# Changes
In case that sapXmakeExecuteBuild is executed twice - only the exception from the first call is handled.
The second call should contain the text from the second call as an error message.

- [ ] Tests
- [ ] Documentation
