### PR TITLE
[feat] creating build settings info from gradle build

### DIFF
--- a/cmd/gradleExecuteBuild.go
+++ b/cmd/gradleExecuteBuild.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	gradleBomFilename = "bom-gradle"
-	stepName          = "gradleExecuteBuild"
+	gradleBomFilename        = "bom-gradle"
+	stepNameForBuildSettings = "gradleExecuteBuild"
 )
 
 var (
@@ -193,7 +193,7 @@ func runGradleExecuteBuild(config *gradleExecuteBuildOptions, telemetryData *tel
 
 	log.Entry().Debugf("creating build settings information...")
 
-	dockerImage, err := GetDockerImageValue(stepName)
+	dockerImage, err := GetDockerImageValue(stepNameForBuildSettings)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func runGradleExecuteBuild(config *gradleExecuteBuildOptions, telemetryData *tel
 		BuildSettingsInfo: config.BuildSettingsInfo,
 		DockerImage:       dockerImage,
 	}
-	buildSettingsInfo, err := buildsettings.CreateBuildSettingsInfo(&gradleConfig, stepName)
+	buildSettingsInfo, err := buildsettings.CreateBuildSettingsInfo(&gradleConfig, stepNameForBuildSettings)
 	if err != nil {
 		log.Entry().Warnf("failed to create build settings info: %v", err)
 	}

--- a/cmd/gradleExecuteBuild.go
+++ b/cmd/gradleExecuteBuild.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/SAP/jenkins-library/pkg/buildsettings"
 	"github.com/SAP/jenkins-library/pkg/command"
 	"github.com/SAP/jenkins-library/pkg/gradle"
 	"github.com/SAP/jenkins-library/pkg/log"
@@ -19,6 +20,7 @@ import (
 
 const (
 	gradleBomFilename = "bom-gradle"
+	stepName          = "gradleExecuteBuild"
 )
 
 var (
@@ -188,6 +190,25 @@ func runGradleExecuteBuild(config *gradleExecuteBuildOptions, telemetryData *tel
 		log.Entry().WithError(err).Errorf("gradle build execution was failed: %v", err)
 		return err
 	}
+
+	log.Entry().Debugf("creating build settings information...")
+
+	dockerImage, err := GetDockerImageValue(stepName)
+	if err != nil {
+		return err
+	}
+
+	gradleConfig := buildsettings.BuildOptions{
+		CreateBOM:         config.CreateBOM,
+		Publish:           config.Publish,
+		BuildSettingsInfo: config.BuildSettingsInfo,
+		DockerImage:       dockerImage,
+	}
+	buildSettingsInfo, err := buildsettings.CreateBuildSettingsInfo(&gradleConfig, stepName)
+	if err != nil {
+		log.Entry().Warnf("failed to create build settings info: %v", err)
+	}
+	pipelineEnv.custom.buildSettingsInfo = buildSettingsInfo
 
 	log.Entry().Info("Publishing of artifacts to staging repository...")
 	if config.Publish {

--- a/cmd/gradleExecuteBuild_generated.go
+++ b/cmd/gradleExecuteBuild_generated.go
@@ -226,7 +226,7 @@ func addGradleExecuteBuildFlags(cmd *cobra.Command, stepConfig *gradleExecuteBui
 	cmd.Flags().StringSliceVar(&stepConfig.ExcludeCreateBOMForProjects, "excludeCreateBOMForProjects", []string{}, "Defines which projects/subprojects will be ignored during bom creation. Only if applyCreateBOMForAllProjects is set to true")
 	cmd.Flags().StringSliceVar(&stepConfig.ExcludePublishingForProjects, "excludePublishingForProjects", []string{}, "Defines which projects/subprojects will be ignored during publishing. Only if applyCreateBOMForAllProjects is set to true")
 	cmd.Flags().StringSliceVar(&stepConfig.BuildFlags, "buildFlags", []string{}, "Defines a list of tasks and/or arguments to be provided for gradle in the respective order to be executed. This list takes precedence if specified over 'task' parameter")
-	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the maven build . This information is typically used for compliance related processes.")
+	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the gradle build . This information is typically used for compliance related processes.")
 
 }
 

--- a/resources/metadata/gradleExecuteBuild.yaml
+++ b/resources/metadata/gradleExecuteBuild.yaml
@@ -157,6 +157,16 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: buildSettingsInfo
+        type: string
+        description: build settings info is typically filled by the step automatically to create information about the build settings that were used during the maven build . This information is typically used for compliance related processes.
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/buildSettingsInfo
   outputs:
     resources:
       - name: reports
@@ -169,6 +179,7 @@ spec:
         params:
           - name: custom/artifacts
             type: "piperenv.Artifacts"
+          - name: custom/buildSettingsInfo
   containers:
     - name: gradle
       image: gradle:6-jdk11-alpine

--- a/resources/metadata/gradleExecuteBuild.yaml
+++ b/resources/metadata/gradleExecuteBuild.yaml
@@ -159,7 +159,7 @@ spec:
           - STEPS
       - name: buildSettingsInfo
         type: string
-        description: build settings info is typically filled by the step automatically to create information about the build settings that were used during the maven build . This information is typically used for compliance related processes.
+        description: build settings info is typically filled by the step automatically to create information about the build settings that were used during the gradle build . This information is typically used for compliance related processes.
         scope:
           - STEPS
           - STAGES


### PR DESCRIPTION
# Changes

creating the build settings common pipeline env metadata , that is later used in downstream process. this is inline with all other build steps 

- [x] Tests
- [x] Documentation
