### PR TITLE
fix(codeqlExecuteScan): exclude codeqlDB from uploaded sources to github

### DIFF
--- a/pkg/codeql/github_repo_upload.go
+++ b/pkg/codeql/github_repo_upload.go
@@ -118,7 +118,7 @@ func (uploader *GitUploaderInstance) UploadProjectToGithub() (string, error) {
 	}
 
 	zipPath := path.Join(uploader.dbDir, SrcZip)
-	err = unzip(zipPath, tmpDir, strings.Trim(srcLocationPrefix, fmt.Sprintf("%c", os.PathSeparator)))
+	err = unzip(zipPath, tmpDir, strings.Trim(srcLocationPrefix, fmt.Sprintf("%c", os.PathSeparator)), strings.Trim(uploader.dbDir, fmt.Sprintf("%c", os.PathSeparator)))
 	if err != nil {
 		return "", err
 	}
@@ -259,7 +259,7 @@ func push(r repository, token string) error {
 	})
 }
 
-func unzip(zipPath, targetDir, srcDir string) error {
+func unzip(zipPath, targetDir, srcDir, dbDir string) error {
 	r, err := zip.OpenReader(zipPath)
 	if err != nil {
 		return err
@@ -277,7 +277,7 @@ func unzip(zipPath, targetDir, srcDir string) error {
 			fNameSplit[0] = strings.Replace(fNameSplit[0], "_", ":", 1)
 			fName = strings.Join(fNameSplit, fmt.Sprintf("%c", os.PathSeparator))
 		}
-		if !strings.Contains(fName, srcDir) {
+		if !strings.Contains(fName, srcDir) || strings.Contains(fName, dbDir) {
 			continue
 		}
 

--- a/pkg/codeql/github_repo_upload_test.go
+++ b/pkg/codeql/github_repo_upload_test.go
@@ -210,6 +210,7 @@ func TestUnzip(t *testing.T) {
 		srcFilenames := []string{
 			filepath.Join(sourceDir, "file1"),
 			filepath.Join(sourceDir, "file2"),
+			filepath.Join(sourceDir, "codeqlDB"),
 			filepath.Join(sourceDir, "subfolder1", "file1"),
 			filepath.Join(sourceDir, "subfolder1", "file2"),
 			filepath.Join(sourceDir, "subfolder2", "file1"),
@@ -218,7 +219,7 @@ func TestUnzip(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		assert.NoError(t, unzip(zipPath, targetDir, sourceDir))
+		assert.NoError(t, unzip(zipPath, targetDir, sourceDir, "codeqlDB"))
 		targetFilenames := []string{
 			filepath.Join(targetDir, "file1"),
 			filepath.Join(targetDir, "file2"),
@@ -247,7 +248,7 @@ func TestUnzip(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		assert.NoError(t, unzip(zipPath, targetDir, sourceDir))
+		assert.NoError(t, unzip(zipPath, targetDir, sourceDir, "codeqlDB"))
 		checkExistedFiles(t, targetDir, filenames)
 	})
 
@@ -264,7 +265,7 @@ func TestUnzip(t *testing.T) {
 		defer os.RemoveAll(sourceDir)
 		zipPath := filepath.Join(sourceDir, "src.zip")
 
-		assert.Error(t, unzip(zipPath, targetDir, sourceDir))
+		assert.Error(t, unzip(zipPath, targetDir, sourceDir, "codeqlDB"))
 	})
 
 	t.Run("extra files in zip", func(t *testing.T) {
@@ -294,7 +295,7 @@ func TestUnzip(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		assert.NoError(t, unzip(zipPath, targetDir, sourceDir))
+		assert.NoError(t, unzip(zipPath, targetDir, sourceDir, "codeqlDB"))
 		targetFilenames := []string{
 			filepath.Join(targetDir, "file1"),
 			filepath.Join(targetDir, "file2"),


### PR DESCRIPTION
# Changes
Fixed unzipping db sources to exclude codeqlDB from uploaded project to Github.

- [ ] Tests
- [ ] Documentation
