### PR TITLE
[tmsUpload, tmsExport] Minor: remove confusing comments

### DIFF
--- a/pkg/tms/tmsClient.go
+++ b/pkg/tms/tmsClient.go
@@ -204,8 +204,6 @@ func (communicationInstance *CommunicationInstance) UploadFileToNode(fileInfo Fi
 
 	json.Unmarshal(data, &nodeUploadResponseEntity)
 	communicationInstance.logger.Info("Node upload executed successfully")
-
-	// Important: there are Customers, who might rely on format of this log message to parse transport request id
 	communicationInstance.logger.Infof("nodeName: %v, nodeId: %v, uploadedFile: %v, createdTransportRequestDescription: %v, createdTransportRequestId: %v", nodeUploadResponseEntity.QueueEntries[0].NodeName, nodeUploadResponseEntity.QueueEntries[0].NodeId, fileInfo.Name, nodeUploadResponseEntity.TransportRequestDescription, nodeUploadResponseEntity.TransportRequestId)
 
 	return nodeUploadResponseEntity, nil
@@ -239,7 +237,7 @@ func (communicationInstance *CommunicationInstance) ExportFileToNode(fileInfo Fi
 	json.Unmarshal(data, &nodeUploadResponseEntity)
 	communicationInstance.logger.Info("Node export executed successfully")
 
-	// Important: there are Customers, who might rely on format of this log message to parse transport request id
+	// Important:
 	communicationInstance.logger.Infof("nodeName: %v, nodeId: %v, uploadedFile: %v, createdTransportRequestDescription: %v, createdTransportRequestId: %v", nodeUploadResponseEntity.QueueEntries[0].NodeName, nodeUploadResponseEntity.QueueEntries[0].NodeId, fileInfo.Name, nodeUploadResponseEntity.TransportRequestDescription, nodeUploadResponseEntity.TransportRequestId)
 	return nodeUploadResponseEntity, nil
 

--- a/pkg/tms/tmsClient.go
+++ b/pkg/tms/tmsClient.go
@@ -236,8 +236,6 @@ func (communicationInstance *CommunicationInstance) ExportFileToNode(fileInfo Fi
 
 	json.Unmarshal(data, &nodeUploadResponseEntity)
 	communicationInstance.logger.Info("Node export executed successfully")
-
-	// Important:
 	communicationInstance.logger.Infof("nodeName: %v, nodeId: %v, uploadedFile: %v, createdTransportRequestDescription: %v, createdTransportRequestId: %v", nodeUploadResponseEntity.QueueEntries[0].NodeName, nodeUploadResponseEntity.QueueEntries[0].NodeId, fileInfo.Name, nodeUploadResponseEntity.TransportRequestDescription, nodeUploadResponseEntity.TransportRequestId)
 	return nodeUploadResponseEntity, nil
 


### PR DESCRIPTION
It has been clarified with the Customer, who requested to extend logging with additional messages https://github.com/SAP/jenkins-library/pull/4624, that they indeed do not parse transport request id out of the logs, but just check it visually. Therefore removing the two confusing comments.

# Changes

- [ ] Tests
- [ ] Documentation
