### PR TITLE
fix(setupCommonPipelineEnvironment): setting git ref for branch with slashes in name

### DIFF
--- a/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
+++ b/test/groovy/SetupCommonPipelineEnvironmentTest.groovy
@@ -337,6 +337,44 @@ class SetupCommonPipelineEnvironmentTest extends BasePiperTest {
     }
 
     @Test
+    void "Set scmInfo parameter sets git reference for branch with slashes in name, origin"() {
+
+        def GitUtils gitUtils = new GitUtils() {
+            boolean isMergeCommit(){
+                return false
+            }
+        }
+
+        helper.registerAllowedMethod("fileExists", [String], { String path ->
+            return path.endsWith('.pipeline/config.yml')
+        })
+
+        def dummyScmInfo = [GIT_COMMIT: 'dummy_git_commit_id', GIT_BRANCH: 'origin/testbranch/001']
+
+        stepRule.step.setupCommonPipelineEnvironment(script: nullScript, utils: utilsMock, scmInfo: dummyScmInfo, gitUtils: gitUtils)
+        assertThat(nullScript.commonPipelineEnvironment.gitRef, is('refs/heads/testbranch/001'))
+    }
+
+    @Test
+    void "Set scmInfo parameter sets git reference for branch with slashes in name, not origin"() {
+
+        def GitUtils gitUtils = new GitUtils() {
+            boolean isMergeCommit(){
+                return false
+            }
+        }
+
+        helper.registerAllowedMethod("fileExists", [String], { String path ->
+            return path.endsWith('.pipeline/config.yml')
+        })
+
+        def dummyScmInfo = [GIT_COMMIT: 'dummy_git_commit_id', GIT_BRANCH: 'testbranch/001']
+
+        stepRule.step.setupCommonPipelineEnvironment(script: nullScript, utils: utilsMock, scmInfo: dummyScmInfo, gitUtils: gitUtils)
+        assertThat(nullScript.commonPipelineEnvironment.gitRef, is('refs/heads/testbranch/001'))
+    }
+
+    @Test
     void "sets gitReference and gitRemoteCommit for pull request, head strategy"() {
 
         def GitUtils gitUtils = new GitUtils() {

--- a/vars/setupCommonPipelineEnvironment.groovy
+++ b/vars/setupCommonPipelineEnvironment.groovy
@@ -271,7 +271,10 @@ private void setGitRefOnCommonPipelineEnvironment(script, String gitCommit, Stri
     }
 
     if(gitBranch.contains("/")){
-        gitBranch = gitBranch.split("/")[1]
+        gitBranchSplit = gitBranch.split("/")
+        if(gitBranchSplit[0] == "origin") {
+            gitBranch = gitBranchSplit[1..-1].join("/")
+        }
     }
 
     if (!gitBranch.contains("PR")) {


### PR DESCRIPTION
# Changes

When users create organization pipelines in Jenkins and use the productive branch with a slash the ref is split wrong. Example: for branch `origin/test/001` splitting will create `test`.

- [x] Tests
- [ ] Documentation