### PR TITLE
exclude .git on stashBack

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -237,7 +237,7 @@ steps:
       workspace: '**/*'
     stashExcludes:
       workspace: 'nohup.out'
-      stashBack: '**/node_modules/**,nohup.out'
+      stashBack: '**/node_modules/**,nohup.out,.git/**'
   dubExecute:
     dockerImage: 'dlang2/dmd-ubuntu:latest'
   githubPublishRelease:


### PR DESCRIPTION
This change allows usage of `stashNoDefaultExcludes` parameter, 
as otherwise I think it it impossible to stash back the .git repository.

It should not affect anything if `stashNoDefaultExcludes` is not used.

# Changes

- [ ] Tests
- [ ] Documentation
