### PR TITLE
fix(detectExecuteScan): sanitize container image name before saving

### DIFF
--- a/cmd/containerSaveImage.go
+++ b/cmd/containerSaveImage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func containerSaveImage(config containerSaveImageOptions, telemetryData *telemetry.CustomData) {
+func containerSaveImage(config containerSaveImageOptions, telemetryData *telemetry.CustomData) (string, error) {
 	var cachePath = "./cache"
 
 	fileUtils := piperutils.Files{}
@@ -23,10 +23,7 @@ func containerSaveImage(config containerSaveImageOptions, telemetryData *telemet
 	dClient := &piperDocker.Client{}
 	dClient.SetOptions(dClientOptions)
 
-	_, err := runContainerSaveImage(&config, telemetryData, cachePath, "", dClient, fileUtils)
-	if err != nil {
-		log.Entry().WithError(err).Fatal("step execution failed")
-	}
+	return runContainerSaveImage(&config, telemetryData, cachePath, "", dClient, fileUtils)
 }
 
 func runContainerSaveImage(config *containerSaveImageOptions, telemetryData *telemetry.CustomData, cachePath, rootPath string, dClient piperDocker.Download, fileUtils piperutils.FileUtils) (string, error) {

--- a/cmd/containerSaveImage.go
+++ b/cmd/containerSaveImage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func containerSaveImage(config containerSaveImageOptions, telemetryData *telemetry.CustomData) (string, error) {
+func containerSaveImage(config containerSaveImageOptions, telemetryData *telemetry.CustomData) {
 	var cachePath = "./cache"
 
 	fileUtils := piperutils.Files{}
@@ -23,7 +23,10 @@ func containerSaveImage(config containerSaveImageOptions, telemetryData *telemet
 	dClient := &piperDocker.Client{}
 	dClient.SetOptions(dClientOptions)
 
-	return runContainerSaveImage(&config, telemetryData, cachePath, "", dClient, fileUtils)
+	_, err := runContainerSaveImage(&config, telemetryData, cachePath, "", dClient, fileUtils)
+	if err != nil {
+		log.Entry().WithError(err).Fatal("step execution failed")
+	}
 }
 
 func runContainerSaveImage(config *containerSaveImageOptions, telemetryData *telemetry.CustomData, cachePath, rootPath string, dClient piperDocker.Download, fileUtils piperutils.FileUtils) (string, error) {

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -266,22 +266,22 @@ func mapDetectError(err error, config detectExecuteScanOptions, utils detectUtil
 }
 
 func runDetectImages(ctx context.Context, config detectExecuteScanOptions, utils detectUtils, sys *blackduckSystem, influx *detectExecuteScanInflux, blackduckSystem *blackduckSystem) error {
-	var err error
 	log.Entry().Infof("Scanning %d images", len(config.ImageNameTags))
 	for _, image := range config.ImageNameTags {
 		// Download image to be scanned
 		log.Entry().Debugf("Scanning image: %q", image)
-		tarName := fmt.Sprintf("%s.tar", strings.Split(image, ":")[0])
 
 		options := containerSaveImageOptions{
 			ContainerRegistryURL:      config.RegistryURL,
 			ContainerImage:            image,
 			ContainerRegistryPassword: config.RepositoryPassword,
 			ContainerRegistryUser:     config.RepositoryUsername,
-			FilePath:                  tarName,
 			ImageFormat:               "legacy",
 		}
-		containerSaveImage(options, &telemetry.CustomData{})
+		tarName, err := containerSaveImage(options, &telemetry.CustomData{})
+		if err != nil {
+			return err
+		}
 
 		args := []string{"./detect.sh"}
 		args, err = addDetectArgsImages(args, config, utils, sys, tarName)

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	bd "github.com/SAP/jenkins-library/pkg/blackduck"
+	piperDocker "github.com/SAP/jenkins-library/pkg/docker"
 	piperGithub "github.com/SAP/jenkins-library/pkg/github"
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/mock"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/google/go-github/v45/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type detectTestUtilsBundle struct {
@@ -31,6 +33,7 @@ type detectTestUtilsBundle struct {
 	*mock.FilesMock
 	customEnv    []string
 	orchestrator *orchestratorConfigProviderMock
+	dClient      *mock.DownloadMock
 }
 
 func (d *detectTestUtilsBundle) GetProvider() orchestrator.ConfigProvider {
@@ -43,6 +46,10 @@ func (d *detectTestUtilsBundle) GetIssueService() *github.IssuesService {
 
 func (d *detectTestUtilsBundle) GetSearchService() *github.SearchService {
 	return nil
+}
+
+func (d *detectTestUtilsBundle) GetDockerClient(options piperDocker.ClientOptions) piperDocker.Download {
+	return d.dClient
 }
 
 type orchestratorConfigProviderMock struct {
@@ -289,6 +296,7 @@ func newDetectTestUtilsBundle(isPullRequest bool) *detectTestUtilsBundle {
 		ShellMockRunner: &mock.ShellMockRunner{},
 		FilesMock:       &mock.FilesMock{},
 		orchestrator:    &orchestratorConfigProviderMock{isPullRequest: isPullRequest},
+		dClient:         &mock.DownloadMock{},
 	}
 	return &utilsBundle
 }
@@ -343,6 +351,28 @@ func TestRunDetect(t *testing.T) {
 
 		expectedParam := "\"--detect.maven.build.command=--global-settings global-settings.xml --settings project-settings.xml -Dmaven.repo.local=" + absoluteLocalPath + "\""
 		assert.Contains(t, utilsMock.Calls[0], expectedParam)
+	})
+
+	t.Run("images scan", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		utilsMock := newDetectTestUtilsBundle(false)
+		utilsMock.CurrentDir = "root_folder"
+		utilsMock.AddFile("detect.sh", []byte(""))
+		err := runDetect(ctx, detectExecuteScanOptions{
+			ScanContainerDistro: "ubuntu",
+			ImageNameTags:       []string{"foo/bar:latest", "bar/bazz:latest"},
+		}, utilsMock, &detectExecuteScanInflux{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, ".", utilsMock.Dir, "Wrong execution directory used")
+		require.Equal(t, 3, len(utilsMock.Calls))
+
+		expectedParam1 := "--detect.docker.tar=./foo_bar_latest.tar --detect.target.type=IMAGE --detect.tools.excluded=DETECTOR --detect.docker.passthrough.shared.dir.path.local=/opt/blackduck/blackduck-imageinspector/shared/ --detect.docker.passthrough.shared.dir.path.imageinspector=/opt/blackduck/blackduck-imageinspector/shared --detect.docker.passthrough.imageinspector.service.distro.default=ubuntu --detect.docker.passthrough.imageinspector.service.start=false --detect.docker.passthrough.output.include.squashedimage=false --detect.docker.passthrough.imageinspector.service.url=http://localhost:8082"
+		assert.Contains(t, utilsMock.Calls[1], expectedParam1)
+
+		expectedParam2 := "--detect.docker.tar=./bar_bazz_latest.tar --detect.target.type=IMAGE --detect.tools.excluded=DETECTOR --detect.docker.passthrough.shared.dir.path.local=/opt/blackduck/blackduck-imageinspector/shared/ --detect.docker.passthrough.shared.dir.path.imageinspector=/opt/blackduck/blackduck-imageinspector/shared --detect.docker.passthrough.imageinspector.service.distro.default=ubuntu --detect.docker.passthrough.imageinspector.service.start=false --detect.docker.passthrough.output.include.squashedimage=false --detect.docker.passthrough.imageinspector.service.url=http://localhost:8082"
+		assert.Contains(t, utilsMock.Calls[2], expectedParam2)
 	})
 }
 


### PR DESCRIPTION
# Changes

If the image name to scan contains special symbols (like `/`) the step fails to create a tarball.
Underlying function `runContainerSaveImage` generates sanitized name for the tarball, escaping special symbols and replacing them with `_`.

- [ ] Tests
- [ ] Documentation
