### PR TITLE
unstash source stash for kubernetesDeploy

### DIFF
--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -242,6 +242,7 @@ func kubernetesDeployMetadata() config.StepData {
 				Resources: []config.StepResources{
 					{Name: "deployDescriptor", Type: "stash"},
 					{Name: "downloadedArtifact", Type: "stash"},
+					{Name: "source", Type: "stash"},
 				},
 				Parameters: []config.StepParameters{
 					{

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -51,6 +51,8 @@ spec:
         type: stash
       - name: downloadedArtifact
         type: stash
+      - name: source
+        type: stash
     params:
       - name: additionalParameters
         aliases:


### PR DESCRIPTION
We need the source-stash since the charts are located in the source stash.

# Changes

- [ ] Tests
- [ ] Documentation
