### PR TITLE
Remove logic related to Windows binary

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -23,11 +23,9 @@ jobs:
           curl --insecure --silent --location --write-out '%{http_code}' --output ./piper_master https://github.com/SAP/jenkins-library/releases/latest/download/piper_master
           curl --insecure --silent --location --write-out '%{http_code}' --output ./piper_master-darwin.x86_64 https://github.com/SAP/jenkins-library/releases/latest/download/piper_master-darwin.x86_64
           curl --insecure --silent --location --write-out '%{http_code}' --output ./piper_master-darwin.arm64 https://github.com/SAP/jenkins-library/releases/latest/download/piper_master-darwin.arm64
-          curl --insecure --silent --location --write-out '%{http_code}' --output ./piper_master-win.x86_64.exe https://github.com/SAP/jenkins-library/releases/latest/download/piper_master-win.x86_64.exe
           cp ./piper_master ./piper
           cp ./piper_master-darwin.x86_64 ./piper-darwin.x86_64
           cp ./piper_master-darwin.arm64 ./piper-darwin.arm64
-          cp ./piper_master-win.x86_64.exe ./piper-win.x86_64.exe
           npm install semver --quiet
           echo "PIPER_version=v$(node_modules/.bin/semver -i minor $(curl --silent "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest" | jq -r .tag_name))" >> $GITHUB_ENV
       - uses: SAP/project-piper-action@master
@@ -35,7 +33,7 @@ jobs:
         with:
           piper-version: master
           command: githubPublishRelease
-          flags: --token ${{ secrets.GITHUB_TOKEN }} --assetPathList ./piper_master --assetPathList ./piper --assetPathList ./piper_master-darwin.x86_64 --assetPathList ./piper-darwin.x86_64 --assetPathList ./piper_master-darwin.arm64 --assetPathList ./piper-darwin.arm64 --assetPathList ./piper_master-win.x86_64.exe --assetPathList ./piper-win.x86_64.exe
+          flags: --token ${{ secrets.GITHUB_TOKEN }} --assetPathList ./piper_master --assetPathList ./piper --assetPathList ./piper_master-darwin.x86_64 --assetPathList ./piper-darwin.x86_64 --assetPathList ./piper_master-darwin.arm64 --assetPathList ./piper-darwin.arm64
       - name: Build and publish jar for consumption in unit tests
         run: mvn package
       - uses: SAP/project-piper-action@master

--- a/.github/workflows/upload-go-master.yml
+++ b/.github/workflows/upload-go-master.yml
@@ -61,19 +61,3 @@ jobs:
           piper-version: master
           command: githubPublishRelease
           flags: --token ${{ secrets.GITHUB_TOKEN }} --version latest --assetPath ./piper_master-darwin.arm64
-      - env:
-          CGO_ENABLED: 0
-          GOOS: windows
-          GOARCH: amd64
-        run: |
-          # See https://golang.org/cmd/link/ for info on -w (omit the DWARF symbol table) and -s (omit the symbol table and debug information)
-          # We use those flags to get a smaller compiled binary for faster downloads.
-          go build -ldflags "-w -s -X github.com/SAP/jenkins-library/cmd.GitCommit=${GITHUB_SHA} \
-                  -X github.com/SAP/jenkins-library/pkg/log.LibraryRepository=${GITHUB_REPOSITORY} \
-                  -X github.com/SAP/jenkins-library/pkg/telemetry.LibraryRepository=https://github.com/${GITHUB_REPOSITORY}.git" \
-            -o piper_master-win.x86_64.exe .
-      - uses: SAP/project-piper-action@master
-        with:
-          piper-version: master
-          command: githubPublishRelease
-          flags: --token ${{ secrets.GITHUB_TOKEN }} --version latest --assetPath ./piper_master-win.x86_64.exe


### PR DESCRIPTION
# Changes

 #4625  causes the Windows binary build to fail. It was [discussed and accepted,](https://github.com/SAP/jenkins-library/pull/4625#discussion_r1365401213) so this PR removes the logic related to creating the Windows binary.

- [ ] Tests
- [ ] Documentation
