### PR TITLE
Pin version of golang BOM to 1.4.0

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -35,7 +35,7 @@ const (
 	integrationJsonReport       = "integration-report.out"
 	golangCoberturaPackage      = "github.com/boumenot/gocover-cobertura@latest"
 	golangTestsumPackage        = "gotest.tools/gotestsum@latest"
-	golangCycloneDXPackage      = "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest"
+	golangCycloneDXPackage      = "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.4.0"
 	sbomFilename                = "bom-golang.xml"
 )
 

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -284,7 +284,7 @@ go 1.17`
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(utils.ExecMockRunner.Calls))
 		assert.Equal(t, "go", utils.ExecMockRunner.Calls[0].Exec)
-		assert.Equal(t, []string{"install", "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest"}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, []string{"install", "github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.4.0"}, utils.ExecMockRunner.Calls[0].Params)
 		assert.Equal(t, "cyclonedx-gomod", utils.ExecMockRunner.Calls[1].Exec)
 		assert.Equal(t, []string{"mod", "-licenses", "-test", "-output", "bom-golang.xml", "-output-version", "1.4"}, utils.ExecMockRunner.Calls[1].Params)
 		assert.Equal(t, "go", utils.ExecMockRunner.Calls[2].Exec)
@@ -330,7 +330,7 @@ go 1.17`
 			CreateBOM: true,
 		}
 		utils := newGolangBuildTestsUtils()
-		utils.ShouldFailOnCommand = map[string]error{"go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest": fmt.Errorf("install failure")}
+		utils.ShouldFailOnCommand = map[string]error{"go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.4.0": fmt.Errorf("install failure")}
 		telemetryData := telemetry.CustomData{}
 
 		err := runGolangBuild(&config, &telemetryData, utils, &cpe)

--- a/integration/integration_golang_test.go
+++ b/integration/integration_golang_test.go
@@ -29,7 +29,7 @@ func TestGolangIntegrationBuildProject1(t *testing.T) {
 
 	container.assertHasOutput(t,
 		"info  golangBuild - running command: go install gotest.tools/gotestsum@latest",
-		"info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest",
+		"info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.4.0",
 		"info  golangBuild - running command: gotestsum --junitfile TEST-go.xml --jsonfile unit-report.out -- -coverprofile=cover.out -tags=unit ./...",
 		"info  golangBuild - DONE 8 tests",
 		"info  golangBuild - running command: go tool cover -html cover.out -o coverage.html",
@@ -64,7 +64,7 @@ func TestGolangIntegrationBuildProject1MultiPackage(t *testing.T) {
 	assert.NoError(t, err)
 
 	container.assertHasOutput(t, "info  golangBuild - running command: go install gotest.tools/gotestsum@latest",
-		"info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest",
+		"info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.4.0",
 		"info  golangBuild - running command: gotestsum --junitfile TEST-go.xml --jsonfile unit-report.out -- -coverprofile=cover.out -tags=unit ./...",
 		"info  golangBuild - DONE 8 tests",
 		"info  golangBuild - running command: go tool cover -html cover.out -o coverage.html",
@@ -102,7 +102,7 @@ func TestGolangIntegrationBuildProject2(t *testing.T) {
 
 	container.assertHasNoOutput(t,
 		"info  golangBuild - running command: go install gotest.tools/gotestsum@latest",
-		"info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest",
+		"info  golangBuild - running command: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.4.0",
 		"info  golangBuild - running command: gotestsum --junitfile TEST-go.xml --jsonfile unit-report.out -- -coverprofile=cover.out -tags=unit ./...",
 		"info  golangBuild - running command: go tool cover -html cover.out -o coverage.html",
 		"info  golangBuild - running command: gotestsum --junitfile TEST-integration.xml --jsonfile integration-report.out -- -tags=integration ./...",


### PR DESCRIPTION
# Changes
Pinning to latest stable version :https://github.com/CycloneDX/cyclonedx-gomod/releases/tag/v1.4.0
We missed to pin here #4368


- [ ] Tests
- [ ] Documentation
