### PR TITLE
chore: Clean up things related to the old dev Splunk instance

### DIFF
--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -62,10 +62,10 @@ type SentryConfiguration struct {
 
 // SplunkConfiguration defines the configuration options for the Splunk logging system
 type SplunkConfiguration struct {
-	CriblEndpoint string `json:"criblEndpoint,omitempty"`
-	CriblToken    string `json:"criblToken,omitempty"`
-	CriblIndex    string `json:"criblIndex,omitempty"`
-	SendLogs      bool   `json:"sendLogs"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Token    string `json:"token,omitempty"`
+	Index    string `json:"index,omitempty"`
+	SendLogs bool   `json:"sendLogs"`
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -62,13 +62,10 @@ type SentryConfiguration struct {
 
 // SplunkConfiguration defines the configuration options for the Splunk logging system
 type SplunkConfiguration struct {
-	Dsn               string `json:"dsn,omitempty"`
-	Token             string `json:"token,omitempty"`
-	Index             string `json:"index,omitempty"`
-	SendLogs          bool   `json:"sendLogs"`
-	ProdCriblEndpoint string `json:"prodCriblEndpoint,omitempty"`
-	ProdCriblToken    string `json:"prodCriblToken,omitempty"`
-	ProdCriblIndex    string `json:"prodCriblIndex,omitempty"`
+	CriblEndpoint string `json:"prodCriblEndpoint,omitempty"`
+	CriblToken    string `json:"prodCriblToken,omitempty"`
+	CriblIndex    string `json:"prodCriblIndex,omitempty"`
+	SendLogs      bool   `json:"sendLogs"`
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -62,9 +62,9 @@ type SentryConfiguration struct {
 
 // SplunkConfiguration defines the configuration options for the Splunk logging system
 type SplunkConfiguration struct {
-	CriblEndpoint string `json:"prodCriblEndpoint,omitempty"`
-	CriblToken    string `json:"prodCriblToken,omitempty"`
-	CriblIndex    string `json:"prodCriblIndex,omitempty"`
+	CriblEndpoint string `json:"criblEndpoint,omitempty"`
+	CriblToken    string `json:"criblToken,omitempty"`
+	CriblIndex    string `json:"criblIndex,omitempty"`
 	SendLogs      bool   `json:"sendLogs"`
 }
 

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -144,7 +144,7 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 				log.RegisterHook(&sentryHook)
 			}
 
-			if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Dsn) > 0 || len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.ProdCriblEndpoint) > 0 {
+			if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblEndpoint) > 0 {
 				splunkClient = &splunk.Splunk{}
 				logCollector = &log.CollectorHook{CorrelationID: {{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.CorrelationID}
 				log.RegisterHook(logCollector)
@@ -185,19 +185,11 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 				stepTelemetryData.PiperCommitHash = {{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GitCommit
 				telemetryClient.SetData(&stepTelemetryData)
 				telemetryClient.Send()
-				if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Dsn) > 0 {
+				if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblEndpoint) > 0 {
 					splunkClient.Initialize({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.CorrelationID,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Dsn,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Token,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Index,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.SendLogs)
-					splunkClient.Send(telemetryClient.GetData(), logCollector)
-				}
-				if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.ProdCriblEndpoint) > 0 {
-					splunkClient.Initialize({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.CorrelationID,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.ProdCriblEndpoint,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.ProdCriblToken,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.ProdCriblIndex,
+					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblEndpoint,
+					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblToken,
+					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblIndex,
 					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.SendLogs)
 					splunkClient.Send(telemetryClient.GetData(), logCollector)
 				}

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -144,7 +144,7 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 				log.RegisterHook(&sentryHook)
 			}
 
-			if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblEndpoint) > 0 {
+			if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Endpoint) > 0 {
 				splunkClient = &splunk.Splunk{}
 				logCollector = &log.CollectorHook{CorrelationID: {{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.CorrelationID}
 				log.RegisterHook(logCollector)
@@ -185,11 +185,11 @@ func {{.CobraCmdFuncName}}() *cobra.Command {
 				stepTelemetryData.PiperCommitHash = {{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GitCommit
 				telemetryClient.SetData(&stepTelemetryData)
 				telemetryClient.Send()
-				if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblEndpoint) > 0 {
+				if len({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Endpoint) > 0 {
 					splunkClient.Initialize({{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.CorrelationID,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblEndpoint,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblToken,
-					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.CriblIndex,
+					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Endpoint,
+					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Token,
+					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.Index,
 					{{if .ExportPrefix}}{{ .ExportPrefix }}.{{end}}GeneralConfig.HookConfig.SplunkConfig.SendLogs)
 					splunkClient.Send(telemetryClient.GetData(), logCollector)
 				}


### PR DESCRIPTION
# Changes

This PR removes things related to the old dev Splunk instance that we are no longer going to use.

`_generated.go` files will be updated once first round of review is done.

- [ ] Tests
- [ ] Documentation
