### PR TITLE
Use new env var for tms service key

### DIFF
--- a/integration/integration_tms_export_test.go
+++ b/integration/integration_tms_export_test.go
@@ -19,7 +19,7 @@ func TestTmsExportIntegrationYaml(t *testing.T) {
 		Image:       "devxci/mbtci-java11-node14",
 		User:        "root",
 		TestDir:     []string{"testdata", "TestTmsIntegration"},
-		Environment: map[string]string{"PIPER_tmsServiceKey": tmsServiceKey},
+		Environment: map[string]string{"PIPER_serviceKey": tmsServiceKey},
 	})
 	defer container.terminate(t)
 
@@ -41,7 +41,7 @@ func TestTmsExportIntegrationBinFailDescription(t *testing.T) {
 		Image:       "devxci/mbtci-java11-node14",
 		User:        "root",
 		TestDir:     []string{"testdata", "TestTmsIntegration"},
-		Environment: map[string]string{"PIPER_tmsServiceKey": tmsServiceKey},
+		Environment: map[string]string{"PIPER_serviceKey": tmsServiceKey},
 	})
 	defer container.terminate(t)
 

--- a/integration/integration_tms_upload_test.go
+++ b/integration/integration_tms_upload_test.go
@@ -32,7 +32,7 @@ func TestTmsUploadIntegrationBinSuccess(t *testing.T) {
 		Image:       "devxci/mbtci-java11-node14",
 		User:        "root",
 		TestDir:     []string{"testdata", "TestTmsIntegration"},
-		Environment: map[string]string{"PIPER_tmsServiceKey": tmsServiceKey},
+		Environment: map[string]string{"PIPER_serviceKey": tmsServiceKey},
 	})
 	defer container.terminate(t)
 
@@ -58,7 +58,7 @@ func TestTmsUploadIntegrationBinNoDescriptionSuccess(t *testing.T) {
 		Image:       "devxci/mbtci-java11-node14",
 		User:        "root",
 		TestDir:     []string{"testdata", "TestTmsIntegration"},
-		Environment: map[string]string{"PIPER_tmsServiceKey": tmsServiceKey},
+		Environment: map[string]string{"PIPER_serviceKey": tmsServiceKey},
 	})
 	defer container.terminate(t)
 
@@ -105,7 +105,7 @@ func TestTmsUploadIntegrationBinFailDescription(t *testing.T) {
 		Image:       "devxci/mbtci-java11-node14",
 		User:        "root",
 		TestDir:     []string{"testdata", "TestTmsIntegration"},
-		Environment: map[string]string{"PIPER_tmsServiceKey": tmsServiceKey},
+		Environment: map[string]string{"PIPER_serviceKey": tmsServiceKey},
 	})
 	defer container.terminate(t)
 
@@ -126,7 +126,7 @@ func TestTmsUploadIntegrationYaml(t *testing.T) {
 		Image:       "devxci/mbtci-java11-node14",
 		User:        "root",
 		TestDir:     []string{"testdata", "TestTmsIntegration"},
-		Environment: map[string]string{"PIPER_tmsServiceKey": tmsServiceKey},
+		Environment: map[string]string{"PIPER_serviceKey": tmsServiceKey},
 	})
 	defer container.terminate(t)
 


### PR DESCRIPTION
# Changes

As we have changed the [default serviceKey parameter for the tms steps](https://github.com/SAP/jenkins-library/pull/4661), we need to adapt the serviceKey parameter used in the integration tests.

- [x] Tests