### PR TITLE
feat(configs): vaultCredentialEnvPrefix to support several prefixes

### DIFF
--- a/documentation/docs/infrastructure/vault.md
+++ b/documentation/docs/infrastructure/vault.md
@@ -132,7 +132,11 @@ The `vaultCredentialKeys`parameter is a list of credential IDs. The secret value
 !!! hint "Using a custom prefix for credentials"
     By default the prefix for credentials is `PIPER_VAULTCREDENTIAL_`.
 
-    It is possible to use a custom prefix by setting for example `vaultCredentialEnvPrefix: ['MY_CUSTOM_PREFIX_1', 'MY_CUSTOM_PREFIX_2']` in your configuration.
+    It is possible to use a custom prefix by setting for example `vaultCredentialEnvPrefix: MY_CUSTOM_PREFIX` in your configuration.
+    With this above credential ID named `myAppId` will be populated into an environment variable with the name `MY_CUSTOM_PREFIX_MYAPPID`.
+
+    In case you want to use specific prefix for secrets retrieved from different vault folders, pass multiple prefixes as
+    `vaultCredentialEnvPrefix: ['MY_CUSTOM_PREFIX_1', 'MY_CUSTOM_PREFIX_2']`.
     With this above credential ID named `myAppId1` will be populated into an environment variable with the name `MY_CUSTOM_PREFIX_1_MYAPPID1` and `myAppId2` will be populated into an environment variable with name `MY_CUSTOM_PREFIX_2_MYAPPID2`
 
 Extended logging for Vault secret fetching (e.g. found credentials and environment variable names) can be activated via `verbose: true` configuration.

--- a/documentation/docs/infrastructure/vault.md
+++ b/documentation/docs/infrastructure/vault.md
@@ -129,11 +129,11 @@ The `vaultCredentialPath` parameter is the endpoint of your credential path in V
 
 The `vaultCredentialKeys`parameter is a list of credential IDs. The secret value of the credential will be exposed as an environment variable prefixed by "PIPER_VAULTCREDENTIAL_" and transformed to a valid variable name. For a credential ID named `myAppId` the forwarded environment variable to the step will be `PIPER_VAULTCREDENTIAL_MYAPPID` containing the secret. The Base64 encoded secret value will be exposed as environment variable to the step as  `PIPER_VAULTCREDENTIAL_MYAPPID_BASE64`. Hyphens will be replaced by underscores and other non-alphanumeric characters will be removed.
 
-!!! hint "Using a custom prefix for test credentials"
-    By default the prefix for test credentials is `PIPER_VAULTCREDENTIAL_`.
+!!! hint "Using a custom prefix for credentials"
+    By default the prefix for credentials is `PIPER_VAULTCREDENTIAL_`.
 
-    It is possible to use a custom prefix by setting for example `vaultCredentialEnvPrefix: MY_CUSTOM_PREFIX` in your configuration.
-    With this above credential ID named `myAppId` will be populated into an environment variable with the name `MY_CUSTOM_PREFIX_MYAPPID`.
+    It is possible to use a custom prefix by setting for example `vaultCredentialEnvPrefix: ['MY_CUSTOM_PREFIX_1', 'MY_CUSTOM_PREFIX_2']` in your configuration.
+    With this above credential ID named `myAppId1` will be populated into an environment variable with the name `MY_CUSTOM_PREFIX_1_MYAPPID1` and `myAppId2` will be populated into an environment variable with name `MY_CUSTOM_PREFIX_2_MYAPPID2`
 
 Extended logging for Vault secret fetching (e.g. found credentials and environment variable names) can be activated via `verbose: true` configuration.
 


### PR DESCRIPTION
# Changes

support for multiple values in `vaultCredentialEnvPrefix` and `vaultTestCredentialEnvPrefix` (with backward compatibility to single string)

- [x] Tests
- [x] Documentation

closes https://github.com/SAP/jenkins-library/issues/4740
