### PR TITLE
feat(orchestrator): add implementation for GitHub

### DIFF
--- a/pkg/orchestrator/azureDevOps.go
+++ b/pkg/orchestrator/azureDevOps.go
@@ -13,20 +13,17 @@ import (
 
 type AzureDevOpsConfigProvider struct {
 	client         piperHttp.Client
-	options        piperHttp.ClientOptions
 	apiInformation map[string]interface{}
 }
 
 // InitOrchestratorProvider initializes http client for AzureDevopsConfigProvider
 func (a *AzureDevOpsConfigProvider) InitOrchestratorProvider(settings *OrchestratorSettings) {
-	a.client = piperHttp.Client{}
-	a.options = piperHttp.ClientOptions{
+	a.client.SetOptions(piperHttp.ClientOptions{
 		Username:         "",
 		Password:         settings.AzureToken,
 		MaxRetries:       3,
 		TransportTimeout: time.Second * 10,
-	}
-	a.client.SetOptions(a.options)
+	})
 	log.Entry().Debug("Successfully initialized Azure config provider")
 }
 
@@ -102,12 +99,12 @@ func (a *AzureDevOpsConfigProvider) GetBuildStatus() string {
 	// cases to align with Jenkins: SUCCESS, FAILURE, NOT_BUILD, ABORTED
 	switch buildStatus := getEnv("AGENT_JOBSTATUS", "FAILURE"); buildStatus {
 	case "Succeeded":
-		return "SUCCESS"
+		return BuildStatusSuccess
 	case "Canceled":
-		return "ABORTED"
+		return BuildStatusAborted
 	default:
 		// Failed, SucceededWithIssues
-		return "FAILURE"
+		return BuildStatusFailure
 	}
 }
 

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -28,6 +28,7 @@ type GitHubActionsConfigProvider struct {
 type run struct {
 	Status    string    `json:"status"`
 	StartedAt time.Time `json:"run_started_at"`
+	HtmlURL   string    `json:"html_url"`
 }
 
 type job struct {
@@ -195,7 +196,7 @@ func (g *GitHubActionsConfigProvider) GetReference() string {
 
 // GetBuildURL returns the builds URL. For example, https://github.com/SAP/jenkins-library/actions/runs/5815297487
 func (g *GitHubActionsConfigProvider) GetBuildURL() string {
-	return g.GetRepoURL() + "/actions/runs/" + getEnv("GITHUB_RUN_ID", "n/a")
+	return g.runData.HtmlURL
 }
 
 // GetJobURL returns the current job HTML URL (not API URL).

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -250,7 +250,7 @@ func isGitHubActions() bool {
 // https://api.github.com/repos/SAP/jenkins-library/actions              - if it's github.com
 // https://github.tools.sap/api/v3/repos/project-piper/sap-piper/actions - if it's GitHub Enterprise
 func actionsURL() string {
-	return fmt.Sprintf("%s/repos/%s/actions", getEnv("GITHUB_API_URL", ""), getEnv("GITHUB_REPOSITORY", ""))
+	return getEnv("GITHUB_API_URL", "") + "/repos/" + getEnv("GITHUB_REPOSITORY", "") + "/actions"
 }
 
 func (g *GitHubActionsConfigProvider) fetchRunData() {

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -22,7 +22,7 @@ type GitHubActionsConfigProvider struct {
 	actionsURL string
 	runData    run
 	jobs       []job
-	currentJob *job
+	currentJob job
 }
 
 type run struct {
@@ -157,7 +157,7 @@ func (g *GitHubActionsConfigProvider) GetPipelineStartTime() time.Time {
 
 // GetStageName returns the human-readable name given to a stage.
 func (g *GitHubActionsConfigProvider) GetStageName() string {
-	if g.currentJob == nil {
+	if g.currentJob.ID == 0 {
 		return "n/a"
 	}
 
@@ -202,7 +202,7 @@ func (g *GitHubActionsConfigProvider) GetBuildURL() string {
 // GetJobURL returns the current job HTML URL (not API URL).
 // For example, https://github.com/SAP/jenkins-library/actions/runs/123456/jobs/7654321
 func (g *GitHubActionsConfigProvider) GetJobURL() string {
-	if g.currentJob == nil {
+	if g.currentJob.ID == 0 {
 		return "n/a"
 	}
 
@@ -299,7 +299,7 @@ func (g *GitHubActionsConfigProvider) fetchJobs() error {
 func (g *GitHubActionsConfigProvider) guessCurrentJob() {
 	for _, j := range g.jobs {
 		if j.Name == getEnv("GITHUB_JOB", "unknown") {
-			g.currentJob = &j
+			g.currentJob = j
 		}
 	}
 }

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -172,7 +172,7 @@ func (g *GitHubActionsConfigProvider) GetReference() string {
 
 // GetBuildURL returns the builds URL. For example, https://github.com/SAP/jenkins-library/actions/runs/5815297487
 func (g *GitHubActionsConfigProvider) GetBuildURL() string {
-	return g.GetRepoURL() + "/actions/runs/" + getEnv("GITHUB_RUN_ID", "n/a")
+	return g.GetRepoURL() + "/actions/runs/" + g.GetBuildID()
 }
 
 // GetJobURL returns the current job HTML URL (not API URL).
@@ -222,8 +222,7 @@ func isGitHubActions() bool {
 }
 
 // actionsURL returns URL to actions resource. For example,
-// https://api.github.com/repos/SAP/jenkins-library/actions              - if it's github.com
-// https://github.tools.sap/api/v3/repos/project-piper/sap-piper/actions - if it's GitHub Enterprise
+// https://api.github.com/repos/SAP/jenkins-library/actions
 func actionsURL() string {
 	return getEnv("GITHUB_API_URL", "") + "/repos/" + getEnv("GITHUB_REPOSITORY", "") + "/actions"
 }
@@ -253,7 +252,7 @@ func (g *GitHubActionsConfigProvider) fetchJobs() error {
 		return nil
 	}
 
-	url := fmt.Sprintf("%s/runs/%s/jobs", actionsURL(), getEnv("GITHUB_RUN_ID", ""))
+	url := fmt.Sprintf("%s/runs/%s/jobs", actionsURL(), g.GetBuildID())
 	resp, err := g.client.GetRequest(url, httpHeaders, nil)
 	if err != nil {
 		return fmt.Errorf("failed to get API data: %w", err)

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -49,6 +49,9 @@ func (g *GitHubActionsConfigProvider) InitOrchestratorProvider(settings *Orchest
 	log.Entry().Debug("Successfully initialized GitHubActions config provider")
 }
 
+// getActionsURL returns URL to actions resource. For example,
+// https://api.github.com/repos/SAP/jenkins-library/actions              - if it's github.com
+// https://github.tools.sap/api/v3/repos/project-piper/sap-piper/actions - if it's GitHub Enterprise
 func getActionsURL() string {
 	ghURL := getEnv("GITHUB_URL", "")
 	switch ghURL {
@@ -60,6 +63,7 @@ func getActionsURL() string {
 	return fmt.Sprintf("%s/repos/%s/actions", ghURL, getEnv("GITHUB_REPOSITORY", ""))
 }
 
+// OrchestratorVersion TODO
 func (g *GitHubActionsConfigProvider) OrchestratorVersion() string {
 	return "n/a"
 }
@@ -68,6 +72,7 @@ func (g *GitHubActionsConfigProvider) OrchestratorType() string {
 	return "GitHubActions"
 }
 
+// GetBuildStatus TODO
 func (g *GitHubActionsConfigProvider) GetBuildStatus() string {
 	log.Entry().Infof("GetBuildStatus() for GitHub Actions not yet implemented.")
 	return "FAILURE"
@@ -118,59 +123,78 @@ func (g *GitHubActionsConfigProvider) GetLog() ([]byte, error) {
 	return bytes.Join(logs.b, []byte("")), nil
 }
 
+// GetBuildID TODO
 func (g *GitHubActionsConfigProvider) GetBuildID() string {
 	log.Entry().Infof("GetBuildID() for GitHub Actions not yet implemented.")
 	return "n/a"
 }
 
+// GetChangeSet TODO
 func (g *GitHubActionsConfigProvider) GetChangeSet() []ChangeSet {
 	log.Entry().Warn("GetChangeSet for GitHubActions not yet implemented")
 	return []ChangeSet{}
 }
 
+// GetPipelineStartTime returns the pipeline start time in UTC
 func (g *GitHubActionsConfigProvider) GetPipelineStartTime() time.Time {
 	log.Entry().Infof("GetPipelineStartTime() for GitHub Actions not yet implemented.")
 	return time.Time{}.UTC()
 }
+
+// GetStageName returns the human-readable name given to a stage. e.g. "Promote" or "Init"
+// TODO
 func (g *GitHubActionsConfigProvider) GetStageName() string {
 	return "GITHUB_WORKFLOW" // TODO: is there something like is "stage" in GH Actions?
 }
 
+// GetBuildReason returns the build reason
+// TODO
 func (g *GitHubActionsConfigProvider) GetBuildReason() string {
 	log.Entry().Infof("GetBuildReason() for GitHub Actions not yet implemented.")
 	return "n/a"
 }
 
+// GetBranch returns the source branch name, e.g. main
 func (g *GitHubActionsConfigProvider) GetBranch() string {
+	// TODO trim different prefixes. See GITHUB_REF description in
+	// https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+	// or just use GITHUB_REF_NAME ???
 	return strings.TrimPrefix(getEnv("GITHUB_REF", "n/a"), "refs/heads/")
 }
 
+// GetReference return the git reference. For example, refs/heads/your_branch_name
 func (g *GitHubActionsConfigProvider) GetReference() string {
 	return getEnv("GITHUB_REF", "n/a")
 }
 
+// GetBuildURL returns the builds URL. For example, https://github.com/SAP/jenkins-library/actions/runs/5815297487
 func (g *GitHubActionsConfigProvider) GetBuildURL() string {
 	return g.GetRepoURL() + "/actions/runs/" + getEnv("GITHUB_RUN_ID", "n/a")
 }
 
+// GetJobURL returns tje current job URL. For example, TODO
 func (g *GitHubActionsConfigProvider) GetJobURL() string {
 	log.Entry().Debugf("Not yet implemented.")
 	return g.GetRepoURL() + "/actions/runs/" + getEnv("GITHUB_RUN_ID", "n/a")
 }
 
+// GetJobName TODO
 func (g *GitHubActionsConfigProvider) GetJobName() string {
 	log.Entry().Debugf("GetJobName() for GitHubActions not yet implemented.")
 	return "n/a"
 }
 
+// GetCommit returns the commit SHA that triggered the workflow. For example, ffac537e6cbbf934b08745a378932722df287a53
 func (g *GitHubActionsConfigProvider) GetCommit() string {
 	return getEnv("GITHUB_SHA", "n/a")
 }
 
+// GetRepoURL returns full url to repository. For example, https://github.com/SAP/jenkins-library
 func (g *GitHubActionsConfigProvider) GetRepoURL() string {
 	return getEnv("GITHUB_SERVER_URL", "n/a") + "/" + getEnv("GITHUB_REPOSITORY", "n/a")
 }
 
+// GetPullRequestConfig returns pull request configuration
 func (g *GitHubActionsConfigProvider) GetPullRequestConfig() PullRequestConfig {
 	// See https://docs.github.com/en/enterprise-server@3.6/actions/learn-github-actions/variables#default-environment-variables
 	githubRef := getEnv("GITHUB_REF", "n/a")
@@ -182,6 +206,7 @@ func (g *GitHubActionsConfigProvider) GetPullRequestConfig() PullRequestConfig {
 	}
 }
 
+// IsPullRequest indicates whether the current build is triggered by a PR
 func (g *GitHubActionsConfigProvider) IsPullRequest() bool {
 	return truthy("GITHUB_HEAD_REF")
 }

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -27,7 +27,6 @@ type run struct {
 	fetched   bool
 	Status    string    `json:"status"`
 	StartedAt time.Time `json:"run_started_at"`
-	HtmlURL   string    `json:"html_url"`
 }
 
 type job struct {
@@ -173,8 +172,7 @@ func (g *GitHubActionsConfigProvider) GetReference() string {
 
 // GetBuildURL returns the builds URL. For example, https://github.com/SAP/jenkins-library/actions/runs/5815297487
 func (g *GitHubActionsConfigProvider) GetBuildURL() string {
-	g.fetchRunData()
-	return g.runData.HtmlURL
+	return g.GetRepoURL() + "/actions/runs/" + getEnv("GITHUB_RUN_ID", "n/a")
 }
 
 // GetJobURL returns the current job HTML URL (not API URL).

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -24,7 +24,8 @@ type GitHubActionsConfigProvider struct {
 }
 
 type run struct {
-	Status string `json:"status"`
+	Status    string    `json:"status"`
+	StartedAt time.Time `json:"run_started_at"`
 }
 
 type job struct {
@@ -126,22 +127,19 @@ func (g *GitHubActionsConfigProvider) GetLog() ([]byte, error) {
 	return bytes.Join(logs.b, []byte("")), nil
 }
 
-// GetBuildID TODO
+// GetBuildID returns current run ID
 func (g *GitHubActionsConfigProvider) GetBuildID() string {
-	log.Entry().Infof("GetBuildID() for GitHub Actions not yet implemented.")
-	return "n/a"
+	return getEnv("GITHUB_RUN_ID", "n/a")
 }
 
-// GetChangeSet TODO
 func (g *GitHubActionsConfigProvider) GetChangeSet() []ChangeSet {
-	log.Entry().Warn("GetChangeSet for GitHubActions not yet implemented")
+	log.Entry().Debug("GetChangeSet for GitHubActions not implemented")
 	return []ChangeSet{}
 }
 
 // GetPipelineStartTime returns the pipeline start time in UTC
 func (g *GitHubActionsConfigProvider) GetPipelineStartTime() time.Time {
-	log.Entry().Infof("GetPipelineStartTime() for GitHub Actions not yet implemented.")
-	return time.Time{}.UTC()
+	return g.runData.StartedAt.UTC()
 }
 
 // GetStageName returns the human-readable name given to a stage. e.g. "Promote" or "Init"

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -142,17 +142,29 @@ func (g *GitHubActionsConfigProvider) GetPipelineStartTime() time.Time {
 	return g.runData.StartedAt.UTC()
 }
 
-// GetStageName returns the human-readable name given to a stage. e.g. "Promote" or "Init"
-// TODO
+// GetStageName returns the human-readable name given to a stage.
 func (g *GitHubActionsConfigProvider) GetStageName() string {
-	return "GITHUB_WORKFLOW" // TODO: is there something like is "stage" in GH Actions?
+	return getEnv("GITHUB_JOB", "unknown")
 }
 
-// GetBuildReason returns the build reason
-// TODO
+// GetBuildReason returns the reason of workflow trigger.
+// BuildReasons are unified with AzureDevOps build reasons, see
+// https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services
 func (g *GitHubActionsConfigProvider) GetBuildReason() string {
-	log.Entry().Infof("GetBuildReason() for GitHub Actions not yet implemented.")
-	return "n/a"
+	switch getEnv("GITHUB_REF", "") {
+	case "workflow_dispatch":
+		return BuildReasonManual
+	case "schedule":
+		return BuildReasonSchedule
+	case "pull_request":
+		return BuildReasonPullRequest
+	case "workflow_call":
+		return BuildReasonResourceTrigger
+	case "push":
+		return BuildReasonIndividualCI
+	default:
+		return BuildReasonUnknown
+	}
 }
 
 // GetBranch returns the source branch name, e.g. main

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -41,7 +41,6 @@ type fullLog struct {
 }
 
 var httpHeaders = http.Header{
-	"Accept": {"application/vnd.github+json"},
 	"Accept":               {"application/vnd.github+json"},
 	"X-GitHub-Api-Version": {"2022-11-28"},
 }

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -40,7 +40,6 @@ type logs struct {
 
 // InitOrchestratorProvider initializes http client for GitHubActionsDevopsConfigProvider
 func (g *GitHubActionsConfigProvider) InitOrchestratorProvider(settings *OrchestratorSettings) {
-	g.client = piperHttp.Client{}
 	g.client.SetOptions(piperHttp.ClientOptions{
 		Password:         settings.GitHubToken,
 		MaxRetries:       3,

--- a/pkg/orchestrator/gitHubActions.go
+++ b/pkg/orchestrator/gitHubActions.go
@@ -178,6 +178,8 @@ func (g *GitHubActionsConfigProvider) GetBuildURL() string {
 // GetJobURL returns the current job HTML URL (not API URL).
 // For example, https://github.com/SAP/jenkins-library/actions/runs/123456/jobs/7654321
 func (g *GitHubActionsConfigProvider) GetJobURL() string {
+	// We need to query the GitHub API here because the environment variable GITHUB_JOB returns
+	// the name of the job, not a numeric ID (which we need to form the URL)
 	g.guessCurrentJob()
 	return g.currentJob.HtmlURL
 }

--- a/pkg/orchestrator/gitHubActions_test.go
+++ b/pkg/orchestrator/gitHubActions_test.go
@@ -5,9 +5,9 @@ package orchestrator
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,187 +17,308 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGitHubActions(t *testing.T) {
-	t.Run("BranchBuild", func(t *testing.T) {
-		defer resetEnv(os.Environ())
-		os.Clearenv()
-		os.Unsetenv("GITHUB_HEAD_REF")
-		os.Setenv("GITHUB_ACTIONS", "true")
-		os.Setenv("GITHUB_REF", "refs/heads/feat/test-gh-actions")
-		os.Setenv("GITHUB_RUN_ID", "42")
-		os.Setenv("GITHUB_SHA", "abcdef42713")
-		os.Setenv("GITHUB_SERVER_URL", "github.com")
-		os.Setenv("GITHUB_REPOSITORY", "foo/bar")
+func TestGitHubActionsConfigProvider_GetBuildStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		runData run
+		want    string
+	}{
+		{"BuildStatusSuccess", run{Status: "success"}, BuildStatusSuccess},
+		{"BuildStatusAborted", run{Status: "cancelled"}, BuildStatusAborted},
+		{"BuildStatusInProgress", run{Status: "in_progress"}, BuildStatusInProgress},
+		{"BuildStatusFailure", run{Status: "qwertyu"}, BuildStatusFailure},
+		{"BuildStatusFailure", run{Status: ""}, BuildStatusFailure},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitHubActionsConfigProvider{
+				runData: tt.runData,
+			}
+			assert.Equalf(t, tt.want, g.GetBuildStatus(), "GetBuildStatus()")
+		})
+	}
+}
 
-		p, _ := NewOrchestratorSpecificConfigProvider()
+func TestGitHubActionsConfigProvider_GetBuildReason(t *testing.T) {
+	tests := []struct {
+		name         string
+		envGithubRef string
+		want         string
+	}{
+		{"BuildReasonManual", "workflow_dispatch", BuildReasonManual},
+		{"BuildReasonSchedule", "schedule", BuildReasonSchedule},
+		{"BuildReasonPullRequest", "pull_request", BuildReasonPullRequest},
+		{"BuildReasonResourceTrigger", "workflow_call", BuildReasonResourceTrigger},
+		{"BuildReasonIndividualCI", "push", BuildReasonIndividualCI},
+		{"BuildReasonUnknown", "qwerty", BuildReasonUnknown},
+		{"BuildReasonUnknown", "", BuildReasonUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitHubActionsConfigProvider{}
 
-		assert.False(t, p.IsPullRequest())
-		assert.Equal(t, "github.com/foo/bar/actions/runs/42", p.GetBuildURL())
-		assert.Equal(t, "feat/test-gh-actions", p.GetBranch())
-		assert.Equal(t, "refs/heads/feat/test-gh-actions", p.GetReference())
-		assert.Equal(t, "abcdef42713", p.GetCommit())
-		assert.Equal(t, "github.com/foo/bar", p.GetRepoURL())
-		assert.Equal(t, "GitHubActions", p.OrchestratorType())
+			_ = os.Setenv("GITHUB_REF", tt.envGithubRef)
+			assert.Equalf(t, tt.want, g.GetBuildReason(), "GetBuildReason()")
+		})
+	}
+}
+
+func TestGitHubActionsConfigProvider_GetRepoURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		envServerURL string
+		envRepo      string
+		want         string
+	}{
+		{"github.com", "https://github.com", "SAP/jenkins-library", "https://github.com/SAP/jenkins-library"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitHubActionsConfigProvider{}
+
+			_ = os.Setenv("GITHUB_SERVER_URL", tt.envServerURL)
+			_ = os.Setenv("GITHUB_REPOSITORY", tt.envRepo)
+			assert.Equalf(t, tt.want, g.GetRepoURL(), "GetRepoURL()")
+		})
+	}
+}
+
+func TestGitHubActionsConfigProvider_GetPullRequestConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		envRef string
+		want   PullRequestConfig
+	}{
+		{"1", "refs/pull/1234/merge", PullRequestConfig{"n/a", "n/a", "1234"}},
+		{"2", "refs/pull/1234", PullRequestConfig{"n/a", "n/a", "1234"}},
+		{"2", "1234/merge", PullRequestConfig{"n/a", "n/a", "1234"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitHubActionsConfigProvider{}
+
+			_ = os.Setenv("GITHUB_REF", tt.envRef)
+			_ = os.Setenv("GITHUB_HEAD_REF", "n/a")
+			_ = os.Setenv("GITHUB_BASE_REF", "n/a")
+			assert.Equalf(t, tt.want, g.GetPullRequestConfig(), "GetPullRequestConfig()")
+		})
+	}
+}
+
+func TestGitHubActionsConfigProvider_guessCurrentJob(t *testing.T) {
+	tests := []struct {
+		name          string
+		jobs          []job
+		targetJobName string
+		wantJob       job
+	}{
+		{
+			name:          "job found",
+			jobs:          []job{{Name: "Job1"}, {Name: "Job2"}, {Name: "Job3"}},
+			targetJobName: "Job2",
+			wantJob:       job{Name: "Job2"},
+		},
+		{
+			name:          "job not found",
+			jobs:          []job{{Name: "Job1"}, {Name: "Job2"}, {Name: "Job3"}},
+			targetJobName: "Job123",
+			wantJob:       job{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GitHubActionsConfigProvider{
+				jobs: tt.jobs,
+			}
+			_ = os.Setenv("GITHUB_JOB", tt.targetJobName)
+			g.guessCurrentJob()
+
+			assert.Equal(t, tt.wantJob, g.currentJob)
+		})
+	}
+}
+
+func TestGitHubActionsConfigProvider_fetchRunData(t *testing.T) {
+	// data
+	respJson := map[string]interface{}{
+		"status":         "completed",
+		"run_started_at": "2023-08-11T07:28:24Z",
+		"html_url":       "https://github.com/SAP/jenkins-library/actions/runs/11111",
+	}
+	startedAt, _ := time.Parse(time.RFC3339, "2023-08-11T07:28:24Z")
+	wantRunData := run{
+		Status:    "completed",
+		StartedAt: startedAt,
+		HtmlURL:   "https://github.com/SAP/jenkins-library/actions/runs/11111",
+	}
+
+	// setup provider
+	g := &GitHubActionsConfigProvider{actionsURL: "https://api.github.com/repos/SAP/jenkins-library/actions"}
+	g.client.SetOptions(piperHttp.ClientOptions{
+		UseDefaultTransport: true, // need to use default transport for http mock
+		MaxRetries:          -1,
 	})
+	// setup http mock
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/SAP/jenkins-library/actions/runs/11111",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, respJson)
+		},
+	)
+	// setup env vars
+	defer resetEnv(os.Environ())
+	os.Clearenv()
+	_ = os.Setenv("GITHUB_RUN_ID", "11111")
 
-	t.Run("PR", func(t *testing.T) {
-		defer resetEnv(os.Environ())
-		os.Clearenv()
-		os.Setenv("GITHUB_HEAD_REF", "feat/test-gh-actions")
-		os.Setenv("GITHUB_BASE_REF", "main")
-		os.Setenv("GITHUB_REF", "refs/pull/42/merge")
+	// run
+	g.fetchRunData()
+	assert.Equal(t, wantRunData, g.runData)
+}
 
-		p := GitHubActionsConfigProvider{}
-		c := p.GetPullRequestConfig()
+func TestGitHubActionsConfigProvider_fetchJobs(t *testing.T) {
+	// data
+	respJson := map[string]interface{}{"jobs": []map[string]interface{}{{
+		"id":       111,
+		"name":     "Piper / Init",
+		"html_url": "https://github.com/SAP/jenkins-library/actions/runs/11111/jobs/111",
+	}, {
+		"id":       222,
+		"name":     "Piper / Build",
+		"html_url": "https://github.com/SAP/jenkins-library/actions/runs/11111/jobs/222",
+	}, {
+		"id":       333,
+		"name":     "Piper / Acceptance",
+		"html_url": "https://github.com/SAP/jenkins-library/actions/runs/11111/jobs/333",
+	},
+	}}
+	wantJobs := []job{{
+		ID:      111,
+		Name:    "Piper / Init",
+		HtmlURL: "https://github.com/SAP/jenkins-library/actions/runs/11111/jobs/111",
+	}, {
+		ID:      222,
+		Name:    "Piper / Build",
+		HtmlURL: "https://github.com/SAP/jenkins-library/actions/runs/11111/jobs/222",
+	}, {
+		ID:      333,
+		Name:    "Piper / Acceptance",
+		HtmlURL: "https://github.com/SAP/jenkins-library/actions/runs/11111/jobs/333",
+	}}
 
-		assert.True(t, p.IsPullRequest())
-		assert.Equal(t, "feat/test-gh-actions", c.Branch)
-		assert.Equal(t, "main", c.Base)
-		assert.Equal(t, "42", c.Key)
+	// setup provider
+	g := &GitHubActionsConfigProvider{actionsURL: "https://api.github.com/repos/SAP/jenkins-library/actions"}
+	g.client.SetOptions(piperHttp.ClientOptions{
+		UseDefaultTransport: true, // need to use default transport for http mock
+		MaxRetries:          -1,
 	})
+	// setup http mock
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpmock.RegisterResponder(
+		http.MethodGet,
+		"https://api.github.com/repos/SAP/jenkins-library/actions/runs/11111/jobs",
+		func(req *http.Request) (*http.Response, error) {
+			return httpmock.NewJsonResponse(200, respJson)
+		},
+	)
+	// setup env vars
+	defer resetEnv(os.Environ())
+	os.Clearenv()
+	_ = os.Setenv("GITHUB_RUN_ID", "11111")
 
-	t.Run("Test get logs - success", func(t *testing.T) {
-		defer resetEnv(os.Environ())
-		os.Clearenv()
-		os.Unsetenv("GITHUB_HEAD_REF")
-		os.Setenv("GITHUB_ACTIONS", "true")
-		os.Setenv("GITHUB_REF_NAME", "feat/test-gh-actions")
-		os.Setenv("GITHUB_REF", "refs/heads/feat/test-gh-actions")
-		os.Setenv("GITHUB_RUN_ID", "42")
-		os.Setenv("GITHUB_SHA", "abcdef42713")
-		os.Setenv("GITHUB_REPOSITORY", "foo/bar")
-		os.Setenv("GITHUB_URL", "https://github.com/")
-		p := func() OrchestratorSpecificConfigProviding {
-			g := GitHubActionsConfigProvider{}
-			g.client = piperHttp.Client{}
-			g.client.SetOptions(piperHttp.ClientOptions{
-				MaxRequestDuration:        5 * time.Second,
-				Password:                  "TOKEN",
-				TransportSkipVerification: true,
-				UseDefaultTransport:       true, // need to use default transport for http mock
-				MaxRetries:                -1,
-			})
-			return &g
-		}()
-		stagesID := stagesID{
-			Jobs: []job{
-				{ID: 123},
-				{ID: 124},
-				{ID: 125},
-			},
-		}
-		logs := []string{
-			"log_record1\n",
-			"log_record2\n",
-		}
-		httpmock.Activate()
-		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/foo/bar/actions/runs/42/jobs",
-			func(req *http.Request) (*http.Response, error) {
-				return httpmock.NewJsonResponse(200, stagesID)
-			},
-		)
-		httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/foo/bar/actions/jobs/123/logs",
-			func(req *http.Request) (*http.Response, error) {
-				return httpmock.NewStringResponse(200, string(logs[0])), nil
-			},
-		)
-		httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/foo/bar/actions/jobs/124/logs",
-			func(req *http.Request) (*http.Response, error) {
-				return httpmock.NewStringResponse(200, string(logs[1])), nil
-			},
-		)
+	// run
+	err := g.fetchJobs()
+	assert.NoError(t, err)
+	assert.Equal(t, wantJobs, g.jobs)
+}
 
-		actual, err := p.GetLog()
+func TestGitHubActionsConfigProvider_GetLog(t *testing.T) {
+	// data
+	respLogs := []string{
+		"log_record11\nlog_record12\nlog_record13\n",
+		"log_record21\nlog_record22\n",
+		"log_record31\nlog_record32\n",
+		"log_record41\n",
+	}
+	wantLogs := "log_record11\nlog_record12\nlog_record13\nlog_record21\n" +
+		"log_record22\nlog_record31\nlog_record32\nlog_record41\n"
+	jobs := []job{
+		{ID: 111}, {ID: 222}, {ID: 333}, {ID: 444}, {ID: 555},
+	}
 
-		assert.NoError(t, err)
-		assert.Equal(t, strings.Join(logs, ""), string(actual))
+	// setup provider
+	g := &GitHubActionsConfigProvider{
+		client:     piperHttp.Client{},
+		actionsURL: "https://api.github.com/repos/SAP/jenkins-library/actions",
+		runData:    run{},
+		jobs:       jobs,
+		currentJob: job{},
+	}
+	g.client.SetOptions(piperHttp.ClientOptions{
+		UseDefaultTransport: true, // need to use default transport for http mock
+		MaxRetries:          -1,
 	})
-
-	t.Run("Test get logs - error: failed to get stages ID", func(t *testing.T) {
-		defer resetEnv(os.Environ())
-		os.Clearenv()
-		os.Unsetenv("GITHUB_HEAD_REF")
-		os.Setenv("GITHUB_ACTIONS", "true")
-		os.Setenv("GITHUB_REF_NAME", "feat/test-gh-actions")
-		os.Setenv("GITHUB_REF", "refs/heads/feat/test-gh-actions")
-		os.Setenv("GITHUB_RUN_ID", "42")
-		os.Setenv("GITHUB_SHA", "abcdef42713")
-		os.Setenv("GITHUB_REPOSITORY", "foo/bar")
-		os.Setenv("GITHUB_URL", "https://github.com/")
-		p := func() OrchestratorSpecificConfigProviding {
-			g := GitHubActionsConfigProvider{}
-			g.client = piperHttp.Client{}
-			g.client.SetOptions(piperHttp.ClientOptions{
-				MaxRequestDuration:        5 * time.Second,
-				Password:                  "TOKEN",
-				TransportSkipVerification: true,
-				UseDefaultTransport:       true, // need to use default transport for http mock
-				MaxRetries:                -1,
-			})
-			return &g
-		}()
-		httpmock.Activate()
-		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/foo/bar/actions/runs/42/jobs",
+	// setup http mock
+	rand.Seed(time.Now().UnixNano())
+	latencyMin, latencyMax := 15, 500 // milliseconds
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	for i, j := range jobs {
+		idx := i
+		httpmock.RegisterResponder(
+			http.MethodGet,
+			fmt.Sprintf("https://api.github.com/repos/SAP/jenkins-library/actions/jobs/%d/logs", j.ID),
 			func(req *http.Request) (*http.Response, error) {
-				return nil, fmt.Errorf("err")
+				// simulate response delay
+				latency := rand.Intn(latencyMax-latencyMin) + latencyMin
+				time.Sleep(time.Duration(latency) * time.Millisecond)
+				return httpmock.NewStringResponse(200, respLogs[idx]), nil
 			},
 		)
-		actual, err := p.GetLog()
+	}
 
-		assert.Nil(t, actual)
-		assert.EqualError(t, err, "failed to get API data: HTTP request to https://api.github.com/repos/foo/bar/actions/runs/42/jobs failed with error: HTTP GET request to https://api.github.com/repos/foo/bar/actions/runs/42/jobs failed: Get \"https://api.github.com/repos/foo/bar/actions/runs/42/jobs\": err")
-	})
+	// run
+	logs, err := g.GetLog()
+	assert.NoError(t, err)
+	assert.Equal(t, wantLogs, string(logs))
+}
 
-	t.Run("Test get logs - failed to get logs", func(t *testing.T) {
-		defer resetEnv(os.Environ())
-		os.Clearenv()
-		os.Unsetenv("GITHUB_HEAD_REF")
-		os.Setenv("GITHUB_ACTIONS", "true")
-		os.Setenv("GITHUB_REF_NAME", "feat/test-gh-actions")
-		os.Setenv("GITHUB_REF", "refs/heads/feat/test-gh-actions")
-		os.Setenv("GITHUB_RUN_ID", "42")
-		os.Setenv("GITHUB_SHA", "abcdef42713")
-		os.Setenv("GITHUB_REPOSITORY", "foo/bar")
-		os.Setenv("GITHUB_URL", "https://github.com/")
-		p := func() OrchestratorSpecificConfigProviding {
-			g := GitHubActionsConfigProvider{}
-			g.client = piperHttp.Client{}
-			g.client.SetOptions(piperHttp.ClientOptions{
-				MaxRequestDuration:        5 * time.Second,
-				Password:                  "TOKEN",
-				TransportSkipVerification: true,
-				UseDefaultTransport:       true, // need to use default transport for http mock
-				MaxRetries:                -1,
-			})
-			return &g
-		}()
-		stagesID := stagesID{
-			Jobs: []job{
-				{ID: 123},
-				{ID: 124},
-				{ID: 125},
-			},
-		}
-		httpmock.Activate()
-		defer httpmock.DeactivateAndReset()
-		httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/foo/bar/actions/runs/42/jobs",
-			func(req *http.Request) (*http.Response, error) {
-				return httpmock.NewJsonResponse(200, stagesID)
-			},
-		)
-		httpmock.RegisterResponder(http.MethodGet, "https://api.github.com/repos/foo/bar/actions/jobs/123/logs",
-			func(req *http.Request) (*http.Response, error) {
-				return nil, fmt.Errorf("err")
-			},
-		)
+func TestGitHubActionsConfigProvider_Others(t *testing.T) {
+	defer resetEnv(os.Environ())
+	os.Clearenv()
+	_ = os.Setenv("GITHUB_ACTION", "1")
+	_ = os.Setenv("GITHUB_RUN_ID", "11111")
+	_ = os.Setenv("GITHUB_REF_NAME", "main")
+	_ = os.Setenv("GITHUB_HEAD_REF", "feature-branch-1")
+	_ = os.Setenv("GITHUB_REF", "refs/pull/42/merge")
+	_ = os.Setenv("GITHUB_WORKFLOW", "Init")
+	_ = os.Setenv("GITHUB_SHA", "ffac537e6cbbf934b08745a378932722df287a53")
+	_ = os.Setenv("GITHUB_API_URL", "https://api.github.com")
+	_ = os.Setenv("GITHUB_REPOSITORY", "SAP/jenkins-library")
 
-		actual, err := p.GetLog()
+	p := GitHubActionsConfigProvider{}
+	startedAt, _ := time.Parse(time.RFC3339, "2023-08-11T07:28:24Z")
+	p.runData = run{
+		Status:    "",
+		StartedAt: startedAt,
+		HtmlURL:   "https://github.com/SAP/jenkins-library/actions/runs/5815297487",
+	}
+	p.currentJob = job{ID: 111, Name: "job1", HtmlURL: "https://github.com/SAP/jenkins-library/actions/runs/123456/jobs/7654321"}
 
-		assert.Nil(t, actual)
-		// GitHubActionsConfigProvider.GetLog calls http.GetRequest concurrently, so we don't know what log (123 or 124) will be got first
-		// ref: pkg/orchestrator/gitHubActions.go:90
-		assert.ErrorContains(t, err, "failed to get logs: failed to get API data: HTTP request to https://api.github.com/repos/foo/bar/actions/jobs/12")
-	})
+	assert.Equal(t, "n/a", p.OrchestratorVersion())
+	assert.Equal(t, "GitHubActions", p.OrchestratorType())
+	assert.Equal(t, "11111", p.GetBuildID())
+	assert.Equal(t, []ChangeSet{}, p.GetChangeSet())
+	assert.Equal(t, startedAt, p.GetPipelineStartTime())
+	assert.Equal(t, "job1", p.GetStageName())
+	assert.Equal(t, "main", p.GetBranch())
+	assert.Equal(t, "refs/pull/42/merge", p.GetReference())
+	assert.Equal(t, "https://github.com/SAP/jenkins-library/actions/runs/5815297487", p.GetBuildURL())
+	assert.Equal(t, "https://github.com/SAP/jenkins-library/actions/runs/123456/jobs/7654321", p.GetJobURL())
+	assert.Equal(t, "Init", p.GetJobName())
+	assert.Equal(t, "ffac537e6cbbf934b08745a378932722df287a53", p.GetCommit())
+	assert.Equal(t, "https://api.github.com/repos/SAP/jenkins-library/actions", actionsURL())
+	assert.True(t, p.IsPullRequest())
+	assert.True(t, isGitHubActions())
 }

--- a/pkg/orchestrator/gitHubActions_test.go
+++ b/pkg/orchestrator/gitHubActions_test.go
@@ -154,7 +154,6 @@ func TestGitHubActionsConfigProvider_fetchRunData(t *testing.T) {
 		fetched:   true,
 		Status:    "completed",
 		StartedAt: startedAt,
-		HtmlURL:   "https://github.com/SAP/jenkins-library/actions/runs/11111",
 	}
 
 	// setup provider
@@ -307,6 +306,7 @@ func TestGitHubActionsConfigProvider_Others(t *testing.T) {
 	_ = os.Setenv("GITHUB_WORKFLOW", "Init")
 	_ = os.Setenv("GITHUB_SHA", "ffac537e6cbbf934b08745a378932722df287a53")
 	_ = os.Setenv("GITHUB_API_URL", "https://api.github.com")
+	_ = os.Setenv("GITHUB_SERVER_URL", "https://github.com")
 	_ = os.Setenv("GITHUB_REPOSITORY", "SAP/jenkins-library")
 
 	p := GitHubActionsConfigProvider{}
@@ -315,7 +315,6 @@ func TestGitHubActionsConfigProvider_Others(t *testing.T) {
 		fetched:   true,
 		Status:    "",
 		StartedAt: startedAt,
-		HtmlURL:   "https://github.com/SAP/jenkins-library/actions/runs/5815297487",
 	}
 	p.currentJob = job{ID: 111, Name: "job1", HtmlURL: "https://github.com/SAP/jenkins-library/actions/runs/123456/jobs/7654321"}
 
@@ -327,7 +326,7 @@ func TestGitHubActionsConfigProvider_Others(t *testing.T) {
 	assert.Equal(t, "job1", p.GetStageName())
 	assert.Equal(t, "main", p.GetBranch())
 	assert.Equal(t, "refs/pull/42/merge", p.GetReference())
-	assert.Equal(t, "https://github.com/SAP/jenkins-library/actions/runs/5815297487", p.GetBuildURL())
+	assert.Equal(t, "https://github.com/SAP/jenkins-library/actions/runs/11111", p.GetBuildURL())
 	assert.Equal(t, "https://github.com/SAP/jenkins-library/actions/runs/123456/jobs/7654321", p.GetJobURL())
 	assert.Equal(t, "Init", p.GetJobName())
 	assert.Equal(t, "ffac537e6cbbf934b08745a378932722df287a53", p.GetCommit())

--- a/pkg/orchestrator/jenkins.go
+++ b/pkg/orchestrator/jenkins.go
@@ -197,12 +197,12 @@ func (j *JenkinsConfigProvider) GetBuildReason() string {
 	marshal, err := json.Marshal(j.apiInformation)
 	if err != nil {
 		log.Entry().WithError(err).Debugf("could not marshal apiInformation")
-		return "Unknown"
+		return BuildReasonUnknown
 	}
 	jsonParsed, err := gabs.ParseJSON(marshal)
 	if err != nil {
 		log.Entry().WithError(err).Debugf("could not parse apiInformation")
-		return "Unknown"
+		return BuildReasonUnknown
 	}
 
 	for _, child := range jsonParsed.Path("actions").Children() {
@@ -214,21 +214,21 @@ func (j *JenkinsConfigProvider) GetBuildReason() string {
 			for _, val := range child.Path("causes").Children() {
 				subclass := val.S("_class")
 				if subclass.Data().(string) == "hudson.model.Cause$UserIdCause" {
-					return "Manual"
+					return BuildReasonManual
 				} else if subclass.Data().(string) == "hudson.triggers.TimerTrigger$TimerTriggerCause" {
-					return "Schedule"
+					return BuildReasonSchedule
 				} else if subclass.Data().(string) == "jenkins.branch.BranchEventCause" {
-					return "PullRequest"
+					return BuildReasonPullRequest
 				} else if subclass.Data().(string) == "org.jenkinsci.plugins.workflow.support.steps.build.BuildUpstreamCause" {
-					return "ResourceTrigger"
+					return BuildReasonResourceTrigger
 				} else {
-					return "Unknown"
+					return BuildReasonUnknown
 				}
 			}
 		}
 
 	}
-	return "Unknown"
+	return BuildReasonUnknown
 }
 
 // GetBranch returns the branch name, only works with the git plugin enabled

--- a/pkg/orchestrator/jenkins.go
+++ b/pkg/orchestrator/jenkins.go
@@ -14,20 +14,17 @@ import (
 
 type JenkinsConfigProvider struct {
 	client         piperHttp.Client
-	options        piperHttp.ClientOptions
 	apiInformation map[string]interface{}
 }
 
 // InitOrchestratorProvider initializes the Jenkins orchestrator with credentials
 func (j *JenkinsConfigProvider) InitOrchestratorProvider(settings *OrchestratorSettings) {
-	j.client = piperHttp.Client{}
-	j.options = piperHttp.ClientOptions{
+	j.client.SetOptions(piperHttp.ClientOptions{
 		Username:         settings.JenkinsUser,
 		Password:         settings.JenkinsToken,
 		MaxRetries:       3,
 		TransportTimeout: time.Second * 10,
-	}
-	j.client.SetOptions(j.options)
+	})
 	log.Entry().Debug("Successfully initialized Jenkins config provider")
 }
 
@@ -77,15 +74,15 @@ func (j *JenkinsConfigProvider) GetBuildStatus() string {
 		// cases in ADO: succeeded, failed, canceled, none, partiallySucceeded
 		switch result := val; result {
 		case "SUCCESS":
-			return "SUCCESS"
+			return BuildStatusSuccess
 		case "ABORTED":
-			return "ABORTED"
+			return BuildStatusAborted
 		default:
 			// FAILURE, NOT_BUILT
-			return "FAILURE"
+			return BuildStatusFailure
 		}
 	}
-	return "FAILURE"
+	return BuildStatusFailure
 }
 
 // GetChangeSet returns the commitIds and timestamp of the changeSet of the current run

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -22,6 +22,13 @@ const (
 	BuildStatusAborted    = "ABORTED"
 	BuildStatusFailure    = "FAILURE"
 	BuildStatusInProgress = "IN_PROGRESS"
+
+	BuildReasonManual          = "Manual"
+	BuildReasonSchedule        = "Schedule"
+	BuildReasonPullRequest     = "PullRequest"
+	BuildReasonResourceTrigger = "ResourceTrigger"
+	BuildReasonIndividualCI    = "IndividualCI"
+	BuildReasonUnknown         = "Unknown"
 )
 
 type OrchestratorSpecificConfigProviding interface {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -18,9 +18,10 @@ const (
 )
 
 const (
-	BuildStatusSuccess = "SUCCESS"
-	BuildStatusAborted = "ABORTED"
-	BuildStatusFailure = "FAILURE"
+	BuildStatusSuccess    = "SUCCESS"
+	BuildStatusAborted    = "ABORTED"
+	BuildStatusFailure    = "FAILURE"
+	BuildStatusInProgress = "IN_PROGRESS"
 )
 
 type OrchestratorSpecificConfigProviding interface {

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -17,6 +17,12 @@ const (
 	Jenkins
 )
 
+const (
+	BuildStatusSuccess = "SUCCESS"
+	BuildStatusAborted = "ABORTED"
+	BuildStatusFailure = "FAILURE"
+)
+
 type OrchestratorSpecificConfigProviding interface {
 	InitOrchestratorProvider(settings *OrchestratorSettings)
 	OrchestratorType() string
@@ -75,13 +81,13 @@ func NewOrchestratorSpecificConfigProvider() (OrchestratorSpecificConfigProvidin
 // DetectOrchestrator returns the name of the current orchestrator e.g. Jenkins, Azure, Unknown
 func DetectOrchestrator() Orchestrator {
 	if isAzure() {
-		return Orchestrator(AzureDevOps)
+		return AzureDevOps
 	} else if isGitHubActions() {
-		return Orchestrator(GitHubActions)
+		return GitHubActions
 	} else if isJenkins() {
-		return Orchestrator(Jenkins)
+		return Jenkins
 	} else {
-		return Orchestrator(Unknown)
+		return Unknown
 	}
 }
 


### PR DESCRIPTION
Few notes about implementation:
1) GitHub Actions runnerr version is unavailable through API and envvars. So OrchestratorVersion is currently unimplemented.
2) Logs for a running job are not available through API, so logs for the last (running) stage will be skipped.