### PR TITLE
fix (gitOpsUpdateDeployment) add CA bundle options to plain clone and commit to trust enterprise github instances

### DIFF
--- a/cmd/batsExecuteTests.go
+++ b/cmd/batsExecuteTests.go
@@ -108,7 +108,9 @@ func runBatsExecuteTests(config *batsExecuteTestsOptions, telemetryData *telemet
 }
 
 func (b *batsExecuteTestsUtilsBundle) CloneRepo(URL string) error {
-	_, err := pipergit.PlainClone("", "", URL, "bats-core")
+	// ToDo: BatsExecute test needs to check if the repo can come from a
+	// enterprise github instance and needs ca-cert handelling seperately
+	_, err := pipergit.PlainClone("", "", URL, "bats-core", []byte{})
 	return err
 
 }

--- a/cmd/gitopsUpdateDeployment.go
+++ b/cmd/gitopsUpdateDeployment.go
@@ -326,13 +326,13 @@ func downloadCACertbunde(customTlsCertificateLinks []string, gitUtils iGitopsUpd
 	certs := []byte{}
 	for _, customTlsCertificateLink := range customTlsCertificateLinks {
 		log.Entry().Infof("Downloading CA certs %s into file '%s'", customTlsCertificateLink, path.Base(customTlsCertificateLink))
-		err := gitUtils.DownloadFile(customTlsCertificateLink, path.Base(customTlsCertificateLink), nil, nil)
+		err := gitUtils.DownloadFile(customTlsCertificateLink, "SAPNetCA_G2.crt", nil, nil)
 		if err != nil {
 			return certs, nil
 		}
 		log.Entry().Infof("Downloaded CA certs successfully from '%s'", customTlsCertificateLink)
 
-		content, err := fileUtils.FileRead(path.Base(customTlsCertificateLink))
+		content, err := fileUtils.FileRead("SAPNetCA_G2.crt")
 		if err != nil {
 			return certs, nil
 		}

--- a/cmd/gitopsUpdateDeployment.go
+++ b/cmd/gitopsUpdateDeployment.go
@@ -340,13 +340,12 @@ func downloadCACertbunde(customTlsCertificateLinks []string, gitUtils iGitopsUpd
 	utils := newGitopsUpdateDeploymentUtilsBundle()
 	for _, customTlsCertificateLink := range customTlsCertificateLinks {
 		log.Entry().Infof("Downloading CA certs %s into file '%s'", customTlsCertificateLink, path.Base(customTlsCertificateLink))
-		err := utils.DownloadFile(customTlsCertificateLink, "SAPNetCA_G2.crt", nil, nil)
+		err := utils.DownloadFile(customTlsCertificateLink, path.Base(customTlsCertificateLink), nil, nil)
 		if err != nil {
 			return certs, nil
 		}
-		log.Entry().Infof("Downloaded CA certs successfully from '%s'", customTlsCertificateLink)
 
-		content, err := fileUtils.FileRead("SAPNetCA_G2.crt")
+		content, err := fileUtils.FileRead(path.Base(customTlsCertificateLink))
 		if err != nil {
 			return certs, nil
 		}

--- a/cmd/gitopsUpdateDeployment.go
+++ b/cmd/gitopsUpdateDeployment.go
@@ -338,20 +338,22 @@ func cloneRepositoryAndChangeBranch(config *gitopsUpdateDeploymentOptions, gitUt
 func downloadCACertbunde(customTlsCertificateLinks []string, gitUtils iGitopsUpdateDeploymentGitUtils, fileUtils gitopsUpdateDeploymentFileUtils) ([]byte, error) {
 	certs := []byte{}
 	utils := newGitopsUpdateDeploymentUtilsBundle()
-	for _, customTlsCertificateLink := range customTlsCertificateLinks {
-		log.Entry().Infof("Downloading CA certs %s into file '%s'", customTlsCertificateLink, path.Base(customTlsCertificateLink))
-		err := utils.DownloadFile(customTlsCertificateLink, path.Base(customTlsCertificateLink), nil, nil)
-		if err != nil {
-			return certs, nil
-		}
+	if len(customTlsCertificateLinks) > 0 {
+		for _, customTlsCertificateLink := range customTlsCertificateLinks {
+			log.Entry().Infof("Downloading CA certs %s into file '%s'", customTlsCertificateLink, path.Base(customTlsCertificateLink))
+			err := utils.DownloadFile(customTlsCertificateLink, path.Base(customTlsCertificateLink), nil, nil)
+			if err != nil {
+				return certs, nil
+			}
 
-		content, err := fileUtils.FileRead(path.Base(customTlsCertificateLink))
-		if err != nil {
-			return certs, nil
-		}
-		log.Entry().Infof("CA certs added successfully to cert pool")
+			content, err := fileUtils.FileRead(path.Base(customTlsCertificateLink))
+			if err != nil {
+				return certs, nil
+			}
+			log.Entry().Infof("CA certs added successfully to cert pool")
 
-		certs = append(certs, content...)
+			certs = append(certs, content...)
+		}
 	}
 
 	return certs, nil

--- a/cmd/gitopsUpdateDeployment.go
+++ b/cmd/gitopsUpdateDeployment.go
@@ -329,11 +329,13 @@ func downloadCACertbunde(customTlsCertificateLinks []string, gitUtils iGitopsUpd
 		if err != nil {
 			return certs, nil
 		}
+		log.Entry().Infof("Downloaded CA certs successfully from '%s'", customTlsCertificateLink)
 
 		content, err := fileUtils.FileRead(path.Base(customTlsCertificateLink))
 		if err != nil {
 			return certs, nil
 		}
+		log.Entry().Infof("CA certs added successfully to cert pool")
 
 		certs = append(certs, content...)
 	}

--- a/cmd/gitopsUpdateDeployment.go
+++ b/cmd/gitopsUpdateDeployment.go
@@ -325,6 +325,7 @@ func cloneRepositoryAndChangeBranch(config *gitopsUpdateDeploymentOptions, gitUt
 func downloadCACertbunde(customTlsCertificateLinks []string, gitUtils iGitopsUpdateDeploymentGitUtils, fileUtils gitopsUpdateDeploymentFileUtils) ([]byte, error) {
 	certs := []byte{}
 	for _, customTlsCertificateLink := range customTlsCertificateLinks {
+		log.Entry().Infof("Downloading CA certs %s into file '%s'", customTlsCertificateLink, path.Base(customTlsCertificateLink))
 		err := gitUtils.DownloadFile(customTlsCertificateLink, path.Base(customTlsCertificateLink), nil, nil)
 		if err != nil {
 			return certs, nil

--- a/cmd/gitopsUpdateDeployment_generated.go
+++ b/cmd/gitopsUpdateDeployment_generated.go
@@ -16,20 +16,21 @@ import (
 )
 
 type gitopsUpdateDeploymentOptions struct {
-	BranchName            string   `json:"branchName,omitempty"`
-	CommitMessage         string   `json:"commitMessage,omitempty"`
-	ServerURL             string   `json:"serverUrl,omitempty"`
-	ForcePush             bool     `json:"forcePush,omitempty"`
-	Username              string   `json:"username,omitempty"`
-	Password              string   `json:"password,omitempty"`
-	FilePath              string   `json:"filePath,omitempty"`
-	ContainerName         string   `json:"containerName,omitempty"`
-	ContainerRegistryURL  string   `json:"containerRegistryUrl,omitempty"`
-	ContainerImageNameTag string   `json:"containerImageNameTag,omitempty"`
-	ChartPath             string   `json:"chartPath,omitempty"`
-	HelmValues            []string `json:"helmValues,omitempty"`
-	DeploymentName        string   `json:"deploymentName,omitempty"`
-	Tool                  string   `json:"tool,omitempty" validate:"possible-values=kubectl helm kustomize"`
+	BranchName                string   `json:"branchName,omitempty"`
+	CommitMessage             string   `json:"commitMessage,omitempty"`
+	ServerURL                 string   `json:"serverUrl,omitempty"`
+	ForcePush                 bool     `json:"forcePush,omitempty"`
+	Username                  string   `json:"username,omitempty"`
+	Password                  string   `json:"password,omitempty"`
+	FilePath                  string   `json:"filePath,omitempty"`
+	ContainerName             string   `json:"containerName,omitempty"`
+	ContainerRegistryURL      string   `json:"containerRegistryUrl,omitempty"`
+	ContainerImageNameTag     string   `json:"containerImageNameTag,omitempty"`
+	ChartPath                 string   `json:"chartPath,omitempty"`
+	HelmValues                []string `json:"helmValues,omitempty"`
+	DeploymentName            string   `json:"deploymentName,omitempty"`
+	Tool                      string   `json:"tool,omitempty" validate:"possible-values=kubectl helm kustomize"`
+	CustomTLSCertificateLinks []string `json:"customTlsCertificateLinks,omitempty"`
 }
 
 // GitopsUpdateDeploymentCommand Updates Kubernetes Deployment Manifest in an Infrastructure Git Repository
@@ -155,6 +156,7 @@ func addGitopsUpdateDeploymentFlags(cmd *cobra.Command, stepConfig *gitopsUpdate
 	cmd.Flags().StringSliceVar(&stepConfig.HelmValues, "helmValues", []string{}, "List of helm values as YAML file reference or URL (as per helm parameter description for `-f` / `--values`)")
 	cmd.Flags().StringVar(&stepConfig.DeploymentName, "deploymentName", os.Getenv("PIPER_deploymentName"), "Defines the name of the deployment. In case of `kustomize` this is the name or alias of the image in the `kustomization.yaml`")
 	cmd.Flags().StringVar(&stepConfig.Tool, "tool", `kubectl`, "Defines the tool which should be used to update the deployment description.")
+	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List containing download links of custom TLS certificates. This is required to ensure trusted connections to registries with custom certificates.")
 
 	cmd.MarkFlagRequired("branchName")
 	cmd.MarkFlagRequired("serverUrl")
@@ -342,6 +344,15 @@ func gitopsUpdateDeploymentMetadata() config.StepData {
 						Mandatory:   true,
 						Aliases:     []config.Alias{},
 						Default:     `kubectl`,
+					},
+					{
+						Name:        "customTlsCertificateLinks",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "[]string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     []string{},
 					},
 				},
 			},

--- a/cmd/gitopsUpdateDeployment_test.go
+++ b/cmd/gitopsUpdateDeployment_test.go
@@ -772,7 +772,7 @@ type filesMock struct {
 	failOnCreation bool
 	failOnDeletion bool
 	failOnWrite    bool
-	failOnRead	   bool
+	failOnRead     bool
 	failOnGlob     bool
 	path           string
 }
@@ -784,9 +784,9 @@ func (f filesMock) FileWrite(path string, content []byte, perm os.FileMode) erro
 	return piperutils.Files{}.FileWrite(path, content, perm)
 }
 
-func (f filesMock) FileRead(path string) ([]byte,error) {
+func (f filesMock) FileRead(path string) ([]byte, error) {
 	if f.failOnRead {
-		return errors.New("error appeared")
+		return []byte{}, errors.New("error appeared")
 	}
 	return piperutils.Files{}.FileRead(path)
 }

--- a/cmd/gitopsUpdateDeployment_test.go
+++ b/cmd/gitopsUpdateDeployment_test.go
@@ -848,7 +848,7 @@ func (v *gitUtilsMock) CommitFiles(newFiles []string, commitMessage string, _ st
 	return [20]byte{123}, nil
 }
 
-func (v gitUtilsMock) PushChangesToRepository(_ string, _ string, force *bool) error {
+func (v gitUtilsMock) PushChangesToRepository(_ string, _ string, force *bool, caCerts []byte) error {
 	if v.failOnPush {
 		return errors.New("error on push")
 	}
@@ -858,7 +858,7 @@ func (v gitUtilsMock) PushChangesToRepository(_ string, _ string, force *bool) e
 	return nil
 }
 
-func (v *gitUtilsMock) PlainClone(_, _, _, directory string) error {
+func (v *gitUtilsMock) PlainClone(_, _, _, directory string, caCerts []byte) error {
 	if v.skipClone {
 		return nil
 	}

--- a/cmd/gitopsUpdateDeployment_test.go
+++ b/cmd/gitopsUpdateDeployment_test.go
@@ -772,6 +772,7 @@ type filesMock struct {
 	failOnCreation bool
 	failOnDeletion bool
 	failOnWrite    bool
+	failOnRead	   bool
 	failOnGlob     bool
 	path           string
 }
@@ -781,6 +782,13 @@ func (f filesMock) FileWrite(path string, content []byte, perm os.FileMode) erro
 		return errors.New("error appeared")
 	}
 	return piperutils.Files{}.FileWrite(path, content, perm)
+}
+
+func (f filesMock) FileRead(path string) ([]byte,error) {
+	if f.failOnRead {
+		return errors.New("error appeared")
+	}
+	return piperutils.Files{}.FileRead(path)
 }
 
 func (f filesMock) TempDir(dir string, pattern string) (name string, err error) {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -54,13 +54,14 @@ func commitSingleFile(filePath, commitMessage, author string, worktree utilsWork
 }
 
 // PushChangesToRepository Pushes all committed changes in the repository to the remote repository
-func PushChangesToRepository(username, password string, force *bool, repository *git.Repository) error {
-	return pushChangesToRepository(username, password, force, repository)
+func PushChangesToRepository(username, password string, force *bool, repository *git.Repository, caCerts []byte) error {
+	return pushChangesToRepository(username, password, force, repository, caCerts)
 }
 
-func pushChangesToRepository(username, password string, force *bool, repository utilsRepository) error {
+func pushChangesToRepository(username, password string, force *bool, repository utilsRepository, caCerts []byte) error {
 	pushOptions := &git.PushOptions{
-		Auth: &http.BasicAuth{Username: username, Password: password},
+		Auth:     &http.BasicAuth{Username: username, Password: password},
+		CABundle: caCerts,
 	}
 	if force != nil {
 		pushOptions.Force = *force

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -60,8 +60,11 @@ func PushChangesToRepository(username, password string, force *bool, repository 
 
 func pushChangesToRepository(username, password string, force *bool, repository utilsRepository, caCerts []byte) error {
 	pushOptions := &git.PushOptions{
-		Auth:     &http.BasicAuth{Username: username, Password: password},
-		CABundle: caCerts,
+		Auth: &http.BasicAuth{Username: username, Password: password},
+	}
+
+	if len(caCerts) > 0 {
+		pushOptions.CABundle = caCerts
 	}
 	if force != nil {
 		pushOptions.Force = *force

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,13 +1,14 @@
 package git
 
 import (
+	"time"
+
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/pkg/errors"
-	"time"
 )
 
 // utilsWorkTree interface abstraction of git.Worktree to enable tests
@@ -72,16 +73,21 @@ func pushChangesToRepository(username, password string, force *bool, repository 
 }
 
 // PlainClone Clones a non-bare repository to the provided directory
-func PlainClone(username, password, serverURL, directory string) (*git.Repository, error) {
+func PlainClone(username, password, serverURL, directory string, caCerts []byte) (*git.Repository, error) {
 	abstractedGit := &abstractionGit{}
-	return plainClone(username, password, serverURL, directory, abstractedGit)
+	return plainClone(username, password, serverURL, directory, abstractedGit, caCerts)
 }
 
-func plainClone(username, password, serverURL, directory string, abstractionGit utilsGit) (*git.Repository, error) {
+func plainClone(username, password, serverURL, directory string, abstractionGit utilsGit, caCerts []byte) (*git.Repository, error) {
 	gitCloneOptions := git.CloneOptions{
 		Auth: &http.BasicAuth{Username: username, Password: password},
 		URL:  serverURL,
 	}
+
+	if len(caCerts) > 0 {
+		gitCloneOptions.CABundle = caCerts
+	}
+
 	repository, err := abstractionGit.plainClone(directory, false, &gitCloneOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to clone git")

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -51,13 +51,13 @@ func TestPushChangesToRepository(t *testing.T) {
 		t.Parallel()
 		err := pushChangesToRepository("user", "password", nil, RepositoryMock{
 			test: t,
-		}, []byte)
+		}, []byte{})
 		assert.NoError(t, err)
 	})
 
 	t.Run("error pushing", func(t *testing.T) {
 		t.Parallel()
-		err := pushChangesToRepository("user", "password", nil, RepositoryMockError{}, []byte)
+		err := pushChangesToRepository("user", "password", nil, RepositoryMockError{}, []byte{})
 		assert.EqualError(t, err, "failed to push commit: error on push commits")
 	})
 }
@@ -67,7 +67,7 @@ func TestPlainClone(t *testing.T) {
 	t.Run("successful clone", func(t *testing.T) {
 		t.Parallel()
 		abstractedGit := &UtilsGitMock{}
-		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte)
+		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte{})
 		assert.NoError(t, err)
 		assert.Equal(t, "directory", abstractedGit.path)
 		assert.False(t, abstractedGit.isBare)
@@ -78,7 +78,7 @@ func TestPlainClone(t *testing.T) {
 	t.Run("error on cloning", func(t *testing.T) {
 		t.Parallel()
 		abstractedGit := UtilsGitMockError{}
-		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte)
+		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte{})
 		assert.EqualError(t, err, "failed to clone git: error during clone")
 	})
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -51,13 +51,13 @@ func TestPushChangesToRepository(t *testing.T) {
 		t.Parallel()
 		err := pushChangesToRepository("user", "password", nil, RepositoryMock{
 			test: t,
-		})
+		}, []byte)
 		assert.NoError(t, err)
 	})
 
 	t.Run("error pushing", func(t *testing.T) {
 		t.Parallel()
-		err := pushChangesToRepository("user", "password", nil, RepositoryMockError{})
+		err := pushChangesToRepository("user", "password", nil, RepositoryMockError{}, []byte)
 		assert.EqualError(t, err, "failed to push commit: error on push commits")
 	})
 }
@@ -67,7 +67,7 @@ func TestPlainClone(t *testing.T) {
 	t.Run("successful clone", func(t *testing.T) {
 		t.Parallel()
 		abstractedGit := &UtilsGitMock{}
-		_, err := plainClone("user", "password", "URL", "directory", abstractedGit)
+		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte)
 		assert.NoError(t, err)
 		assert.Equal(t, "directory", abstractedGit.path)
 		assert.False(t, abstractedGit.isBare)
@@ -78,7 +78,7 @@ func TestPlainClone(t *testing.T) {
 	t.Run("error on cloning", func(t *testing.T) {
 		t.Parallel()
 		abstractedGit := UtilsGitMockError{}
-		_, err := plainClone("user", "password", "URL", "directory", abstractedGit)
+		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte)
 		assert.EqualError(t, err, "failed to clone git: error during clone")
 	})
 }

--- a/resources/metadata/gitopsUpdateDeployment.yaml
+++ b/resources/metadata/gitopsUpdateDeployment.yaml
@@ -190,6 +190,13 @@ spec:
           - kubectl
           - helm
           - kustomize
+      - name: customTlsCertificateLinks
+        type: "[]string"
+        description: List containing download links of custom TLS certificates. This is required to ensure trusted connections to registries with custom certificates.
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
   containers:
     - image: dtzar/helm-kubectl:3.8.0
       workingDir: /config


### PR DESCRIPTION
# Changes

when using enterprise github instance the step will fail as it will not trust the x509 root certs from enterprise github instance. this PR introduces an new list parameter to download the certs and add it to the `CAbundle` option for the git operations

- [x ] Tests
- [x] Documentation
