### PR TITLE
helm execute: avoid trouble with value.yaml lookup when chart path is emtpy

### DIFF
--- a/cmd/helmExecute.go
+++ b/cmd/helmExecute.go
@@ -157,7 +157,13 @@ func parseAndRenderCPETemplate(config helmExecuteOptions, rootPath string, utils
 	}
 
 	valueFiles := []string{}
-	defaultValueFile := fmt.Sprintf("%s/%s", config.ChartPath, "values.yaml")
+	var chartPath string
+	if len(config.ChartPath) == 0 {
+		chartPath = "."
+	} else {
+		chartPath = config.ChartPath
+	}
+	defaultValueFile := fmt.Sprintf("%s/%s", chartPath, "values.yaml")
 	defaultValueFileExists, err := utils.FileExists(defaultValueFile)
 	if err != nil {
 		return err

--- a/cmd/helmExecute_test.go
+++ b/cmd/helmExecute_test.go
@@ -339,7 +339,7 @@ func TestRunHelmDefaultCommand(t *testing.T) {
 			fileUtils:          fileHandlerMock{},
 			// we expect the values file is traversed since parsing and rendering according to cpe template is active
 			assertFunc: func(f fileHandlerMock) error {
-				if len(f.fileExistsCalled) == 1 && f.fileExistsCalled[0] == "/values.yaml" {
+				if len(f.fileExistsCalled) == 1 && f.fileExistsCalled[0] == "./values.yaml" {
 					return nil
 				}
 				return fmt.Errorf("expected FileExists called for ['/values.yaml'] but was: %+v", f.fileExistsCalled)


### PR DESCRIPTION
An empty chart-path seems to be a little bit paranoid, but trouble in that case can be easily avoided.

# Changes

- [ ] Tests
- [ ] Documentation
