### PR TITLE
sapCumulusUpload step deactivation if its the only active step in stage

### DIFF
--- a/cmd/checkIfStepActive.go
+++ b/cmd/checkIfStepActive.go
@@ -85,7 +85,7 @@ func checkIfStepActive(utils piperutils.FileUtils) error {
 	if checkStepActiveOptions.v1Active {
 		runConfig := config.RunConfig{StageConfigFile: stageConfigFile}
 		runConfigV1 := &config.RunConfigV1{RunConfig: runConfig}
-		err = runConfigV1.InitRunConfigV1(projectConfig, nil, nil, nil, nil, utils, GeneralConfig.EnvRootPath)
+		err = runConfigV1.InitRunConfigV1(projectConfig, utils, GeneralConfig.EnvRootPath)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -64,15 +64,18 @@ func (r *RunConfigV1) evaluateConditionsV1(config *Config, filters map[string]St
 					// if no condition is available, step will be active by default
 					stepActive = true
 				} else {
+					var conditionResult bool
 					for _, condition := range step.Conditions {
 						stepActive, err = condition.evaluateV1(stepConfig, utils, step.Name, envRootPath, r.RunSteps[stageName])
 						if err != nil {
 							return fmt.Errorf("failed to evaluate stage conditions: %w", err)
 						}
-						if stepActive {
-							// first condition which matches will be considered to activate the step
+						if condition.DeactivateIfOnlyActive {
 							break
 						}
+
+						// step is active if at least one of the conditions is true
+						stepActive = stepActive || conditionResult
 					}
 				}
 			}

--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -19,7 +19,6 @@ const (
 	filePatternFromConfigCondition = "filePatternFromConfig"
 	filePatternCondition           = "filePattern"
 	npmScriptsCondition            = "npmScripts"
-	deactivateIfOnlyActive         = "deactivateIfOnlyActive"
 )
 
 // EvaluateConditionsV1 validates stage conditions and updates runSteps in runConfig according to V1 schema
@@ -64,18 +63,15 @@ func (r *RunConfigV1) evaluateConditionsV1(config *Config, filters map[string]St
 					// if no condition is available, step will be active by default
 					stepActive = true
 				} else {
-					var conditionResult bool
 					for _, condition := range step.Conditions {
 						stepActive, err = condition.evaluateV1(stepConfig, utils, step.Name, envRootPath, r.RunSteps[stageName])
 						if err != nil {
 							return fmt.Errorf("failed to evaluate stage conditions: %w", err)
 						}
-						if condition.DeactivateIfOnlyActive {
+						if stepActive {
+							// first condition which matches will be considered to activate the step
 							break
 						}
-
-						// step is active if at least one of the conditions is true
-						stepActive = stepActive || conditionResult
 					}
 				}
 			}

--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -195,8 +195,11 @@ func (s *StepCondition) evaluateV1(
 		return false, nil
 	}
 
-	if s.DeactivateIfOnlyActive {
-		return deactivateIfPreviousStepsAreInactive(runSteps), nil
+	if s.OnlyActiveStepInStage {
+		// Used only in NotActiveConditions.
+		// Returns true if all previous steps are inactive, so step will be deactivated
+		// if it's the only active step in stage.
+		return !anyPreviousStepIsActive(runSteps), nil
 	}
 
 	// needs to be checked last:
@@ -502,9 +505,9 @@ func checkForNpmScriptsInPackagesV1(npmScript string, config StepConfig, utils p
 	return false, nil
 }
 
-// deactivateIfPreviousStepsAreInactive loops through previous steps active states and disables current step
-// if all previous steps are inactive
-func deactivateIfPreviousStepsAreInactive(runSteps map[string]bool) bool {
+// anyPreviousStepIsActive loops through previous steps active states and returns true
+// if at least one of them is active, otherwise result is false
+func anyPreviousStepIsActive(runSteps map[string]bool) bool {
 	for _, isActive := range runSteps {
 		if isActive {
 			return true

--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -252,37 +252,40 @@ func (r *RunConfig) evaluateConditions(config *Config, filters map[string]StepFi
 				// respect explicit activation/de-activation if available
 				stepActive = active
 			} else {
+			loop:
 				for conditionName, condition := range stepCondition {
 					var err error
+					var conditionResult bool
 					switch conditionName {
 					case configCondition:
-						if stepActive, err = checkConfig(condition, stepConfig, stepName); err != nil {
+						if conditionResult, err = checkConfig(condition, stepConfig, stepName); err != nil {
 							return errors.Wrapf(err, "error: check config condition failed")
 						}
 					case configKeysCondition:
-						if stepActive, err = checkConfigKeys(condition, stepConfig, stepName); err != nil {
+						if conditionResult, err = checkConfigKeys(condition, stepConfig, stepName); err != nil {
 							return errors.Wrapf(err, "error: check configKeys condition failed")
 						}
 					case filePatternFromConfigCondition:
-						if stepActive, err = checkForFilesWithPatternFromConfig(condition, stepConfig, stepName, glob); err != nil {
+						if conditionResult, err = checkForFilesWithPatternFromConfig(condition, stepConfig, stepName, glob); err != nil {
 							return errors.Wrapf(err, "error: check filePatternFromConfig condition failed")
 						}
 					case filePatternCondition:
-						if stepActive, err = checkForFilesWithPattern(condition, stepConfig, stepName, glob); err != nil {
+						if conditionResult, err = checkForFilesWithPattern(condition, stepConfig, stepName, glob); err != nil {
 							return errors.Wrapf(err, "error: check filePattern condition failed")
 						}
 					case npmScriptsCondition:
-						if stepActive, err = checkForNpmScriptsInPackages(condition, stepConfig, stepName, glob, r.OpenFile); err != nil {
+						if conditionResult, err = checkForNpmScriptsInPackages(condition, stepConfig, stepName, glob, r.OpenFile); err != nil {
 							return errors.Wrapf(err, "error: check npmScripts condition failed")
 						}
 					case deactivateIfOnlyActive:
 						stepActive = deactivateIfPreviousStepsAreInactive(r.RunSteps[stageName])
+						break loop
 					default:
 						return errors.Errorf("unknown condition %s", conditionName)
 					}
-					if stepActive {
-						break
-					}
+
+					// step is active if at least one of the conditions is true
+					stepActive = stepActive || conditionResult
 				}
 			}
 

--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -195,10 +195,10 @@ func (s *StepCondition) evaluateV1(
 
 	if s.OnlyActiveStepInStage {
 		// Used only in NotActiveConditions.
-		// Returns true if all previous steps are inactive, so step will be deactivated
+		// Returns true if all other steps are inactive, so step will be deactivated
 		// if it's the only active step in stage.
 		// For example, sapCumulusUpload step must be deactivated in a stage where others steps are inactive.
-		return !anyPreviousStepIsActive(runSteps), nil
+		return !anyOtherStepIsActive(stepName, runSteps), nil
 	}
 
 	// needs to be checked last:
@@ -504,11 +504,11 @@ func checkForNpmScriptsInPackagesV1(npmScript string, config StepConfig, utils p
 	return false, nil
 }
 
-// anyPreviousStepIsActive loops through previous steps active states and returns true
-// if at least one of them is active, otherwise result is false
-func anyPreviousStepIsActive(runSteps map[string]bool) bool {
-	for _, isActive := range runSteps {
-		if isActive {
+// anyOtherStepIsActive loops through previous steps active states and returns true
+// if at least one of them is active, otherwise result is false. Ignores the step that is being checked.
+func anyOtherStepIsActive(targetStep string, runSteps map[string]bool) bool {
+	for step, isActive := range runSteps {
+		if isActive && step != targetStep {
 			return true
 		}
 	}

--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -199,6 +199,7 @@ func (s *StepCondition) evaluateV1(
 		// Used only in NotActiveConditions.
 		// Returns true if all previous steps are inactive, so step will be deactivated
 		// if it's the only active step in stage.
+		// For example, sapCumulusUpload step must be deactivated in a stage where others steps are inactive.
 		return !anyPreviousStepIsActive(runSteps), nil
 	}
 

--- a/pkg/config/evaluation_test.go
+++ b/pkg/config/evaluation_test.go
@@ -925,6 +925,39 @@ stages:
 				},
 			},
 		},
+		{
+			name:     "test deactivateIfOnlyActive condition - success",
+			globFunc: evaluateConditionsGlobMock,
+			customConfig: &Config{
+				General: map[string]interface{}{},
+				Stages:  map[string]map[string]interface{}{},
+				Steps: map[string]map[string]interface{}{
+					"thirdStep": {
+						"myVal1": "**/conf.js",
+					},
+				},
+			},
+			stageConfig: ioutil.NopCloser(strings.NewReader(`
+stages:
+  testStage1:
+    stepConditions:
+      firstStep:
+        npmScripts: 'npmScript11111111'
+      secondStep:
+        npmScripts: 'npmScript22222222'
+      thirdStep:
+        filePatternFromConfig: myVal1
+        deactivateIfOnlyActive: true
+            `)),
+			runStepsExpected: map[string]map[string]bool{
+				"testStage1": {
+					"firstStep":  false,
+					"secondStep": false,
+					"thirdStep":  false,
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/config/evaluation_test.go
+++ b/pkg/config/evaluation_test.go
@@ -401,18 +401,18 @@ func TestEvaluateV1(t *testing.T) {
 			expected:      false,
 		},
 		{
-			name:          "DeactivateIfOnlyActive - false",
+			name:          "NotActiveCondition: all previous steps are inactive",
 			config:        StepConfig{Config: map[string]interface{}{}},
-			stepCondition: StepCondition{DeactivateIfOnlyActive: true},
+			stepCondition: StepCondition{OnlyActiveStepInStage: true},
 			runSteps:      map[string]bool{"step1": false, "step2": false},
-			expected:      false,
+			expected:      true,
 		},
 		{
-			name:          "DeactivateIfOnlyActive - true",
+			name:          "NotActiveCondition: one of the previous steps is active",
 			config:        StepConfig{Config: map[string]interface{}{}},
-			stepCondition: StepCondition{DeactivateIfOnlyActive: true},
+			stepCondition: StepCondition{OnlyActiveStepInStage: true},
 			runSteps:      map[string]bool{"step1": false, "step2": false, "step3": true},
-			expected:      true,
+			expected:      false,
 		},
 		{
 			name:     "No condition - true",
@@ -939,39 +939,6 @@ stages:
 					"secondStep": false,
 				},
 			},
-		},
-		{
-			name:     "test deactivateIfOnlyActive condition - success",
-			globFunc: evaluateConditionsGlobMock,
-			customConfig: &Config{
-				General: map[string]interface{}{},
-				Stages:  map[string]map[string]interface{}{},
-				Steps: map[string]map[string]interface{}{
-					"thirdStep": {
-						"myVal1": "**/conf.js",
-					},
-				},
-			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
-stages:
-  testStage1:
-    stepConditions:
-      firstStep:
-        npmScripts: 'npmScript11111111'
-      secondStep:
-        npmScripts: 'npmScript22222222'
-      thirdStep:
-        filePatternFromConfig: myVal1
-        deactivateIfOnlyActive: true
-            `)),
-			runStepsExpected: map[string]map[string]bool{
-				"testStage1": {
-					"firstStep":  false,
-					"secondStep": false,
-					"thirdStep":  false,
-				},
-			},
-			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/config/evaluation_test.go
+++ b/pkg/config/evaluation_test.go
@@ -142,7 +142,7 @@ func TestEvaluateConditionsV1(t *testing.T) {
 		"Test Stage 3": false,
 	}
 
-	err := runConfig.evaluateConditionsV1(&config, nil, nil, nil, nil, &filesMock, ".pipeline")
+	err := runConfig.evaluateConditionsV1(&config, &filesMock, ".pipeline")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSteps, runConfig.RunSteps)
 	assert.Equal(t, expectedStages, runConfig.RunStages)
@@ -238,7 +238,7 @@ func TestNotActiveEvaluateConditionsV1(t *testing.T) {
 		"Test Stage 3": false,
 	}
 
-	err := runConfig.evaluateConditionsV1(&config, nil, nil, nil, nil, &filesMock, ".pipeline")
+	err := runConfig.evaluateConditionsV1(&config, &filesMock, ".pipeline")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSteps, runConfig.RunSteps)
 	assert.Equal(t, expectedStages, runConfig.RunStages)

--- a/pkg/config/evaluation_test.go
+++ b/pkg/config/evaluation_test.go
@@ -250,6 +250,7 @@ func TestEvaluateV1(t *testing.T) {
 		name          string
 		config        StepConfig
 		stepCondition StepCondition
+		runSteps      map[string]bool
 		expected      bool
 		expectedError error
 	}{
@@ -400,6 +401,20 @@ func TestEvaluateV1(t *testing.T) {
 			expected:      false,
 		},
 		{
+			name:          "DeactivateIfOnlyActive - false",
+			config:        StepConfig{Config: map[string]interface{}{}},
+			stepCondition: StepCondition{DeactivateIfOnlyActive: true},
+			runSteps:      map[string]bool{"step1": false, "step2": false},
+			expected:      false,
+		},
+		{
+			name:          "DeactivateIfOnlyActive - true",
+			config:        StepConfig{Config: map[string]interface{}{}},
+			stepCondition: StepCondition{DeactivateIfOnlyActive: true},
+			runSteps:      map[string]bool{"step1": false, "step2": false, "step3": true},
+			expected:      true,
+		},
+		{
 			name:     "No condition - true",
 			config:   StepConfig{Config: map[string]interface{}{}},
 			expected: true,
@@ -429,7 +444,7 @@ func TestEvaluateV1(t *testing.T) {
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
-			active, err := test.stepCondition.evaluateV1(test.config, &filesMock, "dummy", dir)
+			active, err := test.stepCondition.evaluateV1(test.config, &filesMock, "dummy", dir, test.runSteps)
 			if test.expectedError == nil {
 				assert.NoError(t, err)
 			} else {
@@ -505,7 +520,7 @@ stages:
   testStage1:
     stepConditions:
       firstStep:
-        config: 
+        config:
          - testGeneral
             `)),
 			runStepsExpected: map[string]map[string]bool{},
@@ -711,7 +726,7 @@ stages:
          - '**/conf.js'
          - 'myCollection.json'
       secondStep:
-        filePattern: 
+        filePattern:
          - '**/conf.jsx'
             `)),
 			runStepsExpected: map[string]map[string]bool{

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -73,7 +73,7 @@ type StepCondition struct {
 	FilePattern               string                   `json:"filePattern,omitempty"`
 	FilePatternFromConfig     string                   `json:"filePatternFromConfig,omitempty"`
 	Inactive                  bool                     `json:"inactive,omitempty"`
-	DeactivateIfOnlyActive    bool                     `json:"deactivateIfOnlyActive,omitempty"`
+	OnlyActiveStepInStage     bool                     `json:"onlyActiveStepInStage,omitempty"`
 	NpmScript                 string                   `json:"npmScript,omitempty"`
 	CommonPipelineEnvironment map[string]interface{}   `json:"commonPipelineEnvironment,omitempty"`
 	PipelineEnvironmentFilled string                   `json:"pipelineEnvironmentFilled,omitempty"`

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -73,6 +73,7 @@ type StepCondition struct {
 	FilePattern               string                   `json:"filePattern,omitempty"`
 	FilePatternFromConfig     string                   `json:"filePatternFromConfig,omitempty"`
 	Inactive                  bool                     `json:"inactive,omitempty"`
+	DeactivateIfOnlyActive    bool                     `json:"deactivateIfOnlyActive,omitempty"`
 	NpmScript                 string                   `json:"npmScript,omitempty"`
 	CommonPipelineEnvironment map[string]interface{}   `json:"commonPipelineEnvironment,omitempty"`
 	PipelineEnvironmentFilled string                   `json:"pipelineEnvironmentFilled,omitempty"`

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -79,8 +79,7 @@ type StepCondition struct {
 	PipelineEnvironmentFilled string                   `json:"pipelineEnvironmentFilled,omitempty"`
 }
 
-func (r *RunConfigV1) InitRunConfigV1(config *Config, filters map[string]StepFilters, parameters map[string][]StepParameters,
-	secrets map[string][]StepSecrets, stepAliases map[string][]Alias, utils piperutils.FileUtils, envRootPath string) error {
+func (r *RunConfigV1) InitRunConfigV1(config *Config, utils piperutils.FileUtils, envRootPath string) error {
 
 	if len(r.PipelineConfig.Spec.Stages) == 0 {
 		if err := r.LoadConditionsV1(); err != nil {
@@ -88,7 +87,7 @@ func (r *RunConfigV1) InitRunConfigV1(config *Config, filters map[string]StepFil
 		}
 	}
 
-	err := r.evaluateConditionsV1(config, filters, parameters, secrets, stepAliases, utils, envRootPath)
+	err := r.evaluateConditionsV1(config, utils, envRootPath)
 	if err != nil {
 		return fmt.Errorf("failed to evaluate step conditions: %w", err)
 	}

--- a/pkg/config/run_test.go
+++ b/pkg/config/run_test.go
@@ -63,7 +63,7 @@ func TestInitRunConfigV1(t *testing.T) {
 		stageConfig := ioutil.NopCloser(strings.NewReader(test.stageConfig))
 		runConfig := RunConfig{StageConfigFile: stageConfig}
 		runConfigV1 := RunConfigV1{RunConfig: runConfig}
-		err := runConfigV1.InitRunConfigV1(&test.config, nil, nil, nil, nil, &filesMock, ".pipeline")
+		err := runConfigV1.InitRunConfigV1(&test.config, &filesMock, ".pipeline")
 		if len(test.errorContains) > 0 {
 			assert.Contains(t, fmt.Sprint(err), test.errorContains)
 		} else {


### PR DESCRIPTION
In piper-stage-config.yml file there should be one more notActiveCondition for this feature to work. Example:
```yaml
spec:
  stages:
    - name: integration
      steps:
        - name: sapCumulusUpload
          description: 'Performs upload of result files of the previous steps of this stage to Cumulus.'
          conditions:
            - configKey: pipelineId
          notActiveConditions:
            - onlyActiveStepInStage: true
```

In general, this condition says that step will be deactivated if all the previous steps are inactive