### PR TITLE
Fixed issue with empty project tokens after scanning

### DIFF
--- a/cmd/whitesourceExecuteScan.go
+++ b/cmd/whitesourceExecuteScan.go
@@ -134,9 +134,10 @@ func newWhitesourceUtils(config *ScanOptions, client *github.Client) *whitesourc
 
 func newWhitesourceScan(config *ScanOptions) *ws.Scan {
 	return &ws.Scan{
-		AggregateProjectName: config.ProjectName,
-		ProductVersion:       config.Version,
-		BuildTool:            config.BuildTool,
+		AggregateProjectName:        config.ProjectName,
+		ProductVersion:              config.Version,
+		BuildTool:                   config.BuildTool,
+		SkipProjectsWithEmptyTokens: config.SkipProjectsWithEmptyTokens,
 	}
 }
 

--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -79,6 +79,7 @@ type whitesourceExecuteScanOptions struct {
 	CustomTLSCertificateLinks            []string `json:"customTlsCertificateLinks,omitempty"`
 	PrivateModules                       string   `json:"privateModules,omitempty"`
 	PrivateModulesGitToken               string   `json:"privateModulesGitToken,omitempty"`
+	SkipProjectsWithEmptyTokens          bool     `json:"SkipProjectsWithEmptyTokens,omitempty"`
 }
 
 type whitesourceExecuteScanCommonPipelineEnvironment struct {
@@ -377,6 +378,7 @@ func addWhitesourceExecuteScanFlags(cmd *cobra.Command, stepConfig *whitesourceE
 	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List of download links to custom TLS certificates. This is required to ensure trusted connections to instances with repositories (like nexus) when publish flag is set to true.")
 	cmd.Flags().StringVar(&stepConfig.PrivateModules, "privateModules", os.Getenv("PIPER_privateModules"), "Tells go which modules shall be considered to be private (by setting [GOPRIVATE](https://pkg.go.dev/cmd/go#hdr-Configuration_for_downloading_non_public_code)).")
 	cmd.Flags().StringVar(&stepConfig.PrivateModulesGitToken, "privateModulesGitToken", os.Getenv("PIPER_privateModulesGitToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line.")
+	cmd.Flags().BoolVar(&stepConfig.SkipProjectsWithEmptyTokens, "SkipProjectsWithEmptyTokens", false, "Skips projects with empty tokens after scanning. This is for testing purposes only and should not be used until we roll out the new parameter")
 
 	cmd.MarkFlagRequired("buildTool")
 	cmd.MarkFlagRequired("orgToken")
@@ -1040,6 +1042,15 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_privateModulesGitToken"),
+					},
+					{
+						Name:        "SkipProjectsWithEmptyTokens",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
 					},
 				},
 			},

--- a/pkg/whitesource/scan.go
+++ b/pkg/whitesource/scan.go
@@ -84,6 +84,9 @@ func (s *Scan) ProjectByName(projectName string) (Project, bool) {
 func (s *Scan) ScannedProjects() []Project {
 	var projects []Project
 	for _, project := range s.scannedProjects {
+		if len(project.Token) == 0 && s.SkipProjectsWithEmptyTokens {
+			continue
+		}
 		projects = append(projects, project)
 	}
 	return projects

--- a/pkg/whitesource/scan.go
+++ b/pkg/whitesource/scan.go
@@ -17,14 +17,15 @@ type Scan struct {
 	// It does not include the ProductVersion.
 	AggregateProjectName string
 	// ProductVersion is the global version that is used across all Projects (modules) during the scan.
-	BuildTool       string
-	ProductToken    string
-	ProductVersion  string
-	scannedProjects map[string]Project
-	scanTimes       map[string]time.Time
-	AgentName       string
-	AgentVersion    string
-	Coordinates     versioning.Coordinates
+	BuildTool                   string
+	ProductToken                string
+	ProductVersion              string
+	scannedProjects             map[string]Project
+	scanTimes                   map[string]time.Time
+	AgentName                   string
+	AgentVersion                string
+	Coordinates                 versioning.Coordinates
+	SkipProjectsWithEmptyTokens bool
 }
 
 func (s *Scan) init() {

--- a/resources/metadata/whitesourceExecuteScan.yaml
+++ b/resources/metadata/whitesourceExecuteScan.yaml
@@ -653,6 +653,14 @@ spec:
           - type: vaultSecret
             name: golangPrivateModulesGitTokenVaultSecret
             default: golang
+      - name: SkipProjectsWithEmptyTokens
+        description: Skips projects with empty tokens after scanning. This is for testing purposes only and should not be used until we roll out the new parameter
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        type: bool
     resources:
       - name: buildDescriptor
         type: stash


### PR DESCRIPTION
### Fixed issue with empty project tokens after scanning by whiteSourceExecute
