### PR TITLE
fix(ci): add conditional coverage upload to CodeClimate 

### DIFF
--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -26,10 +26,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: unit-test
+        id: unit-test
         run: go test -tags=unit ./... -coverprofile cover.out
       # run code coverage upload to code climate on main branch since PR branch will not have access to secret
       - name: unit-test-code-climate-upload
-        if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == github.repository)) && (steps.unit-test.outcome == 'success') }}
         uses: paambaati/codeclimate-action@v4
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -29,7 +29,7 @@ jobs:
         run: go test -tags=unit ./... -coverprofile cover.out
       # run code coverage upload to code climate on main branch since PR branch will not have access to secret
       - name: unit-test-code-climate-upload
-        if: github.event_name != 'pull_request'
+        if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: paambaati/codeclimate-action@v4
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -26,11 +26,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
       - name: unit-test
+        run: go test -tags=unit ./... -coverprofile cover.out
+      # run code coverage upload to code climate on main branch since PR branch will not have access to secret (repo branch will also not upload but that maybe okay ?)
+      - name: unit-test-code-climate-upload
+        if: ${{ github.ref == 'refs/heads/master' }}
         uses: paambaati/codeclimate-action@v4
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
         with:
-          coverageCommand: go test -tags=unit ./... -coverprofile cover.out
           coverageLocations: cover.out:gocov
           # truncate package name from file paths in report
           prefix: github.com/SAP/jenkins-library/

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -27,9 +27,9 @@ jobs:
         uses: actions/checkout@v3
       - name: unit-test
         run: go test -tags=unit ./... -coverprofile cover.out
-      # run code coverage upload to code climate on main branch since PR branch will not have access to secret (repo branch will also not upload but that maybe okay ?)
+      # run code coverage upload to code climate on main branch since PR branch will not have access to secret
       - name: unit-test-code-climate-upload
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: github.event_name != 'pull_request'
         uses: paambaati/codeclimate-action@v4
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -30,7 +30,7 @@ jobs:
         run: go test -tags=unit ./... -coverprofile cover.out
       # run code coverage upload to code climate on main branch since PR branch will not have access to secret
       - name: unit-test-code-climate-upload
-        if: ${{ ((github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == github.repository)) && (steps.unit-test.outcome == 'success') }}
+        if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: paambaati/codeclimate-action@v4
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}

--- a/integration/integration_gauge_test.go
+++ b/integration/integration_gauge_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	installCommand string = "npm install -g @getgauge/cli --prefix=~/.npm-global --unsafe-perm" //option --unsafe-perm need to install gauge in docker container. See this issue: https://github.com/getgauge/gauge/issues/1470
+	installCommand string = "npm install -g @getgauge/cli@1.4.3 --prefix=~/.npm-global --unsafe-perm" //option --unsafe-perm need to install gauge in docker container. See this issue: https://github.com/getgauge/gauge/issues/1470
 )
 
 func runTest(t *testing.T, languageRunner string) {

--- a/integration/integration_gauge_test.go
+++ b/integration/integration_gauge_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	installCommand string = "npm install -g @getgauge/cli@1.4.3 --prefix=~/.npm-global --unsafe-perm" //option --unsafe-perm need to install gauge in docker container. See this issue: https://github.com/getgauge/gauge/issues/1470
+	installCommand string = "npm install -g @getgauge/cli --prefix=~/.npm-global --unsafe-perm" //option --unsafe-perm need to install gauge in docker container. See this issue: https://github.com/getgauge/gauge/issues/1470
 )
 
 func runTest(t *testing.T, languageRunner string) {


### PR DESCRIPTION
# Changes

Since PR cannot access github action secrets, separating the workflows for unit test and code coverage steps

- [ ] Tests
- [ ] Documentation

replaces #4451