### PR TITLE
fix(pkg/versioning): optimize GetCoordinates, fix slice out of range

### DIFF
--- a/pkg/versioning/gomodfile.go
+++ b/pkg/versioning/gomodfile.go
@@ -91,15 +91,9 @@ func (m *GoMod) GetCoordinates() (Coordinates, error) {
 	if parsed.Module == nil {
 		return result, errors.Wrap(err, "failed to parse go.mod file")
 	}
-	if parsed.Module.Mod.Path != "" {
-		artifactSplit := strings.Split(parsed.Module.Mod.Path, "/")
-		artifactID := artifactSplit[len(artifactSplit)-1]
-		result.ArtifactID = artifactID
-
-		goModPath := parsed.Module.Mod.Path
-		lastIndex := strings.LastIndex(goModPath, "/")
-		groupID := goModPath[0:lastIndex]
-		result.GroupID = groupID
+	if lastIndex := strings.LastIndex(parsed.Module.Mod.Path, "/"); lastIndex != -1 {
+		result.ArtifactID = parsed.Module.Mod.Path[lastIndex+1:]
+		result.GroupID = parsed.Module.Mod.Path[:lastIndex]
 	}
 	result.Version = parsed.Module.Mod.Version
 	if result.Version == "" {


### PR DESCRIPTION
# Changes
The user has a panic happening here:
https://github.com/SAP/jenkins-library/blob/c81e322986bb0e12255d8f2213a726dab29c3bcc/pkg/versioning/gomodfile.go#L99-L101

The panic occurs when the project does not have the url of the github repo in the go mod file. For example, the first line of our go.mod was module hotel-creator, but it should have been module.

This PR optimizes GetCoordinates method and fixes out of range panic. 

- [ ] Tests
- [ ] Documentation
