### PR TITLE
feat(cnbbuild): cnbbuild collects SBOM of the produced images

### DIFF
--- a/pkg/syft/syft.go
+++ b/pkg/syft/syft.go
@@ -15,9 +15,42 @@ import (
 	"github.com/pkg/errors"
 )
 
+type SyftScanner struct {
+	syftFile       string
+	additionalArgs []string
+}
+
 func GenerateSBOM(syftDownloadURL, dockerConfigDir string, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender, registryURL string, images []string) error {
+	scanner, err := CreateSyftScanner(syftDownloadURL, fileUtils, httpClient)
+	if err != nil {
+		return err
+	}
+	return scanner.ScanImages(dockerConfigDir, execRunner, registryURL, images)
+}
+
+func CreateSyftScanner(syftDownloadURL string, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) (*SyftScanner, error) {
+
+	tmpDir, err := fileUtils.TempDir("", "syft")
+	if err != nil {
+		return nil, err
+	}
+	syftFile := filepath.Join(tmpDir, "syft")
+
+	err = install(syftDownloadURL, syftFile, fileUtils, httpClient)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to install syft")
+	}
+
+	return &SyftScanner{syftFile: syftFile}, nil
+}
+
+func (s *SyftScanner) AddArgument(arg string) {
+	s.additionalArgs = append(s.additionalArgs, arg)
+}
+
+func (s *SyftScanner) ScanImages(dockerConfigDir string, execRunner command.ExecRunner, registryURL string, images []string) error {
 	if registryURL == "" {
-		return errors.New("syft: regisitry url must not be empty")
+		return errors.New("syft: registry url must not be empty")
 	}
 
 	if len(images) == 0 {
@@ -26,23 +59,14 @@ func GenerateSBOM(syftDownloadURL, dockerConfigDir string, execRunner command.Ex
 
 	execRunner.AppendEnv([]string{fmt.Sprintf("DOCKER_CONFIG=%s", dockerConfigDir)})
 
-	tmpDir, err := fileUtils.TempDir("", "syft")
-	if err != nil {
-		return err
-	}
-	syftFile := filepath.Join(tmpDir, "syft")
-
-	err = install(syftDownloadURL, syftFile, fileUtils, httpClient)
-	if err != nil {
-		return errors.Wrap(err, "failed to install syft")
-	}
-
 	for index, image := range images {
 		if image == "" {
 			return errors.New("syft: image name must not be empty")
 		}
 		// TrimPrefix needed as syft needs containerRegistry name only
-		err = execRunner.RunExecutable(syftFile, "scan", fmt.Sprintf("registry:%s/%s", strings.TrimPrefix(registryURL, "https://"), image), "-o", fmt.Sprintf("cyclonedx-xml=bom-docker-%v.xml", index), "-q")
+		args := []string{"scan", fmt.Sprintf("registry:%s/%s", strings.TrimPrefix(registryURL, "https://"), image), "-o", fmt.Sprintf("cyclonedx-xml=bom-docker-%v.xml", index), "-q"}
+		args = append(args, s.additionalArgs...)
+		err := execRunner.RunExecutable(s.syftFile, args...)
 		if err != nil {
 			return fmt.Errorf("failed to generate SBOM: %w", err)
 		}

--- a/pkg/syft/syft_test.go
+++ b/pkg/syft/syft_test.go
@@ -65,7 +65,7 @@ func TestGenerateSBOM(t *testing.T) {
 	t.Run("error case: no registry", func(t *testing.T) {
 		err := syft.GenerateSBOM("http://test-syft-gh-release.com/syft.tar.gz", "", &execMock, &fileMock, client, "", []string{"image:latest"})
 		assert.Error(t, err)
-		assert.Equal(t, "syft: regisitry url must not be empty", err.Error())
+		assert.Equal(t, "syft: registry url must not be empty", err.Error())
 	})
 
 	t.Run("error case: no images provided", func(t *testing.T) {


### PR DESCRIPTION
Based on https://github.com/SAP/jenkins-library/pull/4933

In case of images built with cloud native buildpacks, creating the sbom is only about collecting the sboms already on the image.
