### PR TITLE
Revert "chore(vault): custom retry check function"

### DIFF
--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -1,10 +1,8 @@
 package vault
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"path"
 	"strconv"
 	"strings"
@@ -42,25 +40,6 @@ func NewClient(config *Config, token string) (Client, error) {
 	if err != nil {
 		return Client{}, err
 	}
-
-	client.SetMinRetryWait(time.Second * 3)
-	client.SetMaxRetryWait(time.Second * 5)
-	client.SetCheckRetry(func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		if resp != nil {
-			log.Entry().Infoln("Vault retry: ", resp.Status, resp.StatusCode, err)
-		} else {
-			log.Entry().Infoln("Vault retry: ", err)
-		}
-
-		retry, err := api.DefaultRetryPolicy(ctx, resp, err)
-		if err != nil || retry {
-			return true, nil
-		}
-		if resp != nil && resp.StatusCode >= 400 {
-			return true, nil
-		}
-		return false, nil
-	})
 
 	if config.Namespace != "" {
 		client.SetNamespace(config.Namespace)


### PR DESCRIPTION
Reverts SAP/jenkins-library#4475

Reverting because retrying might be causing issues with locking in Vault. 