### PR TITLE
fix(kanikoExecute): remove STAGES scope from multipleImages param

### DIFF
--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -399,7 +399,7 @@ func kanikoExecuteMetadata() config.StepData {
 					{
 						Name:        "multipleImages",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"PARAMETERS", "STEPS"},
 						Type:        "[]map[string]interface{}",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "images"}},

--- a/resources/metadata/kanikoExecute.yaml
+++ b/resources/metadata/kanikoExecute.yaml
@@ -172,7 +172,6 @@ spec:
           ```
         scope:
           - PARAMETERS
-          - STAGES
           - STEPS
       - name: containerMultiImageBuild
         type: bool


### PR DESCRIPTION
# Changes
kanikoExecute.multipleImages is not supposed to be configured from STAGES scope. 
one of our users encountered a regression using latest (master) Piper version.

- [ ] Tests
- [ ] Documentation
