### PR TITLE
OSTA-5526: default variables should be applied first, the customer variable last  So basically we have to have customer variable as a priority

### DIFF
--- a/pkg/whitesource/configHelper.go
+++ b/pkg/whitesource/configHelper.go
@@ -64,10 +64,6 @@ func (s *ScanOptions) RewriteUAConfigurationFile(utils Utils, projectName string
 
 func (c *ConfigOptions) updateConfig(originalConfig *map[string]string) map[string]string {
 	newConfig := map[string]string{}
-	for k, v := range *originalConfig {
-		newConfig[k] = v
-	}
-
 	for _, cOpt := range *c {
 		//omit default if value present
 		var dependentValue string
@@ -87,6 +83,10 @@ func (c *ConfigOptions) updateConfig(originalConfig *map[string]string) map[stri
 			}
 		}
 	}
+	for k, v := range *originalConfig {
+		newConfig[k] = v
+	}
+
 	return newConfig
 }
 

--- a/pkg/whitesource/configHelper_test.go
+++ b/pkg/whitesource/configHelper_test.go
@@ -87,14 +87,14 @@ func TestUpdateConfig(t *testing.T) {
 	assert.Equal(t, "dependentValue", updatedConfig["dependent"])
 	assert.Equal(t, "non_existing_forced_val", updatedConfig["non_existing_forced"])
 	assert.Equal(t, "non_existing_not_forced_val", updatedConfig["non_existing_not_forced"])
-	assert.Equal(t, "forced_val", updatedConfig["forced"])
+	assert.Equal(t, "forced_original", updatedConfig["forced"])
 	assert.Equal(t, "not_forced_original", updatedConfig["not_forced"])
-	assert.NotEqual(t, "omit_val", updatedConfig["omit"])
+	assert.NotEqual(t, "dont_omit_forced_original", updatedConfig["omit"])
 	assert.Equal(t, "dont_omit_val", updatedConfig["dont_omit"])
 	assert.Equal(t, "dont_omit_forced_val", updatedConfig["dont_omit_forced"])
 	assert.Equal(t, "dont_omit_not_forced_original", updatedConfig["dont_omit_not_forced"])
-	assert.Equal(t, "original_value appended by appended_val", updatedConfig["append"])
-	assert.Equal(t, "appended_val", updatedConfig["append_empty"])
+	assert.Equal(t, "original_value appended by", updatedConfig["append"])
+	assert.Equal(t, "", updatedConfig["append_empty"])
 }
 
 func TestAddGeneralDefaults(t *testing.T) {


### PR DESCRIPTION
Here is the customer ticker I've created
https://itsm.services.sap/sp?sys_id=fdc83c5f9781f5dc9da3f9300153af37&view=sp&id=sap_ticket_form&table=incident

We are migrating hiperspace project, 
And gradle subproject does not squash, though the gradle.aggregateModules=true in the wss-unified-agent.config
It's takes a lower priority than default https://github.com/SAP/jenkins-library/blob/master/pkg/whitesource/configHelper.go#L184
Basically, my custom settings has never apply.

# Changes

- [ ] Tests
- [ ] Documentation
