### PR TITLE
fix(gitopsUpdateDeployment): take into account branch name when clonning

### DIFF
--- a/cmd/batsExecuteTests.go
+++ b/cmd/batsExecuteTests.go
@@ -110,7 +110,7 @@ func runBatsExecuteTests(config *batsExecuteTestsOptions, telemetryData *telemet
 func (b *batsExecuteTestsUtilsBundle) CloneRepo(URL string) error {
 	// ToDo: BatsExecute test needs to check if the repo can come from a
 	// enterprise github instance and needs ca-cert handelling seperately
-	_, err := pipergit.PlainClone("", "", URL, "bats-core", []byte{})
+	_, err := pipergit.PlainClone("", "", URL, "", "bats-core", []byte{})
 	return err
 
 }

--- a/cmd/gitopsUpdateDeployment.go
+++ b/cmd/gitopsUpdateDeployment.go
@@ -32,7 +32,7 @@ const toolKustomize = "kustomize"
 type iGitopsUpdateDeploymentGitUtils interface {
 	CommitFiles(filePaths []string, commitMessage, author string) (plumbing.Hash, error)
 	PushChangesToRepository(username, password string, force *bool, caCerts []byte) error
-	PlainClone(username, password, serverURL, directory string, caCerts []byte) error
+	PlainClone(username, password, serverURL, branchName, directory string, caCerts []byte) error
 	ChangeBranch(branchName string) error
 }
 
@@ -99,9 +99,9 @@ func (g *gitopsUpdateDeploymentGitUtils) PushChangesToRepository(username, passw
 	return gitUtil.PushChangesToRepository(username, password, force, g.repository, caCerts)
 }
 
-func (g *gitopsUpdateDeploymentGitUtils) PlainClone(username, password, serverURL, directory string, caCerts []byte) error {
+func (g *gitopsUpdateDeploymentGitUtils) PlainClone(username, password, serverURL, branchName, directory string, caCerts []byte) error {
 	var err error
-	g.repository, err = gitUtil.PlainClone(username, password, serverURL, directory, caCerts)
+	g.repository, err = gitUtil.PlainClone(username, password, serverURL, branchName, directory, caCerts)
 	if err != nil {
 		return errors.Wrapf(err, "plain clone failed '%s'", serverURL)
 	}
@@ -323,7 +323,7 @@ func logNotRequiredButFilledFieldForKustomize(config *gitopsUpdateDeploymentOpti
 
 func cloneRepositoryAndChangeBranch(config *gitopsUpdateDeploymentOptions, gitUtils iGitopsUpdateDeploymentGitUtils, fileUtils gitopsUpdateDeploymentFileUtils, temporaryFolder string, certs []byte) error {
 
-	err := gitUtils.PlainClone(config.Username, config.Password, config.ServerURL, temporaryFolder, certs)
+	err := gitUtils.PlainClone(config.Username, config.Password, config.ServerURL, config.BranchName, temporaryFolder, certs)
 	if err != nil {
 		return errors.Wrap(err, "failed to plain clone repository")
 	}

--- a/cmd/gitopsUpdateDeployment_test.go
+++ b/cmd/gitopsUpdateDeployment_test.go
@@ -866,7 +866,7 @@ func (v gitUtilsMock) PushChangesToRepository(_ string, _ string, force *bool, c
 	return nil
 }
 
-func (v *gitUtilsMock) PlainClone(_, _, _, directory string, caCerts []byte) error {
+func (v *gitUtilsMock) PlainClone(_, _, _, _, directory string, caCerts []byte) error {
 	if v.skipClone {
 		return nil
 	}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -77,15 +77,17 @@ func pushChangesToRepository(username, password string, force *bool, repository 
 }
 
 // PlainClone Clones a non-bare repository to the provided directory
-func PlainClone(username, password, serverURL, directory string, caCerts []byte) (*git.Repository, error) {
+func PlainClone(username, password, serverURL, branchName, directory string, caCerts []byte) (*git.Repository, error) {
 	abstractedGit := &abstractionGit{}
-	return plainClone(username, password, serverURL, directory, abstractedGit, caCerts)
+	return plainClone(username, password, serverURL, branchName, directory, abstractedGit, caCerts)
 }
 
-func plainClone(username, password, serverURL, directory string, abstractionGit utilsGit, caCerts []byte) (*git.Repository, error) {
+func plainClone(username, password, serverURL, branchName, directory string, abstractionGit utilsGit, caCerts []byte) (*git.Repository, error) {
 	gitCloneOptions := git.CloneOptions{
-		Auth: &http.BasicAuth{Username: username, Password: password},
-		URL:  serverURL,
+		Auth:          &http.BasicAuth{Username: username, Password: password},
+		URL:           serverURL,
+		ReferenceName: plumbing.NewBranchReferenceName(branchName),
+		SingleBranch:  true, // we don't need other branches, clone only branchName
 	}
 
 	if len(caCerts) > 0 {

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -67,7 +67,7 @@ func TestPlainClone(t *testing.T) {
 	t.Run("successful clone", func(t *testing.T) {
 		t.Parallel()
 		abstractedGit := &UtilsGitMock{}
-		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte{})
+		_, err := plainClone("user", "password", "URL", "", "directory", abstractedGit, []byte{})
 		assert.NoError(t, err)
 		assert.Equal(t, "directory", abstractedGit.path)
 		assert.False(t, abstractedGit.isBare)
@@ -78,7 +78,7 @@ func TestPlainClone(t *testing.T) {
 	t.Run("error on cloning", func(t *testing.T) {
 		t.Parallel()
 		abstractedGit := UtilsGitMockError{}
-		_, err := plainClone("user", "password", "URL", "directory", abstractedGit, []byte{})
+		_, err := plainClone("user", "password", "URL", "", "directory", abstractedGit, []byte{})
 		assert.EqualError(t, err, "failed to clone git: error during clone")
 	})
 }


### PR DESCRIPTION
gitopsUpdateDeployment doesn't take into account **branchName** parameter when clonning a repo. This leads to a bug when specifying branchName other than **default** (main or master). In that case git clones **default** branch and then tries to check out to **branchName** (which doesn't exist in cloned repo) and then creates that **branchName** from **default** branch.

This PR fixes this bug by passing branchName into clone function