### PR TITLE
feat(kaniko): Add optional verbose logging for kaniko command

### DIFF
--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -49,6 +49,11 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 		log.Entry().Warning("Be aware that the host doesn't support binfmt_misc and thus multi archtecture docker builds might not be possible")
 	}
 
+	fmt.Println(GeneralConfig.Verbose)
+	if GeneralConfig.Verbose {
+		fmt.Println("hoi")
+	}
+
 	// backward compatibility for parameter ContainerBuildOptions
 	if len(config.ContainerBuildOptions) > 0 {
 		config.BuildOptions = strings.Split(config.ContainerBuildOptions, " ")
@@ -269,7 +274,7 @@ func runKaniko(dockerFilepath string, buildOptions []string, readDigest bool, ex
 	}
 
 	if GeneralConfig.Verbose {
-		kanikoOpts = append(kanikoOpts, "--verbosity=trace")
+		kanikoOpts = append(kanikoOpts, "--verbosity=debug")
 	}
 
 	err = execRunner.RunExecutable("/kaniko/executor", kanikoOpts...)

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -264,12 +264,12 @@ func runKaniko(dockerFilepath string, buildOptions []string, readDigest bool, ex
 
 	digestFilePath := fmt.Sprintf("%s/digest.txt", tmpDir)
 
-	if GeneralConfig.Verbose {
-		kanikoOpts = append(kanikoOpts, "--verbosity=trace")
-	}
-
 	if readDigest {
 		kanikoOpts = append(kanikoOpts, "--digest-file", digestFilePath)
+	}
+
+	if GeneralConfig.Verbose {
+		kanikoOpts = append(kanikoOpts, "--verbosity=trace")
 	}
 
 	err = execRunner.RunExecutable("/kaniko/executor", kanikoOpts...)

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -264,6 +264,10 @@ func runKaniko(dockerFilepath string, buildOptions []string, readDigest bool, ex
 
 	digestFilePath := fmt.Sprintf("%s/digest.txt", tmpDir)
 
+	if GeneralConfig.Verbose {
+		kanikoOpts = append(kanikoOpts, "--verbosity=trace")
+	}
+
 	if readDigest {
 		kanikoOpts = append(kanikoOpts, "--digest-file", digestFilePath)
 	}

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -49,11 +49,6 @@ func runKanikoExecute(config *kanikoExecuteOptions, telemetryData *telemetry.Cus
 		log.Entry().Warning("Be aware that the host doesn't support binfmt_misc and thus multi archtecture docker builds might not be possible")
 	}
 
-	fmt.Println(GeneralConfig.Verbose)
-	if GeneralConfig.Verbose {
-		fmt.Println("hoi")
-	}
-
 	// backward compatibility for parameter ContainerBuildOptions
 	if len(config.ContainerBuildOptions) > 0 {
 		config.BuildOptions = strings.Split(config.ContainerBuildOptions, " ")


### PR DESCRIPTION
# Changes
Adds some verbose logging of the Kaniko command using the [general `verbose` parameter](https://github.com/SAP/jenkins-library/blob/master/cmd/piper.go#L36).

- [ ] Tests
- [ ] Documentation
