### PR TITLE
fix(mavenBuild): set logSuccessfulMavenTransfers to true

### DIFF
--- a/cmd/mavenBuild_generated.go
+++ b/cmd/mavenBuild_generated.go
@@ -258,7 +258,7 @@ func addMavenBuildFlags(cmd *cobra.Command, stepConfig *mavenBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.ProjectSettingsFile, "projectSettingsFile", os.Getenv("PIPER_projectSettingsFile"), "Path to the mvn settings file that should be used as project settings file.")
 	cmd.Flags().StringVar(&stepConfig.GlobalSettingsFile, "globalSettingsFile", os.Getenv("PIPER_globalSettingsFile"), "Path to the mvn settings file that should be used as global settings file.")
 	cmd.Flags().StringVar(&stepConfig.M2Path, "m2Path", os.Getenv("PIPER_m2Path"), "Path to the location of the local repository that should be used.")
-	cmd.Flags().BoolVar(&stepConfig.LogSuccessfulMavenTransfers, "logSuccessfulMavenTransfers", false, "Configures maven to log successful downloads. This is set to `false` by default to reduce the noise in build logs.")
+	cmd.Flags().BoolVar(&stepConfig.LogSuccessfulMavenTransfers, "logSuccessfulMavenTransfers", true, "Configures maven to log successful downloads.")
 	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using CycloneDX Maven plugin.")
 	cmd.Flags().StringVar(&stepConfig.AltDeploymentRepositoryPassword, "altDeploymentRepositoryPassword", os.Getenv("PIPER_altDeploymentRepositoryPassword"), "Password for the alternative deployment repository to which the project artifacts should be deployed ( other than those specified in <distributionManagement> ). This password will be updated in settings.xml . When no settings.xml is provided a new one is created corresponding with <servers> tag")
 	cmd.Flags().StringVar(&stepConfig.AltDeploymentRepositoryUser, "altDeploymentRepositoryUser", os.Getenv("PIPER_altDeploymentRepositoryUser"), "User for the alternative deployment repository to which the project artifacts should be deployed ( other than those specified in <distributionManagement> ). This user will be updated in settings.xml . When no settings.xml is provided a new one is created corresponding with <servers> tag")
@@ -364,7 +364,7 @@ func mavenBuildMetadata() config.StepData {
 						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "maven/logSuccessfulMavenTransfers"}},
-						Default:     false,
+						Default:     true,
 					},
 					{
 						Name:        "createBOM",

--- a/resources/metadata/mavenBuild.yaml
+++ b/resources/metadata/mavenBuild.yaml
@@ -119,13 +119,13 @@ spec:
           - name: maven/m2Path
       - name: logSuccessfulMavenTransfers
         type: bool
-        description: Configures maven to log successful downloads. This is set to `false` by default to reduce the noise in build logs.
+        description: Configures maven to log successful downloads.
         scope:
           - GENERAL
           - STEPS
           - STAGES
           - PARAMETERS
-        default: false
+        default: true
         aliases:
           - name: maven/logSuccessfulMavenTransfers
       - name: createBOM


### PR DESCRIPTION
it is already true in piper defaults, but the description and default value inside the go step are outdated. 

# Changes

- [ ] Tests
- [ ] Documentation
