### PR TITLE
Introduce filterRegex parameter for performance report publisher

### DIFF
--- a/documentation/docs/steps/testsPublishResults.md
+++ b/documentation/docs/steps/testsPublishResults.md
@@ -58,24 +58,25 @@ testsPublishResults(
 
 ### jmeter
 
-| parameter | mandatory | default | possible values |
-| ----------|-----------|---------|-----------------|
+| parameter | mandatory | default      | possible values |
+| ----------|-----------|--------------|-----------------|
 | pattern | no | `'**/*.jtl'` |  |
-| errorFailedThreshold | no | `20` |  |
-| errorUnstableThreshold | no | `10` |  |
-| errorUnstableResponseTimeThreshold | no | `` |  |
-| relativeFailedThresholdPositive | no | `0` |  |
-| relativeFailedThresholdNegative | no | `0` |  |
-| relativeUnstableThresholdPositive | no | `0` |  |
-| relativeUnstableThresholdNegative | no | `0` |  |
-| modeOfThreshold | no | `false` | true, false |
-| modeThroughput | no | `false` | true, false |
-| nthBuildNumber | no | `0` |  |
-| configType | no | `PRT` |  |
-| failBuildIfNoResultFile | no | `false` | true, false |
-| compareBuildPrevious | no | `true` | true, false |
-| archive | no | `false` | true, false |
-| allowEmptyResults | no | `true` | true, false |
+| errorFailedThreshold | no | `20`         |  |
+| errorUnstableThreshold | no | `10`         |  |
+| errorUnstableResponseTimeThreshold | no | ``           |  |
+| relativeFailedThresholdPositive | no | `0`          |  |
+| relativeFailedThresholdNegative | no | `0`          |  |
+| relativeUnstableThresholdPositive | no | `0`          |  |
+| relativeUnstableThresholdNegative | no | `0`          |  |
+| modeOfThreshold | no | `false`      | true, false |
+| modeThroughput | no | `false`      | true, false |
+| nthBuildNumber | no | `0`          |  |
+| configType | no | `PRT`        |  |
+| failBuildIfNoResultFile | no | `false`      | true, false |
+| compareBuildPrevious | no | `true`       | true, false |
+| archive | no | `false`      | true, false |
+| allowEmptyResults | no | `true`       | true, false |
+| filterRegex | no | ' '           |  |
 
 ## ${docGenConfiguration}
 

--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -481,6 +481,7 @@ steps:
       active: false
     jmeter:
       pattern: '**/*.jtl'
+      filterRegex: ''
       errorFailedThreshold: 20
       errorUnstableThreshold: 10
       errorUnstableResponseTimeThreshold: ''

--- a/vars/testsPublishResults.groovy
+++ b/vars/testsPublishResults.groovy
@@ -163,7 +163,8 @@ def publishJMeterReport(Map settings = [:]){
             nthBuildNumber: settings.get('nthBuildNumber'),
             configType: settings.get('configType'),
             failBuildIfNoResultFile: settings.get('failBuildIfNoResultFile'),
-            compareBuildPrevious: settings.get('compareBuildPrevious')
+            compareBuildPrevious: settings.get('compareBuildPrevious'),
+            filterRegex: settings.get('filterRegex')
         )
         archiveResults(settings.get('archive'), pattern, settings.get('allowEmptyResults'))
     }


### PR DESCRIPTION
Step `testsPublishResults` use the [performance plugin ](https://www.jenkins.io/doc/pipeline/steps/performance/) from jenkins to publish jmeter reports. It is possible to set thresholds per test and fail pipelines if they exceed. This feature was broken as the parameter `filterRegex` was not defined in piper-defaults and was always evaluating to `null`. 

Error observed in pipelines before the change 
```
Creating parser with percentiles:'0,50,90,100,' filterRegex:null
[2023-09-06T19:32:19.582Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-GetOrder-customFields.jtl' with filterRegex 'null'.
[2023-09-06T19:32:19.584Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-GetOrder-expanded.jtl' with filterRegex 'null'.
[2023-09-06T19:32:19.585Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-GetOrderItems-customFields.jtl' with filterRegex 'null'.
[2023-09-06T19:32:19.586Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-GetOrderItems-expanded.jtl' with filterRegex 'null'.
[2023-09-06T19:32:19.587Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-GetOrders-pgSize40-expanded.jtl' with filterRegex 'null'.
[2023-09-06T19:32:19.589Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-PostOrder-5Physical.jtl' with filterRegex 'null'.
[2023-09-06T19:32:19.590Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-PostOrder-5Subscription.jtl' with filterRegex 'null'.
[2023-09-06T19:32:19.591Z] Performance: Parsing report file '/var/jenkins_home/jobs/thilak-test-pipeline/builds/91/performance-reports/JMeter/v2-PostOrder-customFields.jtl' with filterRegex 'null'.
```

With these changes, the plugin is able to set the threshold and parse the file. Working output below
```
Creating parser with percentiles:'0,50,90,100,' filterRegex: 
[2023-09-06T21:16:30.330Z] Performance: Parsing report file '/var/jenkins_home/jobs/dom-ordercapture/branches/testJmeterResults/builds/11/performance-reports/JMeter/v2-PostOrder-5Physical.jtl' with filterRegex ''.
[2023-09-06T21:16:30.331Z] Performance: Parsing report file '/var/jenkins_home/jobs/dom-ordercapture/branches/testJmeterResults/builds/11/performance-reports/JMeter/v2-PostOrder-5Subscription.jtl' with filterRegex ''.
[2023-09-06T21:16:30.332Z] Performance: Parsing report file '/var/jenkins_home/jobs/dom-ordercapture/branches/testJmeterResults/builds/11/performance-reports/JMeter/v2-PostOrder-customFields.jtl' with filterRegex ''.
[2023-09-06T21:16:30.332Z] Performance: Percentage of errors greater or equal than 10% sets the build as unstable
[2023-09-06T21:16:30.332Z] Performance: Percentage of errors greater or equal than 20% sets the build as failure
[2023-09-06T21:16:30.332Z] Setting threshold: v2-PostOrder-5Physical.jtl:200
[2023-09-06T21:16:30.339Z] UNSTABLE: v2-PostOrder-5Physical.jtl has exceeded the threshold of [200] with the time of [319]
[2023-09-06T21:16:30.339Z] Performance: File v2-PostOrder-5Physical.jtl reported 0.0% of errors [UNSTABLE]. Build status is: UNSTABLE
```
This step and the feature from the performance plugin is actively used by our teams to notify on performance degradation for our services. 