### PR TITLE
fix(maven): Add proper error handling for invalid settings.xml when publishing

### DIFF
--- a/pkg/maven/settings.go
+++ b/pkg/maven/settings.go
@@ -169,11 +169,16 @@ func CreateNewProjectSettingsXML(altDeploymentRepositoryID string, altDeployment
 
 func UpdateProjectSettingsXML(projectSettingsFile string, altDeploymentRepositoryID string, altDeploymentRepositoryUser string, altDeploymentRepositoryPassword string, utils SettingsDownloadUtils) (string, error) {
 	projectSettingsFileDestination := ".pipeline/mavenProjectSettings"
+	var err error
 	if exists, _ := utils.FileExists(projectSettingsFile); exists {
 		projectSettingsFileDestination = projectSettingsFile
-		addServerTagtoProjectSettingsXML(projectSettingsFile, altDeploymentRepositoryID, altDeploymentRepositoryUser, altDeploymentRepositoryPassword, utils)
+		err = addServerTagtoProjectSettingsXML(projectSettingsFile, altDeploymentRepositoryID, altDeploymentRepositoryUser, altDeploymentRepositoryPassword, utils)
 	} else {
-		addServerTagtoProjectSettingsXML(".pipeline/mavenProjectSettings", altDeploymentRepositoryID, altDeploymentRepositoryUser, altDeploymentRepositoryPassword, utils)
+		err = addServerTagtoProjectSettingsXML(".pipeline/mavenProjectSettings", altDeploymentRepositoryID, altDeploymentRepositoryUser, altDeploymentRepositoryPassword, utils)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal settings xml file '%v': %w", projectSettingsFile, err)
 	}
 	return projectSettingsFileDestination, nil
 

--- a/pkg/maven/settings_test.go
+++ b/pkg/maven/settings_test.go
@@ -158,6 +158,18 @@ func TestSettings(t *testing.T) {
 		}
 	})
 
+	t.Run("update server tag in existing settings file - invalid settings.xml", func(t *testing.T) {
+
+		utilsMock := newSettingsDownloadTestUtilsBundle()
+		xmlstring := []byte("well this is obviously invalid")
+		utilsMock.FileWrite(".pipeline/mavenProjectSettings", xmlstring, 0777)
+
+		_, err := UpdateProjectSettingsXML(".pipeline/mavenProjectSettings", "dummyRepoId2", "dummyRepoUser2", "dummyRepoPassword2", utilsMock)
+		if assert.Error(t, err) {
+			assert.Contains(t, err.Error(), "failed to unmarshal settings xml file")
+		}
+	})
+
 	t.Run("update active profile tag in existing settings file", func(t *testing.T) {
 
 		utilsMock := newSettingsDownloadTestUtilsBundle()


### PR DESCRIPTION
# Changes

Errors with unmarshalling the `settings.xml` for adding staging repository secrets were not being handled.

- [x] Tests
- [ ] Documentation
