### PR TITLE
feat(helmExecute): automatically set appVersion

### DIFF
--- a/cmd/helmExecute_generated.go
+++ b/cmd/helmExecute_generated.go
@@ -539,13 +539,18 @@ func helmExecuteMetadata() config.StepData {
 						Default:     os.Getenv("PIPER_helmCommand"),
 					},
 					{
-						Name:        "appVersion",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_appVersion"),
+						Name: "appVersion",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "artifactVersion",
+							},
+						},
+						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_appVersion"),
 					},
 					{
 						Name:        "dependency",

--- a/resources/metadata/helmExecute.yaml
+++ b/resources/metadata/helmExecute.yaml
@@ -278,6 +278,9 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: artifactVersion
       - name: dependency
         type: string
         description: "manage a chart's dependencies"


### PR DESCRIPTION
# Changes

The `appVersion` attribute of a helmchart should normally be set to the version of the app which it ships. In our case it's most likely the version which piper generates with `artifactPrepareVersion`. If no other appVersion is specified in the pipeline configuration piper will automatically use the generated version once this is merged.



See https://helm.sh/docs/topics/charts/
```
appVersion: The version of the app that this contains (optional). Needn't be SemVer. Quotes recommended.
```

- [ ] Tests
- [x] Documentation
