### PR TITLE
feat(gcpPublishEvent): Add additionalEventData param

### DIFF
--- a/cmd/gcpPublishEvent.go
+++ b/cmd/gcpPublishEvent.go
@@ -108,6 +108,9 @@ func runGcpPublishEvent(utils gcpPublishEventUtils) error {
 
 func createNewEvent(config *gcpPublishEventOptions) ([]byte, error) {
 	event, err := events.NewEvent(config.EventType, config.EventSource).CreateWithJSONData(config.EventData)
+	if err != nil {
+		return []byte{}, errors.Wrap(err, "failed to create new event")
+	}
 
 	err = event.AddToCloudEventData(config.AdditionalEventData)
 	if err != nil {

--- a/cmd/gcpPublishEvent.go
+++ b/cmd/gcpPublishEvent.go
@@ -101,7 +101,7 @@ func runGcpPublishEvent(utils gcpPublishEventUtils) error {
 		return errors.Wrap(err, "failed to publish event")
 	}
 
-	log.Entry().Info("event published successfully!")
+	log.Entry().Infof("Event published successfully! gcpProjectNumber: %s, topic: %s", config.GcpProjectNumber, config.Topic)
 
 	return nil
 }

--- a/cmd/gcpPublishEvent.go
+++ b/cmd/gcpPublishEvent.go
@@ -81,7 +81,7 @@ func runGcpPublishEvent(utils gcpPublishEventUtils) error {
 		log.Entry().WithError(err).Warning("Cannot infer config from CI environment")
 	}
 
-	data, err = events.NewEvent(config.EventType, config.EventSource).CreateWithJSONData(config.EventData).ToBytes()
+	data, err = events.NewEvent(config.EventType, config.EventSource).CreateWithJSONData([]byte(config.EventData), config.AdditionalEventData).ToBytes()
 	if err != nil {
 		return errors.Wrap(err, "failed to create event data")
 	}

--- a/cmd/gcpPublishEvent.go
+++ b/cmd/gcpPublishEvent.go
@@ -101,7 +101,7 @@ func runGcpPublishEvent(utils gcpPublishEventUtils) error {
 		return errors.Wrap(err, "failed to publish event")
 	}
 
-	log.Entry().Infof("Event published successfully! With topic: %s", config.GcpProjectNumber, config.Topic)
+	log.Entry().Infof("Event published successfully! With topic: %s", config.Topic)
 
 	return nil
 }

--- a/cmd/gcpPublishEvent.go
+++ b/cmd/gcpPublishEvent.go
@@ -101,7 +101,7 @@ func runGcpPublishEvent(utils gcpPublishEventUtils) error {
 		return errors.Wrap(err, "failed to publish event")
 	}
 
-	log.Entry().Infof("Event published successfully! gcpProjectNumber: %s, topic: %s", config.GcpProjectNumber, config.Topic)
+	log.Entry().Infof("Event published successfully! With topic: %s", config.GcpProjectNumber, config.Topic)
 
 	return nil
 }

--- a/cmd/gcpPublishEvent.go
+++ b/cmd/gcpPublishEvent.go
@@ -118,5 +118,6 @@ func createNewEvent(config *gcpPublishEventOptions) ([]byte, error) {
 	if err != nil {
 		return []byte{}, errors.Wrap(err, "casting event to bytes failed")
 	}
+	log.Entry().Debugf("CloudEvent created: %s", string(eventBytes))
 	return eventBytes, nil
 }

--- a/cmd/gcpPublishEvent_generated.go
+++ b/cmd/gcpPublishEvent_generated.go
@@ -139,7 +139,7 @@ func addGcpPublishEventFlags(cmd *cobra.Command, stepConfig *gcpPublishEventOpti
 	cmd.Flags().StringVar(&stepConfig.EventSource, "eventSource", os.Getenv("PIPER_eventSource"), "The events source as defined by CDEvents.")
 	cmd.Flags().StringVar(&stepConfig.EventType, "eventType", os.Getenv("PIPER_eventType"), "")
 	cmd.Flags().StringVar(&stepConfig.EventData, "eventData", os.Getenv("PIPER_eventData"), "Data to be merged with the generated data for the cloud event data field (JSON)")
-	cmd.Flags().StringVar(&stepConfig.AdditionalEventData, "additionalEventData", os.Getenv("PIPER_additionalEventData"), "Data (as JSON string) to add to eventData (in case eventData comes from the pipeline environment)")
+	cmd.Flags().StringVar(&stepConfig.AdditionalEventData, "additionalEventData", os.Getenv("PIPER_additionalEventData"), "Data (formatted as JSON string) to add to eventData. This can be used to enrich eventData that comes from the pipeline environment.")
 
 }
 

--- a/cmd/gcpPublishEvent_generated.go
+++ b/cmd/gcpPublishEvent_generated.go
@@ -26,6 +26,7 @@ type gcpPublishEventOptions struct {
 	EventSource                     string `json:"eventSource,omitempty"`
 	EventType                       string `json:"eventType,omitempty"`
 	EventData                       string `json:"eventData,omitempty"`
+	AdditionalEventData             string `json:"additionalEventData,omitempty"`
 }
 
 // GcpPublishEventCommand Publishes an event to GCP using OIDC authentication (beta)
@@ -138,6 +139,7 @@ func addGcpPublishEventFlags(cmd *cobra.Command, stepConfig *gcpPublishEventOpti
 	cmd.Flags().StringVar(&stepConfig.EventSource, "eventSource", os.Getenv("PIPER_eventSource"), "The events source as defined by CDEvents.")
 	cmd.Flags().StringVar(&stepConfig.EventType, "eventType", os.Getenv("PIPER_eventType"), "")
 	cmd.Flags().StringVar(&stepConfig.EventData, "eventData", os.Getenv("PIPER_eventData"), "Data to be merged with the generated data for the cloud event data field (JSON)")
+	cmd.Flags().StringVar(&stepConfig.AdditionalEventData, "additionalEventData", os.Getenv("PIPER_additionalEventData"), "Data (as JSON string) to add to eventData (in case eventData comes from the pipeline environment)")
 
 }
 
@@ -246,6 +248,15 @@ func gcpPublishEventMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_eventData"),
+					},
+					{
+						Name:        "additionalEventData",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_additionalEventData"),
 					},
 				},
 			},

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -70,8 +70,8 @@ func (e *Event) AddToCloudEventData(additionalDataString string) error {
 	if additionalDataString == "" {
 		return nil
 	}
+	
 	var additionalData map[string]interface{}
-
 	err := json.Unmarshal([]byte(additionalDataString), &additionalData)
 	if err != nil {
 		errors.Wrap(err, "couldn't add additional data to cloud event")
@@ -87,11 +87,6 @@ func (e *Event) AddToCloudEventData(additionalDataString string) error {
 		newEventData[k] = v
 	}
 
-	eventData, err := json.Marshal(newEventData)
-	if err != nil {
-		return errors.Wrap(err, "couldn't add additional data to cloud event")
-	}
 	e.cloudEvent.SetData("application/json", eventData)
-
 	return nil
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -2,10 +2,8 @@ package events
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
-	"github.com/SAP/jenkins-library/pkg/log"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -57,11 +55,6 @@ func (e Event) Create(data any, opts ...Option) Event {
 	for _, applyOpt := range opts {
 		applyOpt(e.cloudEvent.Context.AsV1())
 	}
-
-	eventPretty, _ := json.MarshalIndent(e.cloudEvent, "", "\t")
-	log.Entry().Info("CloudEvent created:")
-	fmt.Print(string(eventPretty))
-
 	return e
 }
 

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/SAP/jenkins-library/pkg/log"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -30,8 +31,13 @@ func NewEvent(eventType, eventSource string) Event {
 	}
 }
 
-func (e Event) CreateWithJSONData(data string, opts ...Option) Event {
-	return e.Create(data, opts...)
+func (e Event) CreateWithJSONData(data []byte, additionalData string, opts ...Option) Event {
+	event := e.Create(data, opts...)
+	err := event.AddToCloudEventData(additionalData)
+	if err != nil {
+		log.Entry().Debugf("couldn't add additionalData to cloud event data: %s", err)
+	}
+	return event
 }
 
 func (e Event) Create(data any, opts ...Option) Event {
@@ -56,4 +62,30 @@ func (e Event) ToBytes() ([]byte, error) {
 		return nil, errors.Wrap(err, "failed to marshal event data")
 	}
 	return data, nil
+}
+
+func (e *Event) AddToCloudEventData(additionalDataString string) error {
+	if additionalDataString == "" {
+		return nil
+	}
+	var additionalData map[string]interface{}
+	json.Unmarshal([]byte(additionalDataString), &additionalData)
+
+	var newEventData map[string]interface{}
+	err := json.Unmarshal(e.cloudEvent.DataEncoded, &newEventData)
+	if err != nil {
+		errors.Wrap(err, "couldn't add additional data to cloud event")
+	}
+
+	for k, v := range additionalData {
+		newEventData[k] = v
+	}
+
+	eventData, err := json.Marshal(newEventData)
+	if err != nil {
+		return errors.Wrap(err, "couldn't add additional data to cloud event")
+	}
+	e.cloudEvent.SetData("application/json", eventData)
+
+	return nil
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -70,7 +70,7 @@ func (e *Event) AddToCloudEventData(additionalDataString string) error {
 	if additionalDataString == "" {
 		return nil
 	}
-	
+
 	var additionalData map[string]interface{}
 	err := json.Unmarshal([]byte(additionalDataString), &additionalData)
 	if err != nil {
@@ -87,6 +87,6 @@ func (e *Event) AddToCloudEventData(additionalDataString string) error {
 		newEventData[k] = v
 	}
 
-	e.cloudEvent.SetData("application/json", eventData)
+	e.cloudEvent.SetData("application/json", newEventData)
 	return nil
 }

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -2,8 +2,10 @@ package events
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
+	"github.com/SAP/jenkins-library/pkg/log"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -55,6 +57,10 @@ func (e Event) Create(data any, opts ...Option) Event {
 	for _, applyOpt := range opts {
 		applyOpt(e.cloudEvent.Context.AsV1())
 	}
+
+	eventPretty, _ := json.MarshalIndent(e.cloudEvent, "", "\t")
+	log.Entry().Info("CloudEvent created:")
+	fmt.Print(string(eventPretty))
 
 	return e
 }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -16,4 +16,16 @@ func TestEventCreation(t *testing.T) {
 		assert.Equal(t, mock.Anything, event.cloudEvent.Type())
 		assert.Equal(t, mock.Anything, event.cloudEvent.Source())
 	})
+
+	t.Run("AddToCloudEventData", func(t *testing.T) {
+		// init
+		additionalData := `{"additionalKey": "additionalValue"}`
+		// test
+		event := NewEvent(mock.Anything, mock.Anything).CreateWithJSONData([]byte(`{"mockKey": "mockValue"}`), additionalData)
+		// asserts
+		assert.Equal(t, mock.Anything, event.cloudEvent.Type())
+		assert.Equal(t, mock.Anything, event.cloudEvent.Source())
+		assert.Contains(t, string(event.cloudEvent.Data()), `"additionalKey":"additionalValue"`)
+	})
+
 }

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -17,15 +17,25 @@ func TestEventCreation(t *testing.T) {
 		assert.Equal(t, mock.Anything, event.cloudEvent.Source())
 	})
 
-	t.Run("AddToCloudEventData", func(t *testing.T) {
+	t.Run("CreateWithJSONData - no additional data", func(t *testing.T) {
 		// init
-		additionalData := `{"additionalKey": "additionalValue"}`
+		testData := `{"testKey":"testValue"}`
 		// test
-		event := NewEvent(mock.Anything, mock.Anything).CreateWithJSONData([]byte(`{"mockKey": "mockValue"}`), additionalData)
+		event, err := NewEvent(mock.Anything, mock.Anything).CreateWithJSONData(testData)
 		// asserts
-		assert.Equal(t, mock.Anything, event.cloudEvent.Type())
-		assert.Equal(t, mock.Anything, event.cloudEvent.Source())
-		assert.Contains(t, string(event.cloudEvent.Data()), `"additionalKey":"additionalValue"`)
+		assert.NoError(t, err)
+		assert.Equal(t, string(event.cloudEvent.Data()), testData)
 	})
 
+	t.Run("CreateWithJSONData + AddToCloudEventData", func(t *testing.T) {
+		// init
+		testData := `{"testKey": "testValue"}`
+		additionalData := `{"additionalKey": "additionalValue"}`
+		// test
+		event, err := NewEvent(mock.Anything, mock.Anything).CreateWithJSONData(testData)
+		event.AddToCloudEventData(additionalData)
+		// asserts
+		assert.NoError(t, err)
+		assert.Equal(t, string(event.cloudEvent.Data()), `{"additionalKey":"additionalValue","testKey":"testValue"}`)
+	})
 }

--- a/pkg/gcp/pubsub.go
+++ b/pkg/gcp/pubsub.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/pkg/errors"
 )
 
@@ -38,6 +39,14 @@ func Publish(projectNumber string, topic string, token string, key string, data 
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal event")
 	}
+
+	// print event
+	eventBytesPretty, err := json.MarshalIndent(event, "", "\t")
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal event")
+	}
+	log.Entry().Info("full event:")
+	fmt.Print(string(eventBytesPretty))
 
 	// create request
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf(api_url, projectNumber, topic), bytes.NewReader(eventBytes))

--- a/pkg/gcp/pubsub.go
+++ b/pkg/gcp/pubsub.go
@@ -39,14 +39,7 @@ func Publish(projectNumber string, topic string, token string, key string, data 
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal event")
 	}
-
-	// print event
-	eventBytesPretty, err := json.MarshalIndent(event, "", "\t")
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal event")
-	}
-	log.Entry().Info("full event:")
-	fmt.Print(string(eventBytesPretty))
+	log.Entry().Debugf("created pubsub event: %s", string(eventBytes))
 
 	// create request
 	request, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf(api_url, projectNumber, topic), bytes.NewReader(eventBytes))

--- a/resources/metadata/gcpPublishEvent.yaml
+++ b/resources/metadata/gcpPublishEvent.yaml
@@ -81,3 +81,8 @@ spec:
         resourceRef:
           - name: commonPipelineEnvironment
             param: custom/eventData
+      - name: additionalEventData
+        description: Data (formatted as JSON string) to add to eventData. This can be used to enrich eventData that comes from the pipeline environment.
+        type: string
+        scope:
+          - PARAMETERS


### PR DESCRIPTION
Makes it possible to insert additional data into the `eventData` JSON, which is useful when the `eventData` comes from the pipeline env.

This also fixes the format of the `"data"` part of the CloudEvent. If you pass a string to `cloudEvent.SetData()`, it will be marshalled and ends up with duplicated escape characters (for example `{\\\\"testKey\\\\": \\\\"testValue\\\\"}`), which causes problems when unmarshalling the data. Passing a `map[string]interface{}` solves it.

# Changes

- [x] Tests
- [x] Documentation
