### PR TITLE
fix(docs): fixing documentation for violating markdownlint rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,5 @@ before opening a pull request.
 
 [piper-library-user-doc]: https://sap.github.io/jenkins-library/
 [piper-library-issues]: https://github.com/SAP/jenkins-library/issues
-[piper-library-license]: ./LICENSE
 [piper-library-contribution]: .github/CONTRIBUTING.md
 [google-group]: https://groups.google.com/forum/#!forum/project-piper

--- a/documentation/docs/guidedtour.md
+++ b/documentation/docs/guidedtour.md
@@ -175,7 +175,6 @@ Browse the steadily increasing list of features you can implement through the pr
 
 The **Configuration** pattern supports simple pipelines that can be reused by multiple applications. To understand the principles of inheritance and customization, have a look at the the [configuration][resources-configuration] documentation.
 
-[guidedtour-my-own-jenkins]:         myownjenkins.md
 [guidedtour-sample.config]:          samples/cloud-cf-helloworld-nodejs/pipeline/config.yml
 [guidedtour-sample.jenkins]:         samples/cloud-cf-helloworld-nodejs/Jenkinsfile
 [guidedtour-sample.mta]:             samples/cloud-cf-helloworld-nodejs/mta.yaml
@@ -186,8 +185,6 @@ The **Configuration** pattern supports simple pipelines that can be reused by mu
 
 [sap]:                               https://www.sap.com
 [sap-cp-trial]:                      https://account.hanatrial.ondemand.com
-
-[devops-docker-images-cxs-guide]:    https://github.com/SAP/devops-docker-cx-server/blob/master/docs/operations/cx-server-operations-guide.md
 
 [cloud-cf-helloworld-nodejs]:        https://github.com/SAP/cloud-cf-helloworld-nodejs
 [github]:                            https://github.com

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -60,20 +60,8 @@ the API and are subjected to change without prior notice. Types and methods anno
 `@API` are considered to be API, used e.g. from other shared libraries. Changes to those
 methods/types needs to be announced, discussed and agreed.
 
-[github]: https://github.com
 [piper-library]: https://github.com/SAP/jenkins-library
-[cloud-sdk-pipeline]: pipelines/cloud-sdk/introduction/
 [devops-docker-images]: https://github.com/SAP/devops-docker-images
-[devops-docker-images-issues]:       https://github.com/SAP/devops-docker-images/issues
-[devops-docker-images-cxs-guide]:     https://github.com/SAP/devops-docker-images/blob/master/docs/operations/cx-server-operations-guide.md
 [piper-library-scenario]: scenarios/ui5-sap-cp/Readme/
 [piper-doc-extensibility]: extensibility
-[piper-library-pages-plugins]: requiredPlugins
-[piper-library-issues]: https://github.com/SAP/jenkins-library/issues
-[piper-library-license]: ./LICENSE
-[piper-library-contribution]: .github/CONTRIBUTING.md
 [jenkins-doc-pipelines]: https://jenkins.io/solutions/pipeline
-[jenkins-doc-libraries]: https://jenkins.io/doc/book/pipeline/shared-libraries
-[jenkins-doc-steps]: https://jenkins.io/doc/pipeline/steps
-[jenkins-plugin-sharedlibs]: https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Shared+Groovy+Libraries+Plugin
-[google-group]: https://groups.google.com/forum/#!forum/project-piper

--- a/documentation/docs/infrastructure/customjenkins.md
+++ b/documentation/docs/infrastructure/customjenkins.md
@@ -102,8 +102,5 @@ If you face such a [user permission issue][piper-issue-781], choose between the 
 [docker-getstarted]: https://docs.docker.com/get-started/
 [jenkins-doc-client]: https://jenkins.io/doc/book/managing/cli/
 [jenkins-docker-image]: https://github.com/jenkinsci/docker/
-[piper-library-pages]: https://sap.github.io/jenkins-library
 [piper-issue-781]: https://github.com/SAP/jenkins-library/issues/781
-
-[devops-docker-images]: https://github.com/SAP/devops-docker-images
 [devops-cxs-plugins]: https://github.com/SAP/devops-docker-cx-server/blob/master/jenkins-master/plugins.txt

--- a/documentation/docs/pipelines/abapEnvironment/configuration.md
+++ b/documentation/docs/pipelines/abapEnvironment/configuration.md
@@ -131,7 +131,7 @@ Please have a look at the [step documentation](https://sap.github.io/jenkins-lib
 
 ### Clone Repositories
 
-If the `Clone Repositories` stage is configured, you can specify the `strategy` that should be performed on the software components and the branches that you have configured in the `respositories.yml` file in step [4. Configuration for Cloning the repositories](#4-configuration-for-cloning-the-repositories). Per default the strategy will be set to `Pull` if not specified. The following strategies are supported and can be used on the software components and branches:
+If the `Clone Repositories` stage is configured, you can specify the `strategy` that should be performed on the software components and the branches that you have configured in the `respositories.yml` file in step [4. Configuration for Cloning the repositories](#3-configuration-for-cloning-the-repositories). Per default the strategy will be set to `Pull` if not specified. The following strategies are supported and can be used on the software components and branches:
 
 * `Pull`: If you have specified Pull as the strategy the [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/) step will be used
 * `Clone`: If you have specified the Clone strategy the [abapEnvironmentCloneGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentCloneGitRepo/) step will be used

--- a/documentation/docs/pipelines/abapEnvironment/configuration.md
+++ b/documentation/docs/pipelines/abapEnvironment/configuration.md
@@ -131,7 +131,7 @@ Please have a look at the [step documentation](https://sap.github.io/jenkins-lib
 
 ### Clone Repositories
 
-If the `Clone Repositories` stage is configured, you can specify the `strategy` that should be performed on the software components and the branches that you have configured in the `respositories.yml` file in step [4. Configuration for Cloning the repositories](#3-configuration-for-cloning-the-repositories). Per default the strategy will be set to `Pull` if not specified. The following strategies are supported and can be used on the software components and branches:
+If the `Clone Repositories` stage is configured, you can specify the `strategy` that should be performed on the software components and the branches that you have configured in the `respositories.yml` file in step [3. Configuration for Cloning the repositories](#3-configuration-for-cloning-the-repositories). Per default the strategy will be set to `Pull` if not specified. The following strategies are supported and can be used on the software components and branches:
 
 * `Pull`: If you have specified Pull as the strategy the [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/) step will be used
 * `Clone`: If you have specified the Clone strategy the [abapEnvironmentCloneGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentCloneGitRepo/) step will be used

--- a/documentation/docs/scenarios/abapEnvironmentAddons.md
+++ b/documentation/docs/scenarios/abapEnvironmentAddons.md
@@ -250,31 +250,31 @@ Pipeline steps can be restarted without causing double execution of already perf
 In case of an error during execution of the pipeline steps:
 
 * Stage: [Prepare System](https://www.project-piper.io/pipelines/abapEnvironment/stages/prepareSystem/)
-  *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
+  * Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
     * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
     <br>ABAP System provisioning requires sufficient entitlements for `abap/standard` as well as `abap/hana_compute_unit` and `abap/abap_compute_unit` to be assigned to the subaccount.
 * Stage: [Clone Repositories](https://www.project-piper.io/pipelines/abapEnvironment/stages/cloneRepositories/)
-  *Step: [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/)
+  * Step: [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/)
     * __e.g. `A4C_A2G/000 - Branch checkout for /NAMESPC/COMPONENTA is currently performed; Try again later...`__
     <br>Parallel execution of multiple actions on the same software component (like checkout, pull etc.) is not supported.
 * Stage: [ATC](https://www.project-piper.io/pipelines/abapEnvironment/stages/Test/)
-  *Step: [abapEnvironmentRunATCCheck](https://sap.github.io/jenkins-library/steps/abapEnvironmentRunATCCheck/)
+  * Step: [abapEnvironmentRunATCCheck](https://sap.github.io/jenkins-library/steps/abapEnvironmentRunATCCheck/)
     * __*Long-running step execution*__
     <br>[Create a custom check variant](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/4ca1896148fe47b5a4507e1f5fb2aa8c.html) and utilize [ATC Exemptions](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/b317b37b06304f99a8cf36e0ebf30861.html) to reduce the test scope and irrelevant findings. Resolve ATC findings early on during development, e.g. by [working with ATC during transport release](https://help.sap.com/viewer/5371047f1273405bb46725a417f95433/Cloud/en-US/c0d95a9263da476eb5b6ae03225ce7ba.html).
 * Stage: [Build](https://www.project-piper.io/pipelines/abapEnvironment/stages/build/)
-  *Step: [abapAddonAssemblyKitReserveNextPackages](https://sap.github.io/jenkins-library/steps/abapAddonAssemblyKitReserveNextPackages/)
+  * Step: [abapAddonAssemblyKitReserveNextPackages](https://sap.github.io/jenkins-library/steps/abapAddonAssemblyKitReserveNextPackages/)
     * __e.g. `Package SAPK00C001CPITAPC1 was already build but with commit d5ffb9717a57c9e65d9e4c8366ea45be958b56cc, not with 86d70dc3`__
     <br>New `commitID`, but no new software component `version` in add-on descriptor: Only by changing the `version` a new delivery package is created.
     * __e.g. `CommitID of package SAPK00C002CPITAPC1 is the same as the one of the predecessor package.`__
     <br>New Patch Level of software component, but same `commitID` in add-on descriptor: The same `commitID` cannot be used as previous/current commit id for a correction package.
 * Stage: [Integration Tests](https://www.project-piper.io/pipelines/abapEnvironment/stages/integrationTest/)
-  *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
+  * Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
     * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
     <br>ABAP System provisioning requires sufficient entitlements for abap/saas_oem as well as abap/hana_compute_unit and abap/abap_compute_unit to be assigned to the subaccount.
     * __`Product installation failed because AddOn XYZ has not been registered in PPMS for productive development`__
     <br>The add-on product is not yet registered for add-on installation, please follow steps in [Register Add-on Product for a Global Account](https://www.project-piper.io/scenarios/abapEnvironmentAddons/)#register-add-on-product-for-a-global-account
 * Stage: [Post](https://www.project-piper.io/pipelines/abapEnvironment/stages/post/)
-  *Step: [cloudFoundryDeleteService](https://sap.github.io/jenkins-library/steps/cloudFoundryDeleteService/)
+  * Step: [cloudFoundryDeleteService](https://sap.github.io/jenkins-library/steps/cloudFoundryDeleteService/)
     * __*Add-on assembly system is deleted unexpectedly*__
     <br>Create a Piper extension of the `Post` stage, similar to [Post.groovy](https://github.com/SAP-samples/abap-platform-ci-cd-samples/blob/addon-build-static/.pipeline/extensions/Post.groovy)
 

--- a/documentation/docs/scenarios/abapEnvironmentAddons.md
+++ b/documentation/docs/scenarios/abapEnvironmentAddons.md
@@ -250,31 +250,31 @@ Pipeline steps can be restarted without causing double execution of already perf
 In case of an error during execution of the pipeline steps:
 
 * Stage: [Prepare System](https://www.project-piper.io/pipelines/abapEnvironment/stages/prepareSystem/)
-      * Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
+      *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
           * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
           <br>ABAP System provisioning requires sufficient entitlements for `abap/standard` as well as `abap/hana_compute_unit` and `abap/abap_compute_unit` to be assigned to the subaccount.
 * Stage: [Clone Repositories](https://www.project-piper.io/pipelines/abapEnvironment/stages/cloneRepositories/)
-      * Step: [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/)
+      *Step: [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/)
           * __e.g. `A4C_A2G/000 - Branch checkout for /NAMESPC/COMPONENTA is currently performed; Try again later...`__
           <br>Parallel execution of multiple actions on the same software component (like checkout, pull etc.) is not supported.
 * Stage: [ATC](https://www.project-piper.io/pipelines/abapEnvironment/stages/Test/)
-      * Step: [abapEnvironmentRunATCCheck](https://sap.github.io/jenkins-library/steps/abapEnvironmentRunATCCheck/)
+      *Step: [abapEnvironmentRunATCCheck](https://sap.github.io/jenkins-library/steps/abapEnvironmentRunATCCheck/)
           * __*Long-running step execution*__
           <br>[Create a custom check variant](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/4ca1896148fe47b5a4507e1f5fb2aa8c.html) and utilize [ATC Exemptions](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/b317b37b06304f99a8cf36e0ebf30861.html) to reduce the test scope and irrelevant findings. Resolve ATC findings early on during development, e.g. by [working with ATC during transport release](https://help.sap.com/viewer/5371047f1273405bb46725a417f95433/Cloud/en-US/c0d95a9263da476eb5b6ae03225ce7ba.html).
 * Stage: [Build](https://www.project-piper.io/pipelines/abapEnvironment/stages/build/)
-      * Step: [abapAddonAssemblyKitReserveNextPackages](https://sap.github.io/jenkins-library/steps/abapAddonAssemblyKitReserveNextPackages/)
+      *Step: [abapAddonAssemblyKitReserveNextPackages](https://sap.github.io/jenkins-library/steps/abapAddonAssemblyKitReserveNextPackages/)
           * __e.g. `Package SAPK00C001CPITAPC1 was already build but with commit d5ffb9717a57c9e65d9e4c8366ea45be958b56cc, not with 86d70dc3`__
           <br>New `commitID`, but no new software component `version` in add-on descriptor: Only by changing the `version` a new delivery package is created.
           * __e.g. `CommitID of package SAPK00C002CPITAPC1 is the same as the one of the predecessor package.`__
           <br>New Patch Level of software component, but same `commitID` in add-on descriptor: The same `commitID` cannot be used as previous/current commit id for a correction package.
 * Stage: [Integration Tests](https://www.project-piper.io/pipelines/abapEnvironment/stages/integrationTest/)
-      * Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
+      *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
           * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
           <br>ABAP System provisioning requires sufficient entitlements for abap/saas_oem as well as abap/hana_compute_unit and abap/abap_compute_unit to be assigned to the subaccount.
           * __`Product installation failed because AddOn XYZ has not been registered in PPMS for productive development`__
           <br>The add-on product is not yet registered for add-on installation, please follow steps in [Register Add-on Product for a Global Account](https://www.project-piper.io/scenarios/abapEnvironmentAddons/)#register-add-on-product-for-a-global-account
 * Stage: [Post](https://www.project-piper.io/pipelines/abapEnvironment/stages/post/)
-      * Step: [cloudFoundryDeleteService](https://sap.github.io/jenkins-library/steps/cloudFoundryDeleteService/)
+      *Step: [cloudFoundryDeleteService](https://sap.github.io/jenkins-library/steps/cloudFoundryDeleteService/)
           * __*Add-on assembly system is deleted unexpectedly*__
           <br>Create a Piper extension of the `Post` stage, similar to [Post.groovy](https://github.com/SAP-samples/abap-platform-ci-cd-samples/blob/addon-build-static/.pipeline/extensions/Post.groovy)
 

--- a/documentation/docs/scenarios/abapEnvironmentAddons.md
+++ b/documentation/docs/scenarios/abapEnvironmentAddons.md
@@ -250,33 +250,33 @@ Pipeline steps can be restarted without causing double execution of already perf
 In case of an error during execution of the pipeline steps:
 
 * Stage: [Prepare System](https://www.project-piper.io/pipelines/abapEnvironment/stages/prepareSystem/)
-      *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
-          * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
-          <br>ABAP System provisioning requires sufficient entitlements for `abap/standard` as well as `abap/hana_compute_unit` and `abap/abap_compute_unit` to be assigned to the subaccount.
+  *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
+    * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
+    <br>ABAP System provisioning requires sufficient entitlements for `abap/standard` as well as `abap/hana_compute_unit` and `abap/abap_compute_unit` to be assigned to the subaccount.
 * Stage: [Clone Repositories](https://www.project-piper.io/pipelines/abapEnvironment/stages/cloneRepositories/)
-      *Step: [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/)
-          * __e.g. `A4C_A2G/000 - Branch checkout for /NAMESPC/COMPONENTA is currently performed; Try again later...`__
-          <br>Parallel execution of multiple actions on the same software component (like checkout, pull etc.) is not supported.
+  *Step: [abapEnvironmentPullGitRepo](https://sap.github.io/jenkins-library/steps/abapEnvironmentPullGitRepo/)
+    * __e.g. `A4C_A2G/000 - Branch checkout for /NAMESPC/COMPONENTA is currently performed; Try again later...`__
+    <br>Parallel execution of multiple actions on the same software component (like checkout, pull etc.) is not supported.
 * Stage: [ATC](https://www.project-piper.io/pipelines/abapEnvironment/stages/Test/)
-      *Step: [abapEnvironmentRunATCCheck](https://sap.github.io/jenkins-library/steps/abapEnvironmentRunATCCheck/)
-          * __*Long-running step execution*__
-          <br>[Create a custom check variant](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/4ca1896148fe47b5a4507e1f5fb2aa8c.html) and utilize [ATC Exemptions](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/b317b37b06304f99a8cf36e0ebf30861.html) to reduce the test scope and irrelevant findings. Resolve ATC findings early on during development, e.g. by [working with ATC during transport release](https://help.sap.com/viewer/5371047f1273405bb46725a417f95433/Cloud/en-US/c0d95a9263da476eb5b6ae03225ce7ba.html).
+  *Step: [abapEnvironmentRunATCCheck](https://sap.github.io/jenkins-library/steps/abapEnvironmentRunATCCheck/)
+    * __*Long-running step execution*__
+    <br>[Create a custom check variant](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/4ca1896148fe47b5a4507e1f5fb2aa8c.html) and utilize [ATC Exemptions](https://help.sap.com/viewer/c238d694b825421f940829321ffa326a/202110.000/en-US/b317b37b06304f99a8cf36e0ebf30861.html) to reduce the test scope and irrelevant findings. Resolve ATC findings early on during development, e.g. by [working with ATC during transport release](https://help.sap.com/viewer/5371047f1273405bb46725a417f95433/Cloud/en-US/c0d95a9263da476eb5b6ae03225ce7ba.html).
 * Stage: [Build](https://www.project-piper.io/pipelines/abapEnvironment/stages/build/)
-      *Step: [abapAddonAssemblyKitReserveNextPackages](https://sap.github.io/jenkins-library/steps/abapAddonAssemblyKitReserveNextPackages/)
-          * __e.g. `Package SAPK00C001CPITAPC1 was already build but with commit d5ffb9717a57c9e65d9e4c8366ea45be958b56cc, not with 86d70dc3`__
-          <br>New `commitID`, but no new software component `version` in add-on descriptor: Only by changing the `version` a new delivery package is created.
-          * __e.g. `CommitID of package SAPK00C002CPITAPC1 is the same as the one of the predecessor package.`__
-          <br>New Patch Level of software component, but same `commitID` in add-on descriptor: The same `commitID` cannot be used as previous/current commit id for a correction package.
+  *Step: [abapAddonAssemblyKitReserveNextPackages](https://sap.github.io/jenkins-library/steps/abapAddonAssemblyKitReserveNextPackages/)
+    * __e.g. `Package SAPK00C001CPITAPC1 was already build but with commit d5ffb9717a57c9e65d9e4c8366ea45be958b56cc, not with 86d70dc3`__
+    <br>New `commitID`, but no new software component `version` in add-on descriptor: Only by changing the `version` a new delivery package is created.
+    * __e.g. `CommitID of package SAPK00C002CPITAPC1 is the same as the one of the predecessor package.`__
+    <br>New Patch Level of software component, but same `commitID` in add-on descriptor: The same `commitID` cannot be used as previous/current commit id for a correction package.
 * Stage: [Integration Tests](https://www.project-piper.io/pipelines/abapEnvironment/stages/integrationTest/)
-      *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
-          * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
-          <br>ABAP System provisioning requires sufficient entitlements for abap/saas_oem as well as abap/hana_compute_unit and abap/abap_compute_unit to be assigned to the subaccount.
-          * __`Product installation failed because AddOn XYZ has not been registered in PPMS for productive development`__
-          <br>The add-on product is not yet registered for add-on installation, please follow steps in [Register Add-on Product for a Global Account](https://www.project-piper.io/scenarios/abapEnvironmentAddons/)#register-add-on-product-for-a-global-account
+  *Step: [abapEnvironmentCreateSystem](https://sap.github.io/jenkins-library/steps/abapEnvironmentCreateSystem/)
+    * __`A service instance for the selected plan cannot be created in this organization` or `Quota is not sufficient for this request.`__
+    <br>ABAP System provisioning requires sufficient entitlements for abap/saas_oem as well as abap/hana_compute_unit and abap/abap_compute_unit to be assigned to the subaccount.
+    * __`Product installation failed because AddOn XYZ has not been registered in PPMS for productive development`__
+    <br>The add-on product is not yet registered for add-on installation, please follow steps in [Register Add-on Product for a Global Account](https://www.project-piper.io/scenarios/abapEnvironmentAddons/)#register-add-on-product-for-a-global-account
 * Stage: [Post](https://www.project-piper.io/pipelines/abapEnvironment/stages/post/)
-      *Step: [cloudFoundryDeleteService](https://sap.github.io/jenkins-library/steps/cloudFoundryDeleteService/)
-          * __*Add-on assembly system is deleted unexpectedly*__
-          <br>Create a Piper extension of the `Post` stage, similar to [Post.groovy](https://github.com/SAP-samples/abap-platform-ci-cd-samples/blob/addon-build-static/.pipeline/extensions/Post.groovy)
+  *Step: [cloudFoundryDeleteService](https://sap.github.io/jenkins-library/steps/cloudFoundryDeleteService/)
+    * __*Add-on assembly system is deleted unexpectedly*__
+    <br>Create a Piper extension of the `Post` stage, similar to [Post.groovy](https://github.com/SAP-samples/abap-platform-ci-cd-samples/blob/addon-build-static/.pipeline/extensions/Post.groovy)
 
 ### Support Components
 

--- a/documentation/docs/steps/isChangeInDevelopment.md
+++ b/documentation/docs/steps/isChangeInDevelopment.md
@@ -6,7 +6,7 @@
 
 * You have an SAP Solution Manager user to which you have assigned the roles required for uploading. See [SAP Solution Manager Administration](https://help.sap.com/viewer/c413647f87a54db59d18cb074ce3dafd/7.2.12/en-US/11505ddff03c4d74976dae648743e10e.html).
 * You have created a change document.
-* You have installed the Change Management Client with the needed certificates. See [Change Management Client](transportRequestUploadSOLMAN.md#Change-Management-Client).
+* You have installed the Change Management Client with the needed certificates. See [Change Management Client](transportRequestUploadSOLMAN.md#change-management-client).
 
 ## Specifying the Change Document
 

--- a/documentation/docs/steps/neoDeploy.md
+++ b/documentation/docs/steps/neoDeploy.md
@@ -12,7 +12,7 @@
 
 * **Neo Java Web SDK 3.39.10 or compatible version** - can be downloaded from [Maven Central](http://central.maven.org/maven2/com/sap/cloud/neo-java-web-sdk/). This step is capable of triggering the neo deploy tool provided inside a docker image. We provide docker image `ppiper/neo-cli`. `neo.sh` needs to be contained in path, e.g by adding a symbolic link to `/usr/local/bin`.
 
-* **Java 8 or compatible version** - needed by the *Neo-Java-Web-SDK*. Java environment needs to be properly configured (JAVA_HOME, java exectutable contained in path).
+* **Java 8 or compatible version** - needed by the _Neo-Java-Web-SDK_. Java environment needs to be properly configured (JAVA_HOME, java exectutable contained in path).
 
 ## ${docGenParameters}
 

--- a/documentation/docs/steps/transportRequestUploadSOLMAN.md
+++ b/documentation/docs/steps/transportRequestUploadSOLMAN.md
@@ -7,7 +7,7 @@
 * You have an SAP Solution Manager user account and the roles required for uploading. See [SAP Solution Manager Administration](https://help.sap.com/viewer/c413647f87a54db59d18cb074ce3dafd/7.2.12/en-US/11505ddff03c4d74976dae648743e10e.html).
 * You have a change document to which your transport request is coupled.
 * You have a transport request, which is the target container of the upload.
-* You have installed the Change Management Client with the needed certificates. See [Change Management Client](#Change-Management-Client).
+* You have installed the Change Management Client with the needed certificates. See [Change Management Client](#change-management-client).
 
 ## Change Management Client
 

--- a/documentation/docs/steps/xsDeploy.md
+++ b/documentation/docs/steps/xsDeploy.md
@@ -36,5 +36,3 @@ steps:
     space: mySpace
     org: myOrg
 ```
-
-[dockerExecute]: ../dockerExecute


### PR DESCRIPTION
# Changes
The markdown linting check is failing for PRs that trigger it. Fixing documentation for failing checks.

Removing unused links for violating MD053 rules.
Removing space between "*" and "Step" in abapEnvironmentAddons.md for violating MD037/no-space-in-emphasis rule.
Changing * to _ in neoDeploy.md for violating MD049/emphasis-style rule.
Fixing links in transportRequestUploadSOLMAN.md:10 and abapEnvironment/configuration.md:134 

- [ ] Tests
- [ ] Documentation
