### PR TITLE
feat (pythonBuild) include pip install of requirements.txt before cyclone dx sbom generation

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -146,8 +146,20 @@ func removeVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions
 }
 
 func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string, config *pythonBuildOptions) error {
-	pipInstallFlags = append(pipInstallFlags, cycloneDxPackageVersion)
-	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallFlags...); err != nil {
+	pipInstallOriginalFlags := pipInstallFlags
+	exists, _ := utils.FileExists(config.RequirementsFilePath)
+	if exists {
+		pipInstallRequirementsFlags := append(pipInstallOriginalFlags, "--requirement", config.RequirementsFilePath)
+		if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallRequirementsFlags...); err != nil {
+			return err
+		}
+	} else {
+		log.Entry().Warnf("unable to find requirements.txt file at %s , continuing SBOM generation without requirements.txt", config.RequirementsFilePath)
+	}
+
+	pipInstallCycloneDxFlags := append(pipInstallOriginalFlags, cycloneDxPackageVersion)
+
+	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallCycloneDxFlags...); err != nil {
 		return err
 	}
 	virutalEnvironmentPathMap["cyclonedx"] = filepath.Join(config.VirutalEnvironmentName, "bin", "cyclonedx-py")

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -74,13 +74,12 @@ func PythonBuildCommand() *cobra.Command {
 		Short: "Step builds a python project",
 		Long: `Step build python project using the setup.py manifest and builds a wheel and tarball artifact . please note that currently python build only supports setup.py
 
-  ### build with depedencies from a private repository
+### build with depedencies from a private repository
 if your build has dependencies from a private repository you can include the standard requirements.txt into the source code with ` + "`" + `--extra-index-url` + "`" + ` as the first line
 
 ` + "`" + `` + "`" + `` + "`" + `
 --extra-index-url https://${PIPER_VAULTCREDENTIAL_USERNAME}:${PIPER_VAULTCREDENTIAL_PASSWORD}@<privateRepoUrl>/simple
 ` + "`" + `` + "`" + `` + "`" + `
-
 ` + "`" + `PIPER_VAULTCREDENTIAL_USERNAME` + "`" + ` and ` + "`" + `PIPER_VAULTCREDENTIAL_PASSWORD` + "`" + ` are the username and password for the private repository
 and are exposed are environment variables that must be present in the environment where the Piper step runs or alternatively can be created using :
 [vault general purpose credentials](../infrastructure/vault.md#using-vault-for-general-purpose-and-test-credentials)`,

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -57,7 +57,7 @@ func (p *pythonBuildCommonPipelineEnvironment) persist(path, resourceName string
 	}
 }
 
-// PythonBuildCommand Step build a python project
+// PythonBuildCommand Step builds a python project
 func PythonBuildCommand() *cobra.Command {
 	const STEP_NAME = "pythonBuild"
 
@@ -71,8 +71,19 @@ func PythonBuildCommand() *cobra.Command {
 
 	var createPythonBuildCmd = &cobra.Command{
 		Use:   STEP_NAME,
-		Short: "Step build a python project",
-		Long:  `Step build python project with using test Vault credentials`,
+		Short: "Step builds a python project",
+		Long: `Step build python project using the setup.py manifest and builds a wheel and tarball artifact . please note that currently python build only supports setup.py
+
+  ### build with depedencies from a private repository
+if your build has dependencies from a private repository you can include the standard requirements.txt into the source code with ` + "`" + `--extra-index-url` + "`" + ` as the first line
+
+` + "`" + `` + "`" + `` + "`" + `
+--extra-index-url https://${PIPER_VAULTCREDENTIAL_USERNAME}:${PIPER_VAULTCREDENTIAL_PASSWORD}@<privateRepoUrl>/simple
+` + "`" + `` + "`" + `` + "`" + `
+
+` + "`" + `PIPER_VAULTCREDENTIAL_USERNAME` + "`" + ` and ` + "`" + `PIPER_VAULTCREDENTIAL_PASSWORD` + "`" + ` are the username and password for the private repository
+and are exposed are environment variables that must be present in the environment where the Piper step runs or alternatively can be created using :
+[vault general purpose credentials](../infrastructure/vault.md#using-vault-for-general-purpose-and-test-credentials)`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			startTime = time.Now()
 			log.SetStepName(STEP_NAME)
@@ -178,7 +189,7 @@ func pythonBuildMetadata() config.StepData {
 		Metadata: config.StepMetadata{
 			Name:        "pythonBuild",
 			Aliases:     []config.Alias{},
-			Description: "Step build a python project",
+			Description: "Step builds a python project",
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -26,6 +26,7 @@ type pythonBuildOptions struct {
 	TargetRepositoryURL      string   `json:"targetRepositoryURL,omitempty"`
 	BuildSettingsInfo        string   `json:"buildSettingsInfo,omitempty"`
 	VirutalEnvironmentName   string   `json:"virutalEnvironmentName,omitempty"`
+	RequirementsFilePath     string   `json:"requirementsFilePath,omitempty"`
 }
 
 type pythonBuildCommonPipelineEnvironment struct {
@@ -167,6 +168,7 @@ func addPythonBuildFlags(cmd *cobra.Command, stepConfig *pythonBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.TargetRepositoryURL, "targetRepositoryURL", os.Getenv("PIPER_targetRepositoryURL"), "URL of the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment.")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the maven build . This information is typically used for compliance related processes.")
 	cmd.Flags().StringVar(&stepConfig.VirutalEnvironmentName, "virutalEnvironmentName", `piperBuild-env`, "name of the virtual environment that will be used for the build")
+	cmd.Flags().StringVar(&stepConfig.RequirementsFilePath, "requirementsFilePath", `requirements.txt`, "file path to the requirements.txt file needed for the sbom cycloneDx file creation.")
 
 }
 
@@ -272,6 +274,15 @@ func pythonBuildMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     `piperBuild-env`,
+					},
+					{
+						Name:        "requirementsFilePath",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `requirements.txt`,
 					},
 				},
 			},

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -1,7 +1,19 @@
 metadata:
   name: pythonBuild
-  description: Step build a python project
-  longDescription: Step build python project with using test Vault credentials
+  description: Step builds a python project
+  longDescription: |
+    Step build python project using the setup.py manifest and builds a wheel and tarball artifact . please note that currently python build only supports setup.py
+
+      ### build with depedencies from a private repository
+    if your build has dependencies from a private repository you can include the standard requirements.txt into the source code with `--extra-index-url` as the first line
+
+    ```
+    --extra-index-url https://${PIPER_VAULTCREDENTIAL_USERNAME}:${PIPER_VAULTCREDENTIAL_PASSWORD}@<privateRepoUrl>/simple
+    ```
+    
+    `PIPER_VAULTCREDENTIAL_USERNAME` and `PIPER_VAULTCREDENTIAL_PASSWORD` are the username and password for the private repository
+    and are exposed are environment variables that must be present in the environment where the Piper step runs or alternatively can be created using :
+    [vault general purpose credentials](../infrastructure/vault.md#using-vault-for-general-purpose-and-test-credentials)
 spec:
   inputs:
     params:

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -79,6 +79,14 @@ spec:
           - STAGES
           - PARAMETERS
         default: piperBuild-env
+      - name: requirementsFilePath
+        type: string
+        description: file path to the requirements.txt file needed for the sbom cycloneDx file creation.
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        default: requirements.txt
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -4,13 +4,12 @@ metadata:
   longDescription: |
     Step build python project using the setup.py manifest and builds a wheel and tarball artifact . please note that currently python build only supports setup.py
 
-      ### build with depedencies from a private repository
+    ### build with depedencies from a private repository
     if your build has dependencies from a private repository you can include the standard requirements.txt into the source code with `--extra-index-url` as the first line
 
     ```
     --extra-index-url https://${PIPER_VAULTCREDENTIAL_USERNAME}:${PIPER_VAULTCREDENTIAL_PASSWORD}@<privateRepoUrl>/simple
     ```
-    
     `PIPER_VAULTCREDENTIAL_USERNAME` and `PIPER_VAULTCREDENTIAL_PASSWORD` are the username and password for the private repository
     and are exposed are environment variables that must be present in the environment where the Piper step runs or alternatively can be created using :
     [vault general purpose credentials](../infrastructure/vault.md#using-vault-for-general-purpose-and-test-credentials)


### PR DESCRIPTION
# Changes

currently cyclone dx sbom is generated without pip installing the dependencies . this PR beings in the ability to run pip install if it finds the requirement.txt file . the file path is defaulted in parameter `requirementsFilePath` and can be overwritten as needed 

- [x] Tests
- [x] Documentation
