### PR TITLE
feat(codeqlExecuteScan): cloning project from non-github scm to github

### DIFF
--- a/cmd/codeqlExecuteScan_generated.go
+++ b/cmd/codeqlExecuteScan_generated.go
@@ -30,6 +30,7 @@ type codeqlExecuteScanOptions struct {
 	UploadResults               bool   `json:"uploadResults,omitempty"`
 	SarifCheckMaxRetries        int    `json:"sarifCheckMaxRetries,omitempty"`
 	SarifCheckRetryInterval     int    `json:"sarifCheckRetryInterval,omitempty"`
+	TargetGithubRepoURL         string `json:"targetGithubRepoURL,omitempty"`
 	Threads                     string `json:"threads,omitempty"`
 	Ram                         string `json:"ram,omitempty"`
 	AnalyzedRef                 string `json:"analyzedRef,omitempty"`
@@ -193,6 +194,7 @@ func addCodeqlExecuteScanFlags(cmd *cobra.Command, stepConfig *codeqlExecuteScan
 	cmd.Flags().BoolVar(&stepConfig.UploadResults, "uploadResults", false, "Allows you to upload codeql SARIF results to your github project. You will need to set githubToken for this.")
 	cmd.Flags().IntVar(&stepConfig.SarifCheckMaxRetries, "sarifCheckMaxRetries", 10, "Maximum number of retries when waiting for the server to finish processing the SARIF upload.")
 	cmd.Flags().IntVar(&stepConfig.SarifCheckRetryInterval, "sarifCheckRetryInterval", 30, "Interval in seconds between retries when waiting for the server to finish processing the SARIF upload.")
+	cmd.Flags().StringVar(&stepConfig.TargetGithubRepoURL, "targetGithubRepoURL", os.Getenv("PIPER_targetGithubRepoURL"), "")
 	cmd.Flags().StringVar(&stepConfig.Threads, "threads", `0`, "Use this many threads for the codeql operations.")
 	cmd.Flags().StringVar(&stepConfig.Ram, "ram", os.Getenv("PIPER_ram"), "Use this much ram (MB) for the codeql operations.")
 	cmd.Flags().StringVar(&stepConfig.AnalyzedRef, "analyzedRef", os.Getenv("PIPER_analyzedRef"), "Name of the ref that was analyzed.")
@@ -323,6 +325,15 @@ func codeqlExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     30,
+					},
+					{
+						Name:        "targetGithubRepoURL",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_targetGithubRepoURL"),
 					},
 					{
 						Name:        "threads",

--- a/pkg/codeql/github_repo_upload.go
+++ b/pkg/codeql/github_repo_upload.go
@@ -1,0 +1,273 @@
+package codeql
+
+import (
+	"archive/zip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/SAP/jenkins-library/pkg/command"
+	sapgithub "github.com/SAP/jenkins-library/pkg/github"
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/google/go-github/v45/github"
+)
+
+type GithubUploader interface {
+	UploadProjectToGithub() error
+}
+
+type gitService interface {
+	GetRef(ctx context.Context, owner, repo, ref string) (*github.Reference, *github.Response, error)
+	CreateRef(ctx context.Context, owner, repo string, ref *github.Reference) (*github.Reference, *github.Response, error)
+	CreateCommit(ctx context.Context, owner, repo string, commit *github.Commit) (*github.Commit, *github.Response, error)
+	UpdateRef(ctx context.Context, owner, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error)
+	CreateTree(ctx context.Context, owner, repo, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error)
+	GetTree(ctx context.Context, owner, repo, sha string, recursive bool) (*github.Tree, *github.Response, error)
+}
+
+type gitRepositoriesService interface {
+	GetCommit(ctx context.Context, owner, repo, sha string, opts *github.ListOptions) (*github.RepositoryCommit, *github.Response, error)
+	Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error)
+	DeleteFile(ctx context.Context, owner, repo, path string, opts *github.RepositoryContentFileOptions) (*github.RepositoryContentResponse, *github.Response, error)
+}
+
+type GithubUploaderInstance struct {
+	*command.Command
+
+	serverUrl      string
+	owner          string
+	repository     string
+	token          string
+	ref            string
+	sourceCommitId string
+	sourceRepo     string
+	dbDir          string
+	trustedCerts   []string
+}
+
+func NewGithubUploaderInstance(serverUrl, owner, repository, token, ref, dbDir,
+	sourceCommitId, sourceRepo string,
+	trustedCerts []string) GithubUploaderInstance {
+	instance := GithubUploaderInstance{
+		Command:        &command.Command{},
+		serverUrl:      serverUrl,
+		owner:          owner,
+		repository:     repository,
+		token:          token,
+		ref:            ref,
+		sourceCommitId: sourceCommitId,
+		sourceRepo:     sourceRepo,
+		dbDir:          dbDir,
+		trustedCerts:   trustedCerts,
+	}
+
+	instance.Stdout(log.Writer())
+	instance.Stderr(log.Writer())
+	return instance
+}
+
+const (
+	CommitMessageRmFiles       = "branch emptying"
+	CommitMessageMirroringCode = "Mirroring code for revision %s from %s"
+	FileType                   = "blob"
+	FileMode                   = "100644"
+	TreeType                   = "tree"
+	SrcZip                     = "src.zip"
+)
+
+func (repoUploader *GithubUploaderInstance) UploadProjectToGithub() (string, error) {
+	apiUrl := getApiUrl(repoUploader.serverUrl)
+	ctx, client, err := sapgithub.NewClient(repoUploader.token, apiUrl, "", repoUploader.trustedCerts)
+	if err != nil {
+		return "", err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "tmp")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	ex, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	sourceDir := filepath.Dir(ex)
+
+	newRef, err := cloneTargetRepo(ctx, client.Git, client.Repositories, repoUploader)
+	if err != nil {
+		return "", err
+	}
+	lastCommitSHA, err := emptyTargetBranch(ctx, client.Git, client.Repositories, repoUploader, *newRef.Object.SHA, "")
+	if err != nil {
+		return "", err
+	}
+	zipPath := path.Join(sourceDir, repoUploader.dbDir, SrcZip)
+	err = unzip(zipPath, tmpDir, strings.Trim(sourceDir, fmt.Sprintf("%c", os.PathSeparator)))
+	if err != nil {
+		return "", err
+	}
+	tree, err := addProjectFiles(ctx, client.Git, repoUploader, lastCommitSHA, tmpDir)
+	if err != nil {
+		return "", err
+	}
+	newCommitId, err := pushProjectToTargetRepo(ctx, client.Repositories, client.Git, repoUploader, newRef, tree)
+
+	return newCommitId, err
+}
+
+func cloneTargetRepo(ctx context.Context, gitService gitService, repoService gitRepositoriesService, uploader *GithubUploaderInstance) (*github.Reference, error) {
+	repo, _, err := repoService.Get(ctx, uploader.owner, uploader.repository)
+	if err != nil {
+		return nil, err
+	}
+	baseRefName := *repo.DefaultBranch
+	ref, _, err := gitService.GetRef(ctx, uploader.owner, uploader.repository, uploader.ref)
+	if err == nil {
+		return ref, nil
+	}
+	baseRef, _, err := gitService.GetRef(ctx, uploader.owner, uploader.repository, "refs/heads/"+baseRefName)
+	if err != nil {
+		return nil, err
+	}
+	newRef := &github.Reference{Ref: &uploader.ref, Object: &github.GitObject{SHA: baseRef.Object.SHA}}
+	ref, _, err = gitService.CreateRef(ctx, uploader.owner, uploader.repository, newRef)
+	return ref, err
+}
+
+func emptyTargetBranch(ctx context.Context, gitService gitService, repoService gitRepositoriesService, uploader *GithubUploaderInstance, objectSHA, entryParentPath string) (string, error) {
+	lastCommitSHA := objectSHA
+	tree, resp, err := gitService.GetTree(ctx, uploader.owner, uploader.repository, objectSHA, false)
+	if resp.Response.StatusCode == 404 {
+		return lastCommitSHA, nil
+	}
+	if err != nil {
+		return lastCommitSHA, err
+	}
+
+	for _, entry := range tree.Entries {
+		entryPath := *entry.Path
+		if entryParentPath != "" {
+			entryPath = fmt.Sprintf("%s/%s", entryParentPath, *entry.Path)
+		}
+		if *entry.Type == TreeType {
+			lastCommitSHA, err = emptyTargetBranch(ctx, gitService, repoService, uploader, *entry.SHA, entryPath)
+			if err != nil {
+				return lastCommitSHA, err
+			}
+			continue
+		}
+		content, _, err := repoService.DeleteFile(ctx, uploader.owner, uploader.repository, entryPath, &github.RepositoryContentFileOptions{
+			Message: github.String(CommitMessageRmFiles),
+			SHA:     entry.SHA,
+			Branch:  &uploader.ref,
+		})
+		if err != nil {
+			return lastCommitSHA, err
+		}
+		lastCommitSHA = *content.Commit.SHA
+	}
+	return lastCommitSHA, nil
+}
+
+func addProjectFiles(ctx context.Context, gitService gitService, uploader *GithubUploaderInstance, lastCommitSHA, dir string) (*github.Tree, error) {
+	var entries []*github.TreeEntry
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		fileName := strings.Trim(strings.TrimPrefix(path, dir), fmt.Sprintf("%c", os.PathSeparator))
+		entries = append(entries, &github.TreeEntry{
+			Path:    &fileName,
+			Type:    github.String(FileType),
+			Content: github.String(string(content)),
+			Mode:    github.String(FileMode),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	newTree, _, err := gitService.CreateTree(ctx, uploader.owner, uploader.repository, lastCommitSHA, entries)
+	return newTree, err
+}
+
+func pushProjectToTargetRepo(ctx context.Context, repoService gitRepositoriesService, gitService gitService, uploader *GithubUploaderInstance, ref *github.Reference, tree *github.Tree) (string, error) {
+	parent, _, err := repoService.GetCommit(ctx, uploader.owner, uploader.repository, *ref.Object.SHA, nil)
+	if err != nil {
+		return "", err
+	}
+	parent.Commit.SHA = parent.SHA
+
+	commit := &github.Commit{
+		Message: github.String(fmt.Sprintf(CommitMessageMirroringCode, uploader.sourceCommitId, uploader.sourceRepo)),
+		Tree:    tree,
+		Parents: []*github.Commit{parent.Commit},
+	}
+	newCommit, _, err := gitService.CreateCommit(ctx, uploader.owner, uploader.repository, commit)
+	if err != nil {
+		return "", err
+	}
+	ref.Object.SHA = newCommit.SHA
+	_, _, err = gitService.UpdateRef(ctx, uploader.owner, uploader.repository, ref, true)
+	return *newCommit.SHA, err
+}
+
+func unzip(zipPath, targetDir, srcDir string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if !strings.Contains(f.Name, srcDir) {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+
+		fName := strings.TrimPrefix(f.Name, srcDir)
+		fpath := filepath.Join(targetDir, fName)
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(fpath, os.ModeDir)
+			rc.Close()
+			continue
+		}
+		err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+
+		fNew, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+		if err != nil {
+			rc.Close()
+			return err
+		}
+
+		_, err = io.Copy(fNew, rc)
+		if err != nil {
+			rc.Close()
+			fNew.Close()
+			return err
+		}
+		rc.Close()
+		fNew.Close()
+	}
+	return nil
+}

--- a/pkg/codeql/github_repo_upload_test.go
+++ b/pkg/codeql/github_repo_upload_test.go
@@ -1,0 +1,439 @@
+package codeql
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/strings/slices"
+)
+
+const (
+	notExists = "not-exists"
+	exists    = "exists"
+	refsHeads = "refs/heads/"
+)
+
+type gitServiceMock struct{}
+
+func (g *gitServiceMock) GetRef(ctx context.Context, owner, repo, ref string) (*github.Reference, *github.Response, error) {
+	if ref == notExists {
+		return nil, nil, &github.Error{Message: "Not Found"}
+	}
+
+	return &github.Reference{
+		Ref: github.String(refsHeads + ref),
+		Object: &github.GitObject{
+			SHA: github.String("SHAofExistingRef"),
+		},
+	}, nil, nil
+}
+
+func (g *gitServiceMock) CreateRef(ctx context.Context, owner, repo string, ref *github.Reference) (*github.Reference, *github.Response, error) {
+	return &github.Reference{
+		Ref: ref.Ref,
+		Object: &github.GitObject{
+			SHA: github.String("SHAofNewRef"),
+		},
+	}, nil, nil
+}
+
+func (g *gitServiceMock) CreateCommit(ctx context.Context, owner, repo string, commit *github.Commit) (*github.Commit, *github.Response, error) {
+	return &github.Commit{
+		SHA: github.String("SHAofNewCommit"),
+	}, nil, nil
+}
+
+func (g *gitServiceMock) UpdateRef(ctx context.Context, owner, repo string, ref *github.Reference, force bool) (*github.Reference, *github.Response, error) {
+	return ref, nil, nil
+}
+
+func (g *gitServiceMock) CreateTree(ctx context.Context, owner, repo, baseTree string, entries []*github.TreeEntry) (*github.Tree, *github.Response, error) {
+	return &github.Tree{
+		SHA:     github.String("SHAofNewTree"),
+		Entries: entries,
+	}, nil, nil
+}
+
+func (g *gitServiceMock) GetTree(ctx context.Context, owner, repo, sha string, recursive bool) (*github.Tree, *github.Response, error) {
+	if sha == "emptyRef" {
+		return nil, &github.Response{
+			Response: &http.Response{StatusCode: 404},
+		}, &github.Error{Message: "Not Found"}
+	}
+	if sha == "withSubfolders" {
+		return &github.Tree{
+				SHA: github.String("SHAofTree"),
+				Entries: []*github.TreeEntry{
+					{
+						SHA:  github.String("SHAofTreeEntry"),
+						Path: github.String("filepath1"),
+						Type: github.String(TreeType),
+					},
+					{
+						SHA:  github.String("SHAofFileEntry"),
+						Path: github.String("filepath2"),
+						Mode: github.String(FileMode),
+						Type: github.String(FileType),
+					},
+				},
+				Truncated: github.Bool(false),
+			}, &github.Response{
+				Response: &http.Response{StatusCode: 200},
+			}, nil
+	}
+	return &github.Tree{
+			SHA: github.String("SHAofTree"),
+			Entries: []*github.TreeEntry{
+				{
+					SHA:  github.String("SHAofFileEntry"),
+					Path: github.String("filepath1"),
+					Mode: github.String(FileMode),
+					Type: github.String(FileType),
+				},
+				{
+					SHA:  github.String("SHAofFileEntry"),
+					Path: github.String("filepath2"),
+					Mode: github.String(FileMode),
+					Type: github.String(FileType),
+				},
+			},
+			Truncated: github.Bool(false),
+		}, &github.Response{
+			Response: &http.Response{StatusCode: 200},
+		}, nil
+}
+
+type gitRepositoriesServiceMock struct{}
+
+func (gr *gitRepositoriesServiceMock) Get(ctx context.Context, owner, repo string) (*github.Repository, *github.Response, error) {
+	if repo == notExists || owner == notExists {
+		return nil, nil, &github.ErrorResponse{
+			Message: "Not Found",
+		}
+	}
+	return &github.Repository{
+		DefaultBranch: github.String(exists),
+	}, nil, nil
+}
+
+func (gr *gitRepositoriesServiceMock) GetCommit(ctx context.Context, owner, repo, sha string, opts *github.ListOptions) (*github.RepositoryCommit, *github.Response, error) {
+	return &github.RepositoryCommit{
+		SHA: &sha,
+		Commit: &github.Commit{
+			SHA: github.String("SHAofCommit"),
+		},
+	}, nil, nil
+}
+
+func (gr *gitRepositoriesServiceMock) DeleteFile(ctx context.Context, owner, repo, path string, opts *github.RepositoryContentFileOptions) (*github.RepositoryContentResponse, *github.Response, error) {
+	return &github.RepositoryContentResponse{
+		Commit: github.Commit{
+			SHA: github.String("SHAofDeletingFile"),
+		},
+	}, nil, nil
+}
+
+func TestCloneTargetRepo(t *testing.T) {
+	ctx := context.Background()
+	ghService := gitServiceMock{}
+	ghRepoService := gitRepositoriesServiceMock{}
+	t.Parallel()
+	t.Run("Created new branch", func(t *testing.T) {
+		ghUploader := NewGithubUploaderInstance("", "", exists, "", notExists, "", "", "", []string{})
+		newRef, err := cloneTargetRepo(ctx, &ghService, &ghRepoService, &ghUploader)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, newRef)
+	})
+	t.Run("Target branch exists", func(t *testing.T) {
+		ghUploader := NewGithubUploaderInstance("", "", exists, "", exists, "", "", "", []string{})
+		newRef, err := cloneTargetRepo(ctx, &ghService, &ghRepoService, &ghUploader)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, newRef)
+	})
+	t.Run("Invalid owner/repository", func(t *testing.T) {
+		ghUploader := NewGithubUploaderInstance("", notExists, notExists, "", notExists, "", "", "", []string{})
+		_, err := cloneTargetRepo(ctx, &ghService, &ghRepoService, &ghUploader)
+		assert.Error(t, err)
+	})
+}
+
+func TestEmptyTargetBranch(t *testing.T) {
+	ctx := context.Background()
+	ghService := gitServiceMock{}
+	ghRepoService := gitRepositoriesServiceMock{}
+	t.Parallel()
+	t.Run("Success with not empty ref", func(t *testing.T) {
+		ghUploader := NewGithubUploaderInstance("", "", "repo", "", refsHeads+exists, "", "", "", []string{})
+		lastCommitSHA, err := emptyTargetBranch(ctx, &ghService, &ghRepoService, &ghUploader, "ObjectSHA", "")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, lastCommitSHA)
+	})
+	t.Run("Success with subfolders in non-empty ref", func(t *testing.T) {
+		ghUploader := NewGithubUploaderInstance("", "", "repo", "", refsHeads+exists, "", "", "", []string{})
+		lastCommitSHA, err := emptyTargetBranch(ctx, &ghService, &ghRepoService, &ghUploader, "withSubfolders", "")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, lastCommitSHA)
+	})
+	t.Run("Success with empty ref", func(t *testing.T) {
+		ghUploader := NewGithubUploaderInstance("", "", "repo", "", refsHeads+exists, "", "", "", []string{})
+		lastCommitSHA, err := emptyTargetBranch(ctx, &ghService, &ghRepoService, &ghUploader, "emptyRef", "")
+		assert.NoError(t, err)
+		assert.NotEmpty(t, lastCommitSHA)
+	})
+}
+
+func TestUnzip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		targetDir, err := os.MkdirTemp("", "tmp_target")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(targetDir)
+		sourceDir, err := os.MkdirTemp("", "tmp_source")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(sourceDir)
+		zipPath := filepath.Join(sourceDir, "src.zip")
+
+		srcFilenames := []string{
+			filepath.Join(sourceDir, "file1"),
+			filepath.Join(sourceDir, "file2"),
+			filepath.Join(sourceDir, "subfolder1", "file1"),
+			filepath.Join(sourceDir, "subfolder1", "file2"),
+			filepath.Join(sourceDir, "subfolder2", "file1"),
+		}
+		err = createZIP(zipPath, srcFilenames)
+		if err != nil {
+			panic(err)
+		}
+		assert.NoError(t, unzip(zipPath, targetDir, sourceDir))
+		targetFilenames := []string{
+			filepath.Join(targetDir, "file1"),
+			filepath.Join(targetDir, "file2"),
+			filepath.Join(targetDir, "subfolder1", "file1"),
+			filepath.Join(targetDir, "subfolder1", "file2"),
+			filepath.Join(targetDir, "subfolder2", "file1"),
+		}
+		checkExistedFiles(t, targetDir, targetFilenames)
+	})
+
+	t.Run("Empty zip", func(t *testing.T) {
+		targetDir, err := os.MkdirTemp("", "tmp_target")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(targetDir)
+		sourceDir, err := os.MkdirTemp("", "tmp_source")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(sourceDir)
+		zipPath := filepath.Join(sourceDir, "src.zip")
+
+		filenames := []string{}
+		err = createZIP(zipPath, filenames)
+		if err != nil {
+			panic(err)
+		}
+		assert.NoError(t, unzip(zipPath, targetDir, sourceDir))
+		checkExistedFiles(t, targetDir, filenames)
+	})
+
+	t.Run("zip not found", func(t *testing.T) {
+		targetDir, err := os.MkdirTemp("", "tmp_target")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(targetDir)
+		sourceDir, err := os.MkdirTemp("", "tmp_source")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(sourceDir)
+		zipPath := filepath.Join(sourceDir, "src.zip")
+
+		assert.Error(t, unzip(zipPath, targetDir, sourceDir))
+	})
+
+	t.Run("extra files in zip", func(t *testing.T) {
+		targetDir, err := os.MkdirTemp("", "tmp_target")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(targetDir)
+		sourceDir, err := os.MkdirTemp("", "tmp_source")
+		if err != nil {
+			panic(err)
+		}
+		defer os.RemoveAll(sourceDir)
+		zipPath := filepath.Join(sourceDir, "src.zip")
+
+		srcFilenames := []string{
+			filepath.Join(sourceDir, "file1"),
+			filepath.Join(sourceDir, "file2"),
+			filepath.Join(sourceDir, "subfolder1", "file1"),
+			filepath.Join(sourceDir, "subfolder1", "file2"),
+			filepath.Join(sourceDir, "subfolder2", "file1"),
+			filepath.Join(targetDir, "extrafile1"),
+			filepath.Join(targetDir, "extrafile2"),
+			filepath.Join(targetDir, "subfolder1", "extrafile1"),
+		}
+		err = createZIP(zipPath, srcFilenames)
+		if err != nil {
+			panic(err)
+		}
+		assert.NoError(t, unzip(zipPath, targetDir, sourceDir))
+		targetFilenames := []string{
+			filepath.Join(targetDir, "file1"),
+			filepath.Join(targetDir, "file2"),
+			filepath.Join(targetDir, "subfolder1", "file1"),
+			filepath.Join(targetDir, "subfolder1", "file2"),
+			filepath.Join(targetDir, "subfolder2", "file1"),
+		}
+		checkExistedFiles(t, targetDir, targetFilenames)
+	})
+}
+
+func TestAddProjectFiles(t *testing.T) {
+	ctx := context.Background()
+	ghService := gitServiceMock{}
+	tmpDir, err := os.MkdirTemp("", "tmp_test")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filenames := []string{
+		filepath.Join(tmpDir, "file1"),
+		filepath.Join(tmpDir, "file2"),
+		filepath.Join(tmpDir, "subfolder1", "file1"),
+		filepath.Join(tmpDir, "subfolder1", "file2"),
+		filepath.Join(tmpDir, "subfolder2", "file1"),
+	}
+	err = fillFolderWithFiles(filenames)
+	if err != nil {
+		panic(err)
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		commitSHA := "SHAofLastCommit"
+		ghUploader := NewGithubUploaderInstance("", "", "", "", refsHeads+exists, "", "", "", []string{})
+		tree, err := addProjectFiles(ctx, &ghService, &ghUploader, commitSHA, tmpDir)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, tree)
+		checkExistedFiles(t, tmpDir, filenames)
+	})
+}
+
+func TestPushProjectToTargetRepo(t *testing.T) {
+	ctx := context.Background()
+	ghService := gitServiceMock{}
+	ghRepoService := gitRepositoriesServiceMock{}
+	ref := &github.Reference{
+		Ref: github.String(refsHeads + exists),
+		Object: &github.GitObject{
+			SHA: github.String("SHAofRef"),
+		},
+	}
+	tree := &github.Tree{
+		SHA: github.String("SHAofTree"),
+		Entries: []*github.TreeEntry{
+			{
+				SHA:     github.String("SHAofTreeEntry"),
+				Path:    github.String("filepath"),
+				Mode:    github.String(FileMode),
+				Type:    github.String(FileType),
+				Content: github.String("some content"),
+			},
+		},
+	}
+	t.Run("Success", func(t *testing.T) {
+		ghUploader := NewGithubUploaderInstance("", "", "", "", refsHeads+exists, "", "", "", []string{})
+		commitID, err := pushProjectToTargetRepo(ctx, &ghRepoService, &ghService, &ghUploader, ref, tree)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, commitID)
+	})
+}
+
+func checkExistedFiles(t *testing.T, dir string, filenames []string) {
+	counter := 0
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == dir || info.IsDir() {
+			return nil
+		}
+		assert.True(t, slices.Contains(filenames, path))
+		counter++
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, len(filenames), counter)
+}
+
+func createZIP(zipPath string, filenames []string) error {
+	archive, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+
+	zipWriter := zip.NewWriter(archive)
+	defer zipWriter.Close()
+
+	for _, filename := range filenames {
+		writer, err := zipWriter.Create(filename)
+		if err != nil {
+			return err
+		}
+
+		reader := strings.NewReader("test content\n")
+		if _, err := io.Copy(writer, reader); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func fillFolderWithFiles(filenames []string) error {
+	for _, fileName := range filenames {
+		err := ensureBaseDir(fileName)
+		if err != nil {
+			return err
+		}
+		f, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+		if err != nil {
+			return err
+		}
+
+		r := strings.NewReader("test content\n")
+		_, err = io.Copy(f, r)
+		f.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ensureBaseDir(fpath string) error {
+	baseDir := path.Dir(fpath)
+	info, err := os.Stat(baseDir)
+	if err == nil && info.IsDir() {
+		return nil
+	}
+	return os.MkdirAll(baseDir, 0755)
+}

--- a/resources/metadata/codeqlExecuteScan.yaml
+++ b/resources/metadata/codeqlExecuteScan.yaml
@@ -120,6 +120,13 @@ spec:
           - STAGES
           - STEPS
         default: 30
+      - name: targetGithubRepoURL
+        type: string
+        descriptoin: "Target github repo url. Only relevant, if project uses a combination of Piper and non-GitHub SCM."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: threads
         type: string
         description: "Use this many threads for the codeql operations."


### PR DESCRIPTION
# Changes

- [x] Tests
- [x] Documentation

We currently have a solution (implemented as a shell script) that can push the scanned code (originating from git/gerrit or some other SCM) to a GitHub repo before uploading the SARIF there. It works, but it is mostly suitable to freestyle pipelines. It is difficult to combine it with Piper, since the push step needs to happen between the scan and the SARIF upload.

The PR contains implementation of the same functionality for Piper.