### PR TITLE
fix(cnbBuild): read dockerConfigJSON from CPE and merge it with user-provided

### DIFF
--- a/cmd/cnbBuild_generated.go
+++ b/cmd/cnbBuild_generated.go
@@ -26,13 +26,12 @@ type cnbBuildOptions struct {
 	ContainerImageAlias       string                   `json:"containerImageAlias,omitempty"`
 	ContainerImageTag         string                   `json:"containerImageTag,omitempty"`
 	ContainerRegistryURL      string                   `json:"containerRegistryUrl,omitempty"`
-	ContainerRegistryUser     string                   `json:"containerRegistryUser,omitempty"`
-	ContainerRegistryPassword string                   `json:"containerRegistryPassword,omitempty"`
 	Buildpacks                []string                 `json:"buildpacks,omitempty"`
 	BuildEnvVars              map[string]interface{}   `json:"buildEnvVars,omitempty"`
 	Path                      string                   `json:"path,omitempty"`
 	ProjectDescriptor         string                   `json:"projectDescriptor,omitempty"`
 	DockerConfigJSON          string                   `json:"dockerConfigJSON,omitempty"`
+	DockerConfigJSONCPE       string                   `json:"dockerConfigJSONCPE,omitempty"`
 	CustomTLSCertificateLinks []string                 `json:"customTlsCertificateLinks,omitempty"`
 	AdditionalTags            []string                 `json:"additionalTags,omitempty"`
 	Bindings                  map[string]interface{}   `json:"bindings,omitempty"`
@@ -158,6 +157,7 @@ func CnbBuildCommand() *cobra.Command {
 				return err
 			}
 			log.RegisterSecret(stepConfig.DockerConfigJSON)
+			log.RegisterSecret(stepConfig.DockerConfigJSONCPE)
 
 			if len(GeneralConfig.HookConfig.SentryConfig.Dsn) > 0 {
 				sentryHook := log.NewSentryHook(GeneralConfig.HookConfig.SentryConfig.Dsn, GeneralConfig.CorrelationID)
@@ -226,13 +226,12 @@ func addCnbBuildFlags(cmd *cobra.Command, stepConfig *cnbBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.ContainerImageAlias, "containerImageAlias", os.Getenv("PIPER_containerImageAlias"), "Logical name used for this image.\n")
 	cmd.Flags().StringVar(&stepConfig.ContainerImageTag, "containerImageTag", os.Getenv("PIPER_containerImageTag"), "Tag of the container which will be built")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryURL, "containerRegistryUrl", os.Getenv("PIPER_containerRegistryUrl"), "Container registry where the image should be pushed to.\n\n**Note**: `containerRegistryUrl` should include only the domain. If you want to publish an image under `docker.io/example/my-image`, you must set `containerRegistryUrl: \"docker.io\"` and `containerImageName: \"example/my-image\"`.\n")
-	cmd.Flags().StringVar(&stepConfig.ContainerRegistryUser, "containerRegistryUser", os.Getenv("PIPER_containerRegistryUser"), "Username of the container registry where the image should be pushed to - which will updated in a docker config json file. If a docker config json file is provided via parameter `dockerConfigJSON`, then the existing file will be enhanced")
-	cmd.Flags().StringVar(&stepConfig.ContainerRegistryPassword, "containerRegistryPassword", os.Getenv("PIPER_containerRegistryPassword"), "Password of the container registry where the image should be pushed to -  which will updated in a docker config json file. If a docker config json file is provided via parameter `dockerConfigJSON`, then the existing file will be enhanced")
 	cmd.Flags().StringSliceVar(&stepConfig.Buildpacks, "buildpacks", []string{}, "List of custom buildpacks to use in the form of `$HOSTNAME/$REPO[:$TAG]`.")
 
 	cmd.Flags().StringVar(&stepConfig.Path, "path", os.Getenv("PIPER_path"), "Glob that should either point to a directory with your sources or one artifact in zip format.\nThis property determines the input to the buildpack.\n")
 	cmd.Flags().StringVar(&stepConfig.ProjectDescriptor, "projectDescriptor", `project.toml`, "Relative path to the project.toml file.\nSee [buildpacks.io](https://buildpacks.io/docs/reference/config/project-descriptor/) for the reference.\nParameters passed to the cnbBuild step will take precedence over the parameters set in the project.toml file, except the `env` block.\nEnvironment variables declared in a project descriptor file, will be merged with the `buildEnvVars` property, with the `buildEnvVars` having a precedence.\n\n*Note*: The project descriptor path should be relative to what is set in the [path](#path) property. If the `path` property is pointing to a zip archive (e.g. jar file), project descriptor path will be relative to the root of the workspace.\n\n*Note*: Inline buildpacks (see [specification](https://buildpacks.io/docs/reference/config/project-descriptor/#build-_table-optional_)) are not supported yet.\n")
 	cmd.Flags().StringVar(&stepConfig.DockerConfigJSON, "dockerConfigJSON", os.Getenv("PIPER_dockerConfigJSON"), "Path to the file `.docker/config.json` - this is typically provided by your CI/CD system. You can find more details about the Docker credentials in the [Docker documentation](https://docs.docker.com/engine/reference/commandline/login/).")
+	cmd.Flags().StringVar(&stepConfig.DockerConfigJSONCPE, "dockerConfigJSONCPE", os.Getenv("PIPER_dockerConfigJSONCPE"), "This property is intended only for reading the `dockerConfigJSON` from the Common Pipeline Environment. If you want to provide your own credentials, please refer to the [dockerConfigJSON](#dockerConfigJSON) property. If both properties are set, the config files will be merged, with the [dockerConfigJSON](#dockerConfigJSON) having higher priority.")
 	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List containing download links of custom TLS certificates. This is required to ensure trusted connections to registries with custom certificates.")
 	cmd.Flags().StringSliceVar(&stepConfig.AdditionalTags, "additionalTags", []string{}, "List of tags which will be pushed to the registry (additionally to the provided `containerImageTag`), e.g. \"latest\".")
 
@@ -313,34 +312,6 @@ func cnbBuildMetadata() config.StepData {
 						Default:   os.Getenv("PIPER_containerRegistryUrl"),
 					},
 					{
-						Name: "containerRegistryUser",
-						ResourceRef: []config.ResourceReference{
-							{
-								Name:  "commonPipelineEnvironment",
-								Param: "container/repositoryUsername",
-							},
-						},
-						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
-						Type:      "string",
-						Mandatory: false,
-						Aliases:   []config.Alias{{Name: "dockerRegistryUser"}},
-						Default:   os.Getenv("PIPER_containerRegistryUser"),
-					},
-					{
-						Name: "containerRegistryPassword",
-						ResourceRef: []config.ResourceReference{
-							{
-								Name:  "commonPipelineEnvironment",
-								Param: "container/repositoryPassword",
-							},
-						},
-						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
-						Type:      "string",
-						Mandatory: false,
-						Aliases:   []config.Alias{{Name: "dockerRegistryPassword"}},
-						Default:   os.Getenv("PIPER_containerRegistryPassword"),
-					},
-					{
 						Name: "buildpacks",
 						ResourceRef: []config.ResourceReference{
 							{
@@ -399,6 +370,20 @@ func cnbBuildMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_dockerConfigJSON"),
+					},
+					{
+						Name: "dockerConfigJSONCPE",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "custom/dockerConfigJSON",
+							},
+						},
+						Scope:     []string{},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_dockerConfigJSONCPE"),
 					},
 					{
 						Name:        "customTlsCertificateLinks",

--- a/cmd/cnbBuild_test.go
+++ b/cmd/cnbBuild_test.go
@@ -230,11 +230,8 @@ func TestRunCnbBuild(t *testing.T) {
 		assert.Contains(t, runner.Calls[0].Params, fmt.Sprintf("%s/%s:%s", config.ContainerRegistryURL, config.ContainerImageName, config.ContainerImageTag))
 		assert.Contains(t, runner.Calls[0].Params, fmt.Sprintf("%s/%s:latest", config.ContainerRegistryURL, config.ContainerImageName))
 
-		initialFileExists, _ := utils.FileExists("/path/to/test.json")
-		renamedFileExists, _ := utils.FileExists("/path/to/config.json")
-
-		assert.False(t, initialFileExists)
-		assert.True(t, renamedFileExists)
+		copiedFileExists, _ := utils.FileExists("/tmp/config.json")
+		assert.True(t, copiedFileExists)
 	})
 
 	t.Run("success case (customTlsCertificates)", func(t *testing.T) {
@@ -420,7 +417,7 @@ func TestRunCnbBuild(t *testing.T) {
 		addBuilderFiles(&utils)
 
 		err := callCnbBuild(&config, &telemetry.CustomData{}, &utils, &cnbBuildCommonPipelineEnvironment{}, &piperhttp.Client{})
-		assert.EqualError(t, err, "failed to generate CNB_REGISTRY_AUTH: could not read 'not-there/config.json'")
+		assert.EqualError(t, err, "failed to create/rename DockerConfigJSON file: cannot copy 'not-there/config.json': file does not exist")
 	})
 
 	t.Run("error case: DockerConfigJSON file not there (not config.json)", func(t *testing.T) {
@@ -436,7 +433,7 @@ func TestRunCnbBuild(t *testing.T) {
 		addBuilderFiles(&utils)
 
 		err := callCnbBuild(&config, &telemetry.CustomData{}, &utils, &cnbBuildCommonPipelineEnvironment{}, &piperhttp.Client{})
-		assert.EqualError(t, err, "failed to rename DockerConfigJSON file 'not-there': renaming file 'not-there' is not supported, since it does not exist, or is not a leaf-entry")
+		assert.EqualError(t, err, "failed to create/rename DockerConfigJSON file: cannot copy 'not-there': file does not exist")
 	})
 
 	t.Run("error case: dockerImage is not a valid builder", func(t *testing.T) {

--- a/integration/testdata/TestCnbIntegration/.pipeline/commonPipelineEnvironment/custom/dockerConfigJSON
+++ b/integration/testdata/TestCnbIntegration/.pipeline/commonPipelineEnvironment/custom/dockerConfigJSON
@@ -1,0 +1,1 @@
+.pipeline/config.json

--- a/integration/testdata/TestCnbIntegration/.pipeline/config.json
+++ b/integration/testdata/TestCnbIntegration/.pipeline/config.json
@@ -1,0 +1,5 @@
+{
+    "auths": {
+        "test2.registry.io": {}
+    }
+}

--- a/integration/testdata/TestCnbIntegration/config.yml
+++ b/integration/testdata/TestCnbIntegration/config.yml
@@ -12,7 +12,7 @@ steps:
         type: dummy
         data:
         - key: dummy.yml
-          file: TestCnbIntegration/config.yml
+          file: config.yml
       dynatrace:
         type: Dynatrace
         data:

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -95,32 +95,6 @@ spec:
         resourceRef:
           - name: commonPipelineEnvironment
             param: container/registryUrl
-      - name: containerRegistryUser
-        aliases:
-          - name: dockerRegistryUser
-        type: string
-        description: Username of the container registry where the image should be pushed to - which will updated in a docker config json file. If a docker config json file is provided via parameter `dockerConfigJSON`, then the existing file will be enhanced
-        scope:
-          - GENERAL
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        resourceRef:
-          - name: commonPipelineEnvironment
-            param: container/repositoryUsername
-      - name: containerRegistryPassword
-        aliases:
-          - name: dockerRegistryPassword
-        type: string
-        description: Password of the container registry where the image should be pushed to -  which will updated in a docker config json file. If a docker config json file is provided via parameter `dockerConfigJSON`, then the existing file will be enhanced
-        scope:
-          - GENERAL
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        resourceRef:
-          - name: commonPipelineEnvironment
-            param: container/repositoryPassword
       - name: buildpacks
         type: "[]string"
         description: List of custom buildpacks to use in the form of `$HOSTNAME/$REPO[:$TAG]`.
@@ -181,6 +155,13 @@ spec:
           - type: vaultSecretFile
             name: dockerConfigFileVaultSecretName
             default: docker-config
+      - name: dockerConfigJSONCPE
+        type: string
+        description: This property is intended only for reading the `dockerConfigJSON` from the Common Pipeline Environment. If you want to provide your own credentials, please refer to the [dockerConfigJSON](#dockerConfigJSON) property. If both properties are set, the config files will be merged, with the [dockerConfigJSON](#dockerConfigJSON) having higher priority.
+        secret: true
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/dockerConfigJSON
       - name: customTlsCertificateLinks
         type: "[]string"
         description: List containing download links of custom TLS certificates. This is required to ensure trusted connections to registries with custom certificates.


### PR DESCRIPTION
# Changes

This change also removes recently (1 day ago) introduced username and password properties, since we observed scenarios where it leads to incorrectly mapped credentials and therefore broken config.json file (username, registry & password are present in CPE, with the user provided registry + `dockerConfigJSON` in `config.yaml`).

- [X] Tests
- [X] Documentation
