### PR TITLE
Removed rescan blackduck

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -286,11 +286,6 @@ func exitCodeMapping(exitCodeKey int) string {
 }
 
 func getDetectScript(config detectExecuteScanOptions, utils detectUtils) error {
-	if config.ScanOnChanges {
-		log.Entry().Infof("Using Detect Rescan script")
-		return utils.DownloadFile("https://raw.githubusercontent.com/blackducksoftware/detect_rescan/master/detect_rescan.sh", "detect.sh", nil, nil)
-	}
-
 	log.Entry().Infof("Downloading Detect7")
 	return utils.DownloadFile("https://detect.synopsys.com/detect7.sh", "detect.sh", nil, nil)
 }
@@ -315,11 +310,6 @@ func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectU
 
 	if len(config.ExcludedDirectories) != 0 && !checkIfArgumentIsInScanProperties(config, "detect.excluded.directories") {
 		args = append(args, fmt.Sprintf("--detect.excluded.directories=%s", strings.Join(config.ExcludedDirectories, ",")))
-	}
-
-	if config.ScanOnChanges {
-		args = append(args, "--report")
-		config.Unmap = false
 	}
 
 	if config.MinScanInterval > 0 {

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -44,7 +44,6 @@ type detectExecuteScanOptions struct {
 	ExcludedPackageManagers     []string `json:"excludedPackageManagers,omitempty"`
 	MavenExcludedScopes         []string `json:"mavenExcludedScopes,omitempty"`
 	DetectTools                 []string `json:"detectTools,omitempty"`
-	ScanOnChanges               bool     `json:"scanOnChanges,omitempty"`
 	CustomEnvironmentVariables  []string `json:"customEnvironmentVariables,omitempty"`
 	MinScanInterval             int      `json:"minScanInterval,omitempty"`
 	GithubToken                 string   `json:"githubToken,omitempty"`
@@ -278,7 +277,6 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringSliceVar(&stepConfig.ExcludedPackageManagers, "excludedPackageManagers", []string{}, "The package managers that need to be excluded for this scan. Providing the package manager names with this parameter will ensure that the build descriptor file of that package manager will be ignored in the scan folder For the complete list of possible values for this parameter, please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fdetector.html&_LANG=enus&anchor=detector-types-excluded-advanced)")
 	cmd.Flags().StringSliceVar(&stepConfig.MavenExcludedScopes, "mavenExcludedScopes", []string{}, "The maven scopes that need to be excluded from the scan. For example, setting the value 'test' will exclude all components which are defined with a test scope in maven")
 	cmd.Flags().StringSliceVar(&stepConfig.DetectTools, "detectTools", []string{}, "The type of BlackDuck scanners to include while running the BlackDuck scan. By default All scanners are included. For the complete list of possible values, Please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html&_LANG=enus&anchor=detect-tools-included)")
-	cmd.Flags().BoolVar(&stepConfig.ScanOnChanges, "scanOnChanges", false, "This flag determines if the scan is submitted to the server. If set to true, then the scan request is submitted to the server only when changes are detected in the Open Source Bill of Materials If the flag is set to false, then the scan request is submitted to server regardless of any changes. For more details please refer to the [documentation](https://github.com/blackducksoftware/detect_rescan/blob/master/README.md)")
 	cmd.Flags().StringSliceVar(&stepConfig.CustomEnvironmentVariables, "customEnvironmentVariables", []string{}, "A list of environment variables which can be set to prepare the environment to run a BlackDuck scan. This includes a list of environment variables defined by Synopsys. The full list can be found [here](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=configuring%2Fenvvars.html&_LANG=enus) This list affects the detect script downloaded while running the scan. Right now only detect7.sh is available for downloading")
 	cmd.Flags().IntVar(&stepConfig.MinScanInterval, "minScanInterval", 0, "This parameter controls the frequency (in number of hours) at which the signature scan is re-submitted for scan. When set to a value greater than 0, the signature scans are skipped until the specified number of hours has elapsed since the last signature scan.")
 	cmd.Flags().StringVar(&stepConfig.GithubToken, "githubToken", os.Getenv("PIPER_githubToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line")
@@ -531,15 +529,6 @@ func detectExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "detect/detectTools"}},
 						Default:     []string{},
-					},
-					{
-						Name:        "scanOnChanges",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "bool",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     false,
 					},
 					{
 						Name:        "customEnvironmentVariables",

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -558,7 +558,7 @@ func TestAddDetectArgs(t *testing.T) {
 			},
 			expected: []string{
 				"--testProp1=1",
-				"--report",
+				"--detect.project.codelocation.unmap=true",
 				"--blackduck.url=https://server.url",
 				"--blackduck.api.token=apiToken",
 				"\"--detect.project.name='testName'\"",
@@ -596,7 +596,7 @@ func TestAddDetectArgs(t *testing.T) {
 			},
 			expected: []string{
 				"--testProp1=1",
-				"--report",
+				"--detect.project.codelocation.unmap=true",
 				"--blackduck.url=https://server.url",
 				"--blackduck.api.token=apiToken",
 				"\"--detect.project.name='testName'\"",
@@ -635,8 +635,8 @@ func TestAddDetectArgs(t *testing.T) {
 			},
 			expected: []string{
 				"--testProp1=1",
-				"--report",
 				"--scan=1",
+				"--detect.project.codelocation.unmap=true",
 				"--blackduck.url=https://server.url",
 				"--blackduck.api.token=apiToken",
 				"\"--detect.project.name='testName'\"",
@@ -747,8 +747,8 @@ func TestAddDetectArgs(t *testing.T) {
 		},
 	}
 
-	for k, v := range testData {
-		v := v
+	for k, _ := range testData {
+		v := testData[k]
 		t.Run(fmt.Sprintf("run %v", k), func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -555,7 +555,6 @@ func TestAddDetectArgs(t *testing.T) {
 				ExcludedPackageManagers: []string{"npm", "NUGET"},
 				MavenExcludedScopes:     []string{"TEST", "compile"},
 				DetectTools:             []string{"DETECTOR"},
-				ScanOnChanges:           true,
 			},
 			expected: []string{
 				"--testProp1=1",
@@ -593,8 +592,7 @@ func TestAddDetectArgs(t *testing.T) {
 				IncludedPackageManagers: []string{"maven", "GRADLE"},
 				ExcludedPackageManagers: []string{"npm", "NUGET"},
 				MavenExcludedScopes:     []string{"TEST", "compile"},
-				DetectTools:             []string{"DETECTOR"},
-				ScanOnChanges:           true,
+				DetectTools:             []string{"DETECTOR"}
 			},
 			expected: []string{
 				"--testProp1=1",
@@ -634,7 +632,6 @@ func TestAddDetectArgs(t *testing.T) {
 				ExcludedPackageManagers: []string{"npm", "NUGET"},
 				MavenExcludedScopes:     []string{"TEST", "compile"},
 				DetectTools:             []string{"DETECTOR"},
-				ScanOnChanges:           true,
 			},
 			expected: []string{
 				"--testProp1=1",

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -592,7 +592,7 @@ func TestAddDetectArgs(t *testing.T) {
 				IncludedPackageManagers: []string{"maven", "GRADLE"},
 				ExcludedPackageManagers: []string{"npm", "NUGET"},
 				MavenExcludedScopes:     []string{"TEST", "compile"},
-				DetectTools:             []string{"DETECTOR"}
+				DetectTools:             []string{"DETECTOR"},
 			},
 			expected: []string{
 				"--testProp1=1",

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -286,16 +286,6 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-      - name: scanOnChanges
-        description:
-          "This flag determines if the scan is submitted to the server. If set to true, then the scan request is submitted to the server only when changes are detected in the Open Source Bill of Materials
-          If the flag is set to false, then the scan request is submitted to server regardless of any changes.
-          For more details please refer to the [documentation](https://github.com/blackducksoftware/detect_rescan/blob/master/README.md)"
-        type: bool
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
       - name: customEnvironmentVariables
         description:
           "A list of environment variables which can be set to prepare the environment to run a BlackDuck scan. This includes a list of environment variables defined by


### PR DESCRIPTION
Removed scanOnChanges parameter in detectExecuteScan. According to the synopsys [documentation] (https://github.com/blackducksoftware/detect_rescan/blob/master/README.md) - it is deprecated.