### PR TITLE
chore(docs): Document selenium step being Jenkins-only

### DIFF
--- a/vars/seleniumExecuteTests.groovy
+++ b/vars/seleniumExecuteTests.groovy
@@ -69,6 +69,8 @@ import groovy.text.GStringTemplateEngine
 /**
  * Enables UI test execution with Selenium in a sidecar container.
  *
+ * This step is Jenkins-only.
+ *
  * The step executes a closure (see example below) connecting to a sidecar container with a Selenium Server.
  *
  * When executing in a


### PR DESCRIPTION
# Changes

It's implementation is in Groovy.
https://github.com/SAP/jenkins-library/blob/jliempt/seleniumDocs/vars/seleniumExecuteTests.groovy

- [ ] Tests
- [ ] Documentation
