### PR TITLE
chore(deps): Replace io/ioutil package

### DIFF
--- a/cmd/abapAddonAssemblyKitRegisterPackages.go
+++ b/cmd/abapAddonAssemblyKitRegisterPackages.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/SAP/jenkins-library/pkg/abap/aakaas"
@@ -98,7 +98,7 @@ func uploadSarFiles(repos []abaputils.Repository, conn abapbuild.Connector, read
 type readFile func(path string) ([]byte, error)
 
 func reader(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
 }
 
 func registerPackages(repos []abaputils.Repository, conn abapbuild.Connector) ([]abaputils.Repository, error) {

--- a/cmd/abapEnvironmentCheckoutBranch.go
+++ b/cmd/abapEnvironmentCheckoutBranch.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/cookiejar"
 	"reflect"
 	"time"
@@ -127,7 +127,7 @@ func triggerCheckout(repositoryName string, branchName string, checkoutConnectio
 	// Parse Response
 	var body abaputils.PullEntity
 	var abapResp map[string]*json.RawMessage
-	bodyText, errRead := ioutil.ReadAll(resp.Body)
+	bodyText, errRead := io.ReadAll(resp.Body)
 	if errRead != nil {
 		return uriConnectionDetails, err
 	}

--- a/cmd/abapEnvironmentCheckoutBranch_test.go
+++ b/cmd/abapEnvironmentCheckoutBranch_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -172,7 +171,7 @@ repositories:
 - name: 'testRepo3'
   branch: 'testBranch3'`
 
-		err := ioutil.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
+		err := os.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
 
 		config := abapEnvironmentCheckoutBranchOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -215,7 +214,7 @@ repositories:
 		manifestFileString := ``
 
 		manifestFileStringBody := []byte(manifestFileString)
-		err := ioutil.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
+		err := os.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
 
 		config := abapEnvironmentCheckoutBranchOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -263,7 +262,7 @@ repositories:
 - repo: 'testRepo2'`
 
 		manifestFileStringBody := []byte(manifestFileString)
-		err := ioutil.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
+		err := os.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
 
 		config := abapEnvironmentCheckoutBranchOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",

--- a/cmd/abapEnvironmentCloneGitRepo.go
+++ b/cmd/abapEnvironmentCloneGitRepo.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"reflect"
@@ -149,7 +149,7 @@ func triggerClone(repo abaputils.Repository, cloneConnectionDetails abaputils.Co
 	// Parse Response
 	var body abaputils.CloneEntity
 	var abapResp map[string]*json.RawMessage
-	bodyText, errRead := ioutil.ReadAll(resp.Body)
+	bodyText, errRead := io.ReadAll(resp.Body)
 	if errRead != nil {
 		return uriConnectionDetails, err, false
 	}

--- a/cmd/abapEnvironmentCloneGitRepo_test.go
+++ b/cmd/abapEnvironmentCloneGitRepo_test.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -421,7 +420,7 @@ func TestALreadyCloned(t *testing.T) {
 		resp := http.Response{
 			Status:     "400 Bad Request",
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}
 
 		repo := abaputils.Repository{
@@ -469,7 +468,7 @@ func TestALreadyCloned(t *testing.T) {
 		resp := http.Response{
 			Status:     "400 Bad Request",
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}
 
 		repo := abaputils.Repository{
@@ -517,7 +516,7 @@ func TestALreadyCloned(t *testing.T) {
 		resp := http.Response{
 			Status:     "400 Bad Request",
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}
 
 		repo := abaputils.Repository{
@@ -555,7 +554,7 @@ func TestALreadyCloned(t *testing.T) {
 		resp := http.Response{
 			Status:     "400 Bad Request",
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}
 
 		repo := abaputils.Repository{

--- a/cmd/abapEnvironmentCloneGitRepo_test.go
+++ b/cmd/abapEnvironmentCloneGitRepo_test.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 	"testing"

--- a/cmd/abapEnvironmentCreateSystem_test.go
+++ b/cmd/abapEnvironmentCreateSystem_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -75,7 +74,7 @@ func TestRunAbapEnvironmentCreateSystem(t *testing.T) {
 		  plan:   "testPlan"`
 
 		manifestFileStringBody := []byte(manifestFileString)
-		err := ioutil.WriteFile("customManifest.yml", manifestFileStringBody, 0644)
+		err := os.WriteFile("customManifest.yml", manifestFileStringBody, 0644)
 
 		err = runAbapEnvironmentCreateSystem(&config, nil, cf, u)
 		if assert.NoError(t, err) {
@@ -124,7 +123,7 @@ repositories:
 `
 
 		addonYMLBytes := []byte(addonYML)
-		err := ioutil.WriteFile("addon.yml", addonYMLBytes, 0644)
+		err := os.WriteFile("addon.yml", addonYMLBytes, 0644)
 
 		expectedResult := "{\"admin_email\":\"user@example.com\",\"is_development_allowed\":true,\"sapsystemname\":\"H02\",\"size_of_persistence\":4,\"size_of_runtime\":4,\"addon_product_name\":\"myProduct\",\"addon_product_version\":\"1.2.3\",\"parent_saas_appname\":\"addon_test\"}"
 
@@ -168,7 +167,7 @@ repositories:
 `
 
 		addonYMLBytes := []byte(addonYML)
-		err := ioutil.WriteFile("addon.yml", addonYMLBytes, 0644)
+		err := os.WriteFile("addon.yml", addonYMLBytes, 0644)
 
 		expectedResult := "{\"admin_email\":\"user@example.com\",\"is_development_allowed\":true,\"sapsystemname\":\"H02\",\"size_of_persistence\":4,\"size_of_runtime\":4}"
 
@@ -214,7 +213,7 @@ repositories:
 `
 
 		addonYMLBytes := []byte(addonYML)
-		err := ioutil.WriteFile("addon.yml", addonYMLBytes, 0644)
+		err := os.WriteFile("addon.yml", addonYMLBytes, 0644)
 
 		expectedResult := "{\"admin_email\":\"user@example.com\",\"is_development_allowed\":false,\"sapsystemname\":\"H02\",\"size_of_persistence\":4,\"size_of_runtime\":4,\"addon_product_name\":\"myProduct\",\"addon_product_version\":\"1.2.3\",\"parent_saas_appname\":\"addon_test\"}"
 

--- a/cmd/abapEnvironmentCreateTag.go
+++ b/cmd/abapEnvironmentCreateTag.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/cookiejar"
 	"strings"
 	"time"
@@ -129,7 +129,7 @@ func createSingleTag(item CreateTagBacklog, index int, telemetryData *telemetry.
 	// Parse response
 	var createTagResponse CreateTagResponse
 	var abapResp map[string]*json.RawMessage
-	bodyText, _ := ioutil.ReadAll(resp.Body)
+	bodyText, _ := io.ReadAll(resp.Body)
 
 	if err = json.Unmarshal(bodyText, &abapResp); err != nil {
 		return err

--- a/cmd/abapEnvironmentPullGitRepo.go
+++ b/cmd/abapEnvironmentPullGitRepo.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/cookiejar"
 	"reflect"
 	"time"
@@ -151,7 +151,7 @@ func triggerPull(repo abaputils.Repository, pullConnectionDetails abaputils.Conn
 	// Parse Response
 	var body abaputils.PullEntity
 	var abapResp map[string]*json.RawMessage
-	bodyText, errRead := ioutil.ReadAll(resp.Body)
+	bodyText, errRead := io.ReadAll(resp.Body)
 	if errRead != nil {
 		return uriConnectionDetails, err
 	}

--- a/cmd/abapEnvironmentPullGitRepo_test.go
+++ b/cmd/abapEnvironmentPullGitRepo_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 

--- a/cmd/abapEnvironmentPullGitRepo_test.go
+++ b/cmd/abapEnvironmentPullGitRepo_test.go
@@ -134,7 +134,7 @@ repositories:
 - name: 'testRepo3'
   branch: 'testBranch3'`
 
-		err := ioutil.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
+		err := os.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
 
 		config := abapEnvironmentPullGitRepoOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -370,7 +370,7 @@ repositories:
 		manifestFileString := ``
 
 		manifestFileStringBody := []byte(manifestFileString)
-		err := ioutil.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
+		err := os.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
 
 		config := abapEnvironmentPullGitRepoOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",
@@ -419,7 +419,7 @@ repositories:
 - repo: 'testRepo2'`
 
 		manifestFileStringBody := []byte(manifestFileString)
-		err := ioutil.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
+		err := os.WriteFile("repositoriesTest.yml", manifestFileStringBody, 0644)
 
 		config := abapEnvironmentPullGitRepoOptions{
 			CfAPIEndpoint:     "https://api.endpoint.com",

--- a/cmd/abapEnvironmentPushATCSystemConfig.go
+++ b/cmd/abapEnvironmentPushATCSystemConfig.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -151,7 +152,7 @@ func readATCSystemConfigurationFile(config *abapEnvironmentPushATCSystemConfigOp
 	if err != nil {
 		return parsedConfigurationJson, atcSystemConfiguartionJsonFile, err
 	}
-	atcSystemConfiguartionJsonFile, err = ioutil.ReadFile(filename)
+	atcSystemConfiguartionJsonFile, err = os.ReadFile(filename)
 	if err != nil {
 		return parsedConfigurationJson, atcSystemConfiguartionJsonFile, err
 	}
@@ -412,7 +413,7 @@ func checkConfigExistsInBackend(config *abapEnvironmentPushATCSystemConfigOption
 		return false, configName, configUUID, configLastChangedAt, err
 	}
 	var body []byte
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return false, configName, configUUID, configLastChangedAt, err
 	}
@@ -443,7 +444,7 @@ func HandleHttpResponse(resp *http.Response, err error, message string, connecti
 		log.Entry().WithError(err).WithField("ABAP Endpoint", connectionDetails.URL).Error("Request failed")
 	} else {
 		log.Entry().WithField("StatusCode", resp.Status).Info(message)
-		bodyText, readError = ioutil.ReadAll(resp.Body)
+		bodyText, readError = io.ReadAll(resp.Body)
 		if readError != nil {
 			defer resp.Body.Close()
 			return readError

--- a/cmd/abapEnvironmentRunATCCheck.go
+++ b/cmd/abapEnvironmentRunATCCheck.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -84,7 +85,7 @@ func fetchAndPersistATCResults(resp *http.Response, details abaputils.Connection
 	// Parse response
 	var body []byte
 	if err == nil {
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 	}
 	if err == nil {
 		defer resp.Body.Close()
@@ -225,7 +226,7 @@ func logAndPersistAndEvaluateATCResults(utils piperutils.FileUtils, body []byte,
 		log.Entry().Info("There were no results from this run, most likely the checked Software Components are empty or contain no ATC findings")
 	}
 
-	err := ioutil.WriteFile(atcResultFileName, body, 0o644)
+	err := os.WriteFile(atcResultFileName, body, 0o644)
 	if err == nil {
 		log.Entry().Infof("Writing %s file was successful", atcResultFileName)
 		var reports []piperutils.Path
@@ -242,7 +243,7 @@ func logAndPersistAndEvaluateATCResults(utils piperutils.FileUtils, body []byte,
 			htmlString := generateHTMLDocument(parsedXML)
 			htmlStringByte := []byte(htmlString)
 			atcResultHTMLFileName := strings.Trim(atcResultFileName, ".xml") + ".html"
-			err = ioutil.WriteFile(atcResultHTMLFileName, htmlStringByte, 0o644)
+			err = os.WriteFile(atcResultHTMLFileName, htmlStringByte, 0o644)
 			if err == nil {
 				log.Entry().Info("Writing " + atcResultHTMLFileName + " file was successful")
 				reports = append(reports, piperutils.Path{Target: atcResultFileName, Name: "ATC Results HTML file", Mandatory: true})
@@ -317,7 +318,7 @@ func logResponseBody(resp *http.Response) error {
 	var bodyText []byte
 	var readError error
 	if resp != nil {
-		bodyText, readError = ioutil.ReadAll(resp.Body)
+		bodyText, readError = io.ReadAll(resp.Body)
 		if readError != nil {
 			return readError
 		}
@@ -353,7 +354,7 @@ func pollATCRun(details abaputils.ConnectionDetailsHTTP, body []byte, client pip
 		if err != nil {
 			return "", errors.Errorf("Getting HTTP response failed: %v", err)
 		}
-		bodyText, err := ioutil.ReadAll(resp.Body)
+		bodyText, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", errors.Errorf("Reading response body failed: %v", err)
 		}

--- a/cmd/abapEnvironmentRunATCCheck_test.go
+++ b/cmd/abapEnvironmentRunATCCheck_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"encoding/xml"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -655,7 +654,7 @@ atcobjects:
     - name: /DMO/SWC
 `
 
-		err := ioutil.WriteFile(config.AtcConfig, []byte(yamlBody), 0o644)
+		err := os.WriteFile(config.AtcConfig, []byte(yamlBody), 0o644)
 		if assert.Equal(t, err, nil) {
 			bodyString, err := buildATCRequestBody(config)
 			assert.Equal(t, nil, err)
@@ -691,7 +690,7 @@ objectset:
 `
 		expectedBodyString := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><atc:runparameters xmlns:atc=\"http://www.sap.com/adt/atc\" xmlns:obj=\"http://www.sap.com/adt/objectset\" checkVariant=\"MY_TEST\" configuration=\"MY_CONFIG\"><osl:objectSet xsi:type=\"multiPropertySet\" xmlns:osl=\"http://www.sap.com/api/osl\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><osl:package name=\"Z_TEST\"/><osl:package name=\"Z_TEST_TREE\" includeSubpackages=\"true\"/><osl:softwareComponent name=\"Z_TEST\"/><osl:softwareComponent name=\"/DMO/SWC\"/></osl:objectSet></atc:runparameters>"
 
-		err := ioutil.WriteFile(config.AtcConfig, []byte(yamlBody), 0o644)
+		err := os.WriteFile(config.AtcConfig, []byte(yamlBody), 0o644)
 		if assert.Equal(t, err, nil) {
 			bodyString, err := buildATCRequestBody(config)
 			assert.Equal(t, nil, err)
@@ -718,7 +717,7 @@ objectset:
   - name: /DMO/SWC
 `
 
-		err := ioutil.WriteFile(config.Repositories, []byte(yamlBody), 0o644)
+		err := os.WriteFile(config.Repositories, []byte(yamlBody), 0o644)
 		if assert.Equal(t, err, nil) {
 			bodyString, err := buildATCRequestBody(config)
 			assert.Equal(t, nil, err)

--- a/cmd/abapEnvironmentRunAUnitTest.go
+++ b/cmd/abapEnvironmentRunAUnitTest.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -148,7 +149,7 @@ func fetchAndPersistAUnitResults(resp *http.Response, details abaputils.Connecti
 	//Parse response
 	var body []byte
 	if err == nil {
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 	}
 	if err == nil {
 		defer resp.Body.Close()
@@ -293,7 +294,7 @@ func pollAUnitRun(details abaputils.ConnectionDetailsHTTP, body []byte, client p
 		if err != nil {
 			return "", fmt.Errorf("Getting HTTP response failed: %w", err)
 		}
-		bodyText, err := ioutil.ReadAll(resp.Body)
+		bodyText, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return "", fmt.Errorf("Reading response body failed: %w", err)
 		}
@@ -360,7 +361,7 @@ func persistAUnitResult(utils piperutils.FileUtils, body []byte, aunitResultFile
 	}
 
 	//Write Results
-	err = ioutil.WriteFile(aunitResultFileName, body, 0644)
+	err = os.WriteFile(aunitResultFileName, body, 0644)
 	if err != nil {
 		return fmt.Errorf("Writing results failed: %w", err)
 	}
@@ -387,7 +388,7 @@ func persistAUnitResult(utils piperutils.FileUtils, body []byte, aunitResultFile
 			htmlString := generateHTMLDocumentAUnit(parsedXML)
 			htmlStringByte := []byte(htmlString)
 			aUnitResultHTMLFileName := strings.Trim(aunitResultFileName, ".xml") + ".html"
-			err = ioutil.WriteFile(aUnitResultHTMLFileName, htmlStringByte, 0644)
+			err = os.WriteFile(aUnitResultHTMLFileName, htmlStringByte, 0644)
 			if err != nil {
 				return fmt.Errorf("Writing HTML document failed: %w", err)
 			}

--- a/cmd/abapEnvironmentRunAUnitTest_test.go
+++ b/cmd/abapEnvironmentRunAUnitTest_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -280,7 +279,7 @@ func TestBuildAUnitRequestBody(t *testing.T) {
     branch: main
 `
 		expectedBodyString := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><aunit:run title=\"AUnit Test Run\" context=\"ABAP Environment Pipeline\" xmlns:aunit=\"http://www.sap.com/adt/api/aunit\"><aunit:options><aunit:measurements type=\"none\"/><aunit:scope ownTests=\"true\" foreignTests=\"true\"/><aunit:riskLevel harmless=\"true\" dangerous=\"true\" critical=\"true\"/><aunit:duration short=\"true\" medium=\"true\" long=\"true\"/></aunit:options><osl:objectSet xsi:type=\"multiPropertySet\" xmlns:osl=\"http://www.sap.com/api/osl\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><osl:softwareComponent name=\"/DMO/REPO\"/></osl:objectSet></aunit:run>"
-		err := ioutil.WriteFile(config.Repositories, []byte(repositories), 0o644)
+		err := os.WriteFile(config.Repositories, []byte(repositories), 0o644)
 		if assert.Equal(t, err, nil) {
 			bodyString, err := buildAUnitRequestBody(config)
 			assert.Equal(t, nil, err)
@@ -311,7 +310,7 @@ objectset:
   - name: /DMO/SWC
 `
 		expectedBodyString := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><aunit:run title=\"My AUnit run\" context=\"ABAP Environment Pipeline\" xmlns:aunit=\"http://www.sap.com/adt/api/aunit\"><aunit:options><aunit:measurements type=\"none\"/><aunit:scope ownTests=\"true\" foreignTests=\"true\"/><aunit:riskLevel harmless=\"true\" dangerous=\"true\" critical=\"true\"/><aunit:duration short=\"true\" medium=\"true\" long=\"true\"/></aunit:options><osl:objectSet xsi:type=\"multiPropertySet\" xmlns:osl=\"http://www.sap.com/api/osl\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><osl:package name=\"Z_TEST\"/><osl:softwareComponent name=\"Z_TEST\"/><osl:softwareComponent name=\"/DMO/SWC\"/></osl:objectSet></aunit:run>"
-		err := ioutil.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
+		err := os.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
 		if assert.Equal(t, err, nil) {
 			bodyString, err := buildAUnitRequestBody(config)
 			assert.Equal(t, nil, err)
@@ -344,7 +343,7 @@ objectset:
       - name: /DMO/SWC
 `
 		expectedBodyString := "<?xml version=\"1.0\" encoding=\"UTF-8\"?><aunit:run title=\"My AUnit run\" context=\"ABAP Environment Pipeline\" xmlns:aunit=\"http://www.sap.com/adt/api/aunit\"><aunit:options><aunit:measurements type=\"none\"/><aunit:scope ownTests=\"true\" foreignTests=\"true\"/><aunit:riskLevel harmless=\"true\" dangerous=\"true\" critical=\"true\"/><aunit:duration short=\"true\" medium=\"true\" long=\"true\"/></aunit:options><osl:objectSet xsi:type=\"multiPropertySet\" xmlns:osl=\"http://www.sap.com/api/osl\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><osl:package name=\"Z_TEST\"/><osl:softwareComponent name=\"Z_TEST\"/><osl:softwareComponent name=\"/DMO/SWC\"/></osl:objectSet></aunit:run>"
-		err := ioutil.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
+		err := os.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
 		if assert.Equal(t, err, nil) {
 			bodyString, err := buildAUnitRequestBody(config)
 			assert.Equal(t, nil, err)
@@ -419,7 +418,7 @@ objectset:
   - name: Z_TEST
 `
 
-		err := ioutil.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
+		err := os.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
 		if assert.Equal(t, err, nil) {
 			_, err := triggerAUnitrun(config, con, client)
 			assert.Equal(t, nil, err)
@@ -473,7 +472,7 @@ objectset:
       - name: Z_TEST_SC
 `
 
-		err := ioutil.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
+		err := os.WriteFile(config.AUnitConfig, []byte(yamlBody), 0o644)
 		if assert.Equal(t, err, nil) {
 			_, err := triggerAUnitrun(config, con, client)
 			assert.Equal(t, nil, err)

--- a/cmd/apiKeyValueMapDownload.go
+++ b/cmd/apiKeyValueMapDownload.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -71,7 +70,7 @@ func runApiKeyValueMapDownload(config *apiKeyValueMapDownloadOptions, telemetryD
 		}
 		return nil
 	}
-	responseBody, readErr := ioutil.ReadAll(downloadResp.Body)
+	responseBody, readErr := io.ReadAll(downloadResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code : %v", downloadResp.StatusCode)

--- a/cmd/apiKeyValueMapDownload_test.go
+++ b/cmd/apiKeyValueMapDownload_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -15,7 +14,7 @@ func TestRunApiKeyValueMapDownload(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Successfull Download of API Key Value Map", func(t *testing.T) {
-		file, err := ioutil.TempFile("", "CustKVM.json")
+		file, err := os.CreateTemp("", "CustKVM.json")
 		if err != nil {
 			t.FailNow()
 		}

--- a/cmd/apiKeyValueMapUpload.go
+++ b/cmd/apiKeyValueMapUpload.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/Jeffail/gabs/v2"
@@ -76,7 +76,7 @@ func runApiKeyValueMapUpload(config *apiKeyValueMapUploadOptions, telemetryData 
 			Info("Successfully created api key value map artefact in API Portal")
 		return nil
 	}
-	response, readErr := ioutil.ReadAll(apiProxyUploadStatusResp.Body)
+	response, readErr := io.ReadAll(apiProxyUploadStatusResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", apiProxyUploadStatusResp.StatusCode)

--- a/cmd/apiProviderDownload.go
+++ b/cmd/apiProviderDownload.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 
@@ -75,7 +75,7 @@ func runApiProviderDownload(config *apiProviderDownloadOptions, telemetryData *t
 	}
 	if downloadResp.StatusCode == 200 {
 		jsonFilePath := config.DownloadPath
-		content, err := ioutil.ReadAll(downloadResp.Body)
+		content, err := io.ReadAll(downloadResp.Body)
 		if err != nil {
 			return err
 		}

--- a/cmd/apiProviderUpload.go
+++ b/cmd/apiProviderUpload.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/SAP/jenkins-library/pkg/apim"
 	"github.com/SAP/jenkins-library/pkg/cpi"
@@ -30,7 +30,7 @@ func runApiProviderUpload(config *apiProviderUploadOptions, telemetryData *telem
 	if err != nil {
 		return err
 	}
-	return createApiProvider(config, apimData, ioutil.ReadFile)
+	return createApiProvider(config, apimData, os.ReadFile)
 }
 
 func createApiProvider(config *apiProviderUploadOptions, apim apim.Bundle, readFile func(string) ([]byte, error)) error {

--- a/cmd/apiProviderUpload_test.go
+++ b/cmd/apiProviderUpload_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -18,7 +17,7 @@ func TestRunApiProviderUpload(t *testing.T) {
 	t.Parallel()
 
 	t.Run("API Provider upload succesfull test", func(t *testing.T) {
-		file, tmpErr := ioutil.TempFile("", "test.json")
+		file, tmpErr := os.CreateTemp("", "test.json")
 		if tmpErr != nil {
 			t.FailNow()
 		}
@@ -44,7 +43,7 @@ func TestRunApiProviderUpload(t *testing.T) {
 	})
 
 	t.Run("API Provider upload failed test", func(t *testing.T) {
-		file, tmpErr := ioutil.TempFile("", "test.json")
+		file, tmpErr := os.CreateTemp("", "test.json")
 		if tmpErr != nil {
 			t.FailNow()
 		}

--- a/cmd/awsS3Upload_test.go
+++ b/cmd/awsS3Upload_test.go
@@ -29,7 +29,7 @@ func TestRunAwsS3Upload(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
 		// create temporary file
-		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use os.CreateTemp
+		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use ioutil.TempFile
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -68,7 +68,7 @@ func TestRunAwsS3Upload(t *testing.T) {
 	t.Run("error bucket", func(t *testing.T) {
 		t.Parallel()
 		// create temporary file
-		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use os.CreateTemp
+		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use ioutil.TempFile
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/awsS3Upload_test.go
+++ b/cmd/awsS3Upload_test.go
@@ -29,7 +29,7 @@ func TestRunAwsS3Upload(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		t.Parallel()
 		// create temporary file
-		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use ioutil.TempFile
+		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use os.CreateTemp
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -68,7 +68,7 @@ func TestRunAwsS3Upload(t *testing.T) {
 	t.Run("error bucket", func(t *testing.T) {
 		t.Parallel()
 		// create temporary file
-		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use ioutil.TempFile
+		f, err := os.CreateTemp("", "tmpfile-") // in Go version older than 1.17 you can use os.CreateTemp
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/checkIfStepActive_test.go
+++ b/cmd/checkIfStepActive_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -39,7 +38,7 @@ steps:
 	default:
 		fileContent = ""
 	}
-	return ioutil.NopCloser(strings.NewReader(fileContent)), nil
+	return io.NopCloser(strings.NewReader(fileContent)), nil
 }
 
 func checkStepActiveFileExistsMock(filename string) (bool, error) {

--- a/cmd/checkmarxExecuteScan_test.go
+++ b/cmd/checkmarxExecuteScan_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -321,7 +320,7 @@ func (c *checkmarxExecuteScanUtilsMock) WriteFile(filename string, data []byte, 
 	if c.errorOnWriteFile {
 		return fmt.Errorf("error on WriteFile")
 	}
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 func (c *checkmarxExecuteScanUtilsMock) MkdirAll(path string, perm os.FileMode) error {
@@ -399,17 +398,17 @@ func TestZipFolder(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 
-		err := ioutil.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
+		err := os.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abcd.yaml"), []byte("abcd.yaml"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abcd.yaml"), []byte("abcd.yaml"), 0o700)
 		assert.NoError(t, err)
 		err = os.Mkdir(filepath.Join(dir, "somepath"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
 		assert.NoError(t, err)
 
 		var zipFileMock bytes.Buffer
@@ -430,15 +429,15 @@ func TestZipFolder(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 
-		err := ioutil.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
+		err := os.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
 		assert.NoError(t, err)
 		err = os.Mkdir(filepath.Join(dir, "somepath"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
 		assert.NoError(t, err)
 
 		var zipFileMock bytes.Buffer
@@ -453,15 +452,15 @@ func TestZipFolder(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 
-		err := ioutil.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
+		err := os.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
 		assert.NoError(t, err)
 		err = os.Mkdir(filepath.Join(dir, "somepath"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
 		assert.NoError(t, err)
 
 		var zipFileMock bytes.Buffer
@@ -476,15 +475,15 @@ func TestZipFolder(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 
-		err := ioutil.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
+		err := os.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
 		assert.NoError(t, err)
 		err = os.Mkdir(filepath.Join(dir, "somepath"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abcd_test.go"), []byte("abcd_test.go"), 0o700)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
+		err = os.WriteFile(filepath.Join(dir, "abc_test.go"), []byte("abc_test.go"), 0o700)
 		assert.NoError(t, err)
 
 		var zipFileMock bytes.Buffer
@@ -588,7 +587,7 @@ func TestRunScan(t *testing.T) {
 	sys := &systemMockForExistingProject{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`)}
 	options := checkmarxExecuteScanOptions{ProjectName: "TestExisting", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "10048", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -612,7 +611,7 @@ func TestRunScan_nonNumeralPreset(t *testing.T) {
 	sys := &systemMockForExistingProject{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`)}
 	options := checkmarxExecuteScanOptions{ProjectName: "TestExisting", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "SAP_JS_Default", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -632,7 +631,7 @@ func TestRunOptimizedScan(t *testing.T) {
 	sys := &systemMockForExistingProject{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`)}
 	options := checkmarxExecuteScanOptions{IsOptimizedAndScheduled: true, ProjectName: "TestExisting", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "1", Incremental: true, FullScansScheduled: true, Preset: "10048", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -713,7 +712,7 @@ func TestRunScanWOtherCycle(t *testing.T) {
 	sys := &systemMock{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`), createProject: true}
 	options := checkmarxExecuteScanOptions{ProjectName: "test", VulnerabilityThresholdUnit: "percentage", FullScanCycle: "3", Incremental: true, FullScansScheduled: true, Preset: "123", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -754,7 +753,7 @@ func TestRunScanForPullRequest(t *testing.T) {
 	sys := &systemMock{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`)}
 	options := checkmarxExecuteScanOptions{PullRequestName: "PR-19", ProjectName: "Test", VulnerabilityThresholdUnit: "percentage", FullScanCycle: "3", Incremental: true, FullScansScheduled: true, Preset: "123", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, AvoidDuplicateProjectScans: false}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -776,7 +775,7 @@ func TestRunScanForPullRequestProjectNew(t *testing.T) {
 	sys := &systemMock{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`), createProject: true}
 	options := checkmarxExecuteScanOptions{PullRequestName: "PR-17", ProjectName: "Test", AvoidDuplicateProjectScans: true, VulnerabilityThresholdUnit: "percentage", FullScanCycle: "3", Incremental: true, FullScansScheduled: true, Preset: "10048", TeamName: "OpenSource/Cracks/15", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -799,7 +798,7 @@ func TestRunScanForPullRequestProjectNew_nonNumeralPreset(t *testing.T) {
 	sys := &systemMock{response: []byte(`<?xml version="1.0" encoding="utf-8"?><CxXMLResults />`), createProject: true}
 	options := checkmarxExecuteScanOptions{PullRequestName: "PR-17", ProjectName: "Test", AvoidDuplicateProjectScans: true, VulnerabilityThresholdUnit: "percentage", FullScanCycle: "3", Incremental: true, FullScansScheduled: true, Preset: "SAP_JS_Default", TeamName: "OpenSource/Cracks/15", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -838,7 +837,7 @@ func TestRunScanHighViolationPercentage(t *testing.T) {
 	</CxXMLResults>`)}
 	options := checkmarxExecuteScanOptions{ProjectName: "test", VulnerabilityThresholdUnit: "percentage", VulnerabilityThresholdResult: "FAILURE", VulnerabilityThresholdHigh: 100, FullScanCycle: "10", FullScansScheduled: true, Preset: "10048", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 
@@ -877,7 +876,7 @@ func TestRunScanHighViolationAbsolute(t *testing.T) {
 		</CxXMLResults>`)}
 	options := checkmarxExecuteScanOptions{ProjectName: "test", VulnerabilityThresholdUnit: "absolute", VulnerabilityThresholdResult: "FAILURE", VulnerabilityThresholdLow: 1, FullScanCycle: "10", FullScansScheduled: true, Preset: "10048", TeamID: "16", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true}
 	workspace := t.TempDir()
-	err := ioutil.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
+	err := os.WriteFile(filepath.Join(workspace, "abcd.go"), []byte("abcd.go"), 0o700)
 	assert.NoError(t, err)
 	options.FilterPattern = "**/abcd.go"
 

--- a/cmd/cloudFoundryCreateService_test.go
+++ b/cmd/cloudFoundryCreateService_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -149,7 +148,7 @@ func TestCloudFoundryCreateService(t *testing.T) {
 		  plan:   "testPlan"`
 
 		manifestFileStringBody := []byte(manifestFileString)
-		err := ioutil.WriteFile("manifestTest.yml", manifestFileStringBody, 0644)
+		err := os.WriteFile("manifestTest.yml", manifestFileStringBody, 0644)
 		assert.NoError(t, err)
 
 		var manifestVariables = []string{"name1=Test1", "name2=Test2"}
@@ -203,11 +202,11 @@ func TestCloudFoundryCreateService(t *testing.T) {
 
 		varsFileStringBody := []byte(varsFileString)
 		manifestFileStringBody := []byte(manifestFileString)
-		err := ioutil.WriteFile("varsTest.yml", varsFileStringBody, 0644)
+		err := os.WriteFile("varsTest.yml", varsFileStringBody, 0644)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile("varsTest2.yml", varsFileStringBody, 0644)
+		err = os.WriteFile("varsTest2.yml", varsFileStringBody, 0644)
 		assert.NoError(t, err)
-		err = ioutil.WriteFile("manifestTest.yml", manifestFileStringBody, 0644)
+		err = os.WriteFile("manifestTest.yml", manifestFileStringBody, 0644)
 		assert.NoError(t, err)
 
 		var manifestVariablesFiles = []string{"varsTest.yml", "varsTest2.yml"}

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -66,7 +65,7 @@ func (c *httpMockClient) SendRequest(method, url string, body io.Reader, header 
 	c.header[url] = header
 	response := http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
 	if c.errorMessageForURL[url] != "" {
@@ -75,7 +74,7 @@ func (c *httpMockClient) SendRequest(method, url string, body io.Reader, header 
 	}
 
 	if c.responseBodyForURL[url] != "" {
-		response.Body = ioutil.NopCloser(bytes.NewReader([]byte(c.responseBodyForURL[url])))
+		response.Body = io.NopCloser(bytes.NewReader([]byte(c.responseBodyForURL[url])))
 		return &response, nil
 	}
 

--- a/cmd/fortifyExecuteScan.go
+++ b/cmd/fortifyExecuteScan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/exec"
@@ -342,7 +341,7 @@ func verifyFFProjectCompliance(ctx context.Context, config fortifyExecuteScanOpt
 	// Generate report
 	if config.Reporting {
 		resultURL := []byte(fmt.Sprintf("%v/html/ssc/version/%v/fix/null/", config.ServerURL, projectVersion.ID))
-		if err := ioutil.WriteFile(fmt.Sprintf("%vtarget/%v-%v.%v", config.ModulePath, *project.Name, *projectVersion.Name, "txt"), resultURL, 0o700); err != nil {
+		if err := os.WriteFile(fmt.Sprintf("%vtarget/%v-%v.%v", config.ModulePath, *project.Name, *projectVersion.Name, "txt"), resultURL, 0o700); err != nil {
 			log.Entry().WithError(err).Error("failed to write file")
 		}
 
@@ -350,7 +349,7 @@ func verifyFFProjectCompliance(ctx context.Context, config fortifyExecuteScanOpt
 		if err != nil {
 			return reports, err
 		}
-		if err := ioutil.WriteFile(fmt.Sprintf("%vtarget/%v-%v.%v", config.ModulePath, *project.Name, *projectVersion.Name, config.ReportType), data, 0o700); err != nil {
+		if err := os.WriteFile(fmt.Sprintf("%vtarget/%v-%v.%v", config.ModulePath, *project.Name, *projectVersion.Name, config.ReportType), data, 0o700); err != nil {
 			log.Entry().WithError(err).Warning("failed to write file")
 		}
 	}
@@ -874,7 +873,7 @@ func readAllClasspathFiles(file string) string {
 }
 
 func readClasspathFile(file string) string {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		log.Entry().WithError(err).Warnf("failed to read classpath from file '%v'", file)
 	}

--- a/cmd/fortifyExecuteScan_test.go
+++ b/cmd/fortifyExecuteScan_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -438,7 +437,7 @@ func (er *execRunnerMock) RunExecutable(e string, p ...string) error {
 		}
 	} else if e == "mvn" {
 		path := strings.ReplaceAll(p[2], "-Dmdep.outputFile=", "")
-		err := ioutil.WriteFile(path, []byte(classpathMaven), 0o644)
+		err := os.WriteFile(path, []byte(classpathMaven), 0o644)
 		if err != nil {
 			return err
 		}

--- a/cmd/gctsCloneRepository.go
+++ b/cmd/gctsCloneRepository.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 
@@ -65,7 +65,7 @@ func cloneRepository(config *gctsCloneRepositoryOptions, telemetryData *telemetr
 		return errors.Errorf("did not retrieve a HTTP response: %v", httpErr)
 	}
 
-	bodyText, readErr := ioutil.ReadAll(resp.Body)
+	bodyText, readErr := io.ReadAll(resp.Body)
 
 	if readErr != nil {
 		return errors.Wrap(readErr, "HTTP response body could not be read")

--- a/cmd/gctsCreateRepository.go
+++ b/cmd/gctsCreateRepository.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 
@@ -103,7 +103,7 @@ func createRepository(config *gctsCreateRepositoryOptions, telemetryData *teleme
 		return errors.Errorf("creating repository on the ABAP system %v failed: %v", config.Host, httpErr)
 	}
 
-	bodyText, readErr := ioutil.ReadAll(resp.Body)
+	bodyText, readErr := io.ReadAll(resp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "creating repository on the ABAP system %v failed", config.Host)

--- a/cmd/gctsCreateRepository_test.go
+++ b/cmd/gctsCreateRepository_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -169,7 +168,7 @@ func (c *httpMockGcts) SendRequest(method string, url string, r io.Reader, heade
 	c.URL = url
 
 	if r != nil {
-		_, err := ioutil.ReadAll(r)
+		_, err := io.ReadAll(r)
 
 		if err != nil {
 			return nil, err
@@ -179,7 +178,7 @@ func (c *httpMockGcts) SendRequest(method string, url string, r io.Reader, heade
 	res := http.Response{
 		StatusCode: c.StatusCode,
 		Header:     c.Header,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
 	}
 
 	if c.StatusCode >= 400 {

--- a/cmd/gctsDeploy.go
+++ b/cmd/gctsDeploy.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -558,7 +558,7 @@ func pullByCommit(config *gctsDeployOptions, telemetryData *telemetry.CustomData
 		return errors.New("did not retrieve a HTTP response")
 	}
 
-	bodyText, readErr := ioutil.ReadAll(resp.Body)
+	bodyText, readErr := io.ReadAll(resp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read")

--- a/cmd/gctsExecuteABAPQualityChecks.go
+++ b/cmd/gctsExecuteABAPQualityChecks.go
@@ -5,10 +5,10 @@ import (
 	"encoding/xml"
 	"fmt"
 	"html"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -733,7 +733,7 @@ func parseUnitResult(config *gctsExecuteABAPQualityChecksOptions, client piperht
 
 	body, _ := xml.Marshal(parsedResult)
 
-	writeErr := ioutil.WriteFile(config.AUnitResultsFileName, body, 0644)
+	writeErr := os.WriteFile(config.AUnitResultsFileName, body, 0644)
 
 	if writeErr != nil {
 		log.Entry().Error("file AUnitResults.xml could not be created")
@@ -1051,7 +1051,7 @@ func parseATCCheckResult(config *gctsExecuteABAPQualityChecksOptions, client pip
 
 	atcBody, _ := xml.Marshal(atcResults)
 
-	writeErr := ioutil.WriteFile(config.AtcResultsFileName, atcBody, 0644)
+	writeErr := os.WriteFile(config.AtcResultsFileName, atcBody, 0644)
 
 	if writeErr != nil {
 		log.Entry().Error("ATCResults.xml could not be created")
@@ -1105,7 +1105,7 @@ func findLine(config *gctsExecuteABAPQualityChecksOptions, client piperhttp.Send
 	if readableSource {
 
 		// the error line that we get from UnitTest Run or ATC Check is not aligned for the readable source, we need to calculated it
-		rawfile, err := ioutil.ReadFile(filePath)
+		rawfile, err := os.ReadFile(filePath)
 
 		if err != nil {
 

--- a/cmd/gctsExecuteABAPQualityChecks_test.go
+++ b/cmd/gctsExecuteABAPQualityChecks_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -1835,7 +1834,7 @@ func (c *httpMockGctsT) SendRequest(method string, url string, r io.Reader, head
 	}
 
 	if r != nil {
-		_, err := ioutil.ReadAll(r)
+		_, err := io.ReadAll(r)
 
 		if err != nil {
 			return nil, err
@@ -1845,7 +1844,7 @@ func (c *httpMockGctsT) SendRequest(method string, url string, r io.Reader, head
 	res := http.Response{
 		StatusCode: c.StatusCode,
 		Header:     c.Header,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
 	}
 
 	if c.StatusCode >= 400 {

--- a/cmd/gctsRollback.go
+++ b/cmd/gctsRollback.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http/cookiejar"
 	"net/url"
 
@@ -156,7 +156,7 @@ func getLastSuccessfullCommit(config *gctsRollbackOptions, telemetryData *teleme
 			return "", errors.New("did not retrieve a HTTP response")
 		}
 
-		bodyText, readErr := ioutil.ReadAll(resp.Body)
+		bodyText, readErr := io.ReadAll(resp.Body)
 
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read")

--- a/cmd/getConfig_test.go
+++ b/cmd/getConfig_test.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,7 +26,7 @@ func configOpenFileMock(name string, tokens map[string]string) (io.ReadCloser, e
 	default:
 		r = ""
 	}
-	return ioutil.NopCloser(strings.NewReader(r)), nil
+	return io.NopCloser(strings.NewReader(r)), nil
 }
 
 func TestConfigCommand(t *testing.T) {

--- a/cmd/getDefaults_test.go
+++ b/cmd/getDefaults_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -49,7 +48,7 @@ func defaultsOpenFileMock(name string, tokens map[string]string) (io.ReadCloser,
 	default:
 		r = ""
 	}
-	return ioutil.NopCloser(strings.NewReader(r)), nil
+	return io.NopCloser(strings.NewReader(r)), nil
 }
 
 func TestDefaultsCommand(t *testing.T) {

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -711,7 +710,7 @@ func TestPrepareLdflags(t *testing.T) {
 	err := os.Mkdir(filepath.Join(dir, "commonPipelineEnvironment"), 0777)
 	assert.NoError(t, err, "Error when creating folder structure")
 
-	err = ioutil.WriteFile(filepath.Join(dir, "commonPipelineEnvironment", "artifactVersion"), []byte("1.2.3"), 0666)
+	err = os.WriteFile(filepath.Join(dir, "commonPipelineEnvironment", "artifactVersion"), []byte("1.2.3"), 0666)
 	assert.NoError(t, err, "Error when creating cpe file")
 
 	t.Run("success - default", func(t *testing.T) {

--- a/cmd/integrationArtifactDeploy.go
+++ b/cmd/integrationArtifactDeploy.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -99,14 +99,14 @@ func runIntegrationArtifactDeploy(config *integrationArtifactDeployOptions, tele
 		log.Entry().
 			WithField("IntegrationFlowID", config.IntegrationFlowID).
 			Info("successfully deployed into CPI runtime")
-		taskId, readErr := ioutil.ReadAll(deployResp.Body)
+		taskId, readErr := io.ReadAll(deployResp.Body)
 		if readErr != nil {
 			return errors.Wrap(readErr, "Task Id not found. HTTP response body could not be read.")
 		}
 		deploymentError := pollIFlowDeploymentStatus(string(taskId), retryCount, config, httpClient, serviceKey.OAuth.Host)
 		return deploymentError
 	}
-	responseBody, readErr := ioutil.ReadAll(deployResp.Body)
+	responseBody, readErr := io.ReadAll(deployResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", deployResp.StatusCode)
@@ -154,7 +154,7 @@ func pollIFlowDeploymentStatus(taskId string, retryCount int, config *integratio
 
 // GetHTTPErrorMessage - Return HTTP failure message
 func getHTTPErrorMessage(httpErr error, response *http.Response, httpMethod, statusURL string) (string, error) {
-	responseBody, readErr := ioutil.ReadAll(response.Body)
+	responseBody, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
 		return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", response.StatusCode)
 	}
@@ -184,7 +184,7 @@ func getIntegrationArtifactDeployStatus(config *integrationArtifactDeployOptions
 			WithField("IntegrationFlowID", config.IntegrationFlowID).
 			Info("Successfully started integration flow artefact in CPI runtime")
 
-		bodyText, readErr := ioutil.ReadAll(deployStatusResp.Body)
+		bodyText, readErr := io.ReadAll(deployStatusResp.Body)
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", deployStatusResp.StatusCode)
 		}
@@ -221,7 +221,7 @@ func getIntegrationArtifactDeployError(config *integrationArtifactDeployOptions,
 		log.Entry().
 			WithField("IntegrationFlowID", config.IntegrationFlowID).
 			Info("Successfully retrieved Integration Flow artefact deploy error details")
-		responseBody, readErr := ioutil.ReadAll(errorStatusResp.Body)
+		responseBody, readErr := io.ReadAll(errorStatusResp.Body)
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", errorStatusResp.StatusCode)
 		}

--- a/cmd/integrationArtifactDeploy_test.go
+++ b/cmd/integrationArtifactDeploy_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -191,7 +190,7 @@ func (c *httpMockCpis) SendRequest(method string, url string, r io.Reader, heade
 	c.URL = url
 
 	if r != nil {
-		_, err := ioutil.ReadAll(r)
+		_, err := io.ReadAll(r)
 
 		if err != nil {
 			return nil, err
@@ -204,7 +203,7 @@ func (c *httpMockCpis) SendRequest(method string, url string, r io.Reader, heade
 		res := http.Response{
 			StatusCode: c.StatusCode,
 			Header:     c.Header,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
 		}
 		return &res, nil
 	}

--- a/cmd/integrationArtifactDownload.go
+++ b/cmd/integrationArtifactDownload.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"os"
@@ -84,7 +83,7 @@ func runIntegrationArtifactDownload(config *integrationArtifactDownloadOptions, 
 		}
 		return nil
 	}
-	responseBody, readErr := ioutil.ReadAll(downloadResp.Body)
+	responseBody, readErr := io.ReadAll(downloadResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code : %v", downloadResp.StatusCode)

--- a/cmd/integrationArtifactGetMplStatus.go
+++ b/cmd/integrationArtifactGetMplStatus.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -69,7 +69,7 @@ func runIntegrationArtifactGetMplStatus(
 	}
 
 	if mplStatusResp.StatusCode == 200 {
-		bodyText, readErr := ioutil.ReadAll(mplStatusResp.Body)
+		bodyText, readErr := io.ReadAll(mplStatusResp.Body)
 		if readErr != nil {
 			return errors.Wrap(readErr, "HTTP response body could not be read")
 		}
@@ -96,7 +96,7 @@ func runIntegrationArtifactGetMplStatus(
 		}
 		return nil
 	}
-	responseBody, readErr := ioutil.ReadAll(mplStatusResp.Body)
+	responseBody, readErr := io.ReadAll(mplStatusResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", mplStatusResp.StatusCode)
@@ -126,7 +126,7 @@ func getIntegrationArtifactMPLError(commonPipelineEnvironment *integrationArtifa
 		log.Entry().
 			WithField("MPLID", mplID).
 			Info("Successfully retrieved Integration Flow artefact message processing error")
-		responseBody, readErr := ioutil.ReadAll(errorStatusResp.Body)
+		responseBody, readErr := io.ReadAll(errorStatusResp.Body)
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", errorStatusResp.StatusCode)
 		}

--- a/cmd/integrationArtifactGetServiceEndpoint.go
+++ b/cmd/integrationArtifactGetServiceEndpoint.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -63,7 +63,7 @@ func runIntegrationArtifactGetServiceEndpoint(config *integrationArtifactGetServ
 	}
 
 	if serviceEndpointResp.StatusCode == 200 {
-		bodyText, readErr := ioutil.ReadAll(serviceEndpointResp.Body)
+		bodyText, readErr := io.ReadAll(serviceEndpointResp.Body)
 		if readErr != nil {
 			return errors.Wrap(readErr, "HTTP response body could not be read")
 		}
@@ -84,7 +84,7 @@ func runIntegrationArtifactGetServiceEndpoint(config *integrationArtifactGetServ
 		return errors.Errorf("Unable to get integration flow service endpoint '%v', Response body: %v, Response Status code: %v",
 			config.IntegrationFlowID, string(bodyText), serviceEndpointResp.StatusCode)
 	}
-	responseBody, readErr := ioutil.ReadAll(serviceEndpointResp.Body)
+	responseBody, readErr := io.ReadAll(serviceEndpointResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", serviceEndpointResp.StatusCode)

--- a/cmd/integrationArtifactResource.go
+++ b/cmd/integrationArtifactResource.go
@@ -5,7 +5,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -221,7 +221,7 @@ func HttpResponseHandler(resp *http.Response, httpErr error, integrationArtifact
 		return nil
 	}
 	if httpErr != nil {
-		responseBody, readErr := ioutil.ReadAll(resp.Body)
+		responseBody, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
 			return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", resp.StatusCode)
 		}

--- a/cmd/integrationArtifactTransport.go
+++ b/cmd/integrationArtifactTransport.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"time"
@@ -65,7 +65,7 @@ func CreateIntegrationArtifactTransportRequest(config *integrationArtifactTransp
 			WithField("IntegrationPackageID", config.IntegrationPackageID).
 			Info("successfully created the integration package transport request")
 
-		bodyText, readErr := ioutil.ReadAll(createTransportRequestResp.Body)
+		bodyText, readErr := io.ReadAll(createTransportRequestResp.Body)
 		if readErr != nil {
 			return errors.Wrap(readErr, "HTTP response body could not be read")
 		}
@@ -81,7 +81,7 @@ func CreateIntegrationArtifactTransportRequest(config *integrationArtifactTransp
 		}
 		return errors.New("Invalid process id")
 	}
-	responseBody, readErr := ioutil.ReadAll(createTransportRequestResp.Body)
+	responseBody, readErr := io.ReadAll(createTransportRequestResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", createTransportRequestResp.StatusCode)
@@ -175,7 +175,7 @@ func getIntegrationTransportProcessingStatus(config *integrationArtifactTranspor
 			WithField("IntegrationPackageID", config.IntegrationPackageID).
 			Info("successfully processed the integration package transport response status")
 
-		bodyText, readErr := ioutil.ReadAll(transportProcStatusResp.Body)
+		bodyText, readErr := io.ReadAll(transportProcStatusResp.Body)
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", transportProcStatusResp.StatusCode)
 		}
@@ -212,7 +212,7 @@ func getIntegrationTransportError(config *integrationArtifactTransportOptions, h
 		log.Entry().
 			WithField("IntegrationPackageId", config.IntegrationPackageID).
 			Info("Successfully retrieved deployment failures error details")
-		responseBody, readErr := ioutil.ReadAll(errorStatusResp.Body)
+		responseBody, readErr := io.ReadAll(errorStatusResp.Body)
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", errorStatusResp.StatusCode)
 		}

--- a/cmd/integrationArtifactTriggerIntegrationTest.go
+++ b/cmd/integrationArtifactTriggerIntegrationTest.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/SAP/jenkins-library/pkg/command"
 	"github.com/SAP/jenkins-library/pkg/cpi"
@@ -116,7 +117,7 @@ func callIFlowURL(
 		}
 
 		var fileErr error
-		fileBody, fileErr = ioutil.ReadFile(config.MessageBodyPath)
+		fileBody, fileErr = os.ReadFile(config.MessageBodyPath)
 		if fileErr != nil {
 			log.SetErrorCategory(log.ErrorUndefined)
 			return fmt.Errorf("failed to read file %s: %w", config.MessageBodyPath, fileErr)
@@ -155,7 +156,7 @@ func callIFlowURL(
 		log.Entry().
 			WithField(config.IntegrationFlowID, serviceEndpointUrl).
 			Infof("successfully triggered %s with status code %d", serviceEndpointUrl, iFlowResp.StatusCode)
-		bodyText, readErr := ioutil.ReadAll(iFlowResp.Body)
+		bodyText, readErr := io.ReadAll(iFlowResp.Body)
 		if readErr != nil {
 			log.Entry().Warnf("HTTP response body could not be read. Error: %s", readErr.Error())
 		} else if len(bodyText) > 0 {

--- a/cmd/integrationArtifactTriggerIntegrationTest_test.go
+++ b/cmd/integrationArtifactTriggerIntegrationTest_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -104,7 +103,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 
 		utils := newIntegrationArtifactTriggerIntegrationTestTestsUtils()
 		utils.AddFile(config.MessageBodyPath, []byte("dummycontent1")) //have to add a file here to see in utils
-		if err := ioutil.WriteFile(config.MessageBodyPath, []byte("dummycontent2"), 0755); err != nil {
+		if err := os.WriteFile(config.MessageBodyPath, []byte("dummycontent2"), 0755); err != nil {
 			t.Fail()
 		}
 		httpClient := httpMockCpis{CPIFunction: "TriggerIntegrationTest", ResponseBody: ``, TestType: "Positive"}
@@ -138,7 +137,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 
 		utils := newIntegrationArtifactTriggerIntegrationTestTestsUtils()
 		//utils.AddFile(config.MessageBodyPath, []byte("dummycontent1")) //have to add a file here to see in utils
-		//ioutil.WriteFile(config.MessageBodyPath, []byte("dummycontent2"), 0755)
+		//os.WriteFile(config.MessageBodyPath, []byte("dummycontent2"), 0755)
 		httpClient := httpMockCpis{CPIFunction: "TriggerIntegrationTest", ResponseBody: ``, TestType: "Positive"}
 		cpe := integrationArtifactTriggerIntegrationTestCommonPipelineEnvironment{}
 
@@ -172,7 +171,7 @@ func TestRunIntegrationArtifactTriggerIntegrationTest(t *testing.T) {
 
 		utils := newIntegrationArtifactTriggerIntegrationTestTestsUtils()
 		utils.AddFile(config.MessageBodyPath, []byte(nil)) //have to add a file here to see in utils
-		if err := ioutil.WriteFile(config.MessageBodyPath, []byte(nil), 0755); err != nil {
+		if err := os.WriteFile(config.MessageBodyPath, []byte(nil), 0755); err != nil {
 			t.Fail()
 		}
 		httpClient := httpMockCpis{CPIFunction: "TriggerIntegrationTest", ResponseBody: ``, TestType: "Positive"}

--- a/cmd/integrationArtifactTriggerIntegrationTest_test.go
+++ b/cmd/integrationArtifactTriggerIntegrationTest_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"io"
 	"path/filepath"
 	"testing"
 

--- a/cmd/integrationArtifactTriggerIntegrationTest_test.go
+++ b/cmd/integrationArtifactTriggerIntegrationTest_test.go
@@ -4,7 +4,7 @@
 package cmd
 
 import (
-	"io"
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/cmd/integrationArtifactUnDeploy.go
+++ b/cmd/integrationArtifactUnDeploy.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/SAP/jenkins-library/pkg/cpi"
@@ -64,7 +64,7 @@ func runIntegrationArtifactUnDeploy(config *integrationArtifactUnDeployOptions, 
 			Info("successfully undeployed from integration runtime")
 		return nil
 	}
-	responseBody, readErr := ioutil.ReadAll(unDeployResp.Body)
+	responseBody, readErr := io.ReadAll(unDeployResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", unDeployResp.StatusCode)

--- a/cmd/integrationArtifactUpdateConfiguration.go
+++ b/cmd/integrationArtifactUpdateConfiguration.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/Jeffail/gabs/v2"
@@ -76,7 +76,7 @@ func runIntegrationArtifactUpdateConfiguration(config *integrationArtifactUpdate
 			Info("successfully updated the integration flow configuration parameter")
 		return nil
 	}
-	response, readErr := ioutil.ReadAll(configUpdateResp.Body)
+	response, readErr := io.ReadAll(configUpdateResp.Body)
 
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", configUpdateResp.StatusCode)

--- a/cmd/integrationArtifactUpload.go
+++ b/cmd/integrationArtifactUpload.go
@@ -5,7 +5,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/Jeffail/gabs/v2"
@@ -71,7 +71,7 @@ func runIntegrationArtifactUpload(config *integrationArtifactUploadOptions, tele
 	}
 
 	if httpErr != nil {
-		responseBody, readErr := ioutil.ReadAll(iFlowStatusResp.Body)
+		responseBody, readErr := io.ReadAll(iFlowStatusResp.Body)
 		if readErr != nil {
 			return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", iFlowStatusResp.StatusCode)
 		}
@@ -109,7 +109,7 @@ func UploadIntegrationArtifact(config *integrationArtifactUploadOptions, httpCli
 		return nil
 	}
 	if httpErr != nil {
-		responseBody, readErr := ioutil.ReadAll(uploadIflowStatusResp.Body)
+		responseBody, readErr := io.ReadAll(uploadIflowStatusResp.Body)
 		if readErr != nil {
 			return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", uploadIflowStatusResp.StatusCode)
 		}
@@ -146,7 +146,7 @@ func UpdateIntegrationArtifact(config *integrationArtifactUploadOptions, httpCli
 		return nil
 	}
 	if httpErr != nil {
-		responseBody, readErr := ioutil.ReadAll(updateIflowStatusResp.Body)
+		responseBody, readErr := io.ReadAll(updateIflowStatusResp.Body)
 		if readErr != nil {
 			return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", updateIflowStatusResp.StatusCode)
 		}

--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -38,7 +37,7 @@ func (c *kanikoMockClient) SendRequest(method, url string, body io.Reader, heade
 	if len(c.errorMessage) > 0 {
 		return nil, fmt.Errorf(c.errorMessage)
 	}
-	return &http.Response{StatusCode: c.httpStatusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte(c.responseBody)))}, nil
+	return &http.Response{StatusCode: c.httpStatusCode, Body: io.NopCloser(bytes.NewReader([]byte(c.responseBody)))}, nil
 }
 func (c *kanikoMockClient) DownloadFile(url, filename string, header http.Header, cookies []*http.Cookie) error {
 	if len(c.errorMessage) > 0 {

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -311,7 +310,7 @@ func runKubectlDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUti
 		tmpFolder := getTempDirForKubeCtlJSON()
 		defer os.RemoveAll(tmpFolder) // clean up
 		jsonData, _ := json.Marshal(dockerRegistrySecretData)
-		if err := ioutil.WriteFile(filepath.Join(tmpFolder, "secret.json"), jsonData, 0777); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpFolder, "secret.json"), jsonData, 0777); err != nil {
 			log.Entry().WithError(err).Warning("failed to write secret")
 		}
 
@@ -465,7 +464,7 @@ func createKey(parts ...string) string {
 }
 
 func getTempDirForKubeCtlJSON() string {
-	tmpFolder, err := ioutil.TempDir(".", "temp-")
+	tmpFolder, err := os.MkdirTemp(".", "temp-")
 	if err != nil {
 		log.Entry().WithError(err).WithField("path", tmpFolder).Debug("creating temp directory failed")
 	}

--- a/cmd/mavenBuild.go
+++ b/cmd/mavenBuild.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -258,7 +257,7 @@ func loadRemoteRepoCertificates(certificateList []string, client piperhttp.Downl
 }
 
 func getTempDirForCertFile() string {
-	tmpFolder, err := ioutil.TempDir(".", "temp-")
+	tmpFolder, err := os.MkdirTemp(".", "temp-")
 	if err != nil {
 		log.Entry().WithError(err).WithField("path", tmpFolder).Debug("Creating temp directory failed")
 	}

--- a/cmd/npmExecuteLint.go
+++ b/cmd/npmExecuteLint.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -55,7 +55,7 @@ func (u *lintUtilsBundle) getGeneralPurposeConfig(configURL string) {
 
 	defer response.Body.Close()
 
-	content, err := ioutil.ReadAll(response.Body)
+	content, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.Entry().Warnf("error while reading the general purpose configuration: %v", err)
 		return

--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -217,7 +216,7 @@ func TestGetProjectConfigFile(t *testing.T) {
 			}
 
 			for _, file := range test.filesAvailable {
-				if err := ioutil.WriteFile(filepath.Join(dir, file), []byte("general:"), 0700); err != nil {
+				if err := os.WriteFile(filepath.Join(dir, file), []byte("general:"), 0700); err != nil {
 					t.Fail()
 				}
 			}

--- a/cmd/protecodeExecuteScan_test.go
+++ b/cmd/protecodeExecuteScan_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -40,7 +39,7 @@ func TestRunProtecodeScan(t *testing.T) {
 
 		if requestURI == "/api/product/4486/" || requestURI == "/api/product/4711/" {
 			violations := filepath.Join("testdata/TestProtecode", "protecode_result_violations.json")
-			byteContent, err := ioutil.ReadFile(violations)
+			byteContent, err := os.ReadFile(violations)
 			require.NoErrorf(t, err, "failed reading %v", violations)
 			response := protecode.ResultData{Result: protecode.Result{ProductID: 4711, ReportURL: requestURI}}
 			err = json.Unmarshal(byteContent, &response)
@@ -49,7 +48,7 @@ func TestRunProtecodeScan(t *testing.T) {
 
 		} else if requestURI == "/api/fetch/" {
 			violations := filepath.Join("testdata/TestProtecode", "protecode_result_violations.json")
-			byteContent, err := ioutil.ReadFile(violations)
+			byteContent, err := os.ReadFile(violations)
 			require.NoErrorf(t, err, "failed reading %v", violations)
 			response := protecode.ResultData{Result: protecode.Result{ProductID: 4486, ReportURL: requestURI}}
 			err = json.Unmarshal(byteContent, &response)
@@ -202,7 +201,7 @@ func TestCreateProtecodeClient(t *testing.T) {
 
 func TestUploadScanOrDeclareFetch(t *testing.T) {
 	// init
-	testFile, err := ioutil.TempFile("", "testFileUpload")
+	testFile, err := os.CreateTemp("", "testFileUpload")
 	require.NoError(t, err)
 	defer os.RemoveAll(testFile.Name()) // clean up
 	fileName := filepath.Base(testFile.Name())
@@ -287,7 +286,7 @@ func TestExecuteProtecodeScan(t *testing.T) {
 		var b bytes.Buffer
 
 		if requestURI == "/api/product/4711/" {
-			byteContent, err := ioutil.ReadFile(violationsAbsPath)
+			byteContent, err := os.ReadFile(violationsAbsPath)
 			require.NoErrorf(t, err, "failed reading %v", violationsAbsPath)
 			response := protecode.ResultData{}
 			err = json.Unmarshal(byteContent, &response)

--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -306,7 +305,7 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 
 	log.Entry().Debugf("Influx values: %v", influx.sonarqube_data.fields)
 
-	err = SonarUtils.WriteReport(reportData, sonar.workingDir, ioutil.WriteFile)
+	err = SonarUtils.WriteReport(reportData, sonar.workingDir, os.WriteFile)
 
 	if err != nil {
 		return err
@@ -469,7 +468,7 @@ func getWorkingDir() string {
 }
 
 func getTempDir() string {
-	tmpFolder, err := ioutil.TempDir(".", "temp-")
+	tmpFolder, err := os.MkdirTemp(".", "temp-")
 	if err != nil {
 		log.Entry().WithError(err).WithField("path", tmpFolder).Debug("Creating temp directory failed")
 	}

--- a/cmd/sonarExecuteScan_test.go
+++ b/cmd/sonarExecuteScan_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -96,7 +95,7 @@ func mockGlob(matchesForPatterns map[string][]string) func(pattern string) ([]st
 
 func createTaskReportFile(t *testing.T, workingDir string) {
 	require.NoError(t, os.MkdirAll(filepath.Join(workingDir, ".scannerwork"), 0o755))
-	require.NoError(t, ioutil.WriteFile(filepath.Join(workingDir, ".scannerwork", "report-task.txt"), []byte(taskReportContent), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".scannerwork", "report-task.txt"), []byte(taskReportContent), 0o755))
 	require.FileExists(t, filepath.Join(workingDir, ".scannerwork", "report-task.txt"))
 }
 

--- a/cmd/writePipelineEnv.go
+++ b/cmd/writePipelineEnv.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
 	"github.com/spf13/cobra"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
 
 // WritePipelineEnv Serializes the commonPipelineEnvironment JSON to disk
@@ -36,7 +37,7 @@ func runWritePipelineEnv() error {
 	inBytes := []byte(pipelineEnv)
 	if !ok {
 		var err error
-		inBytes, err = ioutil.ReadAll(os.Stdin)
+		inBytes, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}

--- a/cmd/xsDeploy.go
+++ b/cmd/xsDeploy.go
@@ -4,18 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/SAP/jenkins-library/pkg/command"
-	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/piperutils"
-	"github.com/SAP/jenkins-library/pkg/telemetry"
-	"github.com/pkg/errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
 	"sync"
 	"text/template"
+
+	"github.com/SAP/jenkins-library/pkg/command"
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/SAP/jenkins-library/pkg/telemetry"
+	"github.com/pkg/errors"
 )
 
 // DeployMode ...
@@ -304,7 +304,7 @@ func handleLog(logDir string) error {
 	if _, e := os.Stat(logDir); !os.IsNotExist(e) {
 		log.Entry().Warningf(fmt.Sprintf("Here are the logs (%s):", logDir))
 
-		logFiles, e := ioutil.ReadDir(logDir)
+		logFiles, e := os.ReadDir(logDir)
 
 		if e != nil {
 			return e

--- a/cmd/xsDeploy_test.go
+++ b/cmd/xsDeploy_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sync"
 	"testing"
 
@@ -135,7 +134,7 @@ func TestDeploy(t *testing.T) {
 		// this file is not denoted in the file exists mock
 		myXsDeployOptions.MtaPath = "doesNotExist"
 
-		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, ioutil.Discard)
+		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, io.Discard)
 		assert.EqualError(t, e, "Deployable 'doesNotExist' does not exist")
 	})
 
@@ -152,7 +151,7 @@ func TestDeploy(t *testing.T) {
 			myXsDeployOptions.Action = "NONE"
 		}()
 
-		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, ioutil.Discard)
+		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, io.Discard)
 		assert.EqualError(t, e, "Cannot perform action 'RETRY' in mode 'DEPLOY'. Only action 'NONE' is allowed.")
 	})
 
@@ -167,7 +166,7 @@ func TestDeploy(t *testing.T) {
 
 		s.ShouldFailOnCommand = map[string]error{"#!/bin/bash\nxs login -a https://example.org:12345 -u me -p 'secretPassword' -o myOrg -s mySpace --skip-ssl-validation\n": errors.New("Error from underlying process")}
 
-		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, ioutil.Discard)
+		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, io.Discard)
 		assert.EqualError(t, e, "Error from underlying process")
 	})
 
@@ -191,7 +190,7 @@ func TestDeploy(t *testing.T) {
 
 		myXsDeployOptions.Mode = "BG_DEPLOY"
 
-		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, ioutil.Discard)
+		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, io.Discard)
 
 		if assert.NoError(t, e) {
 			if assert.Len(t, s.Calls, 2) { // There are two entries --> no logout in this case.
@@ -220,7 +219,7 @@ func TestDeploy(t *testing.T) {
 
 		myXsDeployOptions.Mode = "BG_DEPLOY"
 
-		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, ioutil.Discard)
+		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, io.Discard)
 		assert.EqualError(t, e, "No operationID found")
 	})
 
@@ -245,7 +244,7 @@ func TestDeploy(t *testing.T) {
 		myXsDeployOptions.Action = "ABORT"
 		myXsDeployOptions.OperationID = "12345"
 
-		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, ioutil.Discard)
+		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, io.Discard)
 
 		if assert.NoError(t, e) {
 			if assert.Len(t, s.Calls, 2) { // There is no login --> we have two calls
@@ -275,7 +274,7 @@ func TestDeploy(t *testing.T) {
 		myXsDeployOptions.Mode = "BG_DEPLOY"
 		myXsDeployOptions.Action = "ABORT"
 
-		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, ioutil.Discard)
+		e := runXsDeploy(myXsDeployOptions, &cpeOut, &s, &fileUtilsMock, fRemove, io.Discard)
 		assert.EqualError(t, e, "OperationID was not provided. This is required for action 'ABORT'.")
 	})
 }

--- a/integration/contracts_test.go
+++ b/integration/contracts_test.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,7 +60,7 @@ func TestGenerator(t *testing.T) {
               - name: test_cpe
 `
 
-	ioutil.WriteFile(filepath.Join(dir, "test.yaml"), []byte(metadata), 0755)
+	os.WriteFile(filepath.Join(dir, "test.yaml"), []byte(metadata), 0755)
 
 	openMetaFile := func(name string) (io.ReadCloser, error) { return os.Open(name) }
 	fileWriter := func(filename string, data []byte, perm os.FileMode) error { return nil }

--- a/integration/docker_test_executor.go
+++ b/integration/docker_test_executor.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -93,7 +92,7 @@ func givenThisContainer(t *testing.T, bundle IntegrationTestDockerExecRunnerBund
 		projectDir := path.Join(wd, path.Join(bundle.TestDir...))
 		// 1. Copy test files to a temp dir in order to avoid non-repeatable test executions because of changed state
 		// 2. Don't remove the temp dir to allow investigation of failed tests. Maybe add an option for cleaning it later?
-		tempDir, err := ioutil.TempDir("", "piper-integration-test")
+		tempDir, err := os.MkdirTemp("", "piper-integration-test")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/integration/integration_gauge_test.go
+++ b/integration/integration_gauge_test.go
@@ -9,7 +9,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -44,7 +43,7 @@ cd /test
 /piperbin/piper gaugeExecuteTests --installCommand="%v" --languageRunner=%v --runCommand="run" >test-log.txt 2>&1
 `, installCommand, languageRunner)
 
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "getgauge/gocd-jdk-mvn-node",
@@ -77,7 +76,7 @@ cd /test
 		assert.NoError(t, nodeContainer.Terminate(ctx))
 	})
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}

--- a/integration/integration_gcs_test.go
+++ b/integration/integration_gcs_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -99,11 +98,11 @@ func TestGCSIntegrationClient(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, []string{"placeholder", "test/file1", "test/folder/file2"}, fileNames)
 		go gcsClient.DownloadFile(bucketID, "test/file1", "file1")
-		fileContent, err := ioutil.ReadAll(file1Reader)
+		fileContent, err := io.ReadAll(file1Reader)
 		assert.NoError(t, err)
 		assert.Equal(t, file1Content, string(fileContent))
 		go gcsClient.DownloadFile(bucketID, "test/folder/file2", "file2")
-		fileContent, err = ioutil.ReadAll(file2Reader)
+		fileContent, err = io.ReadAll(file2Reader)
 		assert.NoError(t, err)
 		assert.Equal(t, file2Content, string(fileContent))
 
@@ -166,7 +165,7 @@ func openFileMock(name string) (io.ReadCloser, error) {
 	default:
 		return nil, errors.New("open file faled")
 	}
-	return ioutil.NopCloser(strings.NewReader(fileContent)), nil
+	return io.NopCloser(strings.NewReader(fileContent)), nil
 }
 
 func getCreateFileMock(file1Writer io.WriteCloser, file2Writer io.WriteCloser) func(name string) (io.WriteCloser, error) {

--- a/integration/integration_github_test.go
+++ b/integration/integration_github_test.go
@@ -7,7 +7,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,10 +36,10 @@ func TestGitHubIntegrationPiperPublishRelease(t *testing.T) {
 	dir := t.TempDir()
 
 	testAsset := filepath.Join(dir, "test.txt")
-	err := ioutil.WriteFile(testAsset, []byte("Test"), 0644)
+	err := os.WriteFile(testAsset, []byte("Test"), 0644)
 	assert.NoError(t, err, "Error when writing temporary file")
 	test2Asset := filepath.Join(dir, "test2.txt")
-	err = ioutil.WriteFile(test2Asset, []byte("Test"), 0644)
+	err = os.WriteFile(test2Asset, []byte("Test"), 0644)
 	assert.NoError(t, err, "Error when writing temporary file")
 
 	t.Run("test single asset - success", func(t *testing.T) {

--- a/integration/integration_gradle_test.go
+++ b/integration/integration_gradle_test.go
@@ -9,7 +9,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func TestGradleIntegrationExecuteBuildJavaProjectBOMCreationUsingWrapper(t *test
 cd /test
 /piperbin/piper gradleExecuteBuild >test-log.txt 2>&1
 `)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "adoptopenjdk/openjdk11:jdk-11.0.11_9-alpine",
@@ -60,7 +59,7 @@ cd /test
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}
@@ -76,13 +75,13 @@ cd /test
 cd /test
 ls -l ./build/reports/ >files-list.txt 2>&1
 `)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	code, err = nodeContainer.Exec(ctx, []string{"sh", "/test/runPiper.sh"})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err = ioutil.ReadFile(filepath.Join(tempDir, "/files-list.txt"))
+	content, err = os.ReadFile(filepath.Join(tempDir, "/files-list.txt"))
 	if err != nil {
 		t.Fatal("Could not read files-list.txt.", err)
 	}
@@ -112,7 +111,7 @@ func TestGradleIntegrationExecuteBuildJavaProjectWithBomPlugin(t *testing.T) {
 cd /test
 /piperbin/piper gradleExecuteBuild >test-log.txt 2>&1
 `)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "gradle:6-jdk11-alpine",
@@ -132,7 +131,7 @@ cd /test
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}
@@ -148,13 +147,13 @@ cd /test
 cd /test
 ls -l ./build/reports/ >files-list.txt 2>&1
 `)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	code, err = nodeContainer.Exec(ctx, []string{"sh", "/test/runPiper.sh"})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err = ioutil.ReadFile(filepath.Join(tempDir, "/files-list.txt"))
+	content, err = os.ReadFile(filepath.Join(tempDir, "/files-list.txt"))
 	if err != nil {
 		t.Fatal("Could not read files-list.txt.", err)
 	}

--- a/integration/integration_karma_test.go
+++ b/integration/integration_karma_test.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func TestKarmaIntegration(t *testing.T) {
 cd /test
 /piperbin/piper karmaExecuteTests
 `
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	networkName := "sidecar-" + uuid.New().String()
 

--- a/integration/integration_npm_test.go
+++ b/integration/integration_npm_test.go
@@ -8,7 +8,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func TestNPMIntegrationRunScriptsWithOptions(t *testing.T) {
 cd /test
 /piperbin/piper npmExecuteScripts --runScripts=start --scriptOptions=--tag,tag1 >test-log.txt 2>&1
 `
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "node:12-slim",
@@ -59,7 +58,7 @@ cd /test
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}
@@ -90,7 +89,7 @@ func TestNPMIntegrationRegistrySetInFlags(t *testing.T) {
 cd /test
 /piperbin/piper npmExecuteScripts --install --runScripts=ci-build,ci-backend-unit-test --defaultNpmRegistry=https://foo.bar >test-log.txt 2>&1
 `
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "node:12-slim",
@@ -110,7 +109,7 @@ cd /test
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}
@@ -140,7 +139,7 @@ func TestNPMIntegrationRegistrySetInNpmrc(t *testing.T) {
 cd /test
 /piperbin/piper npmExecuteScripts --install --runScripts=ci-build,ci-backend-unit-test >test-log.txt 2>&1
 `
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "node:12-slim",
@@ -160,7 +159,7 @@ cd /test
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}
@@ -190,7 +189,7 @@ func TestNPMIntegrationRegistryWithTwoModules(t *testing.T) {
 cd /test
 /piperbin/piper npmExecuteScripts --install --runScripts=ci-build,ci-backend-unit-test --defaultNpmRegistry=https://foo.bar >test-log.txt 2>&1
 `
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "node:12-slim",
@@ -210,7 +209,7 @@ cd /test
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}

--- a/integration/integration_piper_test.go
+++ b/integration/integration_piper_test.go
@@ -56,7 +56,7 @@ func getPiperExecutable() string {
 // copyDir copies a directory
 func copyDir(source string, target string) error {
 	var err error
-	var fileInfo []os.FileInfo
+	var fileInfo []os.DirEntry
 	var sourceInfo os.FileInfo
 
 	if sourceInfo, err = os.Stat(source); err != nil {

--- a/integration/integration_piper_test.go
+++ b/integration/integration_piper_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -68,7 +67,7 @@ func copyDir(source string, target string) error {
 		return err
 	}
 
-	if fileInfo, err = ioutil.ReadDir(source); err != nil {
+	if fileInfo, err = os.ReadDir(source); err != nil {
 		return err
 	}
 	for _, info := range fileInfo {

--- a/integration/integration_python_test.go
+++ b/integration/integration_python_test.go
@@ -9,7 +9,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func TestPythonIntegrationBuildProject(t *testing.T) {
 	testScript := fmt.Sprintf(`#!/bin/sh
 		cd /test
 		/piperbin/piper pythonBuild >test-log.txt 2>&1`)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "python:3.9",
@@ -57,7 +56,7 @@ func TestPythonIntegrationBuildProject(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err := ioutil.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
+	content, err := os.ReadFile(filepath.Join(tempDir, "/test-log.txt"))
 	if err != nil {
 		t.Fatal("Could not read test-log.txt.", err)
 	}
@@ -72,13 +71,13 @@ func TestPythonIntegrationBuildProject(t *testing.T) {
 	testScript = fmt.Sprintf(`#!/bin/sh
 		cd /test
 		ls -l . dist build >files-list.txt 2>&1`)
-	ioutil.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
+	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	code, err = nodeContainer.Exec(ctx, []string{"sh", "/test/runPiper.sh"})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, code)
 
-	content, err = ioutil.ReadFile(filepath.Join(tempDir, "/files-list.txt"))
+	content, err = os.ReadFile(filepath.Join(tempDir, "/files-list.txt"))
 	if err != nil {
 		t.Fatal("Could not read files-list.txt.", err)
 	}

--- a/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/handlers/handlers_test.go
+++ b/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/handlers/handlers_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/handlers/handlers_test.go
+++ b/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/handlers/handlers_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -49,7 +48,7 @@ func TestHelloHandler(t *testing.T) {
 				t.Error(err)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/middlewares/middlewares_test.go
+++ b/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/middlewares/middlewares_test.go
@@ -2,6 +2,7 @@ package middlewares
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/middlewares/middlewares_test.go
+++ b/integration/testdata/TestGolangIntegration/golang-project1/pkg/http/middlewares/middlewares_test.go
@@ -2,7 +2,6 @@ package middlewares
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -55,7 +54,7 @@ func TestRecoverMiddleware(t *testing.T) {
 				t.Errorf("\nactual: %v\nexpected: %v\n", actualStatusCode, tt.statusCode)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/abap/build/bfw_mock.go
+++ b/pkg/abap/build/bfw_mock.go
@@ -3,7 +3,6 @@ package build
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -37,7 +36,7 @@ func (c *ClMock) SendRequest(method string, url string, bdy io.Reader, hdr http.
 		body := []byte(fakeResponse(method, url))
 		return &http.Response{
 			StatusCode: c.StatusCode,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}, c.Error
 	} else if method == "HEAD" {
 		var body []byte
@@ -47,7 +46,7 @@ func (c *ClMock) SendRequest(method string, url string, bdy io.Reader, hdr http.
 		return &http.Response{
 			StatusCode: c.StatusCode,
 			Header:     header,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}, c.Error
 	} else {
 		return nil, c.Error

--- a/pkg/abap/build/connector.go
+++ b/pkg/abap/build/connector.go
@@ -2,7 +2,7 @@ package build
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -60,7 +60,7 @@ func (conn *Connector) GetToken(appendum string) error {
 			return errors.Wrap(err, "Fetching X-CSRF-Token failed")
 		}
 		defer response.Body.Close()
-		errorbody, _ := ioutil.ReadAll(response.Body)
+		errorbody, _ := io.ReadAll(response.Body)
 		return errors.Wrapf(err, "Fetching X-CSRF-Token failed: %v", string(errorbody))
 
 	}
@@ -79,12 +79,12 @@ func (conn Connector) Get(appendum string) ([]byte, error) {
 			return nil, errors.Wrap(err, "Get failed")
 		}
 		defer response.Body.Close()
-		errorbody, _ := ioutil.ReadAll(response.Body)
+		errorbody, _ := io.ReadAll(response.Body)
 		return errorbody, errors.Wrapf(err, "Get failed: %v", string(errorbody))
 
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	return body, err
 }
 
@@ -103,12 +103,12 @@ func (conn Connector) Post(appendum string, importBody string) ([]byte, error) {
 			return nil, errors.Wrap(err, "Post failed")
 		}
 		defer response.Body.Close()
-		errorbody, _ := ioutil.ReadAll(response.Body)
+		errorbody, _ := io.ReadAll(response.Body)
 		return errorbody, errors.Wrapf(err, "Post failed: %v", string(errorbody))
 
 	}
 	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	return body, err
 }
 
@@ -201,7 +201,7 @@ func (conn Connector) UploadSarFile(appendum string, sarFile []byte) error {
 	response, err := conn.Client.SendRequest("PUT", url, bytes.NewBuffer(sarFile), conn.Header, nil)
 	if err != nil {
 		defer response.Body.Close()
-		errorbody, _ := ioutil.ReadAll(response.Body)
+		errorbody, _ := io.ReadAll(response.Body)
 		return errors.Wrapf(err, "Upload of SAR file failed: %v", string(errorbody))
 	}
 	defer response.Body.Close()
@@ -236,7 +236,7 @@ func (conn Connector) UploadSarFileInChunks(appendum string, fileName string, sa
 		response, err := conn.Client.SendRequest("POST", url, nextChunk, header, nil)
 		if err != nil {
 			if response != nil && response.Body != nil {
-				errorbody, _ := ioutil.ReadAll(response.Body)
+				errorbody, _ := io.ReadAll(response.Body)
 				response.Body.Close()
 				return errors.Wrapf(err, "Upload of SAR file failed: %v", string(errorbody))
 			} else {

--- a/pkg/abap/build/mockClient.go
+++ b/pkg/abap/build/mockClient.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
@@ -48,7 +47,7 @@ func (mc *MockClient) Add(Method, Url, Body string) {
 	mc.AddResponse(Method, Url, http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{},
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(Body))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(Body))),
 	})
 }
 
@@ -57,7 +56,7 @@ func (mc *MockClient) AddBody(Method, Url, Body string, StatusCode int, header h
 	mc.AddResponse(Method, Url, http.Response{
 		StatusCode: StatusCode,
 		Header:     header,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(Body))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(Body))),
 	})
 }
 
@@ -66,7 +65,7 @@ func (mc *MockClient) AddData(data MockData) {
 	mc.AddResponse(data.Method, data.Url, http.Response{
 		StatusCode: data.StatusCode,
 		Header:     data.Header,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(data.Body))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(data.Body))),
 	})
 }
 

--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -155,7 +155,7 @@ func ReadConfigFile(path string) (file []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	yamlFile, err := ioutil.ReadFile(filename)
+	yamlFile, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func GetErrorDetailsFromResponse(resp *http.Response) (errorString string, error
 
 	// Include the error message of the ABAP Environment system, if available
 	var abapErrorResponse AbapError
-	bodyText, readError := ioutil.ReadAll(resp.Body)
+	bodyText, readError := io.ReadAll(resp.Body)
 	if readError != nil {
 		return "", "", readError
 	}
@@ -398,7 +398,7 @@ func (c *ClientMock) SendRequest(method, url string, bdy io.Reader, hdr http.Hea
 	return &http.Response{
 		StatusCode: c.StatusCode,
 		Header:     header,
-		Body:       ioutil.NopCloser(bytes.NewReader(body)),
+		Body:       io.NopCloser(bytes.NewReader(body)),
 	}, c.Error
 }
 

--- a/pkg/abaputils/abaputils_test.go
+++ b/pkg/abaputils/abaputils_test.go
@@ -6,6 +6,7 @@ package abaputils
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 

--- a/pkg/abaputils/abaputils_test.go
+++ b/pkg/abaputils/abaputils_test.go
@@ -6,7 +6,6 @@ package abaputils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -304,7 +303,7 @@ func TestHandleHTTPError(t *testing.T) {
 		resp := http.Response{
 			Status:     "400 Bad Request",
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}
 		receivedErr := errors.New(errorValue)
 		message := "Custom Error Message"
@@ -323,7 +322,7 @@ func TestHandleHTTPError(t *testing.T) {
 		resp := http.Response{
 			Status:     "400 Bad Request",
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}
 		receivedErr := errors.New(errorValue)
 		message := "Custom Error Message"
@@ -342,7 +341,7 @@ func TestHandleHTTPError(t *testing.T) {
 		resp := http.Response{
 			Status:     "400 Bad Request",
 			StatusCode: 400,
-			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+			Body:       io.NopCloser(bytes.NewReader(body)),
 		}
 		receivedErr := errors.New(errorValue)
 		message := "Custom Error Message"

--- a/pkg/abaputils/descriptor.go
+++ b/pkg/abaputils/descriptor.go
@@ -3,7 +3,7 @@ package abaputils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 
@@ -86,7 +86,7 @@ func readFile(FileName string) ([]byte, error) {
 	}
 
 	var fileContent []byte
-	fileContent, err = ioutil.ReadFile(absoluteFilename)
+	fileContent, err = os.ReadFile(absoluteFilename)
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("Could not read %v", FileName))
 	}

--- a/pkg/abaputils/descriptor_test.go
+++ b/pkg/abaputils/descriptor_test.go
@@ -5,7 +5,6 @@ package abaputils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -137,7 +136,7 @@ func TestReadAddonDescriptor(t *testing.T) {
       - repo: 'testRepo'
       - repo: 'testRepo2'`
 
-		err := ioutil.WriteFile("repositories.yml", []byte(manifestFileString), 0644)
+		err := os.WriteFile("repositories.yml", []byte(manifestFileString), 0644)
 		assert.NoError(t, err)
 
 		addonDescriptor, err := ReadAddonDescriptor("repositories.yml")

--- a/pkg/abaputils/manageGitRepositoryUtils.go
+++ b/pkg/abaputils/manageGitRepositoryUtils.go
@@ -3,7 +3,7 @@ package abaputils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"reflect"
 	"sort"
 	"strconv"
@@ -183,7 +183,7 @@ func GetStatus(failureMessage string, connectionDetails ConnectionDetailsHTTP, c
 
 	// Parse response
 	var abapResp map[string]*json.RawMessage
-	bodyText, _ := ioutil.ReadAll(resp.Body)
+	bodyText, _ := io.ReadAll(resp.Body)
 
 	marshallError := json.Unmarshal(bodyText, &abapResp)
 	if marshallError != nil {
@@ -214,7 +214,7 @@ func GetProtocol(failureMessage string, connectionDetails ConnectionDetailsHTTP,
 
 	// Parse response
 	var abapResp map[string]*json.RawMessage
-	bodyText, _ := ioutil.ReadAll(resp.Body)
+	bodyText, _ := io.ReadAll(resp.Body)
 
 	marshallError := json.Unmarshal(bodyText, &abapResp)
 	if marshallError != nil {

--- a/pkg/abaputils/manageGitRepositoryUtils_test.go
+++ b/pkg/abaputils/manageGitRepositoryUtils_test.go
@@ -6,7 +6,6 @@ package abaputils
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"testing"
@@ -154,7 +153,7 @@ repositories:
 - name: 'testRepo3'
   branch: 'testBranch3'`
 
-		err := ioutil.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
+		err := os.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
 
 		config := RepositoriesConfig{
 			BranchName:      "testBranch",
@@ -185,7 +184,7 @@ repositories:
 - repo: 'testRepo'
 - repo: 'testRepo2'`
 
-		err := ioutil.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
+		err := os.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
 
 		config := RepositoriesConfig{
 			Repositories: "repositoriesTest.yml",
@@ -213,7 +212,7 @@ repositories:
 - repo: 'testRepo'
 - repo: 'testRepo2'`
 
-		err := ioutil.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
+		err := os.WriteFile("repositoriesTest.yml", []byte(manifestFileString), 0644)
 
 		config := RepositoriesConfig{
 			Repositories: "repositoriesTest.yml",

--- a/pkg/ans/ans.go
+++ b/pkg/ans/ans.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/SAP/jenkins-library/pkg/xsuaa"
-	"github.com/pkg/errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/SAP/jenkins-library/pkg/xsuaa"
+	"github.com/pkg/errors"
 )
 
 // ANS holds the setup for the xsuaa service to retrieve a bearer token for authorization and
@@ -129,7 +129,7 @@ func readResponseBody(response *http.Response) ([]byte, error) {
 		return nil, errors.Errorf("did not retrieve an HTTP response")
 	}
 	defer response.Body.Close()
-	bodyText, readErr := ioutil.ReadAll(response.Body)
+	bodyText, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
 		return nil, errors.Wrap(readErr, "HTTP response body could not be read")
 	}

--- a/pkg/ans/ans_test.go
+++ b/pkg/ans/ans_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -77,7 +76,7 @@ func TestANS_Send(t *testing.T) {
 		})
 		t.Run("pass request attribute event", func(t *testing.T) {
 			examinee.initRun(func(rw http.ResponseWriter, req *http.Request) {
-				eventBody, _ := ioutil.ReadAll(req.Body)
+				eventBody, _ := io.ReadAll(req.Body)
 				event := &Event{}
 				json.Unmarshal(eventBody, event)
 				assert.Equal(t, eventDefault, *event, "Mismatch in requested event body")

--- a/pkg/ans/ans_test.go
+++ b/pkg/ans/ans_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/pkg/apim/HttpMockAPIM.go
+++ b/pkg/apim/HttpMockAPIM.go
@@ -43,7 +43,7 @@ func (c *HttpMockAPIM) SendRequest(method string, url string, r io.Reader, heade
 	c.URL = url
 
 	if r != nil {
-		_, err := ioutil.ReadAll(r)
+		_, err := io.ReadAll(r)
 
 		if err != nil {
 			return nil, err
@@ -53,7 +53,7 @@ func (c *HttpMockAPIM) SendRequest(method string, url string, r io.Reader, heade
 	res := http.Response{
 		StatusCode: c.StatusCode,
 		Header:     c.Header,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(c.ResponseBody))),
 	}
 
 	if c.StatusCode >= 400 {

--- a/pkg/apim/HttpMockAPIM.go
+++ b/pkg/apim/HttpMockAPIM.go
@@ -6,7 +6,6 @@ package apim
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"

--- a/pkg/asc/asc.go
+++ b/pkg/asc/asc.go
@@ -4,17 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	piperHttp "github.com/SAP/jenkins-library/pkg/http"
-	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"io"
-	"io/ioutil"
 	"net/http"
 	url2 "net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	piperHttp "github.com/SAP/jenkins-library/pkg/http"
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type App struct {

--- a/pkg/asc/asc.go
+++ b/pkg/asc/asc.go
@@ -103,8 +103,8 @@ func NewSystemInstance(client *piperHttp.Client, serverURL, token string) (*Syst
 func sendRequest(sys *SystemInstance, method, url string, body io.Reader, header http.Header) ([]byte, error) {
 	var requestBody io.Reader
 	if body != nil {
-		closer := ioutil.NopCloser(body)
-		bodyBytes, _ := ioutil.ReadAll(closer)
+		closer := io.NopCloser(body)
+		bodyBytes, _ := io.ReadAll(closer)
 		requestBody = bytes.NewBuffer(bodyBytes)
 		defer closer.Close()
 	}
@@ -114,7 +114,7 @@ func sendRequest(sys *SystemInstance, method, url string, body io.Reader, header
 		return nil, err
 	}
 
-	data, _ := ioutil.ReadAll(response.Body)
+	data, _ := io.ReadAll(response.Body)
 	sys.logger.Debugf("Valid response body: %v", string(data))
 	defer response.Body.Close()
 	return data, nil

--- a/pkg/blackduck/blackduck.go
+++ b/pkg/blackduck/blackduck.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -518,7 +517,7 @@ func (b *Client) sendRequest(method, apiEndpoint string, params map[string]strin
 		return responseBody, errors.Wrap(err, "request to BlackDuck API failed")
 	}
 
-	responseBody, err = ioutil.ReadAll(response.Body)
+	responseBody, err = io.ReadAll(response.Body)
 	if err != nil {
 		return responseBody, errors.Wrap(err, "reading BlackDuck response failed")
 	}

--- a/pkg/blackduck/blackduck_test.go
+++ b/pkg/blackduck/blackduck_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -27,7 +26,7 @@ func (c *httpMockClient) SendRequest(method, url string, body io.Reader, header 
 	c.header[url] = header
 	response := http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(""))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(""))),
 	}
 
 	if c.errorMessageForURL[url] != "" {
@@ -36,7 +35,7 @@ func (c *httpMockClient) SendRequest(method, url string, body io.Reader, header 
 	}
 
 	if c.responseBodyForURL[url] != "" {
-		response.Body = ioutil.NopCloser(bytes.NewReader([]byte(c.responseBodyForURL[url])))
+		response.Body = io.NopCloser(bytes.NewReader([]byte(c.responseBodyForURL[url])))
 		return &response, nil
 	}
 

--- a/pkg/certutils/certutils.go
+++ b/pkg/certutils/certutils.go
@@ -1,7 +1,7 @@
 package certutils
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
@@ -28,7 +28,7 @@ func CertificateUpdate(certLinks []string, httpClient piperhttp.Sender, fileUtil
 			return errors.Wrap(err, "failed to load certificate from url")
 		}
 
-		content, err := ioutil.ReadAll(response.Body)
+		content, err := io.ReadAll(response.Body)
 		if err != nil {
 			return errors.Wrap(err, "error reading response")
 		}

--- a/pkg/checkmarx/checkmarx.go
+++ b/pkg/checkmarx/checkmarx.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"

--- a/pkg/checkmarx/checkmarx.go
+++ b/pkg/checkmarx/checkmarx.go
@@ -295,8 +295,8 @@ func sendRequestInternal(sys *SystemInstance, method, url string, body io.Reader
 	var requestBody io.Reader
 	var requestBodyCopy io.Reader
 	if body != nil {
-		closer := ioutil.NopCloser(body)
-		bodyBytes, _ := ioutil.ReadAll(closer)
+		closer := io.NopCloser(body)
+		bodyBytes, _ := io.ReadAll(closer)
 		requestBody = bytes.NewBuffer(bodyBytes)
 		requestBodyCopy = bytes.NewBuffer(bodyBytes)
 		defer closer.Close()
@@ -308,7 +308,7 @@ func sendRequestInternal(sys *SystemInstance, method, url string, body io.Reader
 		return nil, err
 	}
 
-	data, _ := ioutil.ReadAll(response.Body)
+	data, _ := io.ReadAll(response.Body)
 	sys.logger.Debugf("Valid response body: %v", string(data))
 	defer response.Body.Close()
 	return data, nil
@@ -316,11 +316,11 @@ func sendRequestInternal(sys *SystemInstance, method, url string, body io.Reader
 
 func (sys *SystemInstance) recordRequestDetailsInErrorCase(requestBody io.Reader, response *http.Response) {
 	if requestBody != nil {
-		data, _ := ioutil.ReadAll(ioutil.NopCloser(requestBody))
+		data, _ := io.ReadAll(io.NopCloser(requestBody))
 		sys.logger.Errorf("Request body: %s", data)
 	}
 	if response != nil && response.Body != nil {
-		data, _ := ioutil.ReadAll(response.Body)
+		data, _ := io.ReadAll(response.Body)
 		sys.logger.Errorf("Response body: %s", data)
 		response.Body.Close()
 	}
@@ -499,7 +499,7 @@ func (sys *SystemInstance) UploadProjectSourceCode(projectID int, zipFile string
 		return errors.Wrap(err, "failed to uploaded zipped sources")
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	defer resp.Body.Close()
 	if err != nil {
 		return errors.Wrap(err, "error reading the response data")

--- a/pkg/checkmarx/checkmarx_test.go
+++ b/pkg/checkmarx/checkmarx_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -49,19 +48,19 @@ func (sm *senderMock) SendRequest(method, url string, body io.Reader, header htt
 	if sm.httpStatusCode > 399 {
 		httpError = fmt.Errorf("http error %v", sm.httpStatusCode)
 	}
-	return &http.Response{StatusCode: sm.httpStatusCode, Body: ioutil.NopCloser(strings.NewReader(sm.responseBody))}, httpError
+	return &http.Response{StatusCode: sm.httpStatusCode, Body: io.NopCloser(strings.NewReader(sm.responseBody))}, httpError
 }
 func (sm *senderMock) UploadFile(url, file, fieldName string, header http.Header, cookies []*http.Cookie, uploadType string) (*http.Response, error) {
 	sm.httpMethod = http.MethodPost
 	sm.urlCalled = url
 	sm.header = header
-	return &http.Response{StatusCode: sm.httpStatusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
+	return &http.Response{StatusCode: sm.httpStatusCode, Body: io.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
 }
 func (sm *senderMock) UploadRequest(method, url, file, fieldName string, header http.Header, cookies []*http.Cookie, uploadType string) (*http.Response, error) {
 	sm.httpMethod = http.MethodPost
 	sm.urlCalled = url
 	sm.header = header
-	return &http.Response{StatusCode: sm.httpStatusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
+	return &http.Response{StatusCode: sm.httpStatusCode, Body: io.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
 }
 func (sm *senderMock) Upload(_ piperHttp.UploadRequestData) (*http.Response, error) {
 	return &http.Response{}, fmt.Errorf("not implemented")

--- a/pkg/checkmarx/cxxml_to_sarif.go
+++ b/pkg/checkmarx/cxxml_to_sarif.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -119,7 +119,7 @@ type Line struct {
 func ConvertCxxmlToSarif(sys System, xmlReportName string, scanID int) (format.SARIF, error) {
 	var sarif format.SARIF
 	log.Entry().Debug("Reading audit file.")
-	data, err := ioutil.ReadFile(xmlReportName)
+	data, err := os.ReadFile(xmlReportName)
 	if err != nil {
 		return sarif, err
 	}

--- a/pkg/checkmarxone/checkmarxone.go
+++ b/pkg/checkmarxone/checkmarxone.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 
 	//"strconv"
 	"strings"
@@ -386,8 +386,8 @@ func sendRequestInternal(sys *SystemInstance, method, url string, body io.Reader
 	var requestBody io.Reader
 	var reqBody string
 	if body != nil {
-		closer := ioutil.NopCloser(body)
-		bodyBytes, _ := ioutil.ReadAll(closer)
+		closer := io.NopCloser(body)
+		bodyBytes, _ := io.ReadAll(closer)
 		reqBody = string(bodyBytes)
 		requestBody = bytes.NewBuffer(bodyBytes)
 		defer closer.Close()
@@ -450,7 +450,7 @@ func sendRequestInternal(sys *SystemInstance, method, url string, body io.Reader
 		}
 	}
 
-	data, _ := ioutil.ReadAll(response.Body)
+	data, _ := io.ReadAll(response.Body)
 	//sys.logger.Debugf("Valid response body: %v", string(data))
 	defer response.Body.Close()
 	return data, nil
@@ -828,7 +828,7 @@ func (sys *SystemInstance) UploadProjectSourceCode(projectID string, zipFile str
 	header.Add("Content-Type", "application/zip")
 	header.Add("Accept", "application/json")
 
-	zipContents, err := ioutil.ReadFile(zipFile)
+	zipContents, err := os.ReadFile(zipFile)
 	if err != nil {
 		sys.logger.Error("Failed to Read the File " + zipFile + ": " + err.Error())
 		return "", err

--- a/pkg/checkmarxone/checkmarxone_test.go
+++ b/pkg/checkmarxone/checkmarxone_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -44,19 +43,19 @@ func (sm *senderMock) SendRequest(method, url string, body io.Reader, header htt
 	if sm.httpStatusCode > 399 {
 		httpError = fmt.Errorf("http error %v", sm.httpStatusCode)
 	}
-	return &http.Response{StatusCode: sm.httpStatusCode, Body: ioutil.NopCloser(strings.NewReader(sm.responseBody))}, httpError
+	return &http.Response{StatusCode: sm.httpStatusCode, Body: io.NopCloser(strings.NewReader(sm.responseBody))}, httpError
 }
 func (sm *senderMock) UploadFile(url, file, fieldName string, header http.Header, cookies []*http.Cookie, uploadType string) (*http.Response, error) {
 	sm.httpMethod = http.MethodPost
 	sm.urlCalled = url
 	sm.header = header
-	return &http.Response{StatusCode: sm.httpStatusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
+	return &http.Response{StatusCode: sm.httpStatusCode, Body: io.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
 }
 func (sm *senderMock) UploadRequest(method, url, file, fieldName string, header http.Header, cookies []*http.Cookie, uploadType string) (*http.Response, error) {
 	sm.httpMethod = http.MethodPost
 	sm.urlCalled = url
 	sm.header = header
-	return &http.Response{StatusCode: sm.httpStatusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
+	return &http.Response{StatusCode: sm.httpStatusCode, Body: io.NopCloser(bytes.NewReader([]byte(sm.responseBody)))}, nil
 }
 func (sm *senderMock) Upload(_ piperHttp.UploadRequestData) (*http.Response, error) {
 	return &http.Response{}, fmt.Errorf("not implemented")

--- a/pkg/cloudfoundry/ManifestUtils.go
+++ b/pkg/cloudfoundry/ManifestUtils.go
@@ -2,10 +2,11 @@ package cloudfoundry
 
 import (
 	"fmt"
+	"os"
+	"reflect"
+
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	"io/ioutil"
-	"reflect"
 
 	"github.com/SAP/jenkins-library/pkg/log"
 )
@@ -33,8 +34,8 @@ type manifest struct {
 	name     string
 }
 
-var _readFile = ioutil.ReadFile
-var _writeFile = ioutil.WriteFile
+var _readFile = os.ReadFile
+var _writeFile = os.WriteFile
 
 // ReadManifest Reads the manifest denoted by 'name'
 func ReadManifest(name string) (Manifest, error) {

--- a/pkg/cloudfoundry/ManifestUtils_test.go
+++ b/pkg/cloudfoundry/ManifestUtils_test.go
@@ -8,7 +8,6 @@ import (
 
 	"fmt"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
 	"os"
 )
 
@@ -255,6 +254,6 @@ func TestWriteManifest(t *testing.T) {
 }
 
 func cleanup() {
-	_readFile = ioutil.ReadFile
-	_writeFile = ioutil.WriteFile
+	_readFile = os.ReadFile
+	_writeFile = os.WriteFile
 }

--- a/pkg/cnbutils/bindings/bindings.go
+++ b/pkg/cnbutils/bindings/bindings.go
@@ -4,7 +4,7 @@ package bindings
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -141,7 +141,7 @@ func processBinding(utils cnbutils.BuildUtils, httpClient piperhttp.Sender, plat
 			return errors.Wrap(err, "failed to load binding from url")
 		}
 
-		bindingContent, err = ioutil.ReadAll(response.Body)
+		bindingContent, err = io.ReadAll(response.Body)
 		defer response.Body.Close()
 		if err != nil {
 			return errors.Wrap(err, "error reading response")

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -6,7 +6,6 @@ package command
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -260,7 +259,7 @@ func TestHelperProcess(*testing.T) {
 	cmd, args := args[0], args[1:]
 	switch cmd {
 	case "/bin/bash":
-		o, _ := ioutil.ReadAll(os.Stdin)
+		o, _ := io.ReadAll(os.Stdin)
 		fmt.Fprintf(os.Stdout, "Stdout: command %v - Stdin: %v\n", cmd, string(o))
 		fmt.Fprintf(os.Stderr, "Stderr: command %v\n", cmd)
 	case "echo":

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -6,6 +6,7 @@ package command
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -44,7 +43,7 @@ type StepConfig struct {
 func (c *Config) ReadConfig(configuration io.ReadCloser) error {
 	defer configuration.Close()
 
-	content, err := ioutil.ReadAll(configuration)
+	content, err := io.ReadAll(configuration)
 	if err != nil {
 		return errors.Wrapf(err, "error reading %v", configuration)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -29,7 +28,7 @@ func (errReadCloser) Close() error {
 }
 
 func customDefaultsOpenFileMock(name string, tokens map[string]string) (io.ReadCloser, error) {
-	return ioutil.NopCloser(strings.NewReader("general:\n  p0: p0_custom_default\nstages:\n  stage1:\n    p1: p1_custom_default")), nil
+	return io.NopCloser(strings.NewReader("general:\n  p0: p0_custom_default\nstages:\n  stage1:\n    p1: p1_custom_default")), nil
 }
 
 func TestReadConfig(t *testing.T) {
@@ -40,7 +39,7 @@ func TestReadConfig(t *testing.T) {
 
 		myConfig := strings.NewReader("general:\n  generalTestKey: generalTestValue\nsteps:\n  testStep:\n    testStepKey: testStepValue")
 
-		err := c.ReadConfig(ioutil.NopCloser(myConfig)) // NopCloser "no-ops" the closing interface since strings do not need to be closed
+		err := c.ReadConfig(io.NopCloser(myConfig)) // NopCloser "no-ops" the closing interface since strings do not need to be closed
 		if err != nil {
 			t.Errorf("Got error although no error expected: %v", err)
 		}
@@ -64,7 +63,7 @@ func TestReadConfig(t *testing.T) {
 
 	t.Run("Unmarshalling failure", func(t *testing.T) {
 		myConfig := strings.NewReader("general:\n  generalTestKey: generalTestValue\nsteps:\n  testStep:\n\ttestStepKey: testStepValue")
-		err := c.ReadConfig(ioutil.NopCloser(myConfig))
+		err := c.ReadConfig(io.NopCloser(myConfig))
 		if err == nil {
 			t.Errorf("Got no error although error expected.")
 		}
@@ -126,9 +125,9 @@ steps:
 		flags := map[string]interface{}{"p7": "p7_flag"}
 
 		var c Config
-		defaults := []io.ReadCloser{ioutil.NopCloser(strings.NewReader(defaults1)), ioutil.NopCloser(strings.NewReader(defaults2))}
+		defaults := []io.ReadCloser{io.NopCloser(strings.NewReader(defaults1)), io.NopCloser(strings.NewReader(defaults2))}
 
-		myConfig := ioutil.NopCloser(strings.NewReader(testConfig))
+		myConfig := io.NopCloser(strings.NewReader(testConfig))
 
 		parameterMetadata := []StepParameters{
 			{
@@ -238,9 +237,9 @@ steps:
   p0: p0_general_default
 `
 		var c Config
-		defaults := []io.ReadCloser{ioutil.NopCloser(strings.NewReader(defaults1))}
+		defaults := []io.ReadCloser{io.NopCloser(strings.NewReader(defaults1))}
 
-		myConfig := ioutil.NopCloser(strings.NewReader(testConfig))
+		myConfig := io.NopCloser(strings.NewReader(testConfig))
 
 		stepMeta := StepData{Spec: StepSpec{Inputs: StepInputs{Parameters: []StepParameters{
 			{Name: "p0", ResourceRef: []ResourceReference{{Name: "commonPipelineEnvironment", Param: "p0"}}},
@@ -261,7 +260,7 @@ steps:
 
 		c.openFile = customDefaultsOpenFileMock
 
-		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConfDefaults)), nil, false, StepFilters{General: []string{"p0"}}, StepData{}, nil, "stage1", "step1")
+		stepConfig, err := c.GetStepConfig(nil, "", io.NopCloser(strings.NewReader(testConfDefaults)), nil, false, StepFilters{General: []string{"p0"}}, StepData{}, nil, "stage1", "step1")
 
 		assert.NoError(t, err, "Error occurred but no error expected")
 		assert.Equal(t, "p0_custom_default", stepConfig.Config["p0"])
@@ -275,7 +274,7 @@ steps:
 
 		c.openFile = customDefaultsOpenFileMock
 
-		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConfDefaults)), nil, true, StepFilters{General: []string{"p0"}}, StepData{}, nil, "stage1", "step1")
+		stepConfig, err := c.GetStepConfig(nil, "", io.NopCloser(strings.NewReader(testConfDefaults)), nil, true, StepFilters{General: []string{"p0"}}, StepData{}, nil, "stage1", "step1")
 
 		assert.NoError(t, err, "Error occurred but no error expected")
 		assert.Equal(t, nil, stepConfig.Config["p0"])
@@ -296,7 +295,7 @@ steps:
 		}
 		testConf := "general:\n p1: p1_conf"
 
-		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConf)), nil, false, StepFilters{General: []string{"p0", "p1"}}, metadata, nil, "stage1", "step1")
+		stepConfig, err := c.GetStepConfig(nil, "", io.NopCloser(strings.NewReader(testConf)), nil, false, StepFilters{General: []string{"p0", "p1"}}, metadata, nil, "stage1", "step1")
 
 		assert.NoError(t, err, "Error occurred but no error expected")
 		assert.Equal(t, "p0_step_default", stepConfig.Config["p0"])
@@ -318,7 +317,7 @@ steps:
 		}
 		testConf := "general:\n p0: true"
 
-		stepConfig, err := c.GetStepConfig(nil, "", ioutil.NopCloser(strings.NewReader(testConf)), nil, false, StepFilters{General: []string{"p0", "p1"}}, metadata, nil, "stage1", "step1")
+		stepConfig, err := c.GetStepConfig(nil, "", io.NopCloser(strings.NewReader(testConf)), nil, false, StepFilters{General: []string{"p0", "p1"}}, metadata, nil, "stage1", "step1")
 
 		assert.NoError(t, err, "Error occurred but no error expected")
 		assert.Equal(t, true, stepConfig.Config["p0"])
@@ -340,7 +339,7 @@ steps:
 		testConf := ""
 
 		paramJSON := "{\"p1\":{\"subParam\":\"p1_value\"}}"
-		stepConfig, err := c.GetStepConfig(nil, paramJSON, ioutil.NopCloser(strings.NewReader(testConf)), nil, true, StepFilters{Parameters: []string{"p0"}}, metadata, nil, "stage1", "step1")
+		stepConfig, err := c.GetStepConfig(nil, paramJSON, io.NopCloser(strings.NewReader(testConf)), nil, true, StepFilters{Parameters: []string{"p0"}}, metadata, nil, "stage1", "step1")
 
 		assert.NoError(t, err, "Error occurred but no error expected")
 		assert.Equal(t, "p1_value", stepConfig.Config["p0"])
@@ -348,27 +347,27 @@ steps:
 
 	t.Run("Failure case config", func(t *testing.T) {
 		var c Config
-		myConfig := ioutil.NopCloser(strings.NewReader("invalid config"))
+		myConfig := io.NopCloser(strings.NewReader("invalid config"))
 		_, err := c.GetStepConfig(nil, "", myConfig, nil, false, StepFilters{}, StepData{}, nil, "stage1", "step1")
 		assert.EqualError(t, err, "failed to parse custom pipeline configuration: format of configuration is invalid \"invalid config\": error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type config.Config", "default error expected")
 	})
 
 	t.Run("Failure case defaults", func(t *testing.T) {
 		var c Config
-		myConfig := ioutil.NopCloser(strings.NewReader(""))
-		myDefaults := []io.ReadCloser{ioutil.NopCloser(strings.NewReader("invalid defaults"))}
+		myConfig := io.NopCloser(strings.NewReader(""))
+		myDefaults := []io.ReadCloser{io.NopCloser(strings.NewReader("invalid defaults"))}
 		_, err := c.GetStepConfig(nil, "", myConfig, myDefaults, false, StepFilters{}, StepData{}, nil, "stage1", "step1")
 		assert.EqualError(t, err, "failed to read default configuration: error unmarshalling \"invalid defaults\": error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type config.Config", "default error expected")
 	})
 
 	t.Run("Test reporting parameters with aliases and cpe resources", func(t *testing.T) {
 		var c Config
-		testConfig := ioutil.NopCloser(strings.NewReader(`general:
+		testConfig := io.NopCloser(strings.NewReader(`general:
   gcpJsonKeyFilePath: gcpJsonKeyFilePath_value
 steps:
   step1:
     jsonKeyFilePath: gcpJsonKeyFilePath_from_alias`))
-		testDefaults := []io.ReadCloser{ioutil.NopCloser(strings.NewReader(`general:
+		testDefaults := []io.ReadCloser{io.NopCloser(strings.NewReader(`general:
   pipelineId: gcsBucketId_from_alias
 steps:
   step1:
@@ -380,7 +379,7 @@ steps:
 			t.Fatal("Failed to create sub directory")
 		}
 
-		err = ioutil.WriteFile(filepath.Join(cpeDir, "gcsFolderPath.json"), []byte("\"value_from_cpe\""), 0700)
+		err = os.WriteFile(filepath.Join(cpeDir, "gcsFolderPath.json"), []byte("\"value_from_cpe\""), 0700)
 		assert.NoError(t, err)
 
 		stepMeta := StepData{Spec: StepSpec{Inputs: StepInputs{Parameters: []StepParameters{}}}}
@@ -437,9 +436,9 @@ stages:
 		acceptedParams := []string{"p0", "p1", "p2", "p3"}
 
 		var c Config
-		defaults := []io.ReadCloser{ioutil.NopCloser(strings.NewReader(defaults1))}
+		defaults := []io.ReadCloser{io.NopCloser(strings.NewReader(defaults1))}
 
-		myConfig := ioutil.NopCloser(strings.NewReader(testConfig))
+		myConfig := io.NopCloser(strings.NewReader(testConfig))
 
 		stepConfig, err := c.GetStageConfig(paramJSON, myConfig, defaults, false, acceptedParams, "stage1")
 
@@ -479,9 +478,9 @@ stages:
 		acceptedParams := []string{}
 
 		var c Config
-		defaults := []io.ReadCloser{ioutil.NopCloser(strings.NewReader(defaults1))}
+		defaults := []io.ReadCloser{io.NopCloser(strings.NewReader(defaults1))}
 
-		myConfig := ioutil.NopCloser(strings.NewReader(testConfig))
+		myConfig := io.NopCloser(strings.NewReader(testConfig))
 
 		stepConfig, err := c.GetStageConfig(paramJSON, myConfig, defaults, false, acceptedParams, "stage1")
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
@@ -27,7 +26,7 @@ func (d *PipelineDefaults) ReadPipelineDefaults(defaultSources []io.ReadCloser) 
 		var c Config
 		var err error
 
-		content, err := ioutil.ReadAll(def)
+		content, err := io.ReadAll(def)
 		if err != nil {
 			return errors.Wrapf(err, "error reading %v", def)
 		}

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -17,7 +16,7 @@ func TestReadPipelineDefaults(t *testing.T) {
 	t.Run("Success case", func(t *testing.T) {
 		d0 := strings.NewReader("general:\n  testStepKey1: testStepValue1")
 		d1 := strings.NewReader("general:\n  testStepKey2: testStepValue2")
-		err := d.ReadPipelineDefaults([]io.ReadCloser{ioutil.NopCloser(d0), ioutil.NopCloser(d1)})
+		err := d.ReadPipelineDefaults([]io.ReadCloser{io.NopCloser(d0), io.NopCloser(d1)})
 
 		if err != nil {
 			t.Errorf("Got error although no error expected: %v", err)
@@ -48,7 +47,7 @@ func TestReadPipelineDefaults(t *testing.T) {
 
 	t.Run("Unmarshalling failure", func(t *testing.T) {
 		myConfig := strings.NewReader("general:\n\ttestStepKey: testStepValue")
-		err := d.ReadPipelineDefaults([]io.ReadCloser{ioutil.NopCloser(myConfig)})
+		err := d.ReadPipelineDefaults([]io.ReadCloser{io.NopCloser(myConfig)})
 		if err == nil {
 			t.Errorf("Got no error although error expected.")
 		}

--- a/pkg/config/evaluation_test.go
+++ b/pkg/config/evaluation_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -33,7 +32,7 @@ func evaluateConditionsOpenFileMock(name string, _ map[string]string) (io.ReadCl
 	var fileContent io.ReadCloser
 	switch name {
 	case "package.json":
-		fileContent = ioutil.NopCloser(strings.NewReader(`
+		fileContent = io.NopCloser(strings.NewReader(`
 		{
 			"scripts": {
 				"npmScript": "echo test",
@@ -42,9 +41,9 @@ func evaluateConditionsOpenFileMock(name string, _ map[string]string) (io.ReadCl
 		}
 		`))
 	case "_package.json":
-		fileContent = ioutil.NopCloser(strings.NewReader("wrong json format"))
+		fileContent = io.NopCloser(strings.NewReader("wrong json format"))
 	case "test/package.json":
-		fileContent = ioutil.NopCloser(strings.NewReader("{}"))
+		fileContent = io.NopCloser(strings.NewReader("{}"))
 	}
 	return fileContent, nil
 }
@@ -430,8 +429,8 @@ func TestEvaluateV1(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to create sub directories")
 	}
-	ioutil.WriteFile(filepath.Join(cpeDir, "myCpeTrueFile"), []byte("myTrueValue"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "custom", "myCpeTrueFile"), []byte("myTrueValue"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "myCpeTrueFile"), []byte("myTrueValue"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "custom", "myCpeTrueFile"), []byte("myTrueValue"), 0700)
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
@@ -472,7 +471,7 @@ func TestEvaluateConditions(t *testing.T) {
 					},
 				},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -506,7 +505,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -530,7 +529,7 @@ stages:
 					},
 				},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -572,7 +571,7 @@ stages:
 					},
 				},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -607,7 +606,7 @@ stages:
 				Stages: map[string]map[string]interface{}{},
 				Steps:  map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -629,7 +628,7 @@ stages:
 					},
 				},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -663,7 +662,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -687,7 +686,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -708,7 +707,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -735,7 +734,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -765,7 +764,7 @@ stages:
 					},
 				},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -796,7 +795,7 @@ stages:
 					},
 				},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -817,7 +816,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -842,7 +841,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -870,7 +869,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -891,7 +890,7 @@ stages:
 				Stages:  map[string]map[string]interface{}{},
 				Steps:   map[string]map[string]interface{}{},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -915,7 +914,7 @@ stages:
 					},
 				},
 			},
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:

--- a/pkg/config/reporting_test.go
+++ b/pkg/config/reporting_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -102,11 +101,11 @@ func TestReportingParams_GetResourceParameters(t *testing.T) {
 		t.Fatal("Failed to create sub directory")
 	}
 
-	ioutil.WriteFile(filepath.Join(cpeDir, "envparam1"), []byte("val1"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "envparam2"), []byte("val2"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "jsonList.json"), []byte("[\"value1\",\"value2\"]"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "jsonKeyValue.json"), []byte("{\"key\":\"value\"}"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "jsonKeyValueString"), []byte("{\"key\":\"valueString\"}"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "envparam1"), []byte("val1"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "envparam2"), []byte("val2"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "jsonList.json"), []byte("[\"value1\",\"value2\"]"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "jsonKeyValue.json"), []byte("{\"key\":\"value\"}"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "jsonKeyValueString"), []byte("{\"key\":\"valueString\"}"), 0700)
 
 	for run, test := range tt {
 		t.Run(fmt.Sprintf("Run %v", run), func(t *testing.T) {

--- a/pkg/config/run.go
+++ b/pkg/config/run.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/ghodss/yaml"
@@ -142,7 +141,7 @@ func (r *RunConfig) getStepConfig(config *Config, stageName, stepName string, fi
 
 func (r *RunConfig) loadConditions() error {
 	defer r.StageConfigFile.Close()
-	content, err := ioutil.ReadAll(r.StageConfigFile)
+	content, err := io.ReadAll(r.StageConfigFile)
 	if err != nil {
 		return errors.Wrapf(err, "error: failed to read the stageConfig file")
 	}
@@ -157,7 +156,7 @@ func (r *RunConfig) loadConditions() error {
 // LoadConditionsV1 loads stage conditions (in CRD-style) into PipelineConfig
 func (r *RunConfigV1) LoadConditionsV1() error {
 	defer r.StageConfigFile.Close()
-	content, err := ioutil.ReadAll(r.StageConfigFile)
+	content, err := io.ReadAll(r.StageConfigFile)
 	if err != nil {
 		return errors.Wrapf(err, "error: failed to read the stageConfig file")
 	}

--- a/pkg/config/run_test.go
+++ b/pkg/config/run_test.go
@@ -6,7 +6,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -60,7 +59,7 @@ func TestInitRunConfigV1(t *testing.T) {
 	filesMock := mock.FilesMock{}
 
 	for _, test := range tt {
-		stageConfig := ioutil.NopCloser(strings.NewReader(test.stageConfig))
+		stageConfig := io.NopCloser(strings.NewReader(test.stageConfig))
 		runConfig := RunConfig{StageConfigFile: stageConfig}
 		runConfigV1 := RunConfigV1{RunConfig: runConfig}
 		err := runConfigV1.InitRunConfigV1(&test.config, &filesMock, ".pipeline")
@@ -83,7 +82,7 @@ func TestInitRunConfig(t *testing.T) {
 	}{
 		{
 			name: "init run config with config condition - success",
-			customConfig: ioutil.NopCloser(strings.NewReader(`
+			customConfig: io.NopCloser(strings.NewReader(`
 general: 
   testGeneral: 'myVal1'
 stages: 
@@ -93,7 +92,7 @@ steps:
   thirdStep: 
     testStep: 'myVal3'
             `)),
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -123,7 +122,7 @@ stages:
 		},
 		{
 			name: "init run config with filePattern condition - success",
-			customConfig: ioutil.NopCloser(strings.NewReader(`
+			customConfig: io.NopCloser(strings.NewReader(`
 general: 
   testGeneral: 'myVal1'
 stages: 
@@ -133,7 +132,7 @@ steps:
   thirdStep: 
     testStep: 'myVal3'
             `)),
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage1:
     stepConditions:
@@ -163,12 +162,12 @@ stages:
 		},
 		{
 			name: "init run config - unknown condition in stage config",
-			customConfig: ioutil.NopCloser(strings.NewReader(`
+			customConfig: io.NopCloser(strings.NewReader(`
 steps: 
   testStep: 
     testConfig: 'testVal'
             `)),
-			stageConfig: ioutil.NopCloser(strings.NewReader(`
+			stageConfig: io.NopCloser(strings.NewReader(`
 stages:
   testStage:
     stepConditions:
@@ -180,7 +179,7 @@ stages:
 		},
 		{
 			name:             "init run config - load conditions with invalid format",
-			stageConfig:      ioutil.NopCloser(strings.NewReader("wrong stage config format")),
+			stageConfig:      io.NopCloser(strings.NewReader("wrong stage config format")),
 			runStepsExpected: map[string]map[string]bool{},
 			wantErr:          true,
 		},
@@ -212,13 +211,13 @@ func TestRunConfigLoadConditions(t *testing.T) {
         filePattern: '**/my.file'
 `
 	t.Run("load conditions - file of invalid format", func(t *testing.T) {
-		runConfig := &RunConfig{StageConfigFile: ioutil.NopCloser(strings.NewReader("-- {{ \\ wrong } file format }"))}
+		runConfig := &RunConfig{StageConfigFile: io.NopCloser(strings.NewReader("-- {{ \\ wrong } file format }"))}
 		err := runConfig.loadConditions()
 		assert.Error(t, err, "format of configuration is invalid")
 	})
 
 	t.Run("load conditions - success", func(t *testing.T) {
-		runConfig := &RunConfig{StageConfigFile: ioutil.NopCloser(strings.NewReader(stageConfigContent))}
+		runConfig := &RunConfig{StageConfigFile: io.NopCloser(strings.NewReader(stageConfigContent))}
 
 		err := runConfig.loadConditions()
 		assert.NoError(t, err)

--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"

--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -163,7 +163,7 @@ type StepFilters struct {
 // ReadPipelineStepData loads step definition in yaml format
 func (m *StepData) ReadPipelineStepData(metadata io.ReadCloser) error {
 	defer metadata.Close()
-	content, err := ioutil.ReadAll(metadata)
+	content, err := io.ReadAll(metadata)
 	if err != nil {
 		return errors.Wrapf(err, "error reading %v", metadata)
 	}
@@ -355,7 +355,7 @@ func (m *StepData) GetContextDefaults(stepName string) (io.ReadCloser, error) {
 		return nil, errors.Wrap(err, "failed to create context defaults")
 	}
 
-	r := ioutil.NopCloser(bytes.NewReader(JSON))
+	r := io.NopCloser(bytes.NewReader(JSON))
 	return r, nil
 }
 

--- a/pkg/config/stepmeta_test.go
+++ b/pkg/config/stepmeta_test.go
@@ -6,7 +6,6 @@ package config
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,7 @@ func TestReadPipelineStepData(t *testing.T) {
 
 	t.Run("Success case", func(t *testing.T) {
 		myMeta := strings.NewReader("metadata:\n  name: testIt\nspec:\n  inputs:\n    params:\n      - name: testParamName\n    secrets:\n      - name: testSecret")
-		err := s.ReadPipelineStepData(ioutil.NopCloser(myMeta)) // NopCloser "no-ops" the closing interface since strings do not need to be closed
+		err := s.ReadPipelineStepData(io.NopCloser(myMeta)) // NopCloser "no-ops" the closing interface since strings do not need to be closed
 
 		if err != nil {
 			t.Errorf("Got error although no error expected: %v", err)
@@ -55,7 +54,7 @@ func TestReadPipelineStepData(t *testing.T) {
 
 	t.Run("Unmarshalling failure", func(t *testing.T) {
 		myMeta := strings.NewReader("metadata:\n\tname: testIt")
-		err := s.ReadPipelineStepData(ioutil.NopCloser(myMeta))
+		err := s.ReadPipelineStepData(io.NopCloser(myMeta))
 		if err == nil {
 			t.Errorf("Got no error although error expected.")
 		}
@@ -677,11 +676,11 @@ func TestGetResourceParameters(t *testing.T) {
 		t.Fatal("Failed to create sub directory")
 	}
 
-	ioutil.WriteFile(filepath.Join(cpeDir, "envparam1"), []byte("val1"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "envparam2"), []byte("val2"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "jsonList.json"), []byte("[\"value1\",\"value2\"]"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "jsonKeyValue.json"), []byte("{\"key\":\"value\"}"), 0700)
-	ioutil.WriteFile(filepath.Join(cpeDir, "jsonKeyValueString"), []byte("{\"key\":\"valueString\"}"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "envparam1"), []byte("val1"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "envparam2"), []byte("val2"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "jsonList.json"), []byte("[\"value1\",\"value2\"]"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "jsonKeyValue.json"), []byte("{\"key\":\"value\"}"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "jsonKeyValueString"), []byte("{\"key\":\"valueString\"}"), 0700)
 
 	for run, test := range tt {
 		t.Run(fmt.Sprintf("Run %v", run), func(t *testing.T) {

--- a/pkg/config/vault.go
+++ b/pkg/config/vault.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -426,7 +425,7 @@ func createTemporarySecretFile(namePattern string, content string) (string, erro
 		}
 	}
 
-	file, err := ioutil.TempFile(VaultSecretFileDirectory, namePattern)
+	file, err := os.CreateTemp(VaultSecretFileDirectory, namePattern)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/config/vault_test.go
+++ b/pkg/config/vault_test.go
@@ -5,7 +5,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -155,7 +154,7 @@ func TestVaultSecretFiles(t *testing.T) {
 		resolveAllVaultReferences(&stepConfig, vaultMock, stepParams)
 		assert.NotNil(t, stepConfig.Config[secretName])
 		path := stepConfig.Config[secretName].(string)
-		contentByte, err := ioutil.ReadFile(path)
+		contentByte, err := os.ReadFile(path)
 		assert.NoError(t, err)
 		content := string(contentByte)
 		assert.Equal(t, "value1", content)

--- a/pkg/cpi/commonUtils.go
+++ b/pkg/cpi/commonUtils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"net/http"
 	"os"
@@ -109,7 +108,7 @@ func (tokenParameters TokenParameters) GetBearerToken() (string, error) {
 		return "", errors.Errorf("did not retrieve a valid HTTP response code: %v", httpErr)
 	}
 
-	bodyText, readErr := ioutil.ReadAll(resp.Body)
+	bodyText, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return "", errors.Wrap(readErr, "HTTP response body could not be read")
 	}
@@ -154,7 +153,7 @@ func (httpFileDownloadRequestParameters HttpFileDownloadRequestParameters) Handl
 		}
 		return nil
 	}
-	responseBody, readErr := ioutil.ReadAll(response.Body)
+	responseBody, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", response.StatusCode)
 	}
@@ -182,7 +181,7 @@ func (httpFileUploadRequestParameters HttpFileUploadRequestParameters) HandleHTT
 		return nil
 	}
 	if httpErr != nil {
-		responseBody, readErr := ioutil.ReadAll(response.Body)
+		responseBody, readErr := io.ReadAll(response.Body)
 		if readErr != nil {
 			return errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", response.StatusCode)
 		}
@@ -204,14 +203,14 @@ func (httpGetRequestParameters HttpFileUploadRequestParameters) HandleHTTPGetReq
 		return "", errors.Errorf("did not retrieve a HTTP response: %v", httpErr)
 	}
 	if response.StatusCode == http.StatusOK {
-		responseBody, readErr := ioutil.ReadAll(response.Body)
+		responseBody, readErr := io.ReadAll(response.Body)
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read, response status code: %v", response.StatusCode)
 		}
 		return string(responseBody), nil
 	}
 	if httpErr != nil {
-		responseBody, readErr := ioutil.ReadAll(response.Body)
+		responseBody, readErr := io.ReadAll(response.Body)
 		if readErr != nil {
 			return "", errors.Wrapf(readErr, "HTTP response body could not be read, Response status code: %v", response.StatusCode)
 		}

--- a/pkg/cpi/mockingUtils.go
+++ b/pkg/cpi/mockingUtils.go
@@ -5,7 +5,7 @@ package cpi
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -69,7 +69,7 @@ func GetCPIFunctionMockResponse(functionName, testType string) (*http.Response, 
 	default:
 		res := http.Response{
 			StatusCode: 404,
-			Body:       ioutil.NopCloser(bytes.NewReader([]byte(``))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(``))),
 		}
 		return &res, errors.New("Service not Found")
 	}
@@ -79,7 +79,7 @@ func GetCPIFunctionMockResponse(functionName, testType string) (*http.Response, 
 func GetEmptyHTTPResponseBodyAndErrorNil() (*http.Response, error) {
 	res := http.Response{
 		StatusCode: 202,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(``))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(``))),
 	}
 	return &res, nil
 }
@@ -88,7 +88,7 @@ func GetEmptyHTTPResponseBodyAndErrorNil() (*http.Response, error) {
 func GetParameterKeyMissingResponseBody() (*http.Response, error) {
 	res := http.Response{
 		StatusCode: 404,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Not Found",
 					"message": {
 					"@lang": "en",
@@ -103,7 +103,7 @@ func GetParameterKeyMissingResponseBody() (*http.Response, error) {
 func GetNegativeCaseHTTPResponseBodyAndErrorNil() (*http.Response, error) {
 	res := http.Response{
 		StatusCode: 400,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Bad Request",
 					"message": {
 					"@lang": "en",
@@ -119,7 +119,7 @@ func GetIntegrationArtifactGetMplStatusCommandMockResponse(testType string) (*ht
 	if testType == "Positive" {
 		res := http.Response{
 			StatusCode: 200,
-			Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+			Body: io.NopCloser(bytes.NewReader([]byte(`{
 				"d": {
 					"results": [
 						{
@@ -150,7 +150,7 @@ func GetIntegrationArtifactGetMplStatusCommandMockResponse(testType string) (*ht
 	}
 	res := http.Response{
 		StatusCode: 400,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Bad Request",
 					"message": {
 					"@lang": "en",
@@ -168,7 +168,7 @@ func GetIntegrationArtifactGetServiceEndpointCommandMockResponse(testCaseType st
 	}
 	res := http.Response{
 		StatusCode: 400,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Bad Request",
 					"message": {
 					"@lang": "en",
@@ -184,7 +184,7 @@ func TriggerIntegrationTestMockResponse(testCaseType string) (*http.Response, er
 	if testCaseType == "Positive" {
 		return &http.Response{
 			StatusCode: 200,
-			Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+			Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Good Request",
 					"message": {
 						"@lang": "en",
@@ -198,7 +198,7 @@ func TriggerIntegrationTestMockResponse(testCaseType string) (*http.Response, er
 	}
 	res := http.Response{
 		StatusCode: 400,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Bad Request",
 					"message": {
 					"@lang": "en",
@@ -214,7 +214,7 @@ func GetIntegrationArtifactGetServiceEndpointPositiveCaseRespBody() (*http.Respo
 
 	resp := http.Response{
 		StatusCode: 200,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
 			"d": {
 				"results": [
 					{
@@ -253,7 +253,7 @@ func GetRespBodyHTTPStatusOK() (*http.Response, error) {
 
 	resp := http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(``))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(``))),
 	}
 	return &resp, nil
 }
@@ -263,7 +263,7 @@ func GetRespBodyHTTPStatusCreated() (*http.Response, error) {
 
 	resp := http.Response{
 		StatusCode: 201,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(``))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(``))),
 	}
 	return &resp, nil
 }
@@ -273,7 +273,7 @@ func GetRespBodyHTTPStatusServiceNotFound() (*http.Response, error) {
 
 	resp := http.Response{
 		StatusCode: 404,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(``))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(``))),
 	}
 	return &resp, errors.New("Integration Package not found")
 }
@@ -283,7 +283,7 @@ func GetRespBodyHTTPStatusServiceErrorResponse() (*http.Response, error) {
 
 	resp := http.Response{
 		StatusCode: 500,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(``))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(``))),
 	}
 	return &resp, errors.New("401 Unauthorized")
 }
@@ -331,7 +331,7 @@ func GetMockResponseByTestTypeAndMockFunctionName(mockFuntionName, testType stri
 
 			res := http.Response{
 				StatusCode: 400,
-				Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+				Body: io.NopCloser(bytes.NewReader([]byte(`{
 							"code": "Bad Request",
 							"message": {
 							"@lang": "en",
@@ -344,7 +344,7 @@ func GetMockResponseByTestTypeAndMockFunctionName(mockFuntionName, testType stri
 		case "GetIntegrationArtifactDeployErrorDetailsMockResponse":
 			res := http.Response{
 				StatusCode: 500,
-				Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+				Body: io.NopCloser(bytes.NewReader([]byte(`{
 							"code": "Internal Server Error",
 							"message": {
 							"@lang": "en",
@@ -363,7 +363,7 @@ func NegtiveResForIntegrationArtifactGenericCommandMockResponse(message string) 
 
 	res := http.Response{
 		StatusCode: 400,
-		Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+		Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Bad Request",
 					"message": {
 					"@lang": "en",
@@ -383,7 +383,7 @@ func UpdateIntegrationDesigntimeArtifactMockResponse(testType string) (*http.Res
 
 		res := http.Response{
 			StatusCode: 400,
-			Body: ioutil.NopCloser(bytes.NewReader([]byte(`{
+			Body: io.NopCloser(bytes.NewReader([]byte(`{
 					"code": "Bad Request",
 					"message": {
 					"@lang": "en",
@@ -404,7 +404,7 @@ func IntegrationArtifactDownloadCommandMockResponsePositiveCaseRespBody() (*http
 	resp := http.Response{
 		StatusCode: 200,
 		Header:     header,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(`UEsDBBQACAgIADQ2clAAAAAAAAAAAAAAAAAUAAQATU`))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(`UEsDBBQACAgIADQ2clAAAAAAAAAAAAAAAAAUAAQATU`))),
 	}
 	return &resp, nil
 }
@@ -535,7 +535,7 @@ func GetIntegrationArtifactDeployStatusMockResponseBody() (*http.Response, error
 
 	resp := http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(GetIntegrationArtifactDeployStatusPayload("STARTED")))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(GetIntegrationArtifactDeployStatusPayload("STARTED")))),
 	}
 	return &resp, nil
 }
@@ -545,7 +545,7 @@ func GetIntegrationArtifactDeployStatusErrorMockResponseBody() (*http.Response, 
 
 	resp := http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(GetIntegrationArtifactDeployStatusPayload("FAIL")))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(GetIntegrationArtifactDeployStatusPayload("FAIL")))),
 	}
 	return &resp, nil
 }
@@ -580,7 +580,7 @@ func GetIntegrationArtifactDeployErrorStatusMockResponseBody() (*http.Response, 
 
 	resp := http.Response{
 		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte(`{"message": "java.lang.IllegalStateException: No credentials for 'smtp' found"}`))),
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"message": "java.lang.IllegalStateException: No credentials for 'smtp' found"}`))),
 	}
 	return &resp, nil
 }

--- a/pkg/documentation/generator.go
+++ b/pkg/documentation/generator.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -72,7 +71,7 @@ func main() {
 
 		if len(customLibraryStepFile) > 0 {
 			fmt.Println("Reading custom library step mapping..")
-			content, err := ioutil.ReadFile(customLibraryStepFile)
+			content, err := os.ReadFile(customLibraryStepFile)
 			checkError(err)
 			err = yaml.Unmarshal(content, &generator.CustomLibrarySteps)
 			checkError(err)
@@ -102,7 +101,7 @@ func openDocTemplateFile(docTemplateFilePath string) (io.ReadCloser, error) {
 }
 
 func writeFile(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 func openFile(name string) (io.ReadCloser, error) {

--- a/pkg/documentation/generator/helper.go
+++ b/pkg/documentation/generator/helper.go
@@ -3,14 +3,13 @@ package generator
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 )
 
 func readAndAdjustTemplate(docFile io.ReadCloser) string {
 	//read template content
-	content, err := ioutil.ReadAll(docFile)
+	content, err := io.ReadAll(docFile)
 	checkError(err)
 	contentStr := string(content)
 

--- a/pkg/documentation/generator/main_test.go
+++ b/pkg/documentation/generator/main_test.go
@@ -6,7 +6,6 @@ package generator
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -70,9 +69,9 @@ func configOpenDocTemplateFileMock(docTemplateFilePath string) (io.ReadCloser, e
 `
 	switch docTemplateFilePath {
 	case "testStep.md":
-		return ioutil.NopCloser(strings.NewReader(meta1)), nil
+		return io.NopCloser(strings.NewReader(meta1)), nil
 	default:
-		return ioutil.NopCloser(strings.NewReader("")), fmt.Errorf("Wrong Path: %v", docTemplateFilePath)
+		return io.NopCloser(strings.NewReader("")), fmt.Errorf("Wrong Path: %v", docTemplateFilePath)
 	}
 }
 

--- a/pkg/format/assessment.go
+++ b/pkg/format/assessment.go
@@ -3,7 +3,6 @@ package format
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/ghodss/yaml"
@@ -113,7 +112,7 @@ func ReadAssessments(assessmentFile io.ReadCloser) (*[]Assessment, error) {
 		Assessments: []Assessment{},
 	}
 
-	content, err := ioutil.ReadAll(assessmentFile)
+	content, err := io.ReadAll(assessmentFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %v", assessmentFile)
 	}

--- a/pkg/fortify/fortify.go
+++ b/pkg/fortify/fortify.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -758,7 +757,7 @@ func (sys *SystemInstance) downloadFile(endpoint, method, acceptType, tokenType 
 	if err != nil {
 		return nil, err
 	}
-	data, err := ioutil.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	defer response.Body.Close()
 	if err != nil {
 		return nil, errors.Wrap(err, "Error reading the response data")

--- a/pkg/fortify/fortify_test.go
+++ b/pkg/fortify/fortify_test.go
@@ -5,7 +5,6 @@ package fortify
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -363,7 +362,7 @@ func TestSetProjectVersionAttributesByProjectVersionID(t *testing.T) {
 		if req.URL.Path == "/projectVersions/4711/attributes" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyString := string(bodyBytes)
 			response := `{"data": `
 			response += bodyString
@@ -395,7 +394,7 @@ func TestCreateProjectVersion(t *testing.T) {
 		if req.URL.Path == "/projectVersions" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent := string(bodyBytes)
 			responseContent := `{"data": `
 			responseContent += bodyContent
@@ -449,7 +448,7 @@ func TestProjectVersionCopyFromPartial(t *testing.T) {
 		if req.URL.Path == "/projectVersions/action/copyFromPartial" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent = string(bodyBytes)
 			rw.Write([]byte(
 				`{"data":[{"latestScanId":null,"serverVersion":17.2,"tracesOutOfDate":false,"attachmentsOutOfDate":false,"description":"",
@@ -488,7 +487,7 @@ func TestProjectVersionCopyCurrentState(t *testing.T) {
 		if req.URL.Path == "/projectVersions/action/copyCurrentState" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent = string(bodyBytes)
 			rw.Write([]byte(
 				`{"data":[{"latestScanId":null,"serverVersion":17.2,"tracesOutOfDate":false,"attachmentsOutOfDate":false,"description":"",
@@ -538,7 +537,7 @@ func TestProjectVersionCopyPermissions(t *testing.T) {
 		if req.URL.Path == "/projectVersions/10173/authEntities" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent = string(bodyBytes)
 			rw.Write([]byte(response))
 			return
@@ -566,7 +565,7 @@ func TestCommitProjectVersion(t *testing.T) {
 		if req.URL.Path == "/projectVersions/10172" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent = string(bodyBytes)
 			rw.Write([]byte(response))
 			return
@@ -595,7 +594,7 @@ func TestInactivateProjectVersion(t *testing.T) {
 		if req.URL.Path == "/projectVersions/10172" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent = string(bodyBytes)
 			rw.Write([]byte(response))
 			return
@@ -867,7 +866,7 @@ func TestGenerateQGateReport(t *testing.T) {
 		if req.URL.Path == "/reports" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			data = string(bodyBytes)
 			response := `{"data": `
 			response += data
@@ -922,7 +921,7 @@ func TestGetFileToken(t *testing.T) {
 		if req.URL.Path == "/fileTokens" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent = string(bodyBytes)
 			rw.WriteHeader(201)
 			rw.Write([]byte(response))
@@ -986,7 +985,7 @@ func TestUploadResultFile(t *testing.T) {
 		if req.URL.Path == "/upload/resultFileUpload.html" && req.URL.RawQuery == "mat=89ee873" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent = string(bodyBytes)
 			rw.WriteHeader(200)
 			rw.Write([]byte("OK"))
@@ -996,7 +995,7 @@ func TestUploadResultFile(t *testing.T) {
 	// Close the server when test finishes
 	defer server.Close()
 
-	testFile, err := ioutil.TempFile("", "result.fpr")
+	testFile, err := os.CreateTemp("", "result.fpr")
 	if err != nil {
 		t.FailNow()
 	}
@@ -1111,7 +1110,7 @@ func TestLookupOrCreateProjectVersionDetailsForPullRequest(t *testing.T) {
 		if req.URL.Path == "/projectVersions" && req.Method == "POST" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyContent := string(bodyBytes)
 			responseContent := `{"data": `
 			responseContent += bodyContent
@@ -1132,7 +1131,7 @@ func TestLookupOrCreateProjectVersionDetailsForPullRequest(t *testing.T) {
 		if req.URL.Path == "/projectVersions/4712/attributes" {
 			header := rw.Header()
 			header.Add("Content-type", "application/json")
-			bodyBytes, _ := ioutil.ReadAll(req.Body)
+			bodyBytes, _ := io.ReadAll(req.Body)
 			bodyString := string(bodyBytes)
 			response := `{"data": `
 			response += bodyString

--- a/pkg/fortify/fortify_test.go
+++ b/pkg/fortify/fortify_test.go
@@ -5,6 +5,7 @@ package fortify
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/pkg/fortify/fpr_to_sarif.go
+++ b/pkg/fortify/fpr_to_sarif.go
@@ -502,7 +502,7 @@ func ConvertFprToSarif(sys System, projectVersion *models.ProjectVersion, result
 	log.Entry().Debug("Extracting FPR.")
 	var sarif format.SARIF
 	var sarifSimplified format.SARIF
-	tmpFolder, err := ioutil.TempDir(".", "temp-")
+	tmpFolder, err := os.MkdirTemp(".", "temp-")
 	defer os.RemoveAll(tmpFolder)
 	if err != nil {
 		log.Entry().WithError(err).WithField("path", tmpFolder).Debug("Creating temp directory failed")
@@ -515,7 +515,7 @@ func ConvertFprToSarif(sys System, projectVersion *models.ProjectVersion, result
 	}
 
 	log.Entry().Debug("Reading audit file.")
-	data, err := ioutil.ReadFile(filepath.Join(tmpFolder, "audit.fvdl"))
+	data, err := os.ReadFile(filepath.Join(tmpFolder, "audit.fvdl"))
 	if err != nil {
 		return sarif, sarifSimplified, err
 	}

--- a/pkg/generator/helper/goUtils.go
+++ b/pkg/generator/helper/goUtils.go
@@ -3,7 +3,6 @@ package helper
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/SAP/jenkins-library/pkg/config"
@@ -40,7 +39,7 @@ type ContextDefaultParameters struct {
 // ReadPipelineContextDefaultData loads step definition in yaml format
 func (c *ContextDefaultData) readPipelineContextDefaultData(metadata io.ReadCloser) {
 	defer metadata.Close()
-	content, err := ioutil.ReadAll(metadata)
+	content, err := io.ReadAll(metadata)
 	checkError(err)
 	err = yaml.Unmarshal(content, &c)
 	checkError(err)

--- a/pkg/generator/helper/helper_test.go
+++ b/pkg/generator/helper/helper_test.go
@@ -6,7 +6,6 @@ package helper
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -110,7 +109,7 @@ spec:
 	default:
 		r = ""
 	}
-	return ioutil.NopCloser(strings.NewReader(r)), nil
+	return io.NopCloser(strings.NewReader(r)), nil
 }
 
 var files map[string][]byte
@@ -130,7 +129,7 @@ func TestProcessMetaFiles(t *testing.T) {
 
 	t.Run("step code", func(t *testing.T) {
 		goldenFilePath := filepath.Join("testdata", t.Name()+"_generated.golden")
-		expected, err := ioutil.ReadFile(goldenFilePath)
+		expected, err := os.ReadFile(goldenFilePath)
 		if err != nil {
 			t.Fatalf("failed reading %v", goldenFilePath)
 		}
@@ -141,7 +140,7 @@ func TestProcessMetaFiles(t *testing.T) {
 
 	t.Run("test code", func(t *testing.T) {
 		goldenFilePath := filepath.Join("testdata", t.Name()+"_generated.golden")
-		expected, err := ioutil.ReadFile(goldenFilePath)
+		expected, err := os.ReadFile(goldenFilePath)
 		if err != nil {
 			t.Fatalf("failed reading %v", goldenFilePath)
 		}
@@ -154,7 +153,7 @@ func TestProcessMetaFiles(t *testing.T) {
 		ProcessMetaFiles([]string{"testStep.yaml"}, "./cmd", stepHelperData)
 
 		goldenFilePath := filepath.Join("testdata", t.Name()+"_generated.golden")
-		expected, err := ioutil.ReadFile(goldenFilePath)
+		expected, err := os.ReadFile(goldenFilePath)
 		if err != nil {
 			t.Fatalf("failed reading %v", goldenFilePath)
 		}

--- a/pkg/generator/step-metadata.go
+++ b/pkg/generator/step-metadata.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -53,7 +52,7 @@ func openMetaFile(name string) (io.ReadCloser, error) {
 }
 
 func fileWriter(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }
 
 func checkError(err error) {
@@ -75,5 +74,5 @@ func openDocTemplate(docTemplateFilePath string) (io.ReadCloser, error) {
 }
 
 func docFileWriter(filename string, data []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, data, perm)
+	return os.WriteFile(filename, data, perm)
 }

--- a/pkg/goget/goget_test.go
+++ b/pkg/goget/goget_test.go
@@ -8,7 +8,6 @@ import (
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/stretchr/testify/assert"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -113,7 +112,7 @@ func (c *httpMock) SendRequest(method string, url string, r io.Reader, header ht
 	c.Header = header
 
 	if r != nil {
-		_, err := ioutil.ReadAll(r)
+		_, err := io.ReadAll(r)
 
 		if err != nil {
 			return nil, err

--- a/pkg/http/downloader_test.go
+++ b/pkg/http/downloader_test.go
@@ -6,6 +6,7 @@ package http
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/pkg/http/downloader_test.go
+++ b/pkg/http/downloader_test.go
@@ -4,7 +4,6 @@
 package http
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -34,7 +33,7 @@ func TestDownloadRequest(t *testing.T) {
 	// asserts
 	assert.NoError(t, err, "Error occurred but none expected")
 	assert.FileExists(t, targetFile, "File not found")
-	bytes, err := ioutil.ReadFile(targetFile)
+	bytes, err := os.ReadFile(targetFile)
 	assert.NoError(t, err, "Error occurred but none expected")
 	assert.Equal(t, "my fancy file content", string(bytes))
 }

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -9,11 +9,11 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -401,7 +401,7 @@ func (t *TransportWrapper) logRequest(req *http.Request) {
 		var buf bytes.Buffer
 		tee := io.TeeReader(req.Body, &buf)
 		log.Entry().Debugf("body: %v", transformBody(tee))
-		req.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+		req.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
 		log.Entry().Debugf("body: %v", transformBody(tee))
 	}
 	log.Entry().Debug("--------------------------------")
@@ -419,7 +419,7 @@ func (t *TransportWrapper) logResponse(resp *http.Response) {
 			var buf bytes.Buffer
 			tee := io.TeeReader(resp.Body, &buf)
 			log.Entry().Debugf("body: %v", transformBody(tee))
-			resp.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+			resp.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
 		}
 	} else {
 		log.Entry().Debug("response <nil>")
@@ -601,7 +601,7 @@ func (c *Client) configureTLSToTrustCertificates(transport *TransportWrapper) er
 				}
 				log.Entry().Debugf("wrote %v bytes from response body to file", numWritten)
 
-				certs, err := ioutil.ReadFile(target)
+				certs, err := os.ReadFile(target)
 				if err != nil {
 					return errors.Wrapf(err, "failed to read cert file %v", certificate)
 				}
@@ -616,7 +616,7 @@ func (c *Client) configureTLSToTrustCertificates(transport *TransportWrapper) er
 			}
 		} else {
 			log.Entry().Debugf("existing certificate file %v found, appending it to rootCA", target)
-			certs, err := ioutil.ReadFile(target)
+			certs, err := os.ReadFile(target)
 			if err != nil {
 				return errors.Wrapf(err, "failed to read cert file %v", certificate)
 			}
@@ -652,7 +652,7 @@ func ParseHTTPResponseBodyXML(resp *http.Response, response interface{}) error {
 		return errors.Errorf("cannot parse HTTP response with value <nil>")
 	}
 
-	bodyText, readErr := ioutil.ReadAll(resp.Body)
+	bodyText, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return errors.Wrap(readErr, "HTTP response body could not be read")
 	}
@@ -671,7 +671,7 @@ func ParseHTTPResponseBodyJSON(resp *http.Response, response interface{}) error 
 		return errors.Errorf("cannot parse HTTP response with value <nil>")
 	}
 
-	bodyText, readErr := ioutil.ReadAll(resp.Body)
+	bodyText, readErr := io.ReadAll(resp.Body)
 	if readErr != nil {
 		return errors.Wrapf(readErr, "HTTP response body could not be read")
 	}

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -99,7 +98,7 @@ func TestDefaultTransport(t *testing.T) {
 		assert.NoError(t, err)
 		// assert.NotEmpty(t, count)
 		assert.Equal(t, 1, httpmock.GetTotalCallCount(), "unexpected number of requests")
-		content, err := ioutil.ReadAll(response.Body)
+		content, err := io.ReadAll(response.Body)
 		defer response.Body.Close()
 		require.NoError(t, err, "unexpected error while reading response body")
 		assert.Equal(t, "OK", string(content), "unexpected response content")
@@ -170,7 +169,7 @@ func TestSendRequest(t *testing.T) {
 
 			response, err := test.client.SendRequest("GET", server.URL, test.body, test.header, test.cookies)
 			assert.NoError(t, err, "Error occurred but none expected")
-			content, err := ioutil.ReadAll(response.Body)
+			content, err := io.ReadAll(response.Body)
 			assert.Equal(t, test.expected, string(content), "Returned content incorrect")
 			response.Body.Close()
 
@@ -265,7 +264,7 @@ func TestUploadRequest(t *testing.T) {
 			t.FailNow()
 		}
 		defer req.Body.Close()
-		passedFileContents, err = ioutil.ReadAll(multipartFile)
+		passedFileContents, err = io.ReadAll(multipartFile)
 		if err != nil {
 			t.FailNow()
 		}
@@ -275,13 +274,13 @@ func TestUploadRequest(t *testing.T) {
 	// Close the server when test finishes
 	defer server.Close()
 
-	testFile, err := ioutil.TempFile("", "testFileUpload")
+	testFile, err := os.CreateTemp("", "testFileUpload")
 	if err != nil {
 		t.FailNow()
 	}
 	defer os.RemoveAll(testFile.Name()) // clean up
 
-	fileContents, err := ioutil.ReadFile(testFile.Name())
+	fileContents, err := os.ReadFile(testFile.Name())
 	if err != nil {
 		t.FailNow()
 	}
@@ -308,7 +307,7 @@ func TestUploadRequest(t *testing.T) {
 			client.SetOptions(test.clientOptions)
 			response, err := client.UploadFile(server.URL, testFile.Name(), "Field1", test.header, test.cookies, "form")
 			assert.NoError(t, err, "Error occurred but none expected")
-			content, err := ioutil.ReadAll(response.Body)
+			content, err := io.ReadAll(response.Body)
 			assert.NoError(t, err, "Error occurred but none expected")
 			assert.Equal(t, test.expected, string(content), "Returned content incorrect")
 			response.Body.Close()
@@ -337,7 +336,7 @@ func TestUploadRequest(t *testing.T) {
 			client.SetOptions(test.clientOptions)
 			response, err := client.UploadRequest(test.method, server.URL, testFile.Name(), "Field1", test.header, test.cookies, "form")
 			assert.NoError(t, err, "Error occurred but none expected")
-			content, err := ioutil.ReadAll(response.Body)
+			content, err := io.ReadAll(response.Body)
 			assert.NoError(t, err, "Error occurred but none expected")
 			assert.Equal(t, test.expected, string(content), "Returned content incorrect")
 			response.Body.Close()
@@ -507,7 +506,7 @@ func TestParseHTTPResponseBodyJSON(t *testing.T) {
 
 		json := `{"name":"Test Name","full_name":"test full name","owner":{"login": "octocat"}}`
 		// create a new reader with that JSON
-		r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+		r := io.NopCloser(bytes.NewReader([]byte(json)))
 		httpResponse := http.Response{
 			StatusCode: 200,
 			Body:       r,
@@ -541,7 +540,7 @@ func TestParseHTTPResponseBodyJSON(t *testing.T) {
 	t.Run("wrong JSON formatting", func(t *testing.T) {
 
 		json := `{"name":"Test Name","full_name":"test full name";"owner":{"login": "octocat"}}`
-		r := ioutil.NopCloser(bytes.NewReader([]byte(json)))
+		r := io.NopCloser(bytes.NewReader([]byte(json)))
 		httpResponse := http.Response{
 			StatusCode: 200,
 			Body:       r,
@@ -597,7 +596,7 @@ func TestParseHTTPResponseBodyXML(t *testing.T) {
 		<app:service xmlns:app="http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom"/>
 		`
 		// create a new reader with that xml
-		r := ioutil.NopCloser(bytes.NewReader([]byte(myXML)))
+		r := io.NopCloser(bytes.NewReader([]byte(myXML)))
 		httpResponse := http.Response{
 			StatusCode: 200,
 			Body:       r,
@@ -633,7 +632,7 @@ func TestParseHTTPResponseBodyXML(t *testing.T) {
 		<?xml version="1.0" encoding="utf-8"?>
 		<app:service xmlns:app=http://www.w3.org/2007/app" xmlns:atom="http://www.w3.org/2005/Atom"/>
 		`
-		r := ioutil.NopCloser(bytes.NewReader([]byte(myXML)))
+		r := io.NopCloser(bytes.NewReader([]byte(myXML)))
 		httpResponse := http.Response{
 			StatusCode: 200,
 			Body:       r,

--- a/pkg/log/fatalHook.go
+++ b/pkg/log/fatalHook.go
@@ -3,7 +3,7 @@ package log
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sirupsen/logrus"
@@ -47,11 +47,11 @@ func (f *FatalHook) Fire(entry *logrus.Entry) error {
 	Entry().Infof("fatal error: errorDetails%v", string(errDetails))
 	// Sets the fatal error details in the logging framework to be consumed in the stepTelemetryData
 	SetFatalErrorDetail(errDetails)
-	_, err := ioutil.ReadFile(filePath)
+	_, err := os.ReadFile(filePath)
 	if err != nil {
 		// do not overwrite file in case it already exists
 		// this helps to report the first error which occurred - instead of the last one
-		ioutil.WriteFile(filePath, errDetails, 0666)
+		os.WriteFile(filePath, errDetails, 0666)
 	}
 
 	return nil

--- a/pkg/log/fatalHook_test.go
+++ b/pkg/log/fatalHook_test.go
@@ -4,7 +4,6 @@
 package log
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -36,7 +35,7 @@ func TestFatalHookFire(t *testing.T) {
 		err := hook.Fire(&entry)
 
 		assert.NoError(t, err)
-		fileContent, err := ioutil.ReadFile(filepath.Join(workspace, "testStep_errorDetails.json"))
+		fileContent, err := os.ReadFile(filepath.Join(workspace, "testStep_errorDetails.json"))
 		assert.NoError(t, err)
 		assert.NotContains(t, string(fileContent), `"category":"testCategory"`)
 		assert.Contains(t, string(fileContent), `"correlationId":"https://build.url"`)
@@ -58,7 +57,7 @@ func TestFatalHookFire(t *testing.T) {
 		err := hook.Fire(&entry)
 
 		assert.NoError(t, err)
-		fileContent, err := ioutil.ReadFile(filepath.Join(workspace, "errorDetails.json"))
+		fileContent, err := os.ReadFile(filepath.Join(workspace, "errorDetails.json"))
 		assert.NoError(t, err)
 		assert.NotContains(t, string(fileContent), `"category":"testCategory"`)
 		assert.Contains(t, string(fileContent), `"correlationId":"https://build.url"`)
@@ -74,7 +73,7 @@ func TestFatalHookFire(t *testing.T) {
 		err := hook.Fire(&entry)
 
 		assert.NoError(t, err)
-		fileContent, err := ioutil.ReadFile(filepath.Join(workspace, "errorDetails.json"))
+		fileContent, err := os.ReadFile(filepath.Join(workspace, "errorDetails.json"))
 		assert.NoError(t, err)
 
 		assert.Contains(t, string(fileContent), `"message":"the error message"`)

--- a/pkg/log/fatalHook_test.go
+++ b/pkg/log/fatalHook_test.go
@@ -4,6 +4,7 @@
 package log
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/pkg/log/url.go
+++ b/pkg/log/url.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 
@@ -52,7 +52,7 @@ func (cl *URLLogger) WriteURLsLogToJSON() error {
 			err = fmt.Errorf("can't close file: %w", dErr)
 		}
 	}()
-	fileBuf, err := ioutil.ReadAll(file)
+	fileBuf, err := io.ReadAll(file)
 	if err != nil {
 		return fmt.Errorf("can't read from gile: %w", err)
 	}

--- a/pkg/malwarescan/malwarescan.go
+++ b/pkg/malwarescan/malwarescan.go
@@ -3,11 +3,11 @@ package malwarescan
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/pkg/errors"
-	"io"
-	"io/ioutil"
-	"net/http"
 )
 
 // ScanResult : Returned by the scan endpoint of the malwarescan api of SAP CP
@@ -100,7 +100,7 @@ func (c *ClientImpl) sendAPIRequest(method, endpoint string, body io.Reader, hea
 func (c *ClientImpl) readBody(response *http.Response) ([]byte, error) {
 	if response != nil && response.Body != nil {
 		defer response.Body.Close()
-		return ioutil.ReadAll(response.Body)
+		return io.ReadAll(response.Body)
 	}
 
 	return nil, fmt.Errorf("No response body available")

--- a/pkg/malwarescan/malwarescan_test.go
+++ b/pkg/malwarescan/malwarescan_test.go
@@ -8,7 +8,6 @@ import (
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/stretchr/testify/assert"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 )
@@ -148,7 +147,7 @@ func (c *httpMock) SendRequest(method string, url string, r io.Reader, header ht
 	c.Header = header
 
 	if r != nil {
-		_, err := ioutil.ReadAll(r)
+		_, err := io.ReadAll(r)
 
 		if err != nil {
 			return nil, err

--- a/pkg/mock/runner.go
+++ b/pkg/mock/runner.go
@@ -5,7 +5,6 @@ package mock
 
 import (
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 
@@ -243,5 +242,5 @@ func OpenFileMock(name string, tokens map[string]string) (io.ReadCloser, error) 
 	default:
 		r = ""
 	}
-	return ioutil.NopCloser(strings.NewReader(r)), nil
+	return io.NopCloser(strings.NewReader(r)), nil
 }

--- a/pkg/npm/config.go
+++ b/pkg/npm/config.go
@@ -2,7 +2,7 @@ package npm
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -15,8 +15,8 @@ const (
 )
 
 var (
-	propertiesLoadFile  = ioutil.ReadFile
-	propertiesWriteFile = ioutil.WriteFile
+	propertiesLoadFile  = os.ReadFile
+	propertiesWriteFile = os.WriteFile
 )
 
 func NewNPMRC(path string) NPMRC {

--- a/pkg/npm/ignore.go
+++ b/pkg/npm/ignore.go
@@ -2,7 +2,6 @@ package npm
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,7 +14,7 @@ const (
 )
 
 var (
-	writeIgnoreFile = ioutil.WriteFile
+	writeIgnoreFile = os.WriteFile
 )
 
 func NewNPMIgnore(path string) NPMIgnore {

--- a/pkg/orchestrator/azureDevOps.go
+++ b/pkg/orchestrator/azureDevOps.go
@@ -1,7 +1,7 @@
 package orchestrator
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -153,7 +153,7 @@ func (a *AzureDevOpsConfigProvider) GetLog() ([]byte, error) {
 			log.Entry().Errorf("response code is %v, could not get log information from AzureDevOps ", response.StatusCode)
 			return []byte{}, err
 		}
-		content, err := ioutil.ReadAll(response.Body)
+		content, err := io.ReadAll(response.Body)
 		if err != nil {
 			log.Entry().Error("failed to parse http response", err)
 			return []byte{}, err

--- a/pkg/orchestrator/jenkins.go
+++ b/pkg/orchestrator/jenkins.go
@@ -2,7 +2,7 @@ package orchestrator
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -130,7 +130,7 @@ func (j *JenkinsConfigProvider) GetLog() ([]byte, error) {
 		log.Entry().Error("response code !=200 could not get log information from Jenkins, returning with empty log.")
 		return []byte{}, nil
 	}
-	logFile, err := ioutil.ReadAll(response.Body)
+	logFile, err := io.ReadAll(response.Body)
 	if err != nil {
 		return []byte{}, errors.Wrapf(err, "could not read Jenkins log file from request %v", err)
 	}

--- a/pkg/piperenv/CPEMap.go
+++ b/pkg/piperenv/CPEMap.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -43,7 +42,7 @@ func (c CPEMap) WriteToDisk(rootDirectory string) error {
 		}
 		// if v is a string no json marshalling is needed
 		if vString, ok := v.(string); ok {
-			err := ioutil.WriteFile(entryPath, []byte(vString), 0666)
+			err := os.WriteFile(entryPath, []byte(vString), 0666)
 			if err != nil {
 				return err
 			}
@@ -55,7 +54,7 @@ func (c CPEMap) WriteToDisk(rootDirectory string) error {
 			return err
 		}
 
-		err = ioutil.WriteFile(fmt.Sprintf("%s.json", entryPath), jsonVal, 0666)
+		err = os.WriteFile(fmt.Sprintf("%s.json", entryPath), jsonVal, 0666)
 		if err != nil {
 			return err
 		}
@@ -69,7 +68,7 @@ func dirToMap(m map[string]interface{}, dirPath, prefix string) error {
 		return nil
 	}
 
-	items, err := ioutil.ReadDir(dirPath)
+	items, err := os.ReadDir(dirPath)
 	if err != nil {
 		return err
 	}
@@ -104,7 +103,7 @@ func dirToMap(m map[string]interface{}, dirPath, prefix string) error {
 }
 
 func addEmptyValueToFile(fullPath string) error {
-	err := ioutil.WriteFile(fullPath, []byte(""), 0666)
+	err := os.WriteFile(fullPath, []byte(""), 0666)
 	if err != nil {
 		return err
 	}
@@ -114,7 +113,7 @@ func addEmptyValueToFile(fullPath string) error {
 func readFileContent(fullPath string) (string, interface{}, bool, error) {
 	toBeEmptied := false
 
-	fileContent, err := ioutil.ReadFile(fullPath)
+	fileContent, err := os.ReadFile(fullPath)
 	if err != nil {
 		return "", nil, toBeEmptied, err
 	}

--- a/pkg/piperenv/CPEMap_test.go
+++ b/pkg/piperenv/CPEMap_test.go
@@ -6,7 +6,6 @@ package piperenv
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -49,7 +48,7 @@ func Test_writeMapToDisk(t *testing.T) {
 	for _, testCase := range testData {
 		t.Run(fmt.Sprintf("check path %s", testCase.Path), func(t *testing.T) {
 			tPath := path.Join(tmpDir, testCase.Path)
-			bytes, err := ioutil.ReadFile(tPath)
+			bytes, err := os.ReadFile(tPath)
 			require.NoError(t, err)
 			require.Equal(t, testCase.ExpectedValue, string(bytes))
 		})
@@ -60,18 +59,18 @@ func TestCPEMap_LoadFromDisk(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 
-	err := ioutil.WriteFile(path.Join(tmpDir, "Foo"), []byte("Bar"), 0644)
+	err := os.WriteFile(path.Join(tmpDir, "Foo"), []byte("Bar"), 0644)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path.Join(tmpDir, "Hello"), []byte("World"), 0644)
+	err = os.WriteFile(path.Join(tmpDir, "Hello"), []byte("World"), 0644)
 	require.NoError(t, err)
 	subPath := path.Join(tmpDir, "Batman")
 	err = os.Mkdir(subPath, 0744)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path.Join(subPath, "Bruce"), []byte("Wayne"), 0644)
+	err = os.WriteFile(path.Join(subPath, "Bruce"), []byte("Wayne"), 0644)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path.Join(subPath, "Robin"), []byte("toBeEmptied"), 0644)
+	err = os.WriteFile(path.Join(subPath, "Robin"), []byte("toBeEmptied"), 0644)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path.Join(subPath, "Test.json"), []byte("54"), 0644)
+	err = os.WriteFile(path.Join(subPath, "Test.json"), []byte("54"), 0644)
 	require.NoError(t, err)
 
 	cpe := CPEMap{}
@@ -90,7 +89,7 @@ func TestNumbersArePassedCorrectly(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	const jsonNumber = "5.5000"
-	err := ioutil.WriteFile(path.Join(tmpDir, "test.json"), []byte(jsonNumber), 0644)
+	err := os.WriteFile(path.Join(tmpDir, "test.json"), []byte(jsonNumber), 0644)
 	require.NoError(t, err)
 
 	cpeMap := CPEMap{}

--- a/pkg/piperenv/environment.go
+++ b/pkg/piperenv/environment.go
@@ -3,7 +3,6 @@ package piperenv
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -66,7 +65,7 @@ func writeToDisk(filename string, data []byte) error {
 	//ToDo: make sure to not overwrite file but rather add another file? Create error if already existing?
 	if len(data) > 0 {
 		log.Entry().Debugf("Writing file to disk: %v", filename)
-		return ioutil.WriteFile(filename, data, 0766)
+		return os.WriteFile(filename, data, 0766)
 	}
 	return nil
 }
@@ -74,7 +73,7 @@ func writeToDisk(filename string, data []byte) error {
 func readFromDisk(filename string) string {
 	//ToDo: if multiple files exist, read from latest file
 	log.Entry().Debugf("Reading file from disk: %v", filename)
-	v, err := ioutil.ReadFile(filename)
+	v, err := os.ReadFile(filename)
 	val := string(v)
 	if err != nil {
 		val = ""

--- a/pkg/piperenv/environment_test.go
+++ b/pkg/piperenv/environment_test.go
@@ -4,6 +4,7 @@
 package piperenv
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/pkg/piperenv/environment_test.go
+++ b/pkg/piperenv/environment_test.go
@@ -4,7 +4,6 @@
 package piperenv
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -49,7 +48,7 @@ func TestSetResourceParameter(t *testing.T) {
 				targetFile += ".json"
 			}
 			assert.FileExists(t, targetFile)
-			v, err = ioutil.ReadFile(targetFile)
+			v, err = os.ReadFile(targetFile)
 			require.NoError(t, err)
 			assert.Equal(t, testCase.want, string(v))
 		})

--- a/pkg/piperenv/templating_test.go
+++ b/pkg/piperenv/templating_test.go
@@ -5,6 +5,7 @@ package piperenv
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/pkg/piperenv/templating_test.go
+++ b/pkg/piperenv/templating_test.go
@@ -5,7 +5,6 @@ package piperenv
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -92,7 +91,7 @@ func TestTemplateFunctionCpe(t *testing.T) {
 	t.Run("CPE from files", func(t *testing.T) {
 		theVersion := "1.2.3"
 		dir := t.TempDir()
-		assert.NoError(t, ioutil.WriteFile(filepath.Join(dir, "artifactVersion"), []byte(theVersion), 0o666))
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "artifactVersion"), []byte(theVersion), 0o666))
 		cpe := CPEMap{}
 		assert.NoError(t, cpe.LoadFromDisk(dir))
 

--- a/pkg/piperutils/fileUtils.go
+++ b/pkg/piperutils/fileUtils.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,7 +56,7 @@ func (f Files) TempDir(dir, pattern string) (name string, err error) {
 		}
 	}
 
-	return ioutil.TempDir(dir, pattern)
+	return os.MkdirTemp(dir, pattern)
 }
 
 // FileExists returns true if the file system entry for the given path exists and is not a directory.

--- a/pkg/piperutils/fileUtils_test.go
+++ b/pkg/piperutils/fileUtils_test.go
@@ -4,7 +4,6 @@
 package piperutils
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,7 +22,7 @@ func TestFileExists(t *testing.T) {
 		assert.False(t, result)
 	})
 	runInTempDir(t, "testing file returns true", func(t *testing.T) {
-		file, err := ioutil.TempFile("", "testFile")
+		file, err := os.CreateTemp("", "testFile")
 		assert.NoError(t, err)
 		result, err := FileExists(file.Name())
 		assert.NoError(t, err)
@@ -56,7 +55,7 @@ func TestDirExists(t *testing.T) {
 func TestCopy(t *testing.T) {
 	runInTempDir(t, "copying file succeeds", func(t *testing.T) {
 		file := "testFile"
-		err := ioutil.WriteFile(file, []byte{byte(1), byte(2), byte(3)}, 0700)
+		err := os.WriteFile(file, []byte{byte(1), byte(2), byte(3)}, 0700)
 		if err != nil {
 			t.Fatal("Failed to create temporary workspace directory")
 		}

--- a/pkg/protecode/protecode_test.go
+++ b/pkg/protecode/protecode_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -38,7 +37,7 @@ func TestMapResponse(t *testing.T) {
 	pc := makeProtecode(Options{})
 	for _, c := range cases {
 
-		r := ioutil.NopCloser(bytes.NewReader([]byte(c.give)))
+		r := io.NopCloser(bytes.NewReader([]byte(c.give)))
 		pc.mapResponse(r, c.input)
 		assert.Equal(t, c.want, c.input)
 	}
@@ -82,14 +81,14 @@ func TestParseResultSuccess(t *testing.T) {
 func TestParseResultViolations(t *testing.T) {
 
 	violations := filepath.Join("testdata", "protecode_result_violations.json")
-	byteContent, err := ioutil.ReadFile(violations)
+	byteContent, err := os.ReadFile(violations)
 	if err != nil {
 		t.Fatalf("failed reading %v", violations)
 	}
 	pc := makeProtecode(Options{})
 
 	resultData := new(ResultData)
-	pc.mapResponse(ioutil.NopCloser(strings.NewReader(string(byteContent))), resultData)
+	pc.mapResponse(io.NopCloser(strings.NewReader(string(byteContent))), resultData)
 
 	m, vulns := pc.ParseResultForInflux(resultData.Result, "CVE-2018-1, CVE-2017-1000382")
 	t.Run("Parse Protecode Results", func(t *testing.T) {
@@ -107,14 +106,14 @@ func TestParseResultViolations(t *testing.T) {
 func TestParseResultNoViolations(t *testing.T) {
 
 	noViolations := filepath.Join("testdata", "protecode_result_no_violations.json")
-	byteContent, err := ioutil.ReadFile(noViolations)
+	byteContent, err := os.ReadFile(noViolations)
 	if err != nil {
 		t.Fatalf("failed reading %v", noViolations)
 	}
 
 	pc := makeProtecode(Options{})
 	resultData := new(ResultData)
-	pc.mapResponse(ioutil.NopCloser(strings.NewReader(string(byteContent))), resultData)
+	pc.mapResponse(io.NopCloser(strings.NewReader(string(byteContent))), resultData)
 
 	m, vulns := pc.ParseResultForInflux(resultData.Result, "CVE-2018-1, CVE-2017-1000382")
 	t.Run("Parse Protecode Results", func(t *testing.T) {
@@ -132,14 +131,14 @@ func TestParseResultNoViolations(t *testing.T) {
 func TestParseResultTriaged(t *testing.T) {
 
 	triaged := filepath.Join("testdata", "protecode_result_triaging.json")
-	byteContent, err := ioutil.ReadFile(triaged)
+	byteContent, err := os.ReadFile(triaged)
 	if err != nil {
 		t.Fatalf("failed reading %v", triaged)
 	}
 
 	pc := makeProtecode(Options{})
 	resultData := new(ResultData)
-	pc.mapResponse(ioutil.NopCloser(strings.NewReader(string(byteContent))), resultData)
+	pc.mapResponse(io.NopCloser(strings.NewReader(string(byteContent))), resultData)
 
 	m, vulns := pc.ParseResultForInflux(resultData.Result, "")
 	t.Run("Parse Protecode Results", func(t *testing.T) {
@@ -382,7 +381,7 @@ func TestUploadScanFileSuccess(t *testing.T) {
 		}
 
 		defer req.Body.Close()
-		passedFileContents, err = ioutil.ReadAll(reader)
+		passedFileContents, err = io.ReadAll(reader)
 		if err != nil {
 			t.FailNow()
 		}
@@ -413,13 +412,13 @@ func TestUploadScanFileSuccess(t *testing.T) {
 	defer server.Close()
 	pc := makeProtecode(Options{ServerURL: server.URL})
 
-	testFile, err := ioutil.TempFile("", "testFileUpload")
+	testFile, err := os.CreateTemp("", "testFileUpload")
 	if err != nil {
 		t.FailNow()
 	}
 	defer os.RemoveAll(testFile.Name()) // clean up
 
-	fileContents, err := ioutil.ReadFile(testFile.Name())
+	fileContents, err := os.ReadFile(testFile.Name())
 	if err != nil {
 		t.FailNow()
 	}

--- a/pkg/reporting/reporting_test.go
+++ b/pkg/reporting/reporting_test.go
@@ -4,7 +4,6 @@
 package reporting
 
 import (
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 	"time"
@@ -47,7 +46,7 @@ func TestVulToMarkdown(t *testing.T) {
 			VulnerabilityName:    "CVE-Test-001",
 		}
 		goldenFilePath := filepath.Join("testdata", "markdownVulnerability.golden")
-		expected, err := ioutil.ReadFile(goldenFilePath)
+		expected, err := os.ReadFile(goldenFilePath)
 		assert.NoError(t, err)
 
 		res, err := vulReport.ToMarkdown()

--- a/pkg/reporting/reporting_test.go
+++ b/pkg/reporting/reporting_test.go
@@ -4,6 +4,7 @@
 package reporting
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"

--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -102,7 +101,7 @@ func (s *Splunk) Send(telemetryData telemetry.Data, logCollector *log.CollectorH
 func readCommonPipelineEnvironment(filePath string) string {
 
 	// TODO: Dependent on a groovy step, which creates the folder.
-	contentFile, err := ioutil.ReadFile(".pipeline/commonPipelineEnvironment/" + filePath)
+	contentFile, err := os.ReadFile(".pipeline/commonPipelineEnvironment/" + filePath)
 	if err != nil {
 		log.Entry().Debugf("Could not read %v file. %v", filePath, err)
 		contentFile = []byte("N/A")
@@ -197,7 +196,7 @@ func (s *Splunk) postTelemetry(telemetryData map[string]interface{}) error {
 		if resp.StatusCode != http.StatusOK {
 			// log it to stdout
 			rdr := io.LimitReader(resp.Body, 1000)
-			body, errRead := ioutil.ReadAll(rdr)
+			body, errRead := io.ReadAll(rdr)
 			log.Entry().Infof("%v: Splunk logging failed - %v", resp.Status, string(body))
 			if errRead != nil {
 				return errors.Wrap(errRead, "Error reading response body from Splunk.")
@@ -247,7 +246,7 @@ func (s *Splunk) postLogFile(telemetryData map[string]interface{}, messages []st
 		if resp.StatusCode != http.StatusOK {
 			// log it to stdout
 			rdr := io.LimitReader(resp.Body, 1000)
-			body, errRead := ioutil.ReadAll(rdr)
+			body, errRead := io.ReadAll(rdr)
 			log.Entry().Infof("%v: Splunk logging failed - %v", resp.Status, string(body))
 			if errRead != nil {
 				return errors.Wrap(errRead, "Error reading response body from Splunk.")
@@ -294,7 +293,7 @@ func (s *Splunk) tryPostMessages(telemetryData MonitoringData, messages []log.Me
 		if resp.StatusCode != http.StatusOK {
 			// log it to stdout
 			rdr := io.LimitReader(resp.Body, 1000)
-			body, errRead := ioutil.ReadAll(rdr)
+			body, errRead := io.ReadAll(rdr)
 			log.Entry().Infof("%v: Splunk logging failed - %v", resp.Status, string(body))
 			if errRead != nil {
 				return errors.Wrap(errRead, "Error reading response body from Splunk.")

--- a/pkg/splunk/splunk_test.go
+++ b/pkg/splunk/splunk_test.go
@@ -5,7 +5,6 @@ package splunk
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -544,7 +543,7 @@ func Test_readPipelineEnvironment(t *testing.T) {
 
 				// creating temporarily files with dummy content
 				branch := []byte("master")
-				err = ioutil.WriteFile(path+"git/branch", branch, 0644)
+				err = os.WriteFile(path+"git/branch", branch, 0644)
 				if err != nil {
 					t.Errorf("Could not create branch file: %v", err)
 				}

--- a/pkg/versioning/docker.go
+++ b/pkg/versioning/docker.go
@@ -2,7 +2,6 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,11 +24,11 @@ type Docker struct {
 
 func (d *Docker) init() {
 	if d.readFile == nil {
-		d.readFile = ioutil.ReadFile
+		d.readFile = os.ReadFile
 	}
 
 	if d.writeFile == nil {
-		d.writeFile = ioutil.WriteFile
+		d.writeFile = os.WriteFile
 	}
 }
 

--- a/pkg/versioning/docker_test.go
+++ b/pkg/versioning/docker_test.go
@@ -5,7 +5,6 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,7 @@ func TestDockerGetVersion(t *testing.T) {
 
 		dir := t.TempDir()
 		filePath := filepath.Join(dir, "package.json")
-		err := ioutil.WriteFile(filePath, []byte(`{"version": "1.2.3"}`), 0700)
+		err := os.WriteFile(filePath, []byte(`{"version": "1.2.3"}`), 0700)
 		if err != nil {
 			t.Fatal("Failed to create test file")
 		}
@@ -123,7 +122,7 @@ func TestDockerSetVersion(t *testing.T) {
 	t.Run("success case - buildTool", func(t *testing.T) {
 		dir := t.TempDir()
 		filePath := filepath.Join(dir, "package.json")
-		err := ioutil.WriteFile(filePath, []byte(`{"version": "1.2.3"}`), 0700)
+		err := os.WriteFile(filePath, []byte(`{"version": "1.2.3"}`), 0700)
 		if err != nil {
 			t.Fatal("Failed to create test file")
 		}
@@ -135,9 +134,9 @@ func TestDockerSetVersion(t *testing.T) {
 		assert.NoError(t, err)
 		err = docker.SetVersion("1.2.4")
 		assert.NoError(t, err)
-		packageJSON, err := ioutil.ReadFile(filePath)
+		packageJSON, err := os.ReadFile(filePath)
 		assert.Contains(t, string(packageJSON), `"version": "1.2.4"`)
-		versionContent, err := ioutil.ReadFile(filepath.Join(dir, "VERSION"))
+		versionContent, err := os.ReadFile(filepath.Join(dir, "VERSION"))
 		assert.Equal(t, "1.2.4", string(versionContent))
 	})
 }

--- a/pkg/versioning/gomodfile.go
+++ b/pkg/versioning/gomodfile.go
@@ -1,7 +1,6 @@
 package versioning
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -21,10 +20,10 @@ type GoMod struct {
 
 func (m *GoMod) init() error {
 	if m.readFile == nil {
-		m.readFile = ioutil.ReadFile
+		m.readFile = os.ReadFile
 	}
 	if m.writeFile == nil {
-		m.writeFile = ioutil.WriteFile
+		m.writeFile = os.WriteFile
 	}
 	if len(m.buildDescriptorContent) == 0 {
 		content, err := m.readFile(m.path)

--- a/pkg/versioning/gradle.go
+++ b/pkg/versioning/gradle.go
@@ -2,7 +2,6 @@ package versioning
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -31,7 +30,7 @@ type Gradle struct {
 
 func (g *Gradle) init() error {
 	if g.writeFile == nil {
-		g.writeFile = ioutil.WriteFile
+		g.writeFile = os.WriteFile
 	}
 
 	if g.propertiesFile == nil {

--- a/pkg/versioning/gradle_test.go
+++ b/pkg/versioning/gradle_test.go
@@ -4,7 +4,6 @@
 package versioning
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,7 +16,7 @@ func TestGradleGetVersion(t *testing.T) {
 		tmpFolder := t.TempDir()
 
 		gradlePropsFilePath := filepath.Join(tmpFolder, "gradle.properties")
-		ioutil.WriteFile(gradlePropsFilePath, []byte("version = 1.2.3"), 0666)
+		os.WriteFile(gradlePropsFilePath, []byte("version = 1.2.3"), 0666)
 		gradle := &Gradle{
 			path: gradlePropsFilePath,
 		}
@@ -34,7 +33,7 @@ func TestGradleSetVersion(t *testing.T) {
 		tmpFolder := t.TempDir()
 
 		gradlePropsFilePath := filepath.Join(tmpFolder, "gradle.properties")
-		ioutil.WriteFile(gradlePropsFilePath, []byte("version = 0.0.1"), 0666)
+		os.WriteFile(gradlePropsFilePath, []byte("version = 0.0.1"), 0666)
 
 		var content []byte
 		gradle := &Gradle{

--- a/pkg/versioning/inifile.go
+++ b/pkg/versioning/inifile.go
@@ -3,7 +3,6 @@ package versioning
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -26,10 +25,10 @@ func (i *INIfile) init() error {
 		i.versionField = "version"
 	}
 	if i.readFile == nil {
-		i.readFile = ioutil.ReadFile
+		i.readFile = os.ReadFile
 	}
 	if i.writeFile == nil {
-		i.writeFile = ioutil.WriteFile
+		i.writeFile = os.WriteFile
 	}
 	if i.content == nil {
 		conf, err := i.readFile(i.path)

--- a/pkg/versioning/jsonfile.go
+++ b/pkg/versioning/jsonfile.go
@@ -3,7 +3,6 @@ package versioning
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/iancoleman/orderedmap"
@@ -24,11 +23,11 @@ func (j *JSONfile) init() {
 		j.versionField = "version"
 	}
 	if j.readFile == nil {
-		j.readFile = ioutil.ReadFile
+		j.readFile = os.ReadFile
 	}
 
 	if j.writeFile == nil {
-		j.writeFile = ioutil.WriteFile
+		j.writeFile = os.WriteFile
 	}
 }
 

--- a/pkg/versioning/pip.go
+++ b/pkg/versioning/pip.go
@@ -2,7 +2,6 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -28,11 +27,11 @@ type Pip struct {
 
 func (p *Pip) init() error {
 	if p.readFile == nil {
-		p.readFile = ioutil.ReadFile
+		p.readFile = os.ReadFile
 	}
 
 	if p.writeFile == nil {
-		p.writeFile = ioutil.WriteFile
+		p.writeFile = os.WriteFile
 	}
 
 	if len(p.buildDescriptorContent) == 0 {

--- a/pkg/versioning/properties.go
+++ b/pkg/versioning/properties.go
@@ -3,7 +3,6 @@ package versioning
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/magiconair/properties"
@@ -24,7 +23,7 @@ func (p *PropertiesFile) init() error {
 		p.versionField = "version"
 	}
 	if p.writeFile == nil {
-		p.writeFile = ioutil.WriteFile
+		p.writeFile = os.WriteFile
 	}
 	if p.content == nil {
 		var err error

--- a/pkg/versioning/properties_test.go
+++ b/pkg/versioning/properties_test.go
@@ -5,7 +5,6 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +18,7 @@ func TestPropertiesFileGetVersion(t *testing.T) {
 		tmpFolder := t.TempDir()
 
 		propsFilePath := filepath.Join(tmpFolder, "my.props")
-		ioutil.WriteFile(propsFilePath, []byte("version = 1.2.3"), 0666)
+		os.WriteFile(propsFilePath, []byte("version = 1.2.3"), 0666)
 
 		propsfile := PropertiesFile{
 			path: propsFilePath,
@@ -34,7 +33,7 @@ func TestPropertiesFileGetVersion(t *testing.T) {
 		tmpFolder := t.TempDir()
 
 		propsFilePath := filepath.Join(tmpFolder, "my.props")
-		ioutil.WriteFile(propsFilePath, []byte("customversion = 1.2.3"), 0666)
+		os.WriteFile(propsFilePath, []byte("customversion = 1.2.3"), 0666)
 
 		propsfile := PropertiesFile{
 			path:         propsFilePath,
@@ -63,7 +62,7 @@ func TestPropertiesFileGetVersion(t *testing.T) {
 		tmpFolder := t.TempDir()
 
 		propsFilePath := filepath.Join(tmpFolder, "my.props")
-		ioutil.WriteFile(propsFilePath, []byte("versionx = 1.2.3"), 0666)
+		os.WriteFile(propsFilePath, []byte("versionx = 1.2.3"), 0666)
 
 		propsfile := PropertiesFile{
 			path: propsFilePath,
@@ -79,7 +78,7 @@ func TestPropertiesFileSetVersion(t *testing.T) {
 		tmpFolder := t.TempDir()
 
 		propsFilePath := filepath.Join(tmpFolder, "my.props")
-		ioutil.WriteFile(propsFilePath, []byte("version = 0.0.1"), 0666)
+		os.WriteFile(propsFilePath, []byte("version = 0.0.1"), 0666)
 
 		var content []byte
 		propsfile := PropertiesFile{

--- a/pkg/versioning/versionfile.go
+++ b/pkg/versioning/versionfile.go
@@ -1,7 +1,6 @@
 package versioning
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -21,11 +20,11 @@ func (v *Versionfile) init() {
 		v.path = "VERSION"
 	}
 	if v.readFile == nil {
-		v.readFile = ioutil.ReadFile
+		v.readFile = os.ReadFile
 	}
 
 	if v.writeFile == nil {
-		v.writeFile = ioutil.WriteFile
+		v.writeFile = os.WriteFile
 	}
 }
 

--- a/pkg/versioning/yamlfile.go
+++ b/pkg/versioning/yamlfile.go
@@ -2,7 +2,6 @@ package versioning
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -35,10 +34,10 @@ func (y *YAMLfile) init() {
 		y.artifactIDField = "ID"
 	}
 	if y.readFile == nil {
-		y.readFile = ioutil.ReadFile
+		y.readFile = os.ReadFile
 	}
 	if y.writeFile == nil {
-		y.writeFile = ioutil.WriteFile
+		y.writeFile = os.WriteFile
 	}
 }
 

--- a/pkg/whitesource/reporting_test.go
+++ b/pkg/whitesource/reporting_test.go
@@ -6,6 +6,7 @@ package whitesource
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 

--- a/pkg/whitesource/reporting_test.go
+++ b/pkg/whitesource/reporting_test.go
@@ -6,7 +6,6 @@ package whitesource
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -150,7 +149,7 @@ func TestCreateCycloneSBOM(t *testing.T) {
 		assert.NoError(t, err, "unexpected error")
 
 		goldenFilePath := filepath.Join("testdata", "sbom.golden")
-		expected, err := ioutil.ReadFile(goldenFilePath)
+		expected, err := os.ReadFile(goldenFilePath)
 		assert.NoError(t, err)
 
 		assert.Equal(t, string(expected), string(contents))

--- a/pkg/whitesource/scanNPM.go
+++ b/pkg/whitesource/scanNPM.go
@@ -3,7 +3,7 @@ package whitesource
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -179,7 +179,7 @@ func getNpmProjectName(modulePath string, utils Utils) (string, error) {
 // is used for whitesourceExecuteScan due to a different docker image being used compared to the build stage.
 func reinstallNodeModulesIfLsFails(config *ScanOptions, utils Utils) error {
 	// No need to have output from "npm ls" in the log
-	utils.Stdout(ioutil.Discard)
+	utils.Stdout(io.Discard)
 	defer utils.Stdout(log.Writer())
 
 	err := utils.RunExecutable("npm", "ls")

--- a/pkg/whitesource/whitesource.go
+++ b/pkg/whitesource/whitesource.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -785,7 +785,7 @@ func (s *System) sendRequest(req Request) ([]byte, error) {
 		return responseBody, errors.Wrap(err, "failed to send request to WhiteSource")
 	}
 	defer response.Body.Close()
-	responseBody, err = ioutil.ReadAll(response.Body)
+	responseBody, err = io.ReadAll(response.Body)
 	if err != nil {
 		return responseBody, errors.Wrap(err, "failed to read WhiteSource response")
 	}

--- a/pkg/whitesource/whitesource_test.go
+++ b/pkg/whitesource/whitesource_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
@@ -38,7 +37,7 @@ func (c *whitesourceMockClient) SendRequest(method, url string, body io.Reader, 
 	if c.requestError != nil {
 		return &http.Response{}, c.requestError
 	}
-	return &http.Response{StatusCode: c.httpStatusCode, Body: ioutil.NopCloser(bytes.NewReader([]byte(c.responseBody)))}, nil
+	return &http.Response{StatusCode: c.httpStatusCode, Body: io.NopCloser(bytes.NewReader([]byte(c.responseBody)))}, nil
 }
 
 func TestGetProductsMetaInfo(t *testing.T) {
@@ -61,7 +60,7 @@ func TestGetProductsMetaInfo(t *testing.T) {
 	products, err := sys.GetProductsMetaInfo()
 	assert.NoError(t, err)
 
-	requestBody, err := ioutil.ReadAll(myTestClient.requestBody)
+	requestBody, err := io.ReadAll(myTestClient.requestBody)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRequestBody, string(requestBody))
 
@@ -84,7 +83,7 @@ func TestCreateProduct(t *testing.T) {
 		productToken, err := sys.CreateProduct("test_product_name")
 		// assert
 		assert.EqualError(t, err, "WhiteSource request failed after 3 retries: invalid request, error code 3000, message 'WhiteSource backend has a hickup'")
-		requestBody, err := ioutil.ReadAll(myTestClient.requestBody)
+		requestBody, err := io.ReadAll(myTestClient.requestBody)
 		require.NoError(t, err)
 		assert.Equal(t, "", productToken)
 		assert.Equal(t, expectedRequestBody, string(requestBody))
@@ -100,7 +99,7 @@ func TestCreateProduct(t *testing.T) {
 		productToken, err := sys.CreateProduct("test_product_name")
 		// assert
 		assert.EqualError(t, err, "invalid request, error code 5001, message 'User is not allowed to perform this action'")
-		requestBody, err := ioutil.ReadAll(myTestClient.requestBody)
+		requestBody, err := io.ReadAll(myTestClient.requestBody)
 		require.NoError(t, err)
 		assert.Equal(t, "", productToken)
 		assert.Equal(t, expectedRequestBody, string(requestBody))
@@ -116,7 +115,7 @@ func TestCreateProduct(t *testing.T) {
 		productToken, err := sys.CreateProduct("test_product_name")
 		// assert
 		assert.NoError(t, err)
-		requestBody, err := ioutil.ReadAll(myTestClient.requestBody)
+		requestBody, err := io.ReadAll(myTestClient.requestBody)
 		require.NoError(t, err)
 		assert.Equal(t, "test_product_token", productToken)
 		assert.Equal(t, expectedRequestBody, string(requestBody))
@@ -174,7 +173,7 @@ func TestGetProjectsMetaInfo(t *testing.T) {
 	projects, err := sys.GetProjectsMetaInfo("test_product_token")
 	assert.NoError(t, err)
 
-	requestBody, err := ioutil.ReadAll(myTestClient.requestBody)
+	requestBody, err := io.ReadAll(myTestClient.requestBody)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedRequestBody, string(requestBody))
 
@@ -517,7 +516,7 @@ func TestGetProjectAlertsByType(t *testing.T) {
 		alerts, err := sys.GetProjectAlertsByType("test_project_token", "SECURITY_VULNERABILITY")
 
 		assert.NoError(t, err)
-		requestBody, err := ioutil.ReadAll(myTestClient.requestBody)
+		requestBody, err := io.ReadAll(myTestClient.requestBody)
 		assert.NoError(t, err)
 		assert.Contains(t, string(requestBody), `"requestType":"getProjectAlertsByType"`)
 		assert.Equal(t, []Alert{{Vulnerability: Vulnerability{Name: "testVulnerability1"}, Type: "SECURITY_VULNERABILITY"}}, alerts)

--- a/pkg/xsuaa/xsuaa.go
+++ b/pkg/xsuaa/xsuaa.go
@@ -3,11 +3,12 @@ package xsuaa
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const authHeaderKey = "Authorization"
@@ -128,7 +129,7 @@ func readResponseBody(response *http.Response) ([]byte, error) {
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
-	bodyText, readErr := ioutil.ReadAll(response.Body)
+	bodyText, readErr := io.ReadAll(response.Body)
 	if readErr != nil {
 		return nil, errors.Wrap(readErr, "HTTP response body could not be read")
 	}


### PR DESCRIPTION
`io/ioutil` has been [replaced](https://go.dev/doc/go1.16#ioutil) since Go 1.16, and has been deleted from 1.19 onward.
This PR is a prerequisite for [#4493](https://github.com/SAP/jenkins-library/pull/4493).

# Changes

- [ ] Tests
- [ ] Documentation
