### PR TITLE
fix(cnbBuild): do not set supplementary groups for lifecycle

### DIFF
--- a/cmd/cnbBuild.go
+++ b/cmd/cnbBuild.go
@@ -583,8 +583,9 @@ func runCnbBuild(config *cnbBuildOptions, telemetry *buildpacks.Telemetry, image
 	creatorArgs = append(creatorArgs, fmt.Sprintf("%s:%s", containerImage, targetImage.ContainerImageTag))
 	attr := &syscall.SysProcAttr{
 		Credential: &syscall.Credential{
-			Uid: uint32(uid),
-			Gid: uint32(gid),
+			Uid:         uint32(uid),
+			Gid:         uint32(gid),
+			NoSetGroups: true,
 		},
 	}
 


### PR DESCRIPTION
# Changes

This change allows to override the `dockerOptions` to run the step as `CNB_USER_ID` and `CNB_GROUP_ID` instead of root. 

https://pubs.opengroup.org/onlinepubs/9699919799/functions/setuid.html
> If the process does not have appropriate privileges, but uid is equal to the real user ID or the saved set-user-ID, setuid() shall set the effective user ID to uid; the real user ID and saved set-user-ID shall remain unchanged. 

- [ ] Tests
- [ ] Documentation
