### PR TITLE
fix(helmExecute): only expand environment variables start with PIPER_VAULTCREDENTIAL_

### DIFF
--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -482,7 +482,11 @@ func expandEnv(params []string) []string {
 	expanded := []string{}
 
 	for _, param := range params {
-		expanded = append(expanded, os.ExpandEnv(param))
+		if strings.Contains(param, "PIPER_VAULTCREDENTIAL_") {
+			expanded = append(expanded, os.ExpandEnv(param))
+		} else {
+			expanded = append(expanded, param)
+		}
 	}
 
 	return expanded

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/SAP/jenkins-library/pkg/config"
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/config"
 )
 
 // HelmExecutor is used for mock

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -10,6 +10,7 @@ import (
 
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/config"
 )
 
 // HelmExecutor is used for mock
@@ -482,7 +483,7 @@ func expandEnv(params []string) []string {
 	expanded := []string{}
 
 	for _, param := range params {
-		if strings.Contains(param, "PIPER_VAULTCREDENTIAL_") {
+		if strings.Contains(param, config.VaultCredentialEnvPrefixDefault) {
 			expanded = append(expanded, os.ExpandEnv(param))
 		} else {
 			expanded = append(expanded, param)

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -117,6 +117,7 @@ func TestRunHelmAdd(t *testing.T) {
 
 func TestRunHelmUpgrade(t *testing.T) {
 	os.Setenv("IMAGE", "image")
+	os.Setenv("PIPER_VAULTCREDENTIAL_IMAGE", "image")
 
 	testTable := []struct {
 		config            HelmExecuteOptions
@@ -167,6 +168,23 @@ func TestRunHelmUpgrade(t *testing.T) {
 				ForceUpdates:          true,
 				HelmDeployWaitSeconds: 3456,
 				AdditionalParameters:  []string{"--set", "image.repository=$IMAGE"},
+				Image:                 "dtzar/helm-kubectl:3.4.1",
+				TargetRepositoryName:  "test",
+				TargetRepositoryURL:   "https://charts.helm.sh/stable",
+			},
+			generalVerbose: true,
+			expectedExecCalls: []mock.ExecCall{
+				{Exec: "helm", Params: []string{"upgrade", "test_deployment", ".", "--debug", "--install", "--namespace", "test_namespace", "--force", "--wait", "--timeout", "3456s", "--atomic", "--set", "image.repository=$IMAGE"}},
+			},
+		},
+		{
+			config: HelmExecuteOptions{
+				DeploymentName:        "test_deployment",
+				ChartPath:             ".",
+				Namespace:             "test_namespace",
+				ForceUpdates:          true,
+				HelmDeployWaitSeconds: 3456,
+				AdditionalParameters:  []string{"--set", "image.repository=$PIPER_VAULTCREDENTIAL_IMAGE"},
 				Image:                 "dtzar/helm-kubectl:3.4.1",
 				TargetRepositoryName:  "test",
 				TargetRepositoryURL:   "https://charts.helm.sh/stable",
@@ -239,7 +257,7 @@ func TestRunHelmLint(t *testing.T) {
 }
 
 func TestRunHelmInstall(t *testing.T) {
-	os.Setenv("MY_SCRIPT", "dothings.sh")
+	os.Setenv("PIPER_VAULTCREDENTIAL_MY_SCRIPT", "dothings.sh")
 
 	testTable := []struct {
 		config            HelmExecuteOptions
@@ -300,7 +318,7 @@ func TestRunHelmInstall(t *testing.T) {
 				Namespace:             "test-namespace",
 				HelmDeployWaitSeconds: 525,
 				KeepFailedDeployments: false,
-				AdditionalParameters:  []string{"--set-file", "my_script=$MY_SCRIPT"},
+				AdditionalParameters:  []string{"--set-file", "my_script=$PIPER_VAULTCREDENTIAL_MY_SCRIPT"},
 				TargetRepositoryURL:   "https://charts.helm.sh/stable",
 				TargetRepositoryName:  "test",
 			},


### PR DESCRIPTION
# Changes

- [ ] Tests
- [ ] Documentation

https://github.com/SAP/jenkins-library/pull/4374#issuecomment-1634428135 
@c0d1ngm0nk3y mentioned if the strings contain dollar sign in addistional parameters, expandEnv would parse the strings as environment variables. So to avoid this, I narrow the parse scope to the strings which contain PIPER_VAULTCREDENTIAL_.
