### PR TITLE
Run artifactPrepareVersion inside a docker container for CAP apps

### DIFF
--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -543,7 +543,8 @@ func artifactPrepareVersionMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}, {Name: "buildTool", Value: "CAP"}}}}},
+				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}}}}},
+				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "CAP"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -543,7 +543,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}}}}},
+				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}, {Name: "buildTool", Value: "CAP"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -543,8 +543,7 @@ func artifactPrepareVersionMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}}}}},
-				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "CAP"}}}}},
+				{Image: "maven:3.6-jdk-8", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}, {Name: "buildTool", Value: "CAP"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/resources/metadata/artifactPrepareVersion.yaml
+++ b/resources/metadata/artifactPrepareVersion.yaml
@@ -392,5 +392,9 @@ spec:
           params:
             - name: buildTool
               value: maven
+    - image: maven:3.6-jdk-8
+      conditions:
+        - conditionRef: strings-equal
+          params:
             - name: buildTool
               value: CAP

--- a/resources/metadata/artifactPrepareVersion.yaml
+++ b/resources/metadata/artifactPrepareVersion.yaml
@@ -392,9 +392,6 @@ spec:
           params:
             - name: buildTool
               value: maven
-    - image: maven:3.6-jdk-8
-      conditions:
-        - conditionRef: strings-equal
-          params:
             - name: buildTool
               value: CAP
+            

--- a/resources/metadata/artifactPrepareVersion.yaml
+++ b/resources/metadata/artifactPrepareVersion.yaml
@@ -392,3 +392,5 @@ spec:
           params:
             - name: buildTool
               value: maven
+            - name: buildTool
+              value: CAP

--- a/resources/metadata/artifactPrepareVersion.yaml
+++ b/resources/metadata/artifactPrepareVersion.yaml
@@ -392,6 +392,9 @@ spec:
           params:
             - name: buildTool
               value: maven
+    - image: maven:3.6-jdk-8
+      conditions:
+        - conditionRef: strings-equal
+          params:
             - name: buildTool
               value: CAP
-            


### PR DESCRIPTION
# Changes

When build tool is CAP, artifactPrepareVersion works with pom.xml --> mvn needed --> the step should run inside docker container

- [x] Tests
- [ ] Documentation
