### PR TITLE
Bump CycloneDX Gradle plugin from 1.7.0 to 1.8.2

### DIFF
--- a/cmd/gradleExecuteBuild.go
+++ b/cmd/gradleExecuteBuild.go
@@ -81,7 +81,7 @@ initscript {
     }
   }
   dependencies {
-    classpath "org.cyclonedx:cyclonedx-gradle-plugin:1.7.0"
+    classpath "org.cyclonedx:cyclonedx-gradle-plugin:1.8.2"
   }
 }
 


### PR DESCRIPTION
The 1.7.0 version of the CycloneDX Gradle plugin used in the piper Gradle execute build step seems outdated and causes  java.lang.StackOverflowErrors that do not happen with newer versions. 
This PR updates the plugin to the latest version. 
Thanks
