### PR TITLE
fix(npm): support publishing of scoped npm modules

### DIFF
--- a/pkg/npm/publish.go
+++ b/pkg/npm/publish.go
@@ -195,7 +195,13 @@ func (exec *Execute) publish(packageJSON, registry, username, password string, p
 			return fmt.Errorf("failed to change back into original directory: %w", err)
 		}
 	} else {
-		err := execRunner.RunExecutable("npm", "publish", "--userconfig", npmrc.filepath, "--registry", registry)
+		publishArgs := append(make([]string, 0), "publish", "--userconfig", npmrc.filepath, "--registry", registry)
+
+		if len(scope) > 0 {
+			publishArgs = append(publishArgs, fmt.Sprintf("--%s:registry=%s", scope, registry))
+		}
+
+		err = execRunner.RunExecutable("npm", publishArgs...)
 		if err != nil {
 			return errors.Wrap(err, "failed publishing artifact")
 		}

--- a/pkg/npm/publish_test.go
+++ b/pkg/npm/publish_test.go
@@ -31,8 +31,9 @@ func newNpmMockUtilsBundleRelativeGlob() npmMockUtilsBundleRelativeGlob {
 
 func TestNpmPublish(t *testing.T) {
 	type wants struct {
-		publishConfigPath string
-		publishConfig     string
+		publishConfigPath   string
+		publishConfig       string
+		publishRegistryFlag string
 
 		tarballPath string
 
@@ -196,8 +197,9 @@ func TestNpmPublish(t *testing.T) {
 			registryPassword: "AndHereIsThePassword",
 
 			wants: wants{
-				publishConfigPath: `\.piperNpmrc`,
-				publishConfig:     "registry=https://my.private.npm.registry/\n@piper:registry=https://my.private.npm.registry/\n//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nalways-auth=true\n",
+				publishConfigPath:   `\.piperNpmrc`,
+				publishConfig:       "registry=https://my.private.npm.registry/\n@piper:registry=https://my.private.npm.registry/\n//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nalways-auth=true\n",
+				publishRegistryFlag: "--@piper:registry=https://my.private.npm.registry/",
 			},
 		},
 		{
@@ -215,8 +217,9 @@ func TestNpmPublish(t *testing.T) {
 			registryPassword: "AndHereIsTheOtherPassword",
 
 			wants: wants{
-				publishConfigPath: `\.piperNpmrc`,
-				publishConfig:     "//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nregistry=https://my.other.private.npm.registry/\n@piper:registry=https://my.other.private.npm.registry/\n//my.other.private.npm.registry/:_auth=VGhpc0lzVGhlT3RoZXJVc2VyOkFuZEhlcmVJc1RoZU90aGVyUGFzc3dvcmQ=\nalways-auth=true\n",
+				publishConfigPath:   `\.piperNpmrc`,
+				publishConfig:       "//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nregistry=https://my.other.private.npm.registry/\n@piper:registry=https://my.other.private.npm.registry/\n//my.other.private.npm.registry/:_auth=VGhpc0lzVGhlT3RoZXJVc2VyOkFuZEhlcmVJc1RoZU90aGVyUGFzc3dvcmQ=\nalways-auth=true\n",
+				publishRegistryFlag: "--@piper:registry=https://my.other.private.npm.registry/",
 			},
 		},
 		{
@@ -424,8 +427,9 @@ func TestNpmPublish(t *testing.T) {
 			registryPassword: "AndHereIsThePassword",
 
 			wants: wants{
-				publishConfigPath: `\.piperNpmrc`,
-				publishConfig:     "registry=https://my.private.npm.registry/\n@piper:registry=https://my.private.npm.registry/\n//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nalways-auth=true\n",
+				publishConfigPath:   `\.piperNpmrc`,
+				publishConfig:       "registry=https://my.private.npm.registry/\n@piper:registry=https://my.private.npm.registry/\n//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nalways-auth=true\n",
+				publishRegistryFlag: "--@piper:registry=https://my.private.npm.registry/",
 			},
 		},
 		{
@@ -443,8 +447,9 @@ func TestNpmPublish(t *testing.T) {
 			registryPassword: "AndHereIsTheOtherPassword",
 
 			wants: wants{
-				publishConfigPath: `\.piperNpmrc`,
-				publishConfig:     "//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nregistry=https://my.other.private.npm.registry/\n@piper:registry=https://my.other.private.npm.registry/\n//my.other.private.npm.registry/:_auth=VGhpc0lzVGhlT3RoZXJVc2VyOkFuZEhlcmVJc1RoZU90aGVyUGFzc3dvcmQ=\nalways-auth=true\n",
+				publishConfigPath:   `\.piperNpmrc`,
+				publishConfig:       "//my.private.npm.registry/:_auth=VGhpc0lzVGhlVXNlcjpBbmRIZXJlSXNUaGVQYXNzd29yZA==\nregistry=https://my.other.private.npm.registry/\n@piper:registry=https://my.other.private.npm.registry/\n//my.other.private.npm.registry/:_auth=VGhpc0lzVGhlT3RoZXJVc2VyOkFuZEhlcmVJc1RoZU90aGVyUGFzc3dvcmQ=\nalways-auth=true\n",
+				publishRegistryFlag: "--@piper:registry=https://my.other.private.npm.registry/",
 			},
 		},
 		{
@@ -547,6 +552,10 @@ func TestNpmPublish(t *testing.T) {
 					if len(test.wants.tarballPath) > 0 && assert.Contains(t, publishCmd.Params, "--tarball") {
 						tarballPath := publishCmd.Params[piperutils.FindString(publishCmd.Params, "--tarball")+1]
 						assert.Equal(t, test.wants.tarballPath, filepath.ToSlash(tarballPath))
+					}
+
+					if len(test.wants.publishRegistryFlag) > 0 {
+						assert.Contains(t, publishCmd.Params, test.wants.publishRegistryFlag)
 					}
 
 					if assert.Contains(t, publishCmd.Params, "--userconfig") {


### PR DESCRIPTION
# Changes

The `npm publish` command fails, when using a npm scope and if the `.npmrc` file already contains a registry for that scope (e.g. for local development).
The `publish` command will add the `--registry=<registry>` flag in order to override the `.npmrc` provided registry. This is however not sufficient when publishing scoped packages.

Therefore, add the `--<scope>:registry=<registry>` argument when a scope is used.

- [X] Tests
- [ ] Documentation
