### PR TITLE
chore(logs): print parameters resolved from vault with info level

### DIFF
--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -153,7 +153,7 @@ func resolveVaultReference(ref *ResourceReference, config *StepConfig, client va
 
 		secretValue = lookupPath(client, vaultPath, &param)
 		if secretValue != nil {
-			log.Entry().Debugf("Resolved param '%s' with Vault path '%s'", param.Name, vaultPath)
+			log.Entry().Infof("Resolved param '%s' with Vault path '%s'", param.Name, vaultPath)
 			if ref.Type == "vaultSecret" {
 				config.Config[param.Name] = *secretValue
 			} else if ref.Type == "vaultSecretFile" {


### PR DESCRIPTION
With normal log level, only `01:25:49  info  githubCreateIssue - Fetching secrets from Vault at https://vault.../` is printed to the log. It would be interesting to see which parameters have actually been resolved without going into verbose mode.
