### PR TITLE
materialize chart dependencies from outside in acceptance and release stage

### DIFF
--- a/vars/piperPipelineStageAcceptance.groovy
+++ b/vars/piperPipelineStageAcceptance.groovy
@@ -94,6 +94,8 @@ void call(Map parameters = [:]) {
 
             if (config.kubernetesDeploy){
                 durationMeasure(script: script, measurementName: 'deploy_release_kubernetes_duration') {
+                    helmExecute script: script, helmCommand: 'dependency', dependency: 'update'
+                    stash name: 'charts', includes: "${config.chartPath}/charts/*.tgz", allowEmpty: true
                     kubernetesDeploy script: script
                 }
             }

--- a/vars/piperPipelineStageRelease.groovy
+++ b/vars/piperPipelineStageRelease.groovy
@@ -84,6 +84,8 @@ void call(Map parameters = [:]) {
 
             if (config.kubernetesDeploy){
                 durationMeasure(script: script, measurementName: 'deploy_release_kubernetes_duration') {
+                    helmExecute script: script, helmCommand: 'dependency', dependency: 'update'
+                    stash name: 'charts', includes: "${config.chartPath}/charts/*.tgz", allowEmpty: true
                     kubernetesDeploy script: script
                 }
             }


### PR DESCRIPTION
When executing `kubernetesDeploy` charts from outside chart needs to be updated.

This is not ready-to-merge.
- Maybe we should introduce a flag for performing the update.
- Maybe we decide to do this in the go-layer (see #4512 )
- Tests ...
- Stash handling is poor at the moment. the "charts" stash needs to be provided via config to `kubernetesDeploy`.
# Changes

- [ ] Tests
- [ ] Documentation
