### PR TITLE
fix(githubPublishRelease): ListByRepo - enable pagination

### DIFF
--- a/cmd/githubPublishRelease.go
+++ b/cmd/githubPublishRelease.go
@@ -115,9 +115,19 @@ func getClosedIssuesText(ctx context.Context, publishedAt github.Timestamp, conf
 	if len(config.Labels) > 0 {
 		options.Labels = config.Labels
 	}
-	ghIssues, _, err := ghIssueClient.ListByRepo(ctx, config.Owner, config.Repository, &options)
-	if err != nil {
-		log.Entry().WithError(err).Error("Failed to get GitHub issues.")
+
+	var ghIssues []*github.Issue
+	for {
+		issues, resp, err := ghIssueClient.ListByRepo(ctx, config.Owner, config.Repository, &options)
+		if err != nil {
+			log.Entry().WithError(err).Error("failed to get GitHub issues")
+		}
+
+		ghIssues = append(ghIssues, issues...)
+		if resp.NextPage == 0 {
+			break
+		}
+		options.Page = resp.NextPage
 	}
 
 	prTexts := []string{"**List of closed pull-requests since last release**"}

--- a/cmd/githubPublishRelease_test.go
+++ b/cmd/githubPublishRelease_test.go
@@ -84,6 +84,7 @@ func (g *ghRCMock) UploadReleaseAsset(ctx context.Context, owner string, repo st
 
 type ghICMock struct {
 	issues        []*github.Issue
+	response      github.Response
 	lastPublished time.Time
 	owner         string
 	repo          string
@@ -95,7 +96,7 @@ func (g *ghICMock) ListByRepo(ctx context.Context, owner string, repo string, op
 	g.repo = repo
 	g.options = opt
 	g.lastPublished = opt.Since
-	return g.issues, nil, nil
+	return g.issues, &g.response, nil
 }
 
 func TestRunGithubPublishRelease(t *testing.T) {


### PR DESCRIPTION
# Changes
Github requests should be executed with pagination to fetch all objects.
This PR fixes a bug when githubPublishRelease didn't mention all the closed issues and PRs.  

- [ ] Tests
- [ ] Documentation
