### PR TITLE
fix(helmExecute) allow blanks in AdditionalParams again

### DIFF
--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -479,7 +479,11 @@ func (h *HelmExecute) runHelmCommand(helmParams []string) error {
 
 // expandEnv replaces ${var} or $var in params according to the values of the current environment variables
 func expandEnv(params []string) []string {
-	paramsRaw := strings.Join(params, " ")
+	expanded := []string{}
 
-	return strings.Split(os.ExpandEnv(paramsRaw), " ")
+	for _, param := range params {
+		expanded = append(expanded, os.ExpandEnv(param))
+	}
+
+	return expanded
 }

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -310,6 +310,23 @@ func TestRunHelmInstall(t *testing.T) {
 				{Exec: "helm", Params: []string{"install", "testPackage", ".", "--namespace", "test-namespace", "--create-namespace", "--atomic", "--wait", "--timeout", "525s", "--set-file", "my_script=dothings.sh", "--debug"}},
 			},
 		},
+		{
+			config: HelmExecuteOptions{
+				ChartPath:             ".",
+				DeploymentName:        "testPackage",
+				Namespace:             "test-namespace",
+				HelmDeployWaitSeconds: 525,
+				KeepFailedDeployments: false,
+				AdditionalParameters:  []string{"--set", "auth=Basic user:password"},
+				TargetRepositoryURL:   "https://charts.helm.sh/stable",
+				TargetRepositoryName:  "test",
+			},
+			generalVerbose: true,
+			expectedExecCalls: []mock.ExecCall{
+				{Exec: "helm", Params: []string{"install", "testPackage", ".", "--namespace", "test-namespace", "--create-namespace", "--atomic", "--wait", "--timeout", "525s", "--set", "auth=Basic user:password", "--debug", "--dry-run"}},
+				{Exec: "helm", Params: []string{"install", "testPackage", ".", "--namespace", "test-namespace", "--create-namespace", "--atomic", "--wait", "--timeout", "525s", "--set", "auth=Basic user:password", "--debug"}},
+			},
+		},
 	}
 
 	for i, testCase := range testTable {


### PR DESCRIPTION
#4374 broke `helmExecute` if `AdditionalParameters` contained a blank

# Changes

- [X] Tests
- [ ] Documentation
