### PR TITLE
feat(kubernetesDeploy): Better support for sub-charts

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -112,7 +112,6 @@ func runHelmDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUtils,
 		log.Entry().Info("No/incomplete container registry credentials provided: skipping secret creation")
 		if len(config.ContainerRegistrySecret) > 0 {
 			helmValues.add("imagePullSecrets[0].name", config.ContainerRegistrySecret)
-			helmValues.add("global.imagePullSecrets[0].name", config.ContainerRegistrySecret)
 		}
 	} else {
 		var dockerRegistrySecret bytes.Buffer
@@ -146,10 +145,6 @@ func runHelmDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUtils,
 		helmValues.add("secret.name", config.ContainerRegistrySecret)
 		helmValues.add("secret.dockerconfigjson", dockerRegistrySecretData.Data.DockerConfJSON)
 		helmValues.add("imagePullSecrets[0].name", config.ContainerRegistrySecret)
-
-		helmValues.add("global.secret.name", config.ContainerRegistrySecret)
-		helmValues.add("global.secret.dockerconfigjson", dockerRegistrySecretData.Data.DockerConfJSON)
-		helmValues.add("global.imagePullSecrets[0].name", config.ContainerRegistrySecret)
 	}
 
 	// Deprecated functionality

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -16,44 +16,43 @@ import (
 )
 
 type kubernetesDeployOptions struct {
-	AdditionalParameters       []string               `json:"additionalParameters,omitempty"`
-	APIServer                  string                 `json:"apiServer,omitempty"`
-	AppTemplate                string                 `json:"appTemplate,omitempty"`
-	ChartPath                  string                 `json:"chartPath,omitempty"`
-	ContainerRegistryPassword  string                 `json:"containerRegistryPassword,omitempty"`
-	ContainerImageName         string                 `json:"containerImageName,omitempty"`
-	ContainerImageTag          string                 `json:"containerImageTag,omitempty"`
-	ContainerRegistryURL       string                 `json:"containerRegistryUrl,omitempty"`
-	ContainerRegistryUser      string                 `json:"containerRegistryUser,omitempty"`
-	ContainerRegistrySecret    string                 `json:"containerRegistrySecret,omitempty"`
-	CreateDockerRegistrySecret bool                   `json:"createDockerRegistrySecret,omitempty"`
-	DeploymentName             string                 `json:"deploymentName,omitempty"`
-	DeployTool                 string                 `json:"deployTool,omitempty" validate:"possible-values=kubectl helm helm3"`
-	ForceUpdates               bool                   `json:"forceUpdates,omitempty"`
-	HelmDeployWaitSeconds      int                    `json:"helmDeployWaitSeconds,omitempty"`
-	HelmTestWaitSeconds        int                    `json:"helmTestWaitSeconds,omitempty"`
-	HelmValues                 []string               `json:"helmValues,omitempty"`
-	ValuesMapping              map[string]interface{} `json:"valuesMapping,omitempty"`
-	RenderSubchartNotes        bool                   `json:"renderSubchartNotes,omitempty"`
-	GithubToken                string                 `json:"githubToken,omitempty"`
-	Image                      string                 `json:"image,omitempty"`
-	ImageNames                 []string               `json:"imageNames,omitempty"`
-	ImageNameTags              []string               `json:"imageNameTags,omitempty"`
-	ImageDigests               []string               `json:"imageDigests,omitempty"`
-	IngressHosts               []string               `json:"ingressHosts,omitempty"`
-	KeepFailedDeployments      bool                   `json:"keepFailedDeployments,omitempty"`
-	RunHelmTests               bool                   `json:"runHelmTests,omitempty"`
-	ShowTestLogs               bool                   `json:"showTestLogs,omitempty"`
-	KubeConfig                 string                 `json:"kubeConfig,omitempty"`
-	KubeContext                string                 `json:"kubeContext,omitempty"`
-	KubeToken                  string                 `json:"kubeToken,omitempty"`
-	Namespace                  string                 `json:"namespace,omitempty"`
-	TillerNamespace            string                 `json:"tillerNamespace,omitempty"`
-	DockerConfigJSON           string                 `json:"dockerConfigJSON,omitempty"`
-	DeployCommand              string                 `json:"deployCommand,omitempty" validate:"possible-values=apply replace"`
-	SetupScript                string                 `json:"setupScript,omitempty"`
-	VerificationScript         string                 `json:"verificationScript,omitempty"`
-	TeardownScript             string                 `json:"teardownScript,omitempty"`
+	AdditionalParameters      []string               `json:"additionalParameters,omitempty"`
+	APIServer                 string                 `json:"apiServer,omitempty"`
+	AppTemplate               string                 `json:"appTemplate,omitempty"`
+	ChartPath                 string                 `json:"chartPath,omitempty"`
+	ContainerRegistryPassword string                 `json:"containerRegistryPassword,omitempty"`
+	ContainerImageName        string                 `json:"containerImageName,omitempty"`
+	ContainerImageTag         string                 `json:"containerImageTag,omitempty"`
+	ContainerRegistryURL      string                 `json:"containerRegistryUrl,omitempty"`
+	ContainerRegistryUser     string                 `json:"containerRegistryUser,omitempty"`
+	ContainerRegistrySecret   string                 `json:"containerRegistrySecret,omitempty"`
+	DeploymentName            string                 `json:"deploymentName,omitempty"`
+	DeployTool                string                 `json:"deployTool,omitempty" validate:"possible-values=kubectl helm helm3"`
+	ForceUpdates              bool                   `json:"forceUpdates,omitempty"`
+	HelmDeployWaitSeconds     int                    `json:"helmDeployWaitSeconds,omitempty"`
+	HelmTestWaitSeconds       int                    `json:"helmTestWaitSeconds,omitempty"`
+	HelmValues                []string               `json:"helmValues,omitempty"`
+	ValuesMapping             map[string]interface{} `json:"valuesMapping,omitempty"`
+	RenderSubchartNotes       bool                   `json:"renderSubchartNotes,omitempty"`
+	GithubToken               string                 `json:"githubToken,omitempty"`
+	Image                     string                 `json:"image,omitempty"`
+	ImageNames                []string               `json:"imageNames,omitempty"`
+	ImageNameTags             []string               `json:"imageNameTags,omitempty"`
+	ImageDigests              []string               `json:"imageDigests,omitempty"`
+	IngressHosts              []string               `json:"ingressHosts,omitempty"`
+	KeepFailedDeployments     bool                   `json:"keepFailedDeployments,omitempty"`
+	RunHelmTests              bool                   `json:"runHelmTests,omitempty"`
+	ShowTestLogs              bool                   `json:"showTestLogs,omitempty"`
+	KubeConfig                string                 `json:"kubeConfig,omitempty"`
+	KubeContext               string                 `json:"kubeContext,omitempty"`
+	KubeToken                 string                 `json:"kubeToken,omitempty"`
+	Namespace                 string                 `json:"namespace,omitempty"`
+	TillerNamespace           string                 `json:"tillerNamespace,omitempty"`
+	DockerConfigJSON          string                 `json:"dockerConfigJSON,omitempty"`
+	DeployCommand             string                 `json:"deployCommand,omitempty" validate:"possible-values=apply replace"`
+	SetupScript               string                 `json:"setupScript,omitempty"`
+	VerificationScript        string                 `json:"verificationScript,omitempty"`
+	TeardownScript            string                 `json:"teardownScript,omitempty"`
 }
 
 // KubernetesDeployCommand Deployment to Kubernetes test or production namespace within the specified Kubernetes cluster.
@@ -188,7 +187,6 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryURL, "containerRegistryUrl", os.Getenv("PIPER_containerRegistryUrl"), "http(s) url of the Container registry where the image to deploy is located.")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistryUser, "containerRegistryUser", os.Getenv("PIPER_containerRegistryUser"), "Username for container registry access - typically provided by the CI/CD environment.")
 	cmd.Flags().StringVar(&stepConfig.ContainerRegistrySecret, "containerRegistrySecret", `regsecret`, "Name of the container registry secret used for pulling containers from the registry.")
-	cmd.Flags().BoolVar(&stepConfig.CreateDockerRegistrySecret, "createDockerRegistrySecret", false, "Only for `deployTool:kubectl`: Toggle to turn on `containerRegistrySecret` creation.")
 	cmd.Flags().StringVar(&stepConfig.DeploymentName, "deploymentName", os.Getenv("PIPER_deploymentName"), "Defines the name of the deployment. It is a mandatory parameter when `deployTool:helm` or `deployTool:helm3`.")
 	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", `kubectl`, "Defines the tool which should be used for deployment.")
 	cmd.Flags().BoolVar(&stepConfig.ForceUpdates, "forceUpdates", true, "Adds `--force` flag to a helm resource update command or to a kubectl replace command")
@@ -380,15 +378,6 @@ func kubernetesDeployMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     `regsecret`,
-					},
-					{
-						Name:        "createDockerRegistrySecret",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "bool",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     false,
 					},
 					{
 						Name:        "deploymentName",

--- a/cmd/kubernetesDeploy_test.go
+++ b/cmd/kubernetesDeploy_test.go
@@ -83,7 +83,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			"--namespace",
 			"deploymentNamespace",
 			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2",
+			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2",
 			"--force",
 			"--wait",
 			"--timeout",
@@ -151,7 +151,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong upgrade command")
 
-		assert.Contains(t, mockUtils.Calls[2].Params, "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "Wrong upgrade parameters")
+		assert.Contains(t, mockUtils.Calls[2].Params, "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm - docker config.json path passed as parameter", func(t *testing.T) {
@@ -203,25 +203,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[1].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400",
-			"--atomic",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "--force", "--wait", "--timeout", "400", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm -- keep failed deployment", func(t *testing.T) {
@@ -272,24 +254,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[1].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "--force", "--wait", "--timeout", "400", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm - fails without image information", func(t *testing.T) {
@@ -359,29 +324,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--values",
-			"values1.yaml",
-			"--values",
-			"values2.yaml",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400s",
-			"--atomic",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, &telemetry.CustomData{
 			Custom1Label: "deployTool",
@@ -435,29 +378,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--values",
-			"values1.yaml",
-			"--values",
-			"values2.yaml",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400s",
-			"--atomic",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong test command")
 		assert.Equal(t, []string{
@@ -519,29 +440,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--values",
-			"values1.yaml",
-			"--values",
-			"values2.yaml",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400s",
-			"--atomic",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong test command")
 		assert.Equal(t, []string{
@@ -603,29 +502,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--values",
-			"values1.yaml",
-			"--values",
-			"values2.yaml",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400s",
-			"--atomic",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, 2, len(mockUtils.Calls), "Too many helm calls")
 	})
@@ -676,7 +553,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
 
-		assert.Contains(t, mockUtils.Calls[1].Params, "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 	})
 
@@ -726,7 +603,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
 
-		assert.Contains(t, mockUtils.Calls[1].Params, `image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,image.myImage_sub1.repository=my.registry:55555/myImage-sub1,image.myImage_sub1.tag=myTag,image.myImage_sub2.repository=my.registry:55555/myImage-sub2,image.myImage_sub2.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret`, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.myImage_sub1.repository=my.registry:55555/myImage-sub1,image.myImage_sub1.tag=myTag,myImage_sub1.image.repository=my.registry:55555/myImage-sub1,myImage_sub1.image.tag=myTag,image.myImage_sub2.repository=my.registry:55555/myImage-sub2,image.myImage_sub2.tag=myTag,myImage_sub2.image.repository=my.registry:55555/myImage-sub2,myImage_sub2.image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 	})
 
@@ -776,7 +653,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
 
-		assert.Contains(t, mockUtils.Calls[1].Params, `image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,image.repository=my.registry:55555/myImage,image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret`, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.repository=my.registry:55555/myImage,image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 	})
 
@@ -869,7 +746,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage_sub1.repository=my.registry:55555/myImage-sub1", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage_sub1.tag=myTag", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage_sub2.repository=my.registry:55555/myImage-sub2", "Missing update parameter")
-		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage_sub2.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==", "Missing update parameter")
+		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.myImage_sub1.repository=my.registry:55555/myImage-sub1,image.myImage_sub1.tag=myTag,myImage_sub1.image.repository=my.registry:55555/myImage-sub1,myImage_sub1.image.tag=myTag,image.myImage_sub2.repository=my.registry:55555/myImage-sub2,image.myImage_sub2.tag=myTag,myImage_sub2.image.repository=my.registry:55555/myImage-sub2,myImage_sub2.image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,subchart.image.registry=my.registry:55555/myImage,subchart.image.tag=myTag", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "imagePullSecrets[0].name=testSecret", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "subchart.image.registry=my.registry:55555/myImage", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "subchart.image.tag=myTag", "Missing update parameter")
@@ -978,28 +855,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--values",
-			"values1.yaml",
-			"--values",
-			"values2.yaml",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400s",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm v3 - no container credentials", func(t *testing.T) {
@@ -1025,25 +881,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, 1, len(mockUtils.Calls), "Wrong number of upgrade commands")
 		assert.Equal(t, "helm", mockUtils.Calls[0].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret",
-			"--force",
-			"--wait",
-			"--timeout",
-			"400s",
-			"--atomic",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm - use extensions", func(t *testing.T) {
@@ -1138,43 +976,25 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		var stdout bytes.Buffer
 
 		runKubernetesDeploy(opts, &telemetry.CustomData{}, mockUtils, &stdout)
-		assert.Equal(t, []string{
-			"upgrade",
-			"deploymentName",
-			"path/to/chart",
-			"--install",
-			"--namespace",
-			"deploymentNamespace",
-			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret",
-			"--wait",
-			"--timeout",
-			"400s",
-			"--atomic",
-			"--kube-context",
-			"testCluster",
-			"--testParam",
-			"testValue",
-		}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret,global.imagePullSecrets[0].name=testSecret", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test kubectl - create secret from docker config.json", func(t *testing.T) {
 
 		opts := kubernetesDeployOptions{
-			AppTemplate:                "path/to/test.yaml",
-			ContainerRegistryURL:       "https://my.registry:55555",
-			ContainerRegistryUser:      "registryUser",
-			ContainerRegistryPassword:  "dummy",
-			ContainerRegistrySecret:    "regSecret",
-			CreateDockerRegistrySecret: true,
-			DeployTool:                 "kubectl",
-			Image:                      "path/to/Image:latest",
-			AdditionalParameters:       []string{"--testParam", "testValue"},
-			KubeConfig:                 "This is my kubeconfig",
-			KubeContext:                "testCluster",
-			Namespace:                  "deploymentNamespace",
-			DeployCommand:              "apply",
-			DockerConfigJSON:           ".pipeline/docker/config.json",
+			AppTemplate:               "path/to/test.yaml",
+			ContainerRegistryURL:      "https://my.registry:55555",
+			ContainerRegistryUser:     "registryUser",
+			ContainerRegistryPassword: "dummy",
+			ContainerRegistrySecret:   "regSecret",
+			DeployTool:                "kubectl",
+			Image:                     "path/to/Image:latest",
+			AdditionalParameters:      []string{"--testParam", "testValue"},
+			KubeConfig:                "This is my kubeconfig",
+			KubeContext:               "testCluster",
+			Namespace:                 "deploymentNamespace",
+			DeployCommand:             "apply",
+			DockerConfigJSON:          ".pipeline/docker/config.json",
 		}
 
 		kubeYaml := `kind: Deployment
@@ -1196,20 +1016,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, mockUtils.Env, []string{"KUBECONFIG=This is my kubeconfig"})
 
-		assert.Equal(t, []string{
-			"create",
-			"secret",
-			"generic",
-			"regSecret",
-			"--from-file=.dockerconfigjson=.pipeline/docker/config.json",
-			"--type=kubernetes.io/dockerconfigjson",
-			"--insecure-skip-tls-verify=true",
-			"--dry-run=client",
-			"--output=json",
-			"--insecure-skip-tls-verify=true",
-			"--namespace=deploymentNamespace",
-			"--context=testCluster",
-		},
+		assert.Equal(t, []string{"create", "secret", "generic", "regSecret", "--from-file=.dockerconfigjson=.pipeline/docker/config.json", "--type=kubernetes.io/dockerconfigjson", "--insecure-skip-tls-verify=true", "--dry-run=client", "--output=json", "--insecure-skip-tls-verify=true", "--namespace=deploymentNamespace", "--context=testCluster"},
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Containsf(t, mockUtils.Calls[1].Params, "apply", "Wrong secret creation parameters")
@@ -1419,17 +1226,16 @@ image4: my.registry:55555/myImage-sub2:myTag@sha256:333`, "kubectl parameters in
 
 	t.Run("test kubectl - use replace deploy command", func(t *testing.T) {
 		opts := kubernetesDeployOptions{
-			AppTemplate:                "test.yaml",
-			ContainerRegistryURL:       "https://my.registry:55555",
-			ContainerRegistrySecret:    "regSecret",
-			CreateDockerRegistrySecret: true,
-			DeployTool:                 "kubectl",
-			Image:                      "path/to/Image:latest",
-			AdditionalParameters:       []string{"--testParam", "testValue"},
-			KubeConfig:                 "This is my kubeconfig",
-			KubeContext:                "testCluster",
-			Namespace:                  "deploymentNamespace",
-			DeployCommand:              "replace",
+			AppTemplate:             "test.yaml",
+			ContainerRegistryURL:    "https://my.registry:55555",
+			ContainerRegistrySecret: "regSecret",
+			DeployTool:              "kubectl",
+			Image:                   "path/to/Image:latest",
+			AdditionalParameters:    []string{"--testParam", "testValue"},
+			KubeConfig:              "This is my kubeconfig",
+			KubeContext:             "testCluster",
+			Namespace:               "deploymentNamespace",
+			DeployCommand:           "replace",
 		}
 
 		kubeYaml := `kind: Deployment
@@ -1465,18 +1271,17 @@ image4: my.registry:55555/myImage-sub2:myTag@sha256:333`, "kubectl parameters in
 
 	t.Run("test kubectl - use replace --force deploy command", func(t *testing.T) {
 		opts := kubernetesDeployOptions{
-			AppTemplate:                "test.yaml",
-			ContainerRegistryURL:       "https://my.registry:55555",
-			ContainerRegistrySecret:    "regSecret",
-			CreateDockerRegistrySecret: true,
-			DeployTool:                 "kubectl",
-			Image:                      "path/to/Image:latest",
-			AdditionalParameters:       []string{"--testParam", "testValue"},
-			KubeConfig:                 "This is my kubeconfig",
-			KubeContext:                "testCluster",
-			Namespace:                  "deploymentNamespace",
-			DeployCommand:              "replace",
-			ForceUpdates:               true,
+			AppTemplate:             "test.yaml",
+			ContainerRegistryURL:    "https://my.registry:55555",
+			ContainerRegistrySecret: "regSecret",
+			DeployTool:              "kubectl",
+			Image:                   "path/to/Image:latest",
+			AdditionalParameters:    []string{"--testParam", "testValue"},
+			KubeConfig:              "This is my kubeconfig",
+			KubeContext:             "testCluster",
+			Namespace:               "deploymentNamespace",
+			DeployCommand:           "replace",
+			ForceUpdates:            true,
 		}
 
 		kubeYaml := `kind: Deployment

--- a/cmd/kubernetesDeploy_test.go
+++ b/cmd/kubernetesDeploy_test.go
@@ -83,7 +83,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			"--namespace",
 			"deploymentNamespace",
 			"--set",
-			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2",
+			"image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2",
 			"--force",
 			"--wait",
 			"--timeout",
@@ -151,7 +151,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong upgrade command")
 
-		assert.Contains(t, mockUtils.Calls[2].Params, "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "Wrong upgrade parameters")
+		assert.Contains(t, mockUtils.Calls[2].Params, "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm - docker config.json path passed as parameter", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[1].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "--force", "--wait", "--timeout", "400", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "--force", "--wait", "--timeout", "400", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm -- keep failed deployment", func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[1].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "--force", "--wait", "--timeout", "400", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,ingress.hosts[0]=ingress.host1,ingress.hosts[1]=ingress.host2", "--force", "--wait", "--timeout", "400", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[2].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm - fails without image information", func(t *testing.T) {
@@ -324,7 +324,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, &telemetry.CustomData{
 			Custom1Label: "deployTool",
@@ -378,7 +378,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong test command")
 		assert.Equal(t, []string{
@@ -440,7 +440,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[2].Exec, "Wrong test command")
 		assert.Equal(t, []string{
@@ -502,7 +502,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 		assert.Equal(t, 2, len(mockUtils.Calls), "Too many helm calls")
 	})
@@ -553,7 +553,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
 
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 	})
 
@@ -603,7 +603,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
 
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.myImage_sub1.repository=my.registry:55555/myImage-sub1,image.myImage_sub1.tag=myTag,myImage_sub1.image.repository=my.registry:55555/myImage-sub1,myImage_sub1.image.tag=myTag,image.myImage_sub2.repository=my.registry:55555/myImage-sub2,image.myImage_sub2.tag=myTag,myImage_sub2.image.repository=my.registry:55555/myImage-sub2,myImage_sub2.image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.myImage_sub1.repository=my.registry:55555/myImage-sub1,image.myImage_sub1.tag=myTag,myImage_sub1.image.repository=my.registry:55555/myImage-sub1,myImage_sub1.image.tag=myTag,image.myImage_sub2.repository=my.registry:55555/myImage-sub2,image.myImage_sub2.tag=myTag,myImage_sub2.image.repository=my.registry:55555/myImage-sub2,myImage_sub2.image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 	})
 
@@ -653,7 +653,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
 
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.repository=my.registry:55555/myImage,image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.repository=my.registry:55555/myImage,image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 
 	})
 
@@ -746,7 +746,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage_sub1.repository=my.registry:55555/myImage-sub1", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage_sub1.tag=myTag", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage_sub2.repository=my.registry:55555/myImage-sub2", "Missing update parameter")
-		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.myImage_sub1.repository=my.registry:55555/myImage-sub1,image.myImage_sub1.tag=myTag,myImage_sub1.image.repository=my.registry:55555/myImage-sub1,myImage_sub1.image.tag=myTag,image.myImage_sub2.repository=my.registry:55555/myImage-sub2,image.myImage_sub2.tag=myTag,myImage_sub2.image.repository=my.registry:55555/myImage-sub2,myImage_sub2.image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret,subchart.image.registry=my.registry:55555/myImage,subchart.image.tag=myTag", "Missing update parameter")
+		assert.Contains(t, mockUtils.Calls[1].Params[pos], "image.myImage.repository=my.registry:55555/myImage,image.myImage.tag=myTag,myImage.image.repository=my.registry:55555/myImage,myImage.image.tag=myTag,image.myImage_sub1.repository=my.registry:55555/myImage-sub1,image.myImage_sub1.tag=myTag,myImage_sub1.image.repository=my.registry:55555/myImage-sub1,myImage_sub1.image.tag=myTag,image.myImage_sub2.repository=my.registry:55555/myImage-sub2,image.myImage_sub2.tag=myTag,myImage_sub2.image.repository=my.registry:55555/myImage-sub2,myImage_sub2.image.tag=myTag,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,subchart.image.registry=my.registry:55555/myImage,subchart.image.tag=myTag", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "imagePullSecrets[0].name=testSecret", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "subchart.image.registry=my.registry:55555/myImage", "Missing update parameter")
 		assert.Contains(t, mockUtils.Calls[1].Params[pos], "subchart.image.tag=myTag", "Missing update parameter")
@@ -855,7 +855,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 			mockUtils.Calls[0].Params, "Wrong secret creation parameters")
 
 		assert.Equal(t, "helm", mockUtils.Calls[1].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret,global.secret.name=testSecret,global.secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--values", "values1.yaml", "--values", "values2.yaml", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,secret.name=testSecret,secret.dockerconfigjson=ThisIsOurBase64EncodedSecret==,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[1].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm v3 - no container credentials", func(t *testing.T) {
@@ -881,7 +881,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 
 		assert.Equal(t, 1, len(mockUtils.Calls), "Wrong number of upgrade commands")
 		assert.Equal(t, "helm", mockUtils.Calls[0].Exec, "Wrong upgrade command")
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret,global.imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret", "--force", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test helm - use extensions", func(t *testing.T) {
@@ -976,7 +976,7 @@ func TestRunKubernetesDeploy(t *testing.T) {
 		var stdout bytes.Buffer
 
 		runKubernetesDeploy(opts, &telemetry.CustomData{}, mockUtils, &stdout)
-		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret,global.imagePullSecrets[0].name=testSecret", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
+		assert.Equal(t, []string{"upgrade", "deploymentName", "path/to/chart", "--install", "--namespace", "deploymentNamespace", "--set", "image.repository=my.registry:55555/path/to/Image,image.tag=latest,image.path/to/Image.repository=my.registry:55555/path/to/Image,image.path/to/Image.tag=latest,imagePullSecrets[0].name=testSecret", "--wait", "--timeout", "400s", "--atomic", "--kube-context", "testCluster", "--testParam", "testValue"}, mockUtils.Calls[0].Params, "Wrong upgrade parameters")
 	})
 
 	t.Run("test kubectl - create secret from docker config.json", func(t *testing.T) {

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -231,14 +231,6 @@ spec:
           - STAGES
           - STEPS
         default: regsecret
-      - name: createDockerRegistrySecret
-        type: bool
-        description: "Only for `deployTool:kubectl`: Toggle to turn on `containerRegistrySecret` creation."
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        default: false
       - name: deploymentName
         aliases:
           - name: helmDeploymentName


### PR DESCRIPTION
# Changes

- Create values in the form of `$key.image.repository`/`$key.image.tag` (before there was only `image.$key.repository`/`image.$key.tag`

This supports sub-charts better and reduces drastically the necessity to provide `valuesMapping` in such scenarios.

- [X] Tests
- [X] Documentation
