### PR TITLE
fix(detectExecuteScan): Fix license incorrect fail with FailOn parameter for blackduck

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -194,7 +194,7 @@ func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detec
 		if strings.Contains(reportingErr.Error(), "License Policy Violations found") {
 			log.Entry().Errorf("License Policy Violations found")
 			log.SetErrorCategory(log.ErrorCompliance)
-			if err == nil && !piperutils.ContainsStringPart(config.FailOn, "NONE") {
+			if err == nil && piperutils.ContainsStringPart(config.FailOn, "CRITICAL") {
 				err = errors.New("License Policy Violations found")
 			}
 		} else {


### PR DESCRIPTION
# Changes

The issue of failing pipeline in case of license policy volations if the failOn parametr doesn't contain "CRITICAL" value has been fixed by this PR.

Before: pipeline failed with failon Blocker for license violation (CRITICAL level)
Expected behavior: Should only fail if failon CRITICAL

- [ ] Tests
- [ ] Documentation
