### PR TITLE
fix(codeqlExecuteScan): added waiting for the SARIF file upload

### DIFF
--- a/cmd/codeqlExecuteScan.go
+++ b/cmd/codeqlExecuteScan.go
@@ -209,14 +209,13 @@ func waitSarifUploaded(codeqlSarifUploader codeql.CodeqlSarifUploader) error {
 		if err != nil {
 			return err
 		}
+		if sarifStatus.ProcessingStatus == sarifUploadComplete {
+			return nil
+		}
 		if len(sarifStatus.Errors) > 0 {
 			for e := range sarifStatus.Errors {
 				log.Entry().Error(e)
 			}
-			return errors.New("failed to get sarif file uploading status")
-		}
-		if sarifStatus.ProcessingStatus == sarifUploadComplete {
-			return nil
 		}
 		if sarifStatus.ProcessingStatus == sarifUploadFailed {
 			return errors.New("failed to upload sarif file")

--- a/pkg/codeql/codeql_test.go
+++ b/pkg/codeql/codeql_test.go
@@ -56,21 +56,11 @@ func (g *githubCodeqlScanningMock) ListAlertsForRepo(ctx context.Context, owner,
 	return alerts, &response, nil
 }
 
-func (g *githubCodeqlScanningMock) ListAnalysesForRepo(ctx context.Context, owner, repo string, opts *github.AnalysesListOptions) ([]*github.ScanningAnalysis, *github.Response, error) {
-	resultsCount := 3
-	analysis := []*github.ScanningAnalysis{{ResultsCount: &resultsCount}}
-	return analysis, nil, nil
-}
-
 type githubCodeqlScanningErrorMock struct {
 }
 
 func (g *githubCodeqlScanningErrorMock) ListAlertsForRepo(ctx context.Context, owner, repo string, opts *github.AlertListOptions) ([]*github.Alert, *github.Response, error) {
 	return []*github.Alert{}, nil, errors.New("Some error")
-}
-
-func (g *githubCodeqlScanningErrorMock) ListAnalysesForRepo(ctx context.Context, owner, repo string, opts *github.AnalysesListOptions) ([]*github.ScanningAnalysis, *github.Response, error) {
-	return []*github.ScanningAnalysis{}, nil, errors.New("Some error")
 }
 
 func TestGetVulnerabilitiesFromClient(t *testing.T) {


### PR DESCRIPTION
# Changes

Added waiting for the SARIF to upload before calling code-scanning APIs.
After scanning, the SARIF file is created, which must be uploaded to github. The `codeql github upload-results` command returns the URL of the SARIF file. This URL checks the status of the upload.

- [x] Tests
- [ ] Documentation
