### PR TITLE
fix(codeqlExecuteScan): logging when use both Vault and Jenkins Credentials config

### DIFF
--- a/cmd/codeqlExecuteScan.go
+++ b/cmd/codeqlExecuteScan.go
@@ -202,7 +202,7 @@ func uploadResults(config *codeqlExecuteScanOptions, repoInfo RepoInfo, token st
 		e := bufferErr.String()
 		log.Entry().Error(e)
 		if strings.Contains(e, "Unauthorized") {
-			log.Entry().Error("Either your token is invalid or you use both Vault and Jenkins credentials, to use your Jenkins credentials try setting 'skipVault:true'")
+			log.Entry().Error("Either your Github Token is invalid or you use both Vault and Jenkins credentials where your Vault credentials are invalid, to use your Jenkins credentials try setting 'skipVault:true'")
 		}
 		log.Entry().Error("failed to upload sarif results")
 		return "", err

--- a/cmd/codeqlExecuteScan.go
+++ b/cmd/codeqlExecuteScan.go
@@ -191,8 +191,7 @@ func uploadResults(config *codeqlExecuteScanOptions, repoInfo RepoInfo, token st
 	//if no git params are passed(commitId, reference, serverUrl, repository), then codeql tries to auto populate it based on git information of the checkout repository.
 	//It also depends on the orchestrator. Some orchestrator keep git information and some not.
 
-	var bufferOut bytes.Buffer
-	var bufferErr bytes.Buffer
+	var bufferOut, bufferErr bytes.Buffer
 	utils.Stdout(&bufferOut)
 	defer utils.Stdout(log.Writer())
 	utils.Stderr(&bufferErr)

--- a/cmd/codeqlExecuteScan.go
+++ b/cmd/codeqlExecuteScan.go
@@ -200,13 +200,15 @@ func uploadResults(config *codeqlExecuteScanOptions, repoInfo RepoInfo, token st
 	err := execute(utils, cmd, GeneralConfig.Verbose)
 	if err != nil {
 		e := bufferErr.String()
+		log.Entry().Error(e)
 		if strings.Contains(e, "Unauthorized") {
-			log.Entry().Info("Probably you use both Vault and Jenkins credentials, try to set param 'skipVault:true'")
+			log.Entry().Error("Either your token is invalid or you use both Vault and Jenkins credentials, to use your Jenkins credentials try setting 'skipVault:true'")
 		}
 		log.Entry().Error("failed to upload sarif results")
 		return "", err
 	}
 
+	log.Entry().Info(bufferErr.String())
 	url := bufferOut.String()
 	return strings.TrimSpace(url), nil
 }

--- a/cmd/codeqlExecuteScan.go
+++ b/cmd/codeqlExecuteScan.go
@@ -208,7 +208,6 @@ func uploadResults(config *codeqlExecuteScanOptions, repoInfo RepoInfo, token st
 		return "", err
 	}
 
-	log.Entry().Info(bufferErr.String())
 	url := bufferOut.String()
 	return strings.TrimSpace(url), nil
 }


### PR DESCRIPTION
# Changes

Sometimes users configure Vault and Jenkins. Now if Vault credentials are wrong, and Jenkins is correct, users are unaware which credentials have been used. For this they have to explicitly set - skipvault:true. Added logging with this info.

- [ ] Tests
- [ ] Documentation
