### PR TITLE
fix(helm): forward sourceRepositoryCredentialsId from groovy to go layer

### DIFF
--- a/cmd/helmExecute_generated.go
+++ b/cmd/helmExecute_generated.go
@@ -255,7 +255,8 @@ func helmExecuteMetadata() config.StepData {
 				Secrets: []config.StepSecrets{
 					{Name: "kubeConfigFileCredentialsId", Description: "Jenkins 'Secret file' credentials ID containing kubeconfig file. Details can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).", Type: "jenkins", Aliases: []config.Alias{{Name: "kubeCredentialsId", Deprecated: true}}},
 					{Name: "dockerConfigJsonCredentialsId", Description: "Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)).", Type: "jenkins"},
-					{Name: "targetRepositoryCredentialsId", Description: "Jenkins 'Username Password' credentials ID containing username and password for the Helm Repository authentication", Type: "jenkins"},
+					{Name: "sourceRepositoryCredentialsId", Description: "Jenkins 'Username Password' credentials ID containing username and password for the Helm Repository authentication (source repo)", Type: "jenkins"},
+					{Name: "targetRepositoryCredentialsId", Description: "Jenkins 'Username Password' credentials ID containing username and password for the Helm Repository authentication (target repo)", Type: "jenkins"},
 				},
 				Resources: []config.StepResources{
 					{Name: "deployDescriptor", Type: "stash"},

--- a/resources/metadata/helmExecute.yaml
+++ b/resources/metadata/helmExecute.yaml
@@ -36,8 +36,11 @@ spec:
       - name: dockerConfigJsonCredentialsId
         description: Jenkins 'Secret file' credentials ID containing Docker config.json (with registry credential(s)).
         type: jenkins
+      - name: sourceRepositoryCredentialsId
+        description: Jenkins 'Username Password' credentials ID containing username and password for the Helm Repository authentication (source repo)
+        type: jenkins
       - name: targetRepositoryCredentialsId
-        description: Jenkins 'Username Password' credentials ID containing username and password for the Helm Repository authentication
+        description: Jenkins 'Username Password' credentials ID containing username and password for the Helm Repository authentication (target repo)
         type: jenkins
     resources:
       - name: deployDescriptor

--- a/vars/helmExecute.groovy
+++ b/vars/helmExecute.groovy
@@ -7,6 +7,7 @@ void call(Map parameters = [:]) {
     List credentials = [
         [type: 'file', id: 'kubeConfigFileCredentialsId', env: ['PIPER_kubeConfig']],
         [type: 'file', id: 'dockerConfigJsonCredentialsId', env: ['PIPER_dockerConfigJSON']],
+        [type: 'usernamePassword', id: 'sourceRepositoryCredentialsId', env: ['PIPER_sourceRepositoryUser', 'PIPER_sourceRepositoryPassword']],
         [type: 'usernamePassword', id: 'targetRepositoryCredentialsId', env: ['PIPER_targetRepositoryUser', 'PIPER_targetRepositoryPassword']],
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)


### PR DESCRIPTION
in the same way how this is done for the targetRepositoryCredentialsId

# Changes

- [ ] Tests
- [ ] Documentation
