### PR TITLE
toolrecord/whitesource: improve URL generation 

### DIFF
--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1041,9 +1042,14 @@ func persistScannedProjects(config *ScanOptions, scan *ws.Scan, commonPipelineEn
 // create toolrecord file for whitesource
 func createToolRecordWhitesource(utils whitesourceUtils, workspace string, config *whitesourceExecuteScanOptions, scan *ws.Scan) (string, error) {
 	record := toolrecord.New(utils, workspace, "whitesource", config.ServiceURL)
-	wsUiRoot := "https://saas.whitesourcesoftware.com"
+	// rest api url https://.../api/v1.x
+	apiUrl, err := url.Parse(config.ServiceURL)
+	if err != nil {
+		return "", err
+	}
+	wsUiRoot := "https://" + apiUrl.Hostname()
 	productURL := wsUiRoot + "/Wss/WSS.html#!product;token=" + config.ProductToken
-	err := record.AddKeyData("product",
+	err = record.AddKeyData("product",
 		config.ProductToken,
 		config.ProductName,
 		productURL)
@@ -1054,11 +1060,13 @@ func createToolRecordWhitesource(utils whitesourceUtils, workspace string, confi
 	for idx, project := range scan.ScannedProjects() {
 		max_idx = idx
 		name := project.Name
+		projectId := strconv.FormatInt(project.ID, 10)
 		token := project.Token
 		projectURL := ""
-		if token != "" {
-			projectURL = wsUiRoot + "/Wss/WSS.html#!project;token=" + token
-		} else {
+		if projectId != "" {
+			projectURL = wsUiRoot + "/Wss/WSS.html#!project;id=" + projectId
+		}
+		if token == "" {
 			// token is empty, provide a dummy to have an indication
 			token = "unknown"
 		}


### PR DESCRIPTION
toolrecord file:
- drop the hardcoded default url
- use the more user-friendly project ID instead of the project token

