### PR TITLE
feat(detectExecuteScan): Also scan images that are in the CPE

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -20,6 +20,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/maven"
 	"github.com/SAP/jenkins-library/pkg/orchestrator"
+	"github.com/SAP/jenkins-library/pkg/piperenv"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/SAP/jenkins-library/pkg/reporting"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
@@ -29,6 +30,8 @@ import (
 	"github.com/google/go-github/v45/github"
 	"github.com/pkg/errors"
 )
+
+const NO_VERSION_SUFFIX = ""
 
 type detectUtils interface {
 	piperutils.FileUtils
@@ -202,7 +205,7 @@ func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detec
 	blackduckSystem := newBlackduckSystem(config)
 
 	args := []string{"./detect.sh"}
-	args, err = addDetectArgs(args, config, utils, blackduckSystem)
+	args, err = addDetectArgs(args, config, utils, blackduckSystem, NO_VERSION_SUFFIX)
 	if err != nil {
 		return err
 	}
@@ -215,6 +218,8 @@ func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detec
 	utils.SetEnv(envs)
 
 	err = utils.RunShell("/bin/bash", script)
+	err = mapDetectError(err, config, utils)
+
 	reportingErr := postScanChecksAndReporting(ctx, config, influx, utils, blackduckSystem)
 	if reportingErr != nil {
 		if strings.Contains(reportingErr.Error(), "License Policy Violations found") {
@@ -227,6 +232,24 @@ func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detec
 			log.Entry().Warnf("Failed to generate reports: %v", reportingErr)
 		}
 	}
+	// create Toolrecord file
+	toolRecordFileName, toolRecordErr := createToolRecordDetect(utils, "./", config, blackduckSystem)
+	if toolRecordErr != nil {
+		// do not fail until the framework is well established
+		log.Entry().Warning("TR_DETECT: Failed to create toolrecord file "+toolRecordFileName, err)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if config.ScanImages {
+		err = runDetectImages(ctx, config, utils, blackduckSystem, influx, blackduckSystem)
+	}
+	return err
+}
+
+func mapDetectError(err error, config detectExecuteScanOptions, utils detectUtils) error {
 	if err != nil {
 		// Setting error category based on exit code
 		mapErrorCategory(utils.GetExitCode())
@@ -238,13 +261,59 @@ func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detec
 			err = errors.Wrapf(err, exitCodeMapping(utils.GetExitCode()))
 		}
 	}
-	// create Toolrecord file
-	toolRecordFileName, toolRecordErr := createToolRecordDetect(utils, "./", config, blackduckSystem)
-	if toolRecordErr != nil {
-		// do not fail until the framework is well established
-		log.Entry().Warning("TR_DETECT: Failed to create toolrecord file "+toolRecordFileName, err)
-	}
 	return err
+}
+
+func runDetectImages(ctx context.Context, config detectExecuteScanOptions, utils detectUtils, sys *blackduckSystem, influx *detectExecuteScanInflux, blackduckSystem *blackduckSystem) error {
+	cpePath := filepath.Join(GeneralConfig.EnvRootPath, "commonPipelineEnvironment")
+	imagesRaw := piperenv.GetResourceParameter(cpePath, "container", "imageNameTags.json")
+	if imagesRaw == "" {
+		log.Entry().Debugf("No images found to be scanned")
+		return nil
+	}
+
+	images := []string{}
+	err := json.Unmarshal([]byte(imagesRaw), &images)
+	if err != nil {
+		return errors.Wrap(err, "Unable to read cpe")
+	}
+
+	registryUser := piperenv.GetResourceParameter(cpePath, "container", "repositoryUsername")
+	registryPassword := piperenv.GetResourceParameter(cpePath, "container", "repositoryPassword")
+	registryUrl := piperenv.GetResourceParameter(cpePath, "container", "registryUrl")
+
+	log.Entry().Infof("Scanning %d images", len(images))
+	for _, image := range images {
+		// Download image to be scanned
+		log.Entry().Debugf("Scanning image: %q", image)
+		tarName := fmt.Sprintf("%s.tar", strings.Split(image, ":")[0])
+
+		options := containerSaveImageOptions{
+			ContainerRegistryURL:      registryUrl,
+			ContainerImage:            image,
+			ContainerRegistryPassword: registryPassword,
+			ContainerRegistryUser:     registryUser,
+			FilePath:                  tarName,
+			ImageFormat:               "tarball",
+		}
+		containerSaveImage(options, &telemetry.CustomData{})
+
+		args := []string{"./detect.sh"}
+		args, err = addDetectArgsImages(args, config, utils, sys, tarName)
+		if err != nil {
+			return err
+		}
+		script := strings.Join(args, " ")
+
+		err = utils.RunShell("/bin/bash", script)
+		err = mapDetectError(err, config, utils)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Get proper error category
@@ -331,8 +400,11 @@ func getDetectScript(config detectExecuteScanOptions, utils detectUtils) error {
 	return nil
 }
 
-func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectUtils, sys *blackduckSystem) ([]string, error) {
+func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectUtils, sys *blackduckSystem, versionSuffix string) ([]string, error) {
 	detectVersionName := getVersionName(config)
+	if versionSuffix != NO_VERSION_SUFFIX {
+		detectVersionName = fmt.Sprintf("%s-%s", detectVersionName, versionSuffix)
+	}
 	// Split on spaces, the scanPropeties, so that each property is available as a single string
 	// instead of all properties being part of a single string
 	config.ScanProperties = piperutils.SplitAndTrim(config.ScanProperties, " ")
@@ -463,6 +535,24 @@ func addDetectArgs(args []string, config detectExecuteScanOptions, utils detectU
 		args = append(args, "--detect.cleanup=false")
 		args = append(args, "--detect.output.path='report'")
 	}
+
+	return args, nil
+}
+
+func addDetectArgsImages(args []string, config detectExecuteScanOptions, utils detectUtils, sys *blackduckSystem, imageTar string) ([]string, error) {
+	suffix := strings.Split(imageTar, ".")[0]
+	args, err := addDetectArgs(args, config, utils, sys, suffix)
+	if err != nil {
+		return []string{}, err
+	}
+
+	args = append(args, "--detect.project.version.distribution=SAAS")
+	args = append(args, fmt.Sprintf("--detect.docker.tar=./%s", imageTar))
+	args = append(args, "--detect.docker.passthrough.output.include.squashedimage=false")
+	args = append(args, "--detect.docker.passthrough.shared.dir.path.local=/opt/blackduck/blackduck-imageinspector/shared/")
+	args = append(args, "--detect.docker.passthrough.shared.dir.path.imageinspector=/opt/blackduck/blackduck-imageinspector/shared")
+	//args = append(args, "--detect.docker.passthrough.imageinspector.service.url=http://localhost:8082") //TODO Why needed?
+	args = append(args, "--detect.docker.passthrough.imageinspector.service.start=false")
 
 	return args, nil
 }

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -218,9 +218,15 @@ func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detec
 	utils.SetEnv(envs)
 
 	err = mapDetectError(utils.RunShell("/bin/bash", script), config, utils)
-
 	if config.ScanContainerDistro != "" {
-		err = mapDetectError(runDetectImages(ctx, config, utils, blackduckSystem, influx, blackduckSystem), config, utils)
+		imageError := mapDetectError(runDetectImages(ctx, config, utils, blackduckSystem, influx, blackduckSystem), config, utils)
+		if imageError != nil {
+			if err != nil {
+				err = errors.Wrapf(err, "error during scanning images: %q", imageError.Error())
+			} else {
+				err = imageError
+			}
+		}
 	}
 
 	reportingErr := postScanChecksAndReporting(ctx, config, influx, utils, blackduckSystem)

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -268,27 +268,18 @@ func runDetectImages(ctx context.Context, config detectExecuteScanOptions, utils
 		return nil
 	}
 
-	images := []string{}
-	err := json.Unmarshal([]byte(imagesRaw), &images)
-	if err != nil {
-		return errors.Wrap(err, "Unable to read cpe")
-	}
-
-	registryUser := piperenv.GetResourceParameter(cpePath, "container", "repositoryUsername")
-	registryPassword := piperenv.GetResourceParameter(cpePath, "container", "repositoryPassword")
-	registryURL := piperenv.GetResourceParameter(cpePath, "container", "registryUrl")
-
-	log.Entry().Infof("Scanning %d images", len(images))
-	for _, image := range images {
+	var err error
+	log.Entry().Infof("Scanning %d images", len(config.ImageNameTags))
+	for _, image := range config.ImageNameTags {
 		// Download image to be scanned
 		log.Entry().Debugf("Scanning image: %q", image)
 		tarName := fmt.Sprintf("%s.tar", strings.Split(image, ":")[0])
 
 		options := containerSaveImageOptions{
-			ContainerRegistryURL:      registryURL,
+			ContainerRegistryURL:      config.RegistryURL,
 			ContainerImage:            image,
-			ContainerRegistryPassword: registryPassword,
-			ContainerRegistryUser:     registryUser,
+			ContainerRegistryPassword: config.RepositoryPassword,
+			ContainerRegistryUser:     config.RepositoryUsername,
 			FilePath:                  tarName,
 			ImageFormat:               "legacy",
 		}

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -219,7 +219,7 @@ func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detec
 
 	err = mapDetectError(utils.RunShell("/bin/bash", script), config, utils)
 
-	if config.ScanImages {
+	if config.ScanContainerDistro != "" {
 		err = mapDetectError(runDetectImages(ctx, config, utils, blackduckSystem, influx, blackduckSystem), config, utils)
 	}
 
@@ -554,11 +554,11 @@ func addDetectArgsImages(args []string, config detectExecuteScanOptions, utils d
 	args = append(args, "--detect.tools.excluded=DETECTOR")
 	args = append(args, "--detect.docker.passthrough.shared.dir.path.local=/opt/blackduck/blackduck-imageinspector/shared/")
 	args = append(args, "--detect.docker.passthrough.shared.dir.path.imageinspector=/opt/blackduck/blackduck-imageinspector/shared")
-	args = append(args, fmt.Sprintf("--detect.docker.passthrough.imageinspector.service.distro.default=%s", config.ContainerDistro))
+	args = append(args, fmt.Sprintf("--detect.docker.passthrough.imageinspector.service.distro.default=%s", config.ScanContainerDistro))
 	args = append(args, "--detect.docker.passthrough.imageinspector.service.start=false")
 	args = append(args, "--detect.docker.passthrough.output.include.squashedimage=false")
 
-	switch config.ContainerDistro {
+	switch config.ScanContainerDistro {
 	case "ubuntu":
 		args = append(args, "--detect.docker.passthrough.imageinspector.service.url=http://localhost:8082")
 	case "centos":
@@ -566,7 +566,7 @@ func addDetectArgsImages(args []string, config detectExecuteScanOptions, utils d
 	case "alpine":
 		args = append(args, "--detect.docker.passthrough.imageinspector.service.url=http://localhost:8080")
 	default:
-		return nil, fmt.Errorf("unknown container distro %q", config.ContainerDistro)
+		return nil, fmt.Errorf("unknown container distro %q", config.ScanContainerDistro)
 	}
 
 	return args, nil

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -65,6 +65,10 @@ type detectExecuteScanOptions struct {
 	PrivateModules              string   `json:"privateModules,omitempty"`
 	PrivateModulesGitToken      string   `json:"privateModulesGitToken,omitempty"`
 	ScanContainerDistro         string   `json:"scanContainerDistro,omitempty" validate:"possible-values=ubuntu centos alpine"`
+	ImageNameTags               []string `json:"imageNameTags,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
+	RegistryURL                 string   `json:"registryUrl,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
+	RepositoryUsername          string   `json:"repositoryUsername,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
+	RepositoryPassword          string   `json:"repositoryPassword,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
 }
 
 type detectExecuteScanInflux struct {
@@ -312,6 +316,10 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.PrivateModules, "privateModules", os.Getenv("PIPER_privateModules"), "Tells go which modules shall be considered to be private (by setting [GOPRIVATE](https://pkg.go.dev/cmd/go#hdr-Configuration_for_downloading_non_public_code)).")
 	cmd.Flags().StringVar(&stepConfig.PrivateModulesGitToken, "privateModulesGitToken", os.Getenv("PIPER_privateModulesGitToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line.")
 	cmd.Flags().StringVar(&stepConfig.ScanContainerDistro, "scanContainerDistro", os.Getenv("PIPER_scanContainerDistro"), "To also scan your images in the CPE, choose the distro")
+	cmd.Flags().StringSliceVar(&stepConfig.ImageNameTags, "imageNameTags", []string{}, "Images to be scanned (typically filled by CPE)")
+	cmd.Flags().StringVar(&stepConfig.RegistryURL, "registryUrl", os.Getenv("PIPER_registryUrl"), "Used accessing for the images to be scanned (typically filled by CPE)")
+	cmd.Flags().StringVar(&stepConfig.RepositoryUsername, "repositoryUsername", os.Getenv("PIPER_repositoryUsername"), "Used accessing for the images to be scanned (typically filled by CPE)")
+	cmd.Flags().StringVar(&stepConfig.RepositoryPassword, "repositoryPassword", os.Getenv("PIPER_repositoryPassword"), "Used accessing for the images to be scanned (typically filled by CPE)")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -783,6 +791,62 @@ func detectExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_scanContainerDistro"),
+					},
+					{
+						Name: "imageNameTags",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/imageNameTags",
+							},
+						},
+						Scope:     []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:      "[]string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   []string{},
+					},
+					{
+						Name: "registryUrl",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/registryUrl",
+							},
+						},
+						Scope:     []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_registryUrl"),
+					},
+					{
+						Name: "repositoryUsername",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/repositoryUsername",
+							},
+						},
+						Scope:     []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_repositoryUsername"),
+					},
+					{
+						Name: "repositoryPassword",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/repositoryPassword",
+							},
+						},
+						Scope:     []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_repositoryPassword"),
 					},
 				},
 			},

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -64,6 +64,8 @@ type detectExecuteScanOptions struct {
 	NpmArguments                []string `json:"npmArguments,omitempty"`
 	PrivateModules              string   `json:"privateModules,omitempty"`
 	PrivateModulesGitToken      string   `json:"privateModulesGitToken,omitempty"`
+	ContainerDistro             string   `json:"containerDistro,omitempty" validate:"possible-values=ubuntu centos alpine"`
+	ScanImages                  bool     `json:"scanImages,omitempty"`
 }
 
 type detectExecuteScanInflux struct {
@@ -310,6 +312,8 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringSliceVar(&stepConfig.NpmArguments, "npmArguments", []string{}, "List of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project.")
 	cmd.Flags().StringVar(&stepConfig.PrivateModules, "privateModules", os.Getenv("PIPER_privateModules"), "Tells go which modules shall be considered to be private (by setting [GOPRIVATE](https://pkg.go.dev/cmd/go#hdr-Configuration_for_downloading_non_public_code)).")
 	cmd.Flags().StringVar(&stepConfig.PrivateModulesGitToken, "privateModulesGitToken", os.Getenv("PIPER_privateModulesGitToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line.")
+	cmd.Flags().StringVar(&stepConfig.ContainerDistro, "containerDistro", `ubuntu`, "distro of the container that is scanned")
+	cmd.Flags().BoolVar(&stepConfig.ScanImages, "scanImages", true, "if images found in the cpe, they will also be scanned")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -773,10 +777,33 @@ func detectExecuteScanMetadata() config.StepData {
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_privateModulesGitToken"),
 					},
+					{
+						Name:        "containerDistro",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `ubuntu`,
+					},
+					{
+						Name:        "scanImages",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     true,
+					},
 				},
 			},
 			Containers: []config.Container{
 				{Name: "openjdk", Image: "openjdk:11", WorkingDir: "/root", Options: []config.Option{{Name: "-u", Value: "0"}}},
+			},
+			Sidecars: []config.Container{
+				{Name: "inspector-ubuntu", Image: "blackducksoftware/blackduck-imageinspector-ubuntu:5.0.15", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "ubuntu"}}}}},
+				{Name: "inspector-alpine", Image: "blackducksoftware/blackduck-imageinspector-alpine:5.0.15", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "alpine"}}}}},
+				{Name: "inspector-centos", Image: "blackducksoftware/blackduck-imageinspector-centos:5.0.15", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "centos"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -64,8 +64,8 @@ type detectExecuteScanOptions struct {
 	NpmArguments                []string `json:"npmArguments,omitempty"`
 	PrivateModules              string   `json:"privateModules,omitempty"`
 	PrivateModulesGitToken      string   `json:"privateModulesGitToken,omitempty"`
-	ContainerDistro             string   `json:"containerDistro,omitempty" validate:"possible-values=ubuntu centos alpine"`
 	ScanImages                  bool     `json:"scanImages,omitempty"`
+	ContainerDistro             string   `json:"containerDistro,omitempty" validate:"possible-values=ubuntu centos alpine"`
 }
 
 type detectExecuteScanInflux struct {
@@ -312,8 +312,8 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringSliceVar(&stepConfig.NpmArguments, "npmArguments", []string{}, "List of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project.")
 	cmd.Flags().StringVar(&stepConfig.PrivateModules, "privateModules", os.Getenv("PIPER_privateModules"), "Tells go which modules shall be considered to be private (by setting [GOPRIVATE](https://pkg.go.dev/cmd/go#hdr-Configuration_for_downloading_non_public_code)).")
 	cmd.Flags().StringVar(&stepConfig.PrivateModulesGitToken, "privateModulesGitToken", os.Getenv("PIPER_privateModulesGitToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line.")
-	cmd.Flags().StringVar(&stepConfig.ContainerDistro, "containerDistro", `ubuntu`, "distro of the container that is scanned")
-	cmd.Flags().BoolVar(&stepConfig.ScanImages, "scanImages", true, "if images found in the cpe, they will also be scanned")
+	cmd.Flags().BoolVar(&stepConfig.ScanImages, "scanImages", false, "If images found in the cpe, they will also be scanned")
+	cmd.Flags().StringVar(&stepConfig.ContainerDistro, "containerDistro", `ubuntu`, "Distro of the container that is scanned")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -778,6 +778,15 @@ func detectExecuteScanMetadata() config.StepData {
 						Default:   os.Getenv("PIPER_privateModulesGitToken"),
 					},
 					{
+						Name:        "scanImages",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
+					},
+					{
 						Name:        "containerDistro",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
@@ -786,24 +795,15 @@ func detectExecuteScanMetadata() config.StepData {
 						Aliases:     []config.Alias{},
 						Default:     `ubuntu`,
 					},
-					{
-						Name:        "scanImages",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "bool",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     true,
-					},
 				},
 			},
 			Containers: []config.Container{
 				{Name: "openjdk", Image: "openjdk:11", WorkingDir: "/root", Options: []config.Option{{Name: "-u", Value: "0"}}},
 			},
 			Sidecars: []config.Container{
-				{Name: "inspector-ubuntu", Image: "blackducksoftware/blackduck-imageinspector-ubuntu:5.0.15", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "ubuntu"}}}}},
-				{Name: "inspector-alpine", Image: "blackducksoftware/blackduck-imageinspector-alpine:5.0.15", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "alpine"}}}}},
-				{Name: "inspector-centos", Image: "blackducksoftware/blackduck-imageinspector-centos:5.0.15", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "centos"}}}}},
+				{Name: "inspector-ubuntu", Image: "blackducksoftware/blackduck-imageinspector-ubuntu:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "ubuntu"}}}}},
+				{Name: "inspector-alpine", Image: "blackducksoftware/blackduck-imageinspector-alpine:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "alpine"}}}}},
+				{Name: "inspector-centos", Image: "blackducksoftware/blackduck-imageinspector-centos:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "centos"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -64,8 +64,7 @@ type detectExecuteScanOptions struct {
 	NpmArguments                []string `json:"npmArguments,omitempty"`
 	PrivateModules              string   `json:"privateModules,omitempty"`
 	PrivateModulesGitToken      string   `json:"privateModulesGitToken,omitempty"`
-	ScanImages                  bool     `json:"scanImages,omitempty"`
-	ContainerDistro             string   `json:"containerDistro,omitempty" validate:"possible-values=ubuntu centos alpine"`
+	ScanContainerDistro         string   `json:"scanContainerDistro,omitempty" validate:"possible-values=ubuntu centos alpine"`
 }
 
 type detectExecuteScanInflux struct {
@@ -312,8 +311,7 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringSliceVar(&stepConfig.NpmArguments, "npmArguments", []string{}, "List of additional arguments that Detect will add at then end of the npm ls command line when Detect executes the NPM CLI Detector on an NPM project.")
 	cmd.Flags().StringVar(&stepConfig.PrivateModules, "privateModules", os.Getenv("PIPER_privateModules"), "Tells go which modules shall be considered to be private (by setting [GOPRIVATE](https://pkg.go.dev/cmd/go#hdr-Configuration_for_downloading_non_public_code)).")
 	cmd.Flags().StringVar(&stepConfig.PrivateModulesGitToken, "privateModulesGitToken", os.Getenv("PIPER_privateModulesGitToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line.")
-	cmd.Flags().BoolVar(&stepConfig.ScanImages, "scanImages", false, "If images found in the cpe, they will also be scanned")
-	cmd.Flags().StringVar(&stepConfig.ContainerDistro, "containerDistro", `ubuntu`, "Distro of the container that is scanned")
+	cmd.Flags().StringVar(&stepConfig.ScanContainerDistro, "scanContainerDistro", os.Getenv("PIPER_scanContainerDistro"), "To also scan your images in the CPE, choose the distro")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -778,22 +776,13 @@ func detectExecuteScanMetadata() config.StepData {
 						Default:   os.Getenv("PIPER_privateModulesGitToken"),
 					},
 					{
-						Name:        "scanImages",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "bool",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     false,
-					},
-					{
-						Name:        "containerDistro",
+						Name:        "scanContainerDistro",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     `ubuntu`,
+						Default:     os.Getenv("PIPER_scanContainerDistro"),
 					},
 				},
 			},
@@ -801,9 +790,9 @@ func detectExecuteScanMetadata() config.StepData {
 				{Name: "openjdk", Image: "openjdk:11", WorkingDir: "/root", Options: []config.Option{{Name: "-u", Value: "0"}}},
 			},
 			Sidecars: []config.Container{
-				{Name: "inspector-ubuntu", Image: "blackducksoftware/blackduck-imageinspector-ubuntu:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "ubuntu"}}}}},
-				{Name: "inspector-alpine", Image: "blackducksoftware/blackduck-imageinspector-alpine:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "alpine"}}}}},
-				{Name: "inspector-centos", Image: "blackducksoftware/blackduck-imageinspector-centos:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "containerDistro", Value: "centos"}}}}},
+				{Name: "inspector-ubuntu", Image: "blackducksoftware/blackduck-imageinspector-ubuntu:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "scanContainerDistro", Value: "ubuntu"}}}}},
+				{Name: "inspector-alpine", Image: "blackducksoftware/blackduck-imageinspector-alpine:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "scanContainerDistro", Value: "alpine"}}}}},
+				{Name: "inspector-centos", Image: "blackducksoftware/blackduck-imageinspector-centos:5.1.0", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "scanContainerDistro", Value: "centos"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -807,7 +807,7 @@ func TestAddDetectArgs(t *testing.T) {
 			config := detectExecuteScanOptions{Token: "token", ServerURL: "https://my.blackduck.system", ProjectName: v.options.ProjectName, Version: v.options.Version, CustomScanVersion: v.options.CustomScanVersion}
 			sys := newBlackduckMockSystem(config)
 
-			got, err := addDetectArgs(v.args, v.options, newDetectTestUtilsBundle(v.isPullRequest), &sys, NO_VERSION_SUFFIX)
+			got, err := addDetectArgs(v.args, v.options, newDetectTestUtilsBundle(v.isPullRequest), &sys, NO_VERSION_SUFFIX, "")
 			assert.NoError(t, err)
 			assert.Equal(t, v.expected, got)
 		})

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -807,7 +807,7 @@ func TestAddDetectArgs(t *testing.T) {
 			config := detectExecuteScanOptions{Token: "token", ServerURL: "https://my.blackduck.system", ProjectName: v.options.ProjectName, Version: v.options.Version, CustomScanVersion: v.options.CustomScanVersion}
 			sys := newBlackduckMockSystem(config)
 
-			got, err := addDetectArgs(v.args, v.options, newDetectTestUtilsBundle(v.isPullRequest), &sys)
+			got, err := addDetectArgs(v.args, v.options, newDetectTestUtilsBundle(v.isPullRequest), &sys, NO_VERSION_SUFFIX)
 			assert.NoError(t, err)
 			assert.Equal(t, v.expected, got)
 		})

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -244,7 +244,8 @@ func (c *Client) DownloadImage(imageSource, targetFile string) (v1.Image, error)
 	craneCmd := cranecmd.NewCmdPull(&noOpts)
 	craneCmd.SetOut(log.Writer())
 	craneCmd.SetErr(log.Writer())
-	craneCmd.SetArgs([]string{imageRef.Name(), tmpFile.Name(), "--format=" + c.imageFormat})
+	args := []string{imageRef.Name(), tmpFile.Name(), "--format=" + c.imageFormat}
+	craneCmd.SetArgs(args)
 
 	if err := craneCmd.Execute(); err != nil {
 		defer os.Remove(tmpFile.Name())

--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -155,6 +155,12 @@ func getContainerParameters(container config.Container, sidecar bool) map[string
 		containerParams[ifThenElse(sidecar, "sidecarWorkspace", "dockerWorkspace")] = container.WorkingDir
 	}
 
+	if len(container.VolumeMounts) > 0 {
+		for _, mount := range container.VolumeMounts {
+			containerParams["containerMountPath"] = mount.MountPath
+		}
+	}
+
 	if sidecar {
 		if len(container.ReadyCommand) > 0 {
 			containerParams["sidecarReadyCommand"] = container.ReadyCommand

--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -155,12 +155,6 @@ func getContainerParameters(container config.Container, sidecar bool) map[string
 		containerParams[ifThenElse(sidecar, "sidecarWorkspace", "dockerWorkspace")] = container.WorkingDir
 	}
 
-	if len(container.VolumeMounts) > 0 {
-		for _, mount := range container.VolumeMounts {
-			containerParams["containerMountPath"] = mount.MountPath
-		}
-	}
-
 	if sidecar {
 		if len(container.ReadyCommand) > 0 {
 			containerParams["sidecarReadyCommand"] = container.ReadyCommand

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -511,22 +511,13 @@ spec:
           - type: vaultSecret
             name: golangPrivateModulesGitTokenVaultSecret
             default: golang
-      - name: scanImages
-        description: If images found in the cpe, they will also be scanned
-        type: "bool"
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        default: false
-      - name: containerDistro
-        description: Distro of the container that is scanned
+      - name: scanContainerDistro
+        description: To also scan your images in the CPE, choose the distro
         type: "string"
         scope:
           - PARAMETERS
           - STAGES
           - STEPS
-        default: "ubuntu"
         possibleValues:
           - ubuntu
           - centos
@@ -595,7 +586,7 @@ spec:
       conditions:
         - conditionRef: strings-equal
           params:
-            - name: containerDistro
+            - name: scanContainerDistro
               value: ubuntu
     - name: inspector-alpine
       image: blackducksoftware/blackduck-imageinspector-alpine:5.1.0
@@ -606,7 +597,7 @@ spec:
       conditions:
         - conditionRef: strings-equal
           params:
-            - name: containerDistro
+            - name: scanContainerDistro
               value: alpine
     - name: inspector-centos
       image: blackducksoftware/blackduck-imageinspector-centos:5.1.0
@@ -617,5 +608,5 @@ spec:
       conditions:
         - conditionRef: strings-equal
           params:
-            - name: containerDistro
+            - name: scanContainerDistro
               value: centos

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -511,9 +511,16 @@ spec:
           - type: vaultSecret
             name: golangPrivateModulesGitTokenVaultSecret
             default: golang
+      - name: scanImages
+        description: If images found in the cpe, they will also be scanned
+        type: "bool"
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: false
       - name: containerDistro
-        description:
-          "distro of the container that is scanned"
+        description: Distro of the container that is scanned
         type: "string"
         scope:
           - PARAMETERS
@@ -524,15 +531,6 @@ spec:
           - ubuntu
           - centos
           - alpine
-      - name: scanImages
-        description:
-          "if images found in the cpe, they will also be scanned"
-        type: "bool"
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        default: true
   outputs:
     resources:
       - name: influx
@@ -586,32 +584,36 @@ spec:
           value: "0"
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+          name: imageinspector-shared
   sidecars:
     - name: inspector-ubuntu
-      image: blackducksoftware/blackduck-imageinspector-ubuntu:5.0.15
+      image: blackducksoftware/blackduck-imageinspector-ubuntu:5.1.0
       command: ['']
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+          name: imageinspector-shared
       conditions:
         - conditionRef: strings-equal
           params:
             - name: containerDistro
               value: ubuntu
     - name: inspector-alpine
-      image: blackducksoftware/blackduck-imageinspector-alpine:5.0.15
+      image: blackducksoftware/blackduck-imageinspector-alpine:5.1.0
       command: ['']
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+          name: imageinspector-shared
       conditions:
         - conditionRef: strings-equal
           params:
             - name: containerDistro
               value: alpine
     - name: inspector-centos
-      image: blackducksoftware/blackduck-imageinspector-centos:5.0.15
+      image: blackducksoftware/blackduck-imageinspector-centos:5.1.0
       command: ['']
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+          name: imageinspector-shared
       conditions:
         - conditionRef: strings-equal
           params:

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -511,6 +511,28 @@ spec:
           - type: vaultSecret
             name: golangPrivateModulesGitTokenVaultSecret
             default: golang
+      - name: containerDistro
+        description:
+          "distro of the container that is scanned"
+        type: "string"
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: "ubuntu"
+        possibleValues:
+          - ubuntu
+          - centos
+          - alpine
+      - name: scanImages
+        description:
+          "if images found in the cpe, they will also be scanned"
+        type: "bool"
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: true
   outputs:
     resources:
       - name: influx
@@ -562,3 +584,36 @@ spec:
       options:
         - name: -u
           value: "0"
+      volumeMounts:
+        - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+  sidecars:
+    - name: inspector-ubuntu
+      image: blackducksoftware/blackduck-imageinspector-ubuntu:5.0.15
+      command: ['']
+      volumeMounts:
+        - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+      conditions:
+        - conditionRef: strings-equal
+          params:
+            - name: containerDistro
+              value: ubuntu
+    - name: inspector-alpine
+      image: blackducksoftware/blackduck-imageinspector-alpine:5.0.15
+      command: ['']
+      volumeMounts:
+        - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+      conditions:
+        - conditionRef: strings-equal
+          params:
+            - name: containerDistro
+              value: alpine
+    - name: inspector-centos
+      image: blackducksoftware/blackduck-imageinspector-centos:5.0.15
+      command: ['']
+      volumeMounts:
+        - mountPath: /opt/blackduck/blackduck-imageinspector/shared
+      conditions:
+        - conditionRef: strings-equal
+          params:
+            - name: containerDistro
+              value: centos

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -584,14 +584,14 @@ spec:
           value: "0"
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
-          name: imageinspector-shared
+          name: volume
   sidecars:
     - name: inspector-ubuntu
       image: blackducksoftware/blackduck-imageinspector-ubuntu:5.1.0
       command: ['']
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
-          name: imageinspector-shared
+          name: volume
       conditions:
         - conditionRef: strings-equal
           params:
@@ -602,7 +602,7 @@ spec:
       command: ['']
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
-          name: imageinspector-shared
+          name: volume
       conditions:
         - conditionRef: strings-equal
           params:
@@ -613,7 +613,7 @@ spec:
       command: ['']
       volumeMounts:
         - mountPath: /opt/blackduck/blackduck-imageinspector/shared
-          name: imageinspector-shared
+          name: volume
       conditions:
         - conditionRef: strings-equal
           params:

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -522,6 +522,74 @@ spec:
           - ubuntu
           - centos
           - alpine
+      - name: imageNameTags
+        type: "[]string"
+        mandatoryIf:
+          - name: scanContainerDistro
+            value: ubuntu
+          - name: scanContainerDistro
+            value: centos
+          - name: scanContainerDistro
+            value: alpine
+        description: Images to be scanned (typically filled by CPE)
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/imageNameTags
+      - name: registryUrl
+        type: string
+        mandatoryIf:
+          - name: scanContainerDistro
+            value: ubuntu
+          - name: scanContainerDistro
+            value: centos
+          - name: scanContainerDistro
+            value: alpine
+        description: Used accessing for the images to be scanned (typically filled by CPE)
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/registryUrl
+      - name: repositoryUsername
+        type: string
+        mandatoryIf:
+          - name: scanContainerDistro
+            value: ubuntu
+          - name: scanContainerDistro
+            value: centos
+          - name: scanContainerDistro
+            value: alpine
+        description: Used accessing for the images to be scanned (typically filled by CPE)
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/repositoryUsername
+      - name: repositoryPassword
+        type: string
+        mandatoryIf:
+          - name: scanContainerDistro
+            value: ubuntu
+          - name: scanContainerDistro
+            value: centos
+          - name: scanContainerDistro
+            value: alpine
+        description: Used accessing for the images to be scanned (typically filled by CPE)
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/repositoryPassword
   outputs:
     resources:
       - name: influx


### PR DESCRIPTION
This has following prerequisites to `jenkins-library` (cherry-picked):

* #4672 Allow `sidecars` to have `conditions`
* #4673 Add `volumeMount` support to `sidecars`

The enhances `detectExecuteScan` to not only scan the workspace, but also all images that can be found in the `cpe`. If `kanikoExecute` or `cnbBuild` produce images, the information will be written to the `cpe`. In order to do these scans, a sidecar is needed. The sidecar is different for the distro that is scanned. The user can configure this via the new parameter `containerDistro` (default "ubuntu").

The user can can use `scanImages: false` to prevent this.

# Changes

- [ ] Tests
- [ ] Documentation
