### PR TITLE
fix(codeqlExecuteScan): refactored codeql reporting

### DIFF
--- a/cmd/codeqlExecuteScan_test.go
+++ b/cmd/codeqlExecuteScan_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -75,104 +74,104 @@ func TestRunCodeqlExecuteScan(t *testing.T) {
 
 func TestGetGitRepoInfo(t *testing.T) {
 	t.Run("Valid https URL1", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("https://github.hello.test/Testing/fortify.git", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 
 	t.Run("Valid https URL2", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("https://github.hello.test/Testing/fortify", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 	t.Run("Valid https URL1 with dots", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("https://github.hello.test/Testing/com.sap.fortify.git", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "com.sap.fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "com.sap.fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 
 	t.Run("Valid https URL2 with dots", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("https://github.hello.test/Testing/com.sap.fortify", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "com.sap.fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "com.sap.fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 	t.Run("Valid https URL1 with username and token", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("https://username:token@github.hello.test/Testing/fortify.git", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 
 	t.Run("Valid https URL2 with username and token", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("https://username:token@github.hello.test/Testing/fortify", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 
-	t.Run("Invalid https URL as no org/owner passed", func(t *testing.T) {
-		var repoInfo RepoInfo
+	t.Run("Invalid https URL as no org/Owner passed", func(t *testing.T) {
+		var repoInfo codeql.RepoInfo
 		assert.Error(t, getGitRepoInfo("https://github.com/fortify", &repoInfo))
 	})
 
 	t.Run("Invalid URL as no protocol passed", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		assert.Error(t, getGitRepoInfo("github.hello.test/Testing/fortify", &repoInfo))
 	})
 
 	t.Run("Valid ssh URL1", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("git@github.hello.test/Testing/fortify.git", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 
 	t.Run("Valid ssh URL2", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("git@github.hello.test/Testing/fortify", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 	t.Run("Valid ssh URL1 with dots", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("git@github.hello.test/Testing/com.sap.fortify.git", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "com.sap.fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "com.sap.fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 
 	t.Run("Valid ssh URL2 with dots", func(t *testing.T) {
-		var repoInfo RepoInfo
+		var repoInfo codeql.RepoInfo
 		err := getGitRepoInfo("git@github.hello.test/Testing/com.sap.fortify", &repoInfo)
 		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
-		assert.Equal(t, "com.sap.fortify", repoInfo.repo)
-		assert.Equal(t, "Testing", repoInfo.owner)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
+		assert.Equal(t, "com.sap.fortify", repoInfo.Repo)
+		assert.Equal(t, "Testing", repoInfo.Owner)
 	})
 
-	t.Run("Invalid ssh URL as no org/owner passed", func(t *testing.T) {
-		var repoInfo RepoInfo
+	t.Run("Invalid ssh URL as no org/Owner passed", func(t *testing.T) {
+		var repoInfo codeql.RepoInfo
 		assert.Error(t, getGitRepoInfo("git@github.com/fortify", &repoInfo))
 	})
 }
@@ -182,66 +181,66 @@ func TestInitGitInfo(t *testing.T) {
 		config := codeqlExecuteScanOptions{Repository: "https://github.hello.test/Testing/codeql.git", AnalyzedRef: "refs/head/branch", CommitID: "abcd1234"}
 		repoInfo, err := initGitInfo(&config)
 		assert.NoError(t, err)
-		assert.Equal(t, "abcd1234", repoInfo.commitId)
-		assert.Equal(t, "Testing", repoInfo.owner)
-		assert.Equal(t, "codeql", repoInfo.repo)
-		assert.Equal(t, "refs/head/branch", repoInfo.ref)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
+		assert.Equal(t, "abcd1234", repoInfo.CommitId)
+		assert.Equal(t, "Testing", repoInfo.Owner)
+		assert.Equal(t, "codeql", repoInfo.Repo)
+		assert.Equal(t, "refs/head/branch", repoInfo.Ref)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
 	})
 
 	t.Run("Valid URL2", func(t *testing.T) {
 		config := codeqlExecuteScanOptions{Repository: "https://github.hello.test/Testing/codeql", AnalyzedRef: "refs/head/branch", CommitID: "abcd1234"}
 		repoInfo, err := initGitInfo(&config)
 		assert.NoError(t, err)
-		assert.Equal(t, "abcd1234", repoInfo.commitId)
-		assert.Equal(t, "Testing", repoInfo.owner)
-		assert.Equal(t, "codeql", repoInfo.repo)
-		assert.Equal(t, "refs/head/branch", repoInfo.ref)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
+		assert.Equal(t, "abcd1234", repoInfo.CommitId)
+		assert.Equal(t, "Testing", repoInfo.Owner)
+		assert.Equal(t, "codeql", repoInfo.Repo)
+		assert.Equal(t, "refs/head/branch", repoInfo.Ref)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
 	})
 
 	t.Run("Valid url with dots URL1", func(t *testing.T) {
 		config := codeqlExecuteScanOptions{Repository: "https://github.hello.test/Testing/com.sap.codeql.git", AnalyzedRef: "refs/head/branch", CommitID: "abcd1234"}
 		repoInfo, err := initGitInfo(&config)
 		assert.NoError(t, err)
-		assert.Equal(t, "abcd1234", repoInfo.commitId)
-		assert.Equal(t, "Testing", repoInfo.owner)
-		assert.Equal(t, "com.sap.codeql", repoInfo.repo)
-		assert.Equal(t, "refs/head/branch", repoInfo.ref)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
+		assert.Equal(t, "abcd1234", repoInfo.CommitId)
+		assert.Equal(t, "Testing", repoInfo.Owner)
+		assert.Equal(t, "com.sap.codeql", repoInfo.Repo)
+		assert.Equal(t, "refs/head/branch", repoInfo.Ref)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
 	})
 
 	t.Run("Valid url with dots URL2", func(t *testing.T) {
 		config := codeqlExecuteScanOptions{Repository: "https://github.hello.test/Testing/com.sap.codeql", AnalyzedRef: "refs/head/branch", CommitID: "abcd1234"}
 		repoInfo, err := initGitInfo(&config)
 		assert.NoError(t, err)
-		assert.Equal(t, "abcd1234", repoInfo.commitId)
-		assert.Equal(t, "Testing", repoInfo.owner)
-		assert.Equal(t, "com.sap.codeql", repoInfo.repo)
-		assert.Equal(t, "refs/head/branch", repoInfo.ref)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
+		assert.Equal(t, "abcd1234", repoInfo.CommitId)
+		assert.Equal(t, "Testing", repoInfo.Owner)
+		assert.Equal(t, "com.sap.codeql", repoInfo.Repo)
+		assert.Equal(t, "refs/head/branch", repoInfo.Ref)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
 	})
 
 	t.Run("Valid url with username and token URL1", func(t *testing.T) {
 		config := codeqlExecuteScanOptions{Repository: "https://username:token@github.hello.test/Testing/codeql.git", AnalyzedRef: "refs/head/branch", CommitID: "abcd1234"}
 		repoInfo, err := initGitInfo(&config)
 		assert.NoError(t, err)
-		assert.Equal(t, "abcd1234", repoInfo.commitId)
-		assert.Equal(t, "Testing", repoInfo.owner)
-		assert.Equal(t, "codeql", repoInfo.repo)
-		assert.Equal(t, "refs/head/branch", repoInfo.ref)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
+		assert.Equal(t, "abcd1234", repoInfo.CommitId)
+		assert.Equal(t, "Testing", repoInfo.Owner)
+		assert.Equal(t, "codeql", repoInfo.Repo)
+		assert.Equal(t, "refs/head/branch", repoInfo.Ref)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
 	})
 
 	t.Run("Valid url with username and token URL2", func(t *testing.T) {
 		config := codeqlExecuteScanOptions{Repository: "https://username:token@github.hello.test/Testing/codeql", AnalyzedRef: "refs/head/branch", CommitID: "abcd1234"}
 		repoInfo, err := initGitInfo(&config)
 		assert.NoError(t, err)
-		assert.Equal(t, "abcd1234", repoInfo.commitId)
-		assert.Equal(t, "Testing", repoInfo.owner)
-		assert.Equal(t, "codeql", repoInfo.repo)
-		assert.Equal(t, "refs/head/branch", repoInfo.ref)
-		assert.Equal(t, "https://github.hello.test", repoInfo.serverUrl)
+		assert.Equal(t, "abcd1234", repoInfo.CommitId)
+		assert.Equal(t, "Testing", repoInfo.Owner)
+		assert.Equal(t, "codeql", repoInfo.Repo)
+		assert.Equal(t, "refs/head/branch", repoInfo.Ref)
+		assert.Equal(t, "https://github.hello.test", repoInfo.ServerUrl)
 	})
 
 	t.Run("Invalid URL with no org/reponame", func(t *testing.T) {
@@ -249,98 +248,13 @@ func TestInitGitInfo(t *testing.T) {
 		repoInfo, err := initGitInfo(&config)
 		assert.NoError(t, err)
 		_, err = orchestrator.NewOrchestratorSpecificConfigProvider()
-		assert.Equal(t, "abcd1234", repoInfo.commitId)
-		assert.Equal(t, "refs/head/branch", repoInfo.ref)
+		assert.Equal(t, "abcd1234", repoInfo.CommitId)
+		assert.Equal(t, "refs/head/branch", repoInfo.Ref)
 		if err != nil {
-			assert.Equal(t, "", repoInfo.owner)
-			assert.Equal(t, "", repoInfo.repo)
-			assert.Equal(t, "", repoInfo.serverUrl)
+			assert.Equal(t, "", repoInfo.Owner)
+			assert.Equal(t, "", repoInfo.Repo)
+			assert.Equal(t, "", repoInfo.ServerUrl)
 		}
-	})
-}
-
-func TestBuildRepoReference(t *testing.T) {
-	t.Run("Valid ref with branch", func(t *testing.T) {
-		repository := "https://github.hello.test/Testing/fortify"
-		analyzedRef := "refs/head/branch"
-		ref, err := buildRepoReference(repository, analyzedRef)
-		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test/Testing/fortify/tree/branch", ref)
-	})
-	t.Run("Valid ref with PR", func(t *testing.T) {
-		repository := "https://github.hello.test/Testing/fortify"
-		analyzedRef := "refs/pull/1/merge"
-		ref, err := buildRepoReference(repository, analyzedRef)
-		assert.NoError(t, err)
-		assert.Equal(t, "https://github.hello.test/Testing/fortify/pull/1", ref)
-	})
-	t.Run("Invalid ref without branch name", func(t *testing.T) {
-		repository := "https://github.hello.test/Testing/fortify"
-		analyzedRef := "refs/head"
-		ref, err := buildRepoReference(repository, analyzedRef)
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "Wrong analyzedRef format")
-		assert.Equal(t, "", ref)
-	})
-	t.Run("Invalid ref without PR id", func(t *testing.T) {
-		repository := "https://github.hello.test/Testing/fortify"
-		analyzedRef := "refs/pull/merge"
-		ref, err := buildRepoReference(repository, analyzedRef)
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "Wrong analyzedRef format")
-		assert.Equal(t, "", ref)
-	})
-}
-
-func getRepoReferences(repoInfo RepoInfo) (string, string, string) {
-	repoUrl := fmt.Sprintf("%s/%s/%s", repoInfo.serverUrl, repoInfo.owner, repoInfo.repo)
-	repoReference, _ := buildRepoReference(repoUrl, repoInfo.ref)
-	repoCodeqlScanUrl := fmt.Sprintf("%s/security/code-scanning?query=is:open+ref:%s", repoUrl, repoInfo.ref)
-	return repoUrl, repoReference, repoCodeqlScanUrl
-}
-func TestCreateToolRecordCodeql(t *testing.T) {
-	t.Run("Valid toolrun file", func(t *testing.T) {
-		repoInfo := RepoInfo{serverUrl: "https://github.hello.test", commitId: "test", ref: "refs/head/branch", owner: "Testing", repo: "fortify"}
-		repoUrl, repoReference, repoCodeqlScanUrl := getRepoReferences(repoInfo)
-		toolRecord, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, repoCodeqlScanUrl)
-		assert.NoError(t, err)
-		assert.Equal(t, toolRecord.ToolName, "codeql")
-		assert.Equal(t, toolRecord.ToolInstance, "https://github.hello.test")
-		assert.Equal(t, toolRecord.DisplayName, "Testing fortify - refs/head/branch test")
-		assert.Equal(t, toolRecord.DisplayURL, "https://github.hello.test/Testing/fortify/security/code-scanning?query=is:open+ref:refs/head/branch")
-	})
-	t.Run("Empty repository URL", func(t *testing.T) {
-		repoInfo := RepoInfo{serverUrl: "", commitId: "test", ref: "refs/head/branch", owner: "Testing", repo: "fortify"}
-		repoUrl, repoReference, repoCodeqlScanUrl := getRepoReferences(repoInfo)
-		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, repoCodeqlScanUrl)
-
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "Repository not set")
-	})
-
-	t.Run("Empty analyzedRef", func(t *testing.T) {
-		repoInfo := RepoInfo{serverUrl: "https://github.hello.test", commitId: "test", ref: "", owner: "Testing", repo: "fortify"}
-		repoUrl, repoReference, repoCodeqlScanUrl := getRepoReferences(repoInfo)
-		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, repoCodeqlScanUrl)
-
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "Analyzed Reference not set")
-	})
-
-	t.Run("Empty CommitId", func(t *testing.T) {
-		repoInfo := RepoInfo{serverUrl: "https://github.hello.test", commitId: "", ref: "refs/head/branch", owner: "Testing", repo: "fortify"}
-		repoUrl, repoReference, repoCodeqlScanUrl := getRepoReferences(repoInfo)
-		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, repoCodeqlScanUrl)
-
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "CommitId not set")
-	})
-	t.Run("Invalid analyzedRef", func(t *testing.T) {
-		repoInfo := RepoInfo{serverUrl: "https://github.hello.test", commitId: "", ref: "refs/branch", owner: "Testing", repo: "fortify"}
-		repoUrl, repoReference, repoCodeqlScanUrl := getRepoReferences(repoInfo)
-		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, repoCodeqlScanUrl)
-
-		assert.Error(t, err)
 	})
 }
 

--- a/pkg/codeql/reporting.go
+++ b/pkg/codeql/reporting.go
@@ -2,10 +2,13 @@ package codeql
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/SAP/jenkins-library/pkg/toolrecord"
 	"github.com/pkg/errors"
 )
 
@@ -22,6 +25,14 @@ type CodeqlFindings struct {
 	ClassificationName string `json:"classificationName"`
 	Total              int    `json:"total"`
 	Audited            int    `json:"audited"`
+}
+
+type RepoInfo struct {
+	ServerUrl string
+	Repo      string
+	CommitId  string
+	Ref       string
+	Owner     string
 }
 
 func WriteJSONReport(jsonReport CodeqlAudit, modulePath string) ([]piperutils.Path, error) {
@@ -43,4 +54,85 @@ func WriteJSONReport(jsonReport CodeqlAudit, modulePath string) ([]piperutils.Pa
 	reportPaths = append(reportPaths, piperutils.Path{Name: "Codeql JSON Compliance Report", Target: jsonComplianceReportPath})
 
 	return reportPaths, nil
+}
+
+func BuildRepoReference(repository, analyzedRef string) (string, error) {
+	ref := strings.Split(analyzedRef, "/")
+	if len(ref) < 3 {
+		return "", errors.New(fmt.Sprintf("Wrong analyzedRef format: %s", analyzedRef))
+	}
+	if strings.Contains(analyzedRef, "pull") {
+		if len(ref) < 4 {
+			return "", errors.New(fmt.Sprintf("Wrong analyzedRef format: %s", analyzedRef))
+		}
+		return fmt.Sprintf("%s/pull/%s", repository, ref[2]), nil
+	}
+	return fmt.Sprintf("%s/tree/%s", repository, ref[2]), nil
+}
+
+func CreateAndPersistToolRecord(utils piperutils.FileUtils, repoInfo RepoInfo, repoReference, repoUrl, modulePath string) (string, error) {
+	toolRecord, err := createToolRecordCodeql(utils, repoInfo, repoReference, repoUrl, modulePath)
+	if err != nil {
+		return "", err
+	}
+
+	toolRecordFileName, err := persistToolRecord(toolRecord)
+	if err != nil {
+		return "", err
+	}
+
+	return toolRecordFileName, nil
+}
+
+func createToolRecordCodeql(utils piperutils.FileUtils, repoInfo RepoInfo, repoUrl, repoReference, modulePath string) (*toolrecord.Toolrecord, error) {
+	record := toolrecord.New(utils, modulePath, "codeql", repoInfo.ServerUrl)
+
+	if repoInfo.ServerUrl == "" {
+		return record, errors.New("Repository not set")
+	}
+
+	if repoInfo.CommitId == "" || repoInfo.CommitId == "NA" {
+		return record, errors.New("CommitId not set")
+	}
+
+	if repoInfo.Ref == "" {
+		return record, errors.New("Analyzed Reference not set")
+	}
+
+	record.DisplayName = fmt.Sprintf("%s %s - %s %s", repoInfo.Owner, repoInfo.Repo, repoInfo.Ref, repoInfo.CommitId)
+	record.DisplayURL = fmt.Sprintf("%s/security/code-scanning?query=is:open+ref:%s", repoUrl, repoInfo.Ref)
+
+	err := record.AddKeyData("repository",
+		fmt.Sprintf("%s/%s", repoInfo.Owner, repoInfo.Repo),
+		fmt.Sprintf("%s %s", repoInfo.Owner, repoInfo.Repo),
+		repoUrl)
+	if err != nil {
+		return record, err
+	}
+
+	err = record.AddKeyData("repositoryReference",
+		repoInfo.Ref,
+		fmt.Sprintf("%s - %s", repoInfo.Repo, repoInfo.Ref),
+		repoReference)
+	if err != nil {
+		return record, err
+	}
+
+	err = record.AddKeyData("scanResult",
+		fmt.Sprintf("%s/%s", repoInfo.Ref, repoInfo.CommitId),
+		fmt.Sprintf("%s %s - %s %s", repoInfo.Owner, repoInfo.Repo, repoInfo.Ref, repoInfo.CommitId),
+		fmt.Sprintf("%s/security/code-scanning?query=is:open+ref:%s", repoUrl, repoInfo.Ref))
+	if err != nil {
+		return record, err
+	}
+
+	return record, nil
+}
+
+func persistToolRecord(toolRecord *toolrecord.Toolrecord) (string, error) {
+	err := toolRecord.Persist()
+	if err != nil {
+		return "", err
+	}
+	return toolRecord.GetFileName(), nil
 }

--- a/pkg/codeql/reporting_test.go
+++ b/pkg/codeql/reporting_test.go
@@ -1,0 +1,108 @@
+package codeql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/SAP/jenkins-library/pkg/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+type codeqlExecuteScanMockUtils struct {
+	*mock.ExecMockRunner
+	*mock.FilesMock
+}
+
+func newCodeqlExecuteScanTestsUtils() codeqlExecuteScanMockUtils {
+	utils := codeqlExecuteScanMockUtils{
+		ExecMockRunner: &mock.ExecMockRunner{},
+		FilesMock:      &mock.FilesMock{},
+	}
+	return utils
+}
+
+func TestBuildRepoReference(t *testing.T) {
+	t.Run("Valid Ref with branch", func(t *testing.T) {
+		repository := "https://github.hello.test/Testing/fortify"
+		analyzedRef := "refs/head/branch"
+		ref, err := BuildRepoReference(repository, analyzedRef)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://github.hello.test/Testing/fortify/tree/branch", ref)
+	})
+	t.Run("Valid Ref with PR", func(t *testing.T) {
+		repository := "https://github.hello.test/Testing/fortify"
+		analyzedRef := "refs/pull/1/merge"
+		ref, err := BuildRepoReference(repository, analyzedRef)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://github.hello.test/Testing/fortify/pull/1", ref)
+	})
+	t.Run("Invalid Ref without branch name", func(t *testing.T) {
+		repository := "https://github.hello.test/Testing/fortify"
+		analyzedRef := "refs/head"
+		ref, err := BuildRepoReference(repository, analyzedRef)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "Wrong analyzedRef format")
+		assert.Equal(t, "", ref)
+	})
+	t.Run("Invalid Ref without PR id", func(t *testing.T) {
+		repository := "https://github.hello.test/Testing/fortify"
+		analyzedRef := "refs/pull/merge"
+		ref, err := BuildRepoReference(repository, analyzedRef)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "Wrong analyzedRef format")
+		assert.Equal(t, "", ref)
+	})
+}
+
+func getRepoReferences(repoInfo RepoInfo) (string, string) {
+	repoUrl := fmt.Sprintf("%s/%s/%s", repoInfo.ServerUrl, repoInfo.Owner, repoInfo.Repo)
+	repoReference, _ := BuildRepoReference(repoUrl, repoInfo.Ref)
+	return repoUrl, repoReference
+}
+
+func TestCreateToolRecordCodeql(t *testing.T) {
+	modulePath := "./"
+	t.Run("Valid toolrun file", func(t *testing.T) {
+		repoInfo := RepoInfo{ServerUrl: "https://github.hello.test", CommitId: "test", Ref: "refs/head/branch", Owner: "Testing", Repo: "fortify"}
+		repoUrl, repoReference := getRepoReferences(repoInfo)
+		toolRecord, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, modulePath)
+		assert.NoError(t, err)
+		assert.Equal(t, toolRecord.ToolName, "codeql")
+		assert.Equal(t, toolRecord.ToolInstance, "https://github.hello.test")
+		assert.Equal(t, toolRecord.DisplayName, "Testing fortify - refs/head/branch test")
+		assert.Equal(t, toolRecord.DisplayURL, "https://github.hello.test/Testing/fortify/security/code-scanning?query=is:open+ref:refs/head/branch")
+	})
+	t.Run("Empty repository URL", func(t *testing.T) {
+		repoInfo := RepoInfo{ServerUrl: "", CommitId: "test", Ref: "refs/head/branch", Owner: "Testing", Repo: "fortify"}
+		repoUrl, repoReference := getRepoReferences(repoInfo)
+		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, modulePath)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "Repository not set")
+	})
+
+	t.Run("Empty analyzedRef", func(t *testing.T) {
+		repoInfo := RepoInfo{ServerUrl: "https://github.hello.test", CommitId: "test", Ref: "", Owner: "Testing", Repo: "fortify"}
+		repoUrl, repoReference := getRepoReferences(repoInfo)
+		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, modulePath)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "Analyzed Reference not set")
+	})
+
+	t.Run("Empty CommitId", func(t *testing.T) {
+		repoInfo := RepoInfo{ServerUrl: "https://github.hello.test", CommitId: "", Ref: "refs/head/branch", Owner: "Testing", Repo: "fortify"}
+		repoUrl, repoReference := getRepoReferences(repoInfo)
+		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, modulePath)
+
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "CommitId not set")
+	})
+	t.Run("Invalid analyzedRef", func(t *testing.T) {
+		repoInfo := RepoInfo{ServerUrl: "https://github.hello.test", CommitId: "", Ref: "refs/branch", Owner: "Testing", Repo: "fortify"}
+		repoUrl, repoReference := getRepoReferences(repoInfo)
+		_, err := createToolRecordCodeql(newCodeqlExecuteScanTestsUtils(), repoInfo, repoUrl, repoReference, modulePath)
+
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
# Changes
Refactored codeql reports generation to allow it to be used as standalone tool.

- [x] Tests
- [ ] Documentation
