### PR TITLE
fix(checkmarx):disable failOnMissingReports

### DIFF
--- a/test/groovy/CheckmarxExecuteScanTest.groovy
+++ b/test/groovy/CheckmarxExecuteScanTest.groovy
@@ -75,21 +75,4 @@ class CheckmarxExecuteScanTest extends BasePiperTest {
         assertThat(withEnvArgs[0], allOf(startsWith('PIPER_parametersJSON'), containsString('"testParam":"This is test content"')))
         assertThat(shellCallRule.shell[2], is('./piper checkmarxExecuteScan'))
     }
-
-    @Test
-    void testCheckmarxExecuteScanNoReports() {
-        helper.registerAllowedMethod('fileExists', [Map], {
-            return false
-        })
-
-        exception.expect(AbortException)
-        exception.expectMessage("Expected to find checkmarxExecuteScan_reports.json in workspace but it is not there")
-
-        stepRule.step.checkmarxExecuteScan(
-            juStabUtils: utils,
-            jenkinsUtilsStub: jenkinsUtils,
-            testParam: "This is test content",
-            script: nullScript
-        )
-    }
 }

--- a/vars/checkmarxExecuteScan.groovy
+++ b/vars/checkmarxExecuteScan.groovy
@@ -7,5 +7,5 @@ import groovy.transform.Field
 
 void call(Map parameters = [:]) {
     List credentials = [[type: 'usernamePassword', id: 'checkmarxCredentialsId', env: ['PIPER_username', 'PIPER_password']], [type: 'token', id: 'githubTokenCredentialsId', env: ['PIPER_githubToken']]]
-    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials, true)
+    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }

--- a/vars/checkmarxOneExecuteScan.groovy
+++ b/vars/checkmarxOneExecuteScan.groovy
@@ -8,5 +8,5 @@ import groovy.transform.Field
 void call(Map parameters = [:]) {
     List credentials = [[type: 'usernamePassword', id: 'checkmarxOneCredentialsId', env: ['PIPER_clientId', 'PIPER_clientSecret']],
                         [type: 'token', id: 'checkmarxOneAPIKey', env: ['PIPER_APIKey']]]
-    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials, true)
+    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Changes
This change aims to align Cx/CxOne steps with others to no longer fail when the checkmarx_reports.json JSON file is not found in the workspace.
- [ ] Tests
- [ ] Documentation
