### PR TITLE
pass POM path to Maven flatten command

### DIFF
--- a/cmd/mavenExecuteIntegration.go
+++ b/cmd/mavenExecuteIntegration.go
@@ -27,6 +27,7 @@ func runMavenExecuteIntegration(config *mavenExecuteIntegrationOptions, utils ma
 	}
 
 	if config.InstallArtifacts {
+		log.Entry().Debug(fmt.Sprintf("Passing POM path %s to InstallArtifacts", pomPath))
 		err := maven.InstallMavenArtifacts(&maven.EvaluateOptions{
 			M2Path:              config.M2Path,
 			ProjectSettingsFile: config.ProjectSettingsFile,

--- a/cmd/mavenExecuteIntegration.go
+++ b/cmd/mavenExecuteIntegration.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/SAP/jenkins-library/pkg/log"
-	"github.com/SAP/jenkins-library/pkg/maven"
-	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode"
+
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/maven"
+	"github.com/SAP/jenkins-library/pkg/telemetry"
 )
 
 func mavenExecuteIntegration(config mavenExecuteIntegrationOptions, _ *telemetry.CustomData) {
@@ -30,6 +31,7 @@ func runMavenExecuteIntegration(config *mavenExecuteIntegrationOptions, utils ma
 			M2Path:              config.M2Path,
 			ProjectSettingsFile: config.ProjectSettingsFile,
 			GlobalSettingsFile:  config.GlobalSettingsFile,
+			PomPath:             pomPath,
 		}, utils)
 		if err != nil {
 			return err

--- a/pkg/maven/maven.go
+++ b/pkg/maven/maven.go
@@ -83,6 +83,8 @@ func Execute(options *ExecuteOptions, utils Utils) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to construct parameters from options: %w", err)
 	}
+	log.Entry().Debug("Maven execution parameters:")
+	log.Entry().Debug(parameters)
 
 	err = utils.RunExecutable(mavenExecutable, parameters...)
 	if err != nil {
@@ -290,6 +292,7 @@ func warFile(dir, finalName string) string {
 }
 
 func flattenPom(options *EvaluateOptions, utils Utils) error {
+	log.Entry().Debug(fmt.Sprintf("Flattening POM %s", options.PomPath))
 	mavenOptionsFlatten := ExecuteOptions{
 		Goals:               []string{"flatten:flatten"},
 		Defines:             []string{"-Dflatten.mode=resolveCiFriendliesOnly"},


### PR DESCRIPTION
# Changes

The `pomPath` was not being passed to `maven.InstallMavenArtifacts()`. And subsequently not to `flattenPom()`, which would then look for a POM in the root, that can be non-existent.

- [ ] Tests
- [ ] Documentation
