### PR TITLE
helmExecute triggered by  buildExecute

### DIFF
--- a/cmd/helmExecute_generated.go
+++ b/cmd/helmExecute_generated.go
@@ -271,7 +271,7 @@ func helmExecuteMetadata() config.StepData {
 					{
 						Name:        "chartPath",
 						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "helmChartPath"}},

--- a/resources/metadata/helmExecute.yaml
+++ b/resources/metadata/helmExecute.yaml
@@ -58,6 +58,7 @@ spec:
         type: string
         description: Defines the chart path for helm. chartPath is mandatory for install/upgrade/publish commands.
         scope:
+          - GENERAL
           - PARAMETERS
           - STAGES
           - STEPS

--- a/test/groovy/BuildExecuteTest.groovy
+++ b/test/groovy/BuildExecuteTest.groovy
@@ -314,4 +314,41 @@ class BuildExecuteTest extends BasePiperTest {
         )
         assertThat(buildToolCalled, is(true))
     }
+
+    @Test
+    void testHelmExecuteCalledWhenConfigured() {
+        def helmExecuteCalled = false
+        helper.registerAllowedMethod('helmExecute', [Map.class], { m ->
+            helmExecuteCalled = true
+            return
+        })
+        helper.registerAllowedMethod('npmExecuteScripts', [Map.class], { m ->
+        })
+
+        stepRule.step.buildExecute(
+            script: nullScript,
+            buildTool: 'npm',
+            helmExecute: true
+        )
+
+        assertThat(helmExecuteCalled, is(true))
+    }
+
+    @Test
+    void testHelmExecuteNotCalledWhenNotConfigured() {
+        def helmExecuteCalled = false
+        helper.registerAllowedMethod('helmExecute', [Map.class], { m ->
+            helmExecuteCalled = true
+            return
+        })
+        helper.registerAllowedMethod('npmExecuteScripts', [Map.class], { m ->
+        })
+        stepRule.step.buildExecute(
+            script: nullScript,
+            buildTool: 'npm',
+            helmExecute: false
+        )
+
+        assertThat(helmExecuteCalled, is(false))
+    }
 }

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -34,7 +34,7 @@ import static com.sap.piper.Prerequisites.checkScript
     /** For buildTool npm: List of npm run scripts to execute */
     'npmRunScripts',
     /** toggles if a helmExecute is triggered at end of the step after invoking the build tool  */
-    'helmExecute',
+    'helmExecute'
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
 

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -32,7 +32,8 @@ import static com.sap.piper.Prerequisites.checkScript
     /** For buildTool npm: Execute npm install (boolean, default 'true') */
     'npmInstall',
     /** For buildTool npm: List of npm run scripts to execute */
-    'npmRunScripts'
+    'npmRunScripts',
+    'helmExecute',
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS
 
@@ -99,6 +100,10 @@ void call(Map parameters = [:]) {
                 } else {
                     error "[${STEP_NAME}] buildTool not set and no dockerImage & dockerCommand provided."
                 }
+        }
+
+        if(config.helmExecute) {
+          helmExecute script: script
         }
     }
 }

--- a/vars/buildExecute.groovy
+++ b/vars/buildExecute.groovy
@@ -33,6 +33,7 @@ import static com.sap.piper.Prerequisites.checkScript
     'npmInstall',
     /** For buildTool npm: List of npm run scripts to execute */
     'npmRunScripts',
+    /** toggles if a helmExecute is triggered at end of the step after invoking the build tool  */
     'helmExecute',
 ])
 @Field Set PARAMETER_KEYS = STEP_CONFIG_KEYS


### PR DESCRIPTION
With this it is possible to e.g. perform a `helm dependency: update` at end of the build phase.

Since the `chartPath` is also used e.g. by `kubernetesDeploy` which is typically used in another stage it makes sense to define the `chartPath` in the `general´ section so that it can be shared. Hence we add also that. 
