### PR TITLE
feat(detectExecuteScan): Add `useDetect9` for latest BlackDuck script

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -389,6 +389,17 @@ func getDetectScript(config detectExecuteScanOptions, utils detectUtils) error {
 
 	log.Entry().Infof("Downloading Detect Script")
 
+	if config.UseDetect9 {
+		err := utils.DownloadFile("https://detect.synopsys.com/detect9.sh", "detect.sh", nil, nil)
+		if err != nil {
+			time.Sleep(time.Second * 5)
+			err = utils.DownloadFile("https://detect.synopsys.com/detect9.sh", "detect.sh", nil, nil)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
 	err := utils.DownloadFile("https://detect.synopsys.com/detect8.sh", "detect.sh", nil, nil)
 	if err != nil {
 		time.Sleep(time.Second * 5)
@@ -474,7 +485,7 @@ func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectU
 		args = append(args, fmt.Sprintf("\"--detect.project.user.groups=%v\"", strings.Join(config.Groups, ",")))
 	}
 
-	// Atleast 1, non-empty category to fail on must be provided
+	// At least 1, non-empty category to fail on must be provided
 	if len(config.FailOn) > 0 && len(config.FailOn[0]) > 0 {
 		args = append(args, fmt.Sprintf("--detect.policy.check.fail.on.severities=%v", strings.Join(config.FailOn, ",")))
 	}

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -48,6 +48,7 @@ type detectExecuteScanOptions struct {
 	MavenExcludedScopes             []string `json:"mavenExcludedScopes,omitempty"`
 	DetectTools                     []string `json:"detectTools,omitempty"`
 	ScanOnChanges                   bool     `json:"scanOnChanges,omitempty"`
+	UseDetect9                      bool     `json:"useDetect9,omitempty"`
 	SuccessOnSkip                   bool     `json:"successOnSkip,omitempty"`
 	CustomEnvironmentVariables      []string `json:"customEnvironmentVariables,omitempty"`
 	MinScanInterval                 int      `json:"minScanInterval,omitempty"`
@@ -300,6 +301,7 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringSliceVar(&stepConfig.MavenExcludedScopes, "mavenExcludedScopes", []string{}, "The maven scopes that need to be excluded from the scan. For example, setting the value 'test' will exclude all components which are defined with a test scope in maven")
 	cmd.Flags().StringSliceVar(&stepConfig.DetectTools, "detectTools", []string{}, "The type of BlackDuck scanners to include while running the BlackDuck scan. By default All scanners are included. For the complete list of possible values, Please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html&_LANG=enus&anchor=detect-tools-included)")
 	cmd.Flags().BoolVar(&stepConfig.ScanOnChanges, "scanOnChanges", false, "This flag determines if the scan is submitted to the server. If set to true, then the scan request is submitted to the server only when changes are detected in the Open Source Bill of Materials If the flag is set to false, then the scan request is submitted to server regardless of any changes. For more details please refer to the [documentation](https://github.com/blackducksoftware/detect_rescan/blob/master/README.md)")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag allows to use version 9 of Detect Script")
 	cmd.Flags().BoolVar(&stepConfig.SuccessOnSkip, "successOnSkip", true, "This flag allows forces Black Duck to exit with 0 error code if any step is skipped")
 	cmd.Flags().StringSliceVar(&stepConfig.CustomEnvironmentVariables, "customEnvironmentVariables", []string{}, "A list of environment variables which can be set to prepare the environment to run a BlackDuck scan. This includes a list of environment variables defined by Synopsys. The full list can be found [here](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=configuring%2Fenvvars.html&_LANG=enus) This list affects the detect script downloaded while running the scan. Right now only detect7.sh is available for downloading")
 	cmd.Flags().IntVar(&stepConfig.MinScanInterval, "minScanInterval", 0, "[DEPRECATED] This parameter controls the frequency (in number of hours) at which the signature scan is re-submitted for scan. When set to a value greater than 0, the signature scans are skipped until the specified number of hours has elapsed since the last signature scan.")
@@ -596,6 +598,15 @@ func detectExecuteScanMetadata() config.StepData {
 						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
+						Default:     false,
+					},
+					{
+						Name:        "useDetect9",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "detect/useDetect9"}},
 						Default:     false,
 					},
 					{

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -326,6 +326,17 @@ spec:
           - STAGES
           - STEPS
         deprecated: true
+      - name: useDetect9
+        description:
+          "This flag allows to use version 9 of Detect Script"
+        aliases:
+          - name: detect/useDetect9
+        type: bool
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: false
       - name: successOnSkip
         description:
           "This flag allows forces Black Duck to exit with 0 error code if any step is skipped"


### PR DESCRIPTION
`detect8.sh` is no longer the most recent version of the BlackDuck runner. `detect9.sh` is now available and fixes some important bugs such as incorrect dependency reporting for `package-lock.json`'s in version 2 and 3.

This commit adds `detect9.sh` support by adding a new `detectExecuteScan` option `useDetect9`, similar to the old option `useDetect8`.

See release notes of Synopsis Detect:
 - https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/currentreleasenotes.html

# Changes

- [ ] Tests
- [ ] Documentation

