### PR TITLE
dependency update inside kubernetes deploy

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -148,6 +148,8 @@ func runHelmDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUtils,
 		helmValues.add("imagePullSecrets[0].name", config.ContainerRegistrySecret)
 	}
 
+	utils.Stdout(stdout)
+
 	// Deprecated functionality
 	// only for backward compatible handling of ingress.hosts
 	// this requires an adoption of the default ingress.yaml template
@@ -208,7 +210,6 @@ func runHelmDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUtils,
 		upgradeParams = append(upgradeParams, config.AdditionalParameters...)
 	}
 
-	utils.Stdout(stdout)
 	log.Entry().Info("Calling helm upgrade ...")
 	log.Entry().Debugf("Helm parameters %v", upgradeParams)
 	if err := utils.RunExecutable("helm", upgradeParams...); err != nil {

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -150,6 +150,19 @@ func runHelmDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUtils,
 
 	utils.Stdout(stdout)
 
+	if config.DependencyUpdate {
+		dependencyUpdateParams := []string{
+			"dependency", "update",
+			config.ChartPath,
+		}
+
+		log.Entry().Info("Calling helm dependency update ...")
+		log.Entry().Debugf("Helm parameters %v", dependencyUpdateParams)
+		if err := utils.RunExecutable("helm", dependencyUpdateParams...); err != nil {
+			log.Entry().WithError(err).Fatal("Helm dependency update call failed")
+		}
+	}
+
 	// Deprecated functionality
 	// only for backward compatible handling of ingress.hosts
 	// this requires an adoption of the default ingress.yaml template

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -28,6 +28,7 @@ type kubernetesDeployOptions struct {
 	ContainerRegistrySecret    string                 `json:"containerRegistrySecret,omitempty"`
 	CreateDockerRegistrySecret bool                   `json:"createDockerRegistrySecret,omitempty"`
 	DeploymentName             string                 `json:"deploymentName,omitempty"`
+	DependencyUpdate           bool                   `json:"dependencyUpdate,omitempty"`
 	DeployTool                 string                 `json:"deployTool,omitempty" validate:"possible-values=kubectl helm helm3"`
 	ForceUpdates               bool                   `json:"forceUpdates,omitempty"`
 	HelmDeployWaitSeconds      int                    `json:"helmDeployWaitSeconds,omitempty"`
@@ -190,6 +191,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistrySecret, "containerRegistrySecret", `regsecret`, "Name of the container registry secret used for pulling containers from the registry.")
 	cmd.Flags().BoolVar(&stepConfig.CreateDockerRegistrySecret, "createDockerRegistrySecret", false, "Only for `deployTool:kubectl`: Toggle to turn on `containerRegistrySecret` creation.")
 	cmd.Flags().StringVar(&stepConfig.DeploymentName, "deploymentName", os.Getenv("PIPER_deploymentName"), "Defines the name of the deployment. It is a mandatory parameter when `deployTool:helm` or `deployTool:helm3`.")
+	cmd.Flags().BoolVar(&stepConfig.DependencyUpdate, "dependencyUpdate", false, "Runs a helm dependency update prior to performing updates on the cluster")
 	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", `kubectl`, "Defines the tool which should be used for deployment.")
 	cmd.Flags().BoolVar(&stepConfig.ForceUpdates, "forceUpdates", true, "Adds `--force` flag to a helm resource update command or to a kubectl replace command")
 	cmd.Flags().IntVar(&stepConfig.HelmDeployWaitSeconds, "helmDeployWaitSeconds", 300, "Number of seconds before helm deploy returns.")
@@ -398,6 +400,15 @@ func kubernetesDeployMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "helmDeploymentName"}},
 						Default:     os.Getenv("PIPER_deploymentName"),
+					},
+					{
+						Name:        "dependencyUpdate",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
 					},
 					{
 						Name:        "deployTool",

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -247,6 +247,15 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: dependencyUpdate
+        type: bool
+        description: "Runs a helm dependency update prior to performing updates on the cluster"
+        mandatory: false
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: false
       - name: deployTool
         type: string
         description: Defines the tool which should be used for deployment.


### PR DESCRIPTION
When the new flag `dependencyUpdate` is provided we perform a `helm dependency update` command prior to deployment. The default value for that flag is `false` in order to ensure backward-compatibility.

Alternate approaches

- Would be possible to run a similar `helmExecute` command and to stash the chart tgz files prior to the `kubernetesDeploy` command . This stash could be provided to `kubernetesDeploy`. With such an approach it would be possible to avoid a duplicate `helm dependency update` when `kubernetesDeploy` is invoked several times during a pipeline (e.g. acceptance, release). &lt;paranoia&gt;It can happen that there is a repository update so that two calls to `helm dependency update` return different dependencies&lt;/paranoia&gt;

# Changes

- [ ] Tests
- [ ] Documentation
