### PR TITLE
support upper case Values.yaml files

### DIFF
--- a/cmd/helmExecute.go
+++ b/cmd/helmExecute.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/kubernetes"
 	"github.com/SAP/jenkins-library/pkg/log"
@@ -157,10 +158,21 @@ func parseAndRenderCPETemplate(config helmExecuteOptions, rootPath string, utils
 	}
 
 	valueFiles := []string{}
-	defaultValueFile := fmt.Sprintf("%s/%s", config.ChartPath, "values.yaml")
-	defaultValueFileExists, err := utils.FileExists(defaultValueFile)
-	if err != nil {
-		return err
+	var defaultValueFile string
+	var defaultValueFileExists bool
+	valuesFileDefaultName := "Values.yaml"
+	// The default values file is uppercase, for backward compatibility we lookup also with lower case
+	for _, vFile := range []string{valuesFileDefaultName, strings.ToLower(valuesFileDefaultName)} {
+		defaultValueFile = fmt.Sprintf("%s/%s", config.ChartPath, vFile)
+		defaultValueFileExists, err = utils.FileExists(defaultValueFile)
+		if err != nil {
+			return err
+		}
+		if defaultValueFileExists {
+			// would be better to check if upper and lower case are present at the same time and to
+			// fail in that case. But this does not work since we have file systems which are not case sensitive.
+			break
+		}
 	}
 
 	if defaultValueFileExists {

--- a/cmd/helmExecute_test.go
+++ b/cmd/helmExecute_test.go
@@ -339,7 +339,7 @@ func TestRunHelmDefaultCommand(t *testing.T) {
 			fileUtils:          fileHandlerMock{},
 			// we expect the values file is traversed since parsing and rendering according to cpe template is active
 			assertFunc: func(f fileHandlerMock) error {
-				if len(f.fileExistsCalled) == 1 && f.fileExistsCalled[0] == "/values.yaml" {
+				if len(f.fileExistsCalled) == 1 && (f.fileExistsCalled[0] == "/values.yaml" || f.fileExistsCalled[0] == "/Values.yaml") {
 					return nil
 				}
 				return fmt.Errorf("expected FileExists called for ['/values.yaml'] but was: %+v", f.fileExistsCalled)


### PR DESCRIPTION
upper case is the convention.

See here: https://helm.sh/docs/chart_best_practices/conventions/#usage-of-the-words-helm-and-chart

# Changes

- [ ] Tests
- [ ] Documentation
