### PR TITLE
fixes `go build` on windows

### DIFF
--- a/cmd/cnbBuild.go
+++ b/cmd/cnbBuild.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"syscall"
 
 	"github.com/SAP/jenkins-library/pkg/buildpacks"
 	"github.com/SAP/jenkins-library/pkg/buildsettings"
@@ -21,7 +20,6 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/SAP/jenkins-library/pkg/syft"
-
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"github.com/imdario/mergo"
 	"github.com/mitchellh/mapstructure"
@@ -585,13 +583,7 @@ func runCnbBuild(config *cnbBuildOptions, telemetry *buildpacks.Telemetry, image
 	}
 
 	creatorArgs = append(creatorArgs, fmt.Sprintf("%s:%s", containerImage, targetImage.ContainerImageTag))
-	attr := &syscall.SysProcAttr{
-		Credential: &syscall.Credential{
-			Uid:         uint32(uid),
-			Gid:         uint32(gid),
-			NoSetGroups: true,
-		},
-	}
+	attr := getSysProcAttr(uid, gid)
 
 	err = utils.RunExecutableWithAttrs(creatorPath, attr, creatorArgs...)
 	if err != nil {

--- a/cmd/cnbBuildAttr.go
+++ b/cmd/cnbBuildAttr.go
@@ -1,4 +1,5 @@
 //go:build !windows
+
 package cmd
 
 import (

--- a/cmd/cnbBuildAttr.go
+++ b/cmd/cnbBuildAttr.go
@@ -1,0 +1,17 @@
+//go:build !windows
+// +build !windows
+package cmd
+
+import (
+	"syscall"
+)
+
+func getSysProcAttr(uid int, gid int) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid:         uint32(uid),
+			Gid:         uint32(gid),
+			NoSetGroups: true,
+		},
+	}
+}

--- a/cmd/cnbBuildAttr.go
+++ b/cmd/cnbBuildAttr.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 package cmd
 
 import (

--- a/cmd/cnbBuildAttr_windows.go
+++ b/cmd/cnbBuildAttr_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package cmd
+
+import (
+	"syscall"
+)
+
+func getSysProcAttr(_ int, _ int) *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{}
+}

--- a/cmd/cnbBuildAttr_windows.go
+++ b/cmd/cnbBuildAttr_windows.go
@@ -1,6 +1,4 @@
 //go:build windows
-// +build windows
-
 package cmd
 
 import (

--- a/cmd/cnbBuildAttr_windows.go
+++ b/cmd/cnbBuildAttr_windows.go
@@ -1,4 +1,5 @@
 //go:build windows
+
 package cmd
 
 import (


### PR DESCRIPTION
Currently the `go build` fails on windows machines with the following error:

```
cmd\cnbBuild.go:589:3: unknown field Credential in struct literal of type "syscall".SysProcAttr
cmd\cnbBuild.go:589:24: undefined: syscall.Credential
```

Because on Windows the `exec_windows.go` contains the struct like this:

```go
type SysProcAttr struct {
	HideWindow                 bool
	CmdLine                    string // used if non-empty, else the windows command line is built by escaping the arguments passed to StartProcess
	CreationFlags              uint32
	Token                      Token               // if set, runs new process in the security context represented by the token
	ProcessAttributes          *SecurityAttributes // if set, applies these security attributes as the descriptor for the new process
	ThreadAttributes           *SecurityAttributes // if set, applies these security attributes as the descriptor for the main thread of the new process
	NoInheritHandles           bool                // if set, no handles are inherited by the new process, not even the standard handles, contained in ProcAttr.Files, nor the ones contained in AdditionalInheritedHandles
	AdditionalInheritedHandles []Handle            // a list of additional handles, already marked as inheritable, that will be inherited by the new process
	ParentProcess              Handle              // if non-zero, the new process regards the process given by this handle as its parent process, and AdditionalInheritedHandles, if set, should exist in this parent process
}
```

Which obviously doesn't have `Credential`