### PR TITLE
chore(deps): update syft version to 1.4.1

### DIFF
--- a/cmd/cnbBuild_generated.go
+++ b/cmd/cnbBuild_generated.go
@@ -250,7 +250,7 @@ func addCnbBuildFlags(cmd *cobra.Command, stepConfig *cnbBuildOptions) {
 	cmd.Flags().StringSliceVar(&stepConfig.PreserveFiles, "preserveFiles", []string{}, "List of globs, for keeping build results in the Jenkins workspace.\n\n*Note*: globs will be calculated relative to the [path](#path) property.\n")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "Build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build. This information is typically used for compliance related processes.")
 	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using Syft and stores it in a file in CycloneDX 1.4 format.")
-	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v0.62.3/syft_0.62.3_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
+	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v1.4.1/syft_1.4.1_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
 	cmd.Flags().StringVar(&stepConfig.RunImage, "runImage", os.Getenv("PIPER_runImage"), "Base image from which application images are built. Will be defaulted to the image provided by the builder.")
 	cmd.Flags().StringVar(&stepConfig.DefaultProcess, "defaultProcess", os.Getenv("PIPER_defaultProcess"), "Process that should be started by default. See https://buildpacks.io/docs/app-developer-guide/run-an-app/")
 
@@ -507,7 +507,7 @@ func cnbBuildMetadata() config.StepData {
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     `https://github.com/anchore/syft/releases/download/v0.62.3/syft_0.62.3_linux_amd64.tar.gz`,
+						Default:     `https://github.com/anchore/syft/releases/download/v1.4.1/syft_1.4.1_linux_amd64.tar.gz`,
 					},
 					{
 						Name:        "runImage",

--- a/cmd/kanikoExecute_generated.go
+++ b/cmd/kanikoExecute_generated.go
@@ -314,7 +314,7 @@ func addKanikoExecuteFlags(cmd *cobra.Command, stepConfig *kanikoExecuteOptions)
 	cmd.Flags().StringSliceVar(&stepConfig.TargetArchitectures, "targetArchitectures", []string{``}, "Defines the target architectures for which the build should run using OS and architecture separated by a comma. (EXPERIMENTAL)")
 	cmd.Flags().BoolVar(&stepConfig.ReadImageDigest, "readImageDigest", false, "")
 	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using Syft and stores it in a file in CycloneDX 1.4 format.")
-	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v0.62.3/syft_0.62.3_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
+	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v1.4.1/syft_1.4.1_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
 
 }
 
@@ -554,7 +554,7 @@ func kanikoExecuteMetadata() config.StepData {
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     `https://github.com/anchore/syft/releases/download/v0.62.3/syft_0.62.3_linux_amd64.tar.gz`,
+						Default:     `https://github.com/anchore/syft/releases/download/v1.4.1/syft_1.4.1_linux_amd64.tar.gz`,
 					},
 				},
 			},

--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -360,7 +360,7 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.Equal(t, "https://index.docker.io", commonPipelineEnvironment.container.registryURL)
 
 		assert.Equal(t, "/tmp/syfttest/syft", execRunner.Calls[2].Exec)
-		assert.Equal(t, []string{"packages", "registry:index.docker.io/myImage:tag", "-o", "cyclonedx-xml", "--file", "bom-docker-0.xml", "-q"}, execRunner.Calls[2].Params)
+		assert.Equal(t, []string{"scan", "registry:index.docker.io/myImage:tag", "-o", "cyclonedx-xml=bom-docker-0.xml", "-q"}, execRunner.Calls[2].Params)
 	})
 
 	t.Run("success case - multi image build with root image", func(t *testing.T) {
@@ -509,16 +509,16 @@ func TestRunKanikoExecute(t *testing.T) {
 			{"--dockerfile", "Dockerfile", "--context", "dir://" + cwd, "--destination", "my.registry.com:50000/myImage:myTag"},
 			{"--dockerfile", filepath.Join("sub1", "Dockerfile"), "--context", "dir://" + cwd, "--destination", "my.registry.com:50000/myImage-sub1:myTag"},
 			{"--dockerfile", filepath.Join("sub2", "Dockerfile"), "--context", "dir://" + cwd, "--destination", "my.registry.com:50000/myImage-sub2:myTag"},
-			{"packages", "registry:my.registry.com:50000/myImage:myTag", "-o", "cyclonedx-xml", "--file"},
-			{"packages", "registry:my.registry.com:50000/myImage-sub1:myTag", "-o", "cyclonedx-xml", "--file"},
-			{"packages", "registry:my.registry.com:50000/myImage-sub2:myTag", "-o", "cyclonedx-xml", "--file"},
+			{"scan", "registry:my.registry.com:50000/myImage:myTag", "-o"},
+			{"scan", "registry:my.registry.com:50000/myImage-sub1:myTag", "-o"},
+			{"scan", "registry:my.registry.com:50000/myImage-sub2:myTag", "-o"},
 		}
 		// need to go this way since we cannot count on the correct order
 		for index, call := range execRunner.Calls {
 			found := false
 			for _, expected := range expectedParams {
-				if expected[0] == "packages" {
-					expected = append(expected, fmt.Sprintf("bom-docker-%d.xml", index-3), "-q")
+				if expected[0] == "scan" {
+					expected = append(expected, fmt.Sprintf("cyclonedx-xml=bom-docker-%d.xml", index-3), "-q")
 				}
 				if strings.Join(call.Params, " ") == strings.Join(expected, " ") {
 					found = true
@@ -662,15 +662,15 @@ func TestRunKanikoExecute(t *testing.T) {
 		expectedParams := [][]string{
 			{"--dockerfile", "Dockerfile", "--context", "dir://" + cwd, "--context-sub-path", "/test1", "--destination", "my.registry.com:50000/myImageOne:myTag"},
 			{"--dockerfile", "Dockerfile", "--context", "dir://" + cwd, "--context-sub-path", "/test2", "--destination", "my.registry.com:50000/myImageTwo:myTagTwo"},
-			{"packages", "registry:my.registry.com:50000/myImageOne:myTag", "-o", "cyclonedx-xml", "--file"},
-			{"packages", "registry:my.registry.com:50000/myImageTwo:myTagTwo", "-o", "cyclonedx-xml", "--file"},
+			{"scan", "registry:my.registry.com:50000/myImageOne:myTag", "-o"},
+			{"scan", "registry:my.registry.com:50000/myImageTwo:myTagTwo", "-o"},
 		}
 		// need to go this way since we cannot count on the correct order
 		for index, call := range execRunner.Calls {
 			found := false
 			for _, expected := range expectedParams {
-				if expected[0] == "packages" {
-					expected = append(expected, fmt.Sprintf("bom-docker-%d.xml", index-2), "-q")
+				if expected[0] == "scan" {
+					expected = append(expected, fmt.Sprintf("cyclonedx-xml=bom-docker-%d.xml", index-2), "-q")
 				}
 				if strings.Join(call.Params, " ") == strings.Join(expected, " ") {
 					found = true

--- a/integration/integration_cnb_test.go
+++ b/integration/integration_cnb_test.go
@@ -163,7 +163,7 @@ func TestCNBIntegrationZipPath(t *testing.T) {
 		fmt.Sprintf("Saving %s/not-found:0.0.1", registryURL),
 		"*** Images (sha256:",
 		"SUCCESS",
-		"syft packages registry:localhost:5000/not-found:0.0.1 -o cyclonedx-xml --file bom-docker-0.xml -q",
+		"syft scan registry:localhost:5000/not-found:0.0.1 -o cyclonedx-xml=bom-docker-0.xml -q",
 	)
 	container.assertHasFiles(t, "/project/bom-docker-0.xml")
 	container.terminate(t)
@@ -309,9 +309,9 @@ func TestCNBIntegrationMultiImage(t *testing.T) {
 		"Saving localhost:5000/go-app:v1.0.0...",
 		"Using cached buildpack",
 		"Saving localhost:5000/my-app2:latest...",
-		"syft packages registry:localhost:5000/io-buildpacks-my-app:latest -o cyclonedx-xml --file bom-docker-0.xml -q",
-		"syft packages registry:localhost:5000/go-app:v1.0.0 -o cyclonedx-xml --file bom-docker-1.xml -q",
-		"syft packages registry:localhost:5000/my-app2:latest -o cyclonedx-xml --file bom-docker-2.xml -q",
+		"syft scan registry:localhost:5000/io-buildpacks-my-app:latest -o cyclonedx-xml=bom-docker-0.xml -q",
+		"syft scan registry:localhost:5000/go-app:v1.0.0 -o cyclonedx-xml=bom-docker-1.xml -q",
+		"syft scan registry:localhost:5000/my-app2:latest -o cyclonedx-xml=bom-docker-2.xml -q",
 	)
 
 	container.assertHasFiles(t, "/project/bom-docker-0.xml")

--- a/pkg/syft/syft.go
+++ b/pkg/syft/syft.go
@@ -42,7 +42,7 @@ func GenerateSBOM(syftDownloadURL, dockerConfigDir string, execRunner command.Ex
 			return errors.New("syft: image name must not be empty")
 		}
 		// TrimPrefix needed as syft needs containerRegistry name only
-		err = execRunner.RunExecutable(syftFile, "packages", fmt.Sprintf("registry:%s/%s", strings.TrimPrefix(registryURL, "https://"), image), "-o", "cyclonedx-xml", "--file", fmt.Sprintf("bom-docker-%v.xml", index), "-q")
+		err = execRunner.RunExecutable(syftFile, "scan", fmt.Sprintf("registry:%s/%s", strings.TrimPrefix(registryURL, "https://"), image), "-o", fmt.Sprintf("cyclonedx-xml=bom-docker-%v.xml", index), "-q")
 		if err != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", err)
 		}

--- a/pkg/syft/syft_test.go
+++ b/pkg/syft/syft_test.go
@@ -44,17 +44,17 @@ func TestGenerateSBOM(t *testing.T) {
 		assert.Len(t, execMock.Calls, 2)
 		firstCall := execMock.Calls[0]
 		assert.Equal(t, firstCall.Exec, "/tmp/syfttest/syft")
-		assert.Equal(t, firstCall.Params, []string{"packages", "registry:my-registry/image:latest", "-o", "cyclonedx-xml", "--file", "bom-docker-0.xml", "-q"})
+		assert.Equal(t, firstCall.Params, []string{"scan", "registry:my-registry/image:latest", "-o", "cyclonedx-xml=bom-docker-0.xml", "-q"})
 
 		secondCall := execMock.Calls[1]
 		assert.Equal(t, secondCall.Exec, "/tmp/syfttest/syft")
-		assert.Equal(t, secondCall.Params, []string{"packages", "registry:my-registry/image:1.2.3", "-o", "cyclonedx-xml", "--file", "bom-docker-1.xml", "-q"})
+		assert.Equal(t, secondCall.Params, []string{"scan", "registry:my-registry/image:1.2.3", "-o", "cyclonedx-xml=bom-docker-1.xml", "-q"})
 	})
 
 	t.Run("error case: syft execution failed", func(t *testing.T) {
 		execMock = mock.ExecMockRunner{}
 		execMock.ShouldFailOnCommand = map[string]error{
-			"/tmp/syfttest/syft packages registry:my-registry/image:latest -o cyclonedx-xml --file bom-docker-0.xml -q": errors.New("failed"),
+			"/tmp/syfttest/syft scan registry:my-registry/image:latest -o cyclonedx-xml=bom-docker-0.xml -q": errors.New("failed"),
 		}
 
 		err := syft.GenerateSBOM("http://test-syft-gh-release.com/syft.tar.gz", "", &execMock, &fileMock, client, "https://my-registry", []string{"image:latest"})

--- a/resources/metadata/cnbBuild.yaml
+++ b/resources/metadata/cnbBuild.yaml
@@ -339,7 +339,7 @@ spec:
         scope:
           - PARAMETERS
           - STEPS
-        default: "https://github.com/anchore/syft/releases/download/v0.62.3/syft_0.62.3_linux_amd64.tar.gz"
+        default: "https://github.com/anchore/syft/releases/download/v1.4.1/syft_1.4.1_linux_amd64.tar.gz"
       - name: runImage
         type: string
         description: "Base image from which application images are built. Will be defaulted to the image provided by the builder."

--- a/resources/metadata/kanikoExecute.yaml
+++ b/resources/metadata/kanikoExecute.yaml
@@ -305,7 +305,7 @@ spec:
         scope:
           - PARAMETERS
           - STEPS
-        default: "https://github.com/anchore/syft/releases/download/v0.62.3/syft_0.62.3_linux_amd64.tar.gz"
+        default: "https://github.com/anchore/syft/releases/download/v1.4.1/syft_1.4.1_linux_amd64.tar.gz"
   outputs:
     resources:
       - name: commonPipelineEnvironment


### PR DESCRIPTION
Bump the rather outdated version of the `syft` command using for generating a `sbom` for images.

# Changes

- [ ] Tests
- [ ] Documentation
