### PR TITLE
fix(url-logger): Enable access log generation for mavenBuild

### DIFF
--- a/cmd/mavenBuild.go
+++ b/cmd/mavenBuild.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/buildsettings"
@@ -24,6 +25,12 @@ const (
 
 func mavenBuild(config mavenBuildOptions, telemetryData *telemetry.CustomData, commonPipelineEnvironment *mavenBuildCommonPipelineEnvironment) {
 	utils := maven.NewUtilsBundle()
+
+	// enables url-log.json creation
+	cmd := reflect.ValueOf(utils).Elem().FieldByName("Command")
+	if cmd.IsValid() {
+		reflect.Indirect(cmd).FieldByName("StepName").SetString("mavenBuild")
+	}
 
 	err := runMavenBuild(&config, telemetryData, utils, commonPipelineEnvironment)
 	if err != nil {


### PR DESCRIPTION
# Changes

By setting the `stepName` in the `Command` struct of the `utils`, the URL log generation is activated. This is done for all build tools, see for example this line of [golangBuild](https://github.com/SAP/jenkins-library/blob/master/cmd/golangBuild.go#L99).

The `maven.NewUtilsBundle()` function that mavenBuild uses however is shared by multiple steps, and for the others we don't want to generate the URL log, so I used reflection to change the value only in this step.

- [ ] Tests
- [ ] Documentation
