### PR TITLE
Adjust npmExecuteLint (output-format, print output to console)

### DIFF
--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -153,7 +153,7 @@ func runDefaultLint(npmExecutor npm.Executor, utils lintUtils, failOnError bool,
 				"-f", outputFormat,
 				"--ignore-pattern", "node_modules/",
 				"--ignore-pattern", ".eslintrc.js",
-			}, fmt.Sprintf("./%s_%s", strconv.Itoa(i), outputFileName))
+			}, fmt.Sprintf("./%s_%%s", strconv.Itoa(i)), outputFileName)
 
 			err = execRunner.RunExecutable("npx", args...)
 			if err != nil {
@@ -179,7 +179,7 @@ func runDefaultLint(npmExecutor npm.Executor, utils lintUtils, failOnError bool,
 			"-c", ".pipeline/.eslintrc.json",
 			"-f", outputFormat,
 			"--ignore-pattern", ".eslintrc.js",
-		}, fmt.Sprintf("./%s", outputFileName))
+		}, "./%s", outputFileName)
 
 		_ = execRunner.RunExecutable("npx", args...)
 	}
@@ -208,9 +208,10 @@ func findEslintConfigs(utils lintUtils) []string {
 	return eslintConfigs
 }
 
-func prepareArgs(defaultArgs []string, outputFileName string) []string {
+func prepareArgs(defaultArgs []string, outputFileNamePattern, outputFileName string) []string {
+	fmt.Printf("[MH] outputFileName:%s", outputFileName)
 	if outputFileName != "-" { // in this case we omit the -o flag and output will go to the log
-		defaultArgs = append(defaultArgs, "-o", outputFileName)
+		defaultArgs = append(defaultArgs, "-o", fmt.Sprintf(outputFileNamePattern, outputFileName))
 	}
 	return defaultArgs
 

--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -209,7 +209,6 @@ func findEslintConfigs(utils lintUtils) []string {
 }
 
 func prepareArgs(defaultArgs []string, outputFileNamePattern, outputFileName string) []string {
-	fmt.Printf("[MH] outputFileName:%s", outputFileName)
 	if outputFileName != "-" { // in this case we omit the -o flag and output will go to the log
 		defaultArgs = append(defaultArgs, "-o", fmt.Sprintf(outputFileNamePattern, outputFileName))
 	}

--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -209,7 +209,7 @@ func findEslintConfigs(utils lintUtils) []string {
 }
 
 func prepareArgs(defaultArgs []string, outputFileNamePattern, outputFileName string) []string {
-	if outputFileName != "-" { // in this case we omit the -o flag and output will go to the log
+	if outputFileName != "" { // in this case we omit the -o flag and output will go to the log
 		defaultArgs = append(defaultArgs, "-o", fmt.Sprintf(outputFileNamePattern, outputFileName))
 	}
 	return defaultArgs

--- a/cmd/npmExecuteLint_generated.go
+++ b/cmd/npmExecuteLint_generated.go
@@ -20,6 +20,8 @@ type npmExecuteLintOptions struct {
 	RunScript          string `json:"runScript,omitempty"`
 	FailOnError        bool   `json:"failOnError,omitempty"`
 	DefaultNpmRegistry string `json:"defaultNpmRegistry,omitempty"`
+	OutputFormat       string `json:"outputFormat,omitempty"`
+	OutputFileName     string `json:"outputFileName,omitempty"`
 }
 
 // NpmExecuteLintCommand Execute ci-lint script on all npm packages in a project or execute default linting
@@ -120,6 +122,8 @@ func addNpmExecuteLintFlags(cmd *cobra.Command, stepConfig *npmExecuteLintOption
 	cmd.Flags().StringVar(&stepConfig.RunScript, "runScript", `ci-lint`, "List of additional run scripts to execute from package.json.")
 	cmd.Flags().BoolVar(&stepConfig.FailOnError, "failOnError", false, "Defines the behavior in case linting errors are found.")
 	cmd.Flags().StringVar(&stepConfig.DefaultNpmRegistry, "defaultNpmRegistry", os.Getenv("PIPER_defaultNpmRegistry"), "URL of the npm registry to use. Defaults to https://registry.npmjs.org/")
+	cmd.Flags().StringVar(&stepConfig.OutputFormat, "outputFormat", `checkstyle`, "eslint output format, e.g. stylish, checkmarx")
+	cmd.Flags().StringVar(&stepConfig.OutputFileName, "outputFileName", `defaultlint.xml`, "name of the output file. There might be a 'N_' prefix where 'N' is a number. '-' will print to console")
 
 }
 
@@ -169,6 +173,24 @@ func npmExecuteLintMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "npm/defaultNpmRegistry"}},
 						Default:     os.Getenv("PIPER_defaultNpmRegistry"),
+					},
+					{
+						Name:        "outputFormat",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "npm/outputFormat"}},
+						Default:     `checkstyle`,
+					},
+					{
+						Name:        "outputFileName",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "GENERAL", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "npm/outputFormat"}},
+						Default:     `defaultlint.xml`,
 					},
 				},
 			},

--- a/cmd/npmExecuteLint_generated.go
+++ b/cmd/npmExecuteLint_generated.go
@@ -123,7 +123,7 @@ func addNpmExecuteLintFlags(cmd *cobra.Command, stepConfig *npmExecuteLintOption
 	cmd.Flags().BoolVar(&stepConfig.FailOnError, "failOnError", false, "Defines the behavior in case linting errors are found.")
 	cmd.Flags().StringVar(&stepConfig.DefaultNpmRegistry, "defaultNpmRegistry", os.Getenv("PIPER_defaultNpmRegistry"), "URL of the npm registry to use. Defaults to https://registry.npmjs.org/")
 	cmd.Flags().StringVar(&stepConfig.OutputFormat, "outputFormat", `checkstyle`, "eslint output format, e.g. stylish, checkstyle")
-	cmd.Flags().StringVar(&stepConfig.OutputFileName, "outputFileName", `defaultlint.xml`, "name of the output file. There might be a 'N_' prefix where 'N' is a number. '-' will print to console")
+	cmd.Flags().StringVar(&stepConfig.OutputFileName, "outputFileName", `defaultlint.xml`, "name of the output file. There might be a 'N_' prefix where 'N' is a number. When the empty string is provided, we will print to console")
 
 }
 

--- a/cmd/npmExecuteLint_generated.go
+++ b/cmd/npmExecuteLint_generated.go
@@ -122,7 +122,7 @@ func addNpmExecuteLintFlags(cmd *cobra.Command, stepConfig *npmExecuteLintOption
 	cmd.Flags().StringVar(&stepConfig.RunScript, "runScript", `ci-lint`, "List of additional run scripts to execute from package.json.")
 	cmd.Flags().BoolVar(&stepConfig.FailOnError, "failOnError", false, "Defines the behavior in case linting errors are found.")
 	cmd.Flags().StringVar(&stepConfig.DefaultNpmRegistry, "defaultNpmRegistry", os.Getenv("PIPER_defaultNpmRegistry"), "URL of the npm registry to use. Defaults to https://registry.npmjs.org/")
-	cmd.Flags().StringVar(&stepConfig.OutputFormat, "outputFormat", `checkstyle`, "eslint output format, e.g. stylish, checkmarx")
+	cmd.Flags().StringVar(&stepConfig.OutputFormat, "outputFormat", `checkstyle`, "eslint output format, e.g. stylish, checkstyle")
 	cmd.Flags().StringVar(&stepConfig.OutputFileName, "outputFileName", `defaultlint.xml`, "name of the output file. There might be a 'N_' prefix where 'N' is a number. '-' will print to console")
 
 }

--- a/cmd/npmExecuteLint_test.go
+++ b/cmd/npmExecuteLint_test.go
@@ -83,7 +83,7 @@ func TestNpmExecuteLint(t *testing.T) {
 		lintUtils.AddFile("package.json", []byte("{\"name\": \"Test\" }"))
 		lintUtils.AddFile(".eslintrc.json", []byte("{\"name\": \"Test\" }"))
 
-		config := npmExecuteLintOptions{RunScript: "ci-lint", OutputFormat: "stylish", OutputFileName: "-"}
+		config := npmExecuteLintOptions{RunScript: "ci-lint", OutputFormat: "stylish", OutputFileName: ""}
 		config.DefaultNpmRegistry = "foo.bar"
 
 		npmUtils := newNpmMockUtilsBundle()
@@ -153,7 +153,7 @@ func TestNpmExecuteLint(t *testing.T) {
 		config := defaultConfig
 		config.DefaultNpmRegistry = "foo.bar"
 		config.OutputFormat = "stylish"
-		config.OutputFileName = "-"
+		config.OutputFileName = ""
 
 		npmUtils := newNpmMockUtilsBundle()
 		npmUtils.execRunner = lintUtils.execRunner
@@ -221,7 +221,7 @@ func TestNpmExecuteLint(t *testing.T) {
 		config := defaultConfig
 		config.DefaultNpmRegistry = "foo.bar"
 		config.OutputFormat = "stylish"
-		config.OutputFileName = "-"
+		config.OutputFileName = ""
 
 		npmUtils := newNpmMockUtilsBundle()
 		npmUtils.execRunner = lintUtils.execRunner
@@ -311,7 +311,7 @@ func TestNpmExecuteLint(t *testing.T) {
 		config := defaultConfig
 		config.FailOnError = true
 		config.OutputFormat = "stylish"
-		config.OutputFileName = "-"
+		config.OutputFileName = ""
 		config.DefaultNpmRegistry = "foo.bar"
 
 		npmUtils := newNpmMockUtilsBundle()

--- a/cmd/npmExecuteLint_test.go
+++ b/cmd/npmExecuteLint_test.go
@@ -32,7 +32,7 @@ func newLintMockUtilsBundle() mockLintUtilsBundle {
 }
 
 func TestNpmExecuteLint(t *testing.T) {
-	defaultConfig := npmExecuteLintOptions{RunScript: "ci-lint"}
+	defaultConfig := npmExecuteLintOptions{RunScript: "ci-lint", OutputFormat: "checkstyle", OutputFileName: "defaultlint.xml"}
 
 	t.Run("Call with ci-lint script and one package.json", func(t *testing.T) {
 		lintUtils := newLintMockUtilsBundle()
@@ -67,7 +67,13 @@ func TestNpmExecuteLint(t *testing.T) {
 
 		if assert.NoError(t, err) {
 			if assert.Equal(t, 2, len(lintUtils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{
+					"eslint",
+					".",
+					"-f", "checkstyle",
+					"--ignore-pattern", "node_modules/",
+					"--ignore-pattern", ".eslintrc.js",
+					"-o", "./0_defaultlint.xml"}}, lintUtils.execRunner.Calls[1])
 			}
 		}
 	})
@@ -89,8 +95,22 @@ func TestNpmExecuteLint(t *testing.T) {
 
 		if assert.NoError(t, err) {
 			if assert.Equal(t, 3, len(lintUtils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", "src/**/*.js", "-f", "checkstyle", "-o", "./1_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[2])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{
+					"eslint",
+					".",
+					"-f", "checkstyle",
+					"--ignore-pattern", "node_modules/",
+					"--ignore-pattern", ".eslintrc.js",
+					"-o", "./0_defaultlint.xml",
+				}}, lintUtils.execRunner.Calls[1])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{
+					"eslint",
+					"src/**/*.js",
+					"-f", "checkstyle",
+					"--ignore-pattern", "node_modules/",
+					"--ignore-pattern", ".eslintrc.js",
+					"-o", "./1_defaultlint.xml",
+				}}, lintUtils.execRunner.Calls[2])
 			}
 		}
 	})
@@ -111,7 +131,17 @@ func TestNpmExecuteLint(t *testing.T) {
 		if assert.NoError(t, err) {
 			if assert.Equal(t, 3, len(lintUtils.execRunner.Calls)) {
 				assert.Equal(t, mock.ExecCall{Exec: "npm", Params: []string{"install", "eslint@^7.0.0", "typescript@^3.7.4", "@typescript-eslint/parser@^3.0.0", "@typescript-eslint/eslint-plugin@^3.0.0"}}, lintUtils.execRunner.Calls[1])
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"--no-install", "eslint", ".", "--ext", ".js,.jsx,.ts,.tsx", "-c", ".pipeline/.eslintrc.json", "-f", "checkstyle", "-o", "./defaultlint.xml", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[2])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{
+					"--no-install",
+					"eslint",
+					".",
+					"--ext",
+					".js,.jsx,.ts,.tsx",
+					"-c", ".pipeline/.eslintrc.json",
+					"-f", "checkstyle",
+					"--ignore-pattern", ".eslintrc.js",
+					"-o", "./defaultlint.xml",
+				}}, lintUtils.execRunner.Calls[2])
 			}
 		}
 	})
@@ -143,7 +173,8 @@ func TestNpmExecuteLint(t *testing.T) {
 		lintUtils := newLintMockUtilsBundle()
 		lintUtils.AddFile("package.json", []byte("{\"name\": \"Test\" }"))
 		lintUtils.AddFile(".eslintrc.json", []byte("{\"name\": \"Test\" }"))
-		lintUtils.execRunner = &mock.ExecMockRunner{ShouldFailOnCommand: map[string]error{"eslint . -f checkstyle -o ./0_defaultlint.xml --ignore-pattern node_modules/ --ignore-pattern .eslintrc.js": errors.New("exit 1")}}
+		lintUtils.execRunner = &mock.ExecMockRunner{ShouldFailOnCommand: map[string]error{
+			"eslint . -f checkstyle --ignore-pattern node_modules/ --ignore-pattern .eslintrc.js -o ./0_defaultlint.xml": errors.New("exit 1")}}
 
 		config := defaultConfig
 		config.FailOnError = true
@@ -157,7 +188,14 @@ func TestNpmExecuteLint(t *testing.T) {
 
 		if assert.EqualError(t, err, "Lint execution failed. This might be the result of severe linting findings, problems with the provided ESLint configuration (.eslintrc.json), or another issue. Please examine the linting results in the UI or in 0_defaultlint.xml, if available, or the log above. ") {
 			if assert.Equal(t, 2, len(lintUtils.execRunner.Calls)) {
-				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{"eslint", ".", "-f", "checkstyle", "-o", "./0_defaultlint.xml", "--ignore-pattern", "node_modules/", "--ignore-pattern", ".eslintrc.js"}}, lintUtils.execRunner.Calls[1])
+				assert.Equal(t, mock.ExecCall{Exec: "npx", Params: []string{
+					"eslint",
+					".",
+					"-f", "checkstyle",
+					"--ignore-pattern", "node_modules/",
+					"--ignore-pattern", ".eslintrc.js",
+					"-o", "./0_defaultlint.xml",
+				}}, lintUtils.execRunner.Calls[1])
 			}
 		}
 	})

--- a/resources/metadata/npmExecuteLint.yaml
+++ b/resources/metadata/npmExecuteLint.yaml
@@ -47,7 +47,7 @@ spec:
           - name: npm/defaultNpmRegistry
       - name: outputFormat
         type: string
-        description: eslint output format, e.g. stylish, checkmarx
+        description: eslint output format, e.g. stylish, checkstyle
         scope:
           - PARAMETERS
           - GENERAL

--- a/resources/metadata/npmExecuteLint.yaml
+++ b/resources/metadata/npmExecuteLint.yaml
@@ -45,6 +45,30 @@ spec:
         mandatory: false
         aliases:
           - name: npm/defaultNpmRegistry
+      - name: outputFormat
+        type: string
+        description: eslint output format, e.g. stylish, checkmarx
+        scope:
+          - PARAMETERS
+          - GENERAL
+          - STAGES
+          - STEPS
+        mandatory: false
+        default: checkstyle
+        aliases:
+          - name: npm/outputFormat
+      - name: outputFileName
+        type: string
+        description: name of the output file. There might be a 'N_' prefix where 'N' is a number. '-' will print to console
+        scope:
+          - PARAMETERS
+          - GENERAL
+          - STAGES
+          - STEPS
+        mandatory: false
+        default: defaultlint.xml
+        aliases:
+          - name: npm/outputFormat
   containers:
     - name: node
       image: node:lts-buster

--- a/resources/metadata/npmExecuteLint.yaml
+++ b/resources/metadata/npmExecuteLint.yaml
@@ -59,7 +59,7 @@ spec:
           - name: npm/outputFormat
       - name: outputFileName
         type: string
-        description: name of the output file. There might be a 'N_' prefix where 'N' is a number. '-' will print to console
+        description: name of the output file. There might be a 'N_' prefix where 'N' is a number. When the empty string is provided, we will print to console
         scope:
           - PARAMETERS
           - GENERAL


### PR DESCRIPTION
Up to now
- we support only output format `checkstyle`
- we redirect the lint results into a log file

With this change
- we support several output formats, default is `checkstyle`
- we provide the option to write the lint results to the log instead to a file. By default the log will still be redirected to a file with the same pattern as before.

How can this change be tested?
- build the `piper` binary (`go build -o piper -tags release`)
- invoke the piper binary on a suitable test project:

```
./piper npmExecuteLint --failOnError --outputFormat stylish --outputFileName ""
```

prints the same logs to the console like BAS does.

```
./piper npmExecuteLint --failOnError --outputFormat checkstyle --outputFileName ""
```

prints the checkstyle format to console.

When `outputFileName` is omitted the corresponding lint results are written to a file (`[0,1,2,3,...]_defaultlint.xml` or `defaultlint.xml`)

~~⚠️ Tests are missing at the moment (... will be added to this PR soon)~~ Tests are contained in the PR.

# Changes

- [ ] Tests
- [ ] Documentation
