### PR TITLE
Splunk: use `repository` and `organization` CPE from `git` instead of `github` folder

### DIFF
--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -123,8 +123,8 @@ func (s *Splunk) prepareTelemetry(telemetryData telemetry.Data) MonitoringData {
 		CorrelationID:   s.correlationID,
 		CommitHash:      readCommonPipelineEnvironment("git/headCommitId"),
 		Branch:          readCommonPipelineEnvironment("git/branch"),
-		GitOwner:        readCommonPipelineEnvironment("github/owner"),
-		GitRepository:   readCommonPipelineEnvironment("github/repository"),
+		GitOwner:        readCommonPipelineEnvironment("git/organization"),
+		GitRepository:   readCommonPipelineEnvironment("git/repository"),
 	}
 	monitoringJson, err := json.Marshal(monitoringData)
 	if err != nil {


### PR DESCRIPTION
# Changes

Since `github/owner` and `github/repository` are written to CPE by [logic written in groovy](https://github.com/SAP/jenkins-library/blob/7ab2386337c287ce89b41820b41369fca7e87bf9/vars/commonPipelineEnvironment.groovy#L212-L213), `github/owner` and `github/repository` are not filled for ADO and Actions.

This PR allows reading repository name from `git/repository` CPE and repository owner from `git/organization` CPE which were written to CPE by go step (sapPipelineInit.go), so that the `owner` and `repository` are available for Jenkins, ADO and Actions. 

- [x] Tests
- [ ] ~~Documentation~~
