### PR TITLE
Update gatlingExecuteTests.md

### DIFF
--- a/documentation/docs/steps/gatlingExecuteTests.md
+++ b/documentation/docs/steps/gatlingExecuteTests.md
@@ -19,5 +19,5 @@ We recommend to define values of step parameters via [config.yml file](../config
 Pipeline step:
 
 ```groovy
-gatlingExecuteTests script: this, testModule: 'performance-tests/pom.xml'
+gatlingExecuteTests script: this, pomPath: 'performance-tests/pom.xml'
 ```


### PR DESCRIPTION
There is no testModule parameter in gatlingExecuteTests, the correct parameter to be used is pomPath

# Changes

- [ ] Tests
- [ x ] Documentation
