### PR TITLE
Improving buildDescriptorExcludeList for npm

### DIFF
--- a/pkg/whitesource/configHelper.go
+++ b/pkg/whitesource/configHelper.go
@@ -266,6 +266,19 @@ func (c *ConfigOptions) addBuildToolDefaults(config *ScanOptions, utils Utils) e
 		}
 
 	}
+	if config.BuildTool == "npm" {
+		if len(config.BuildDescriptorExcludeList) > 0 {
+			var excludePaths []string
+			for _, buildDescriptor := range config.BuildDescriptorExcludeList {
+				if strings.HasSuffix(buildDescriptor, "pom.xml") {
+					continue
+				}
+				modulePath, _ := filepath.Split(buildDescriptor)
+				excludePaths = append(excludePaths, modulePath)
+			}
+			*c = append(*c, ConfigOption{Name: "npm.ignoreDirectoryPatterns", Value: strings.Join(excludePaths, ",")})
+		}
+	}
 
 	if config.BuildTool == "docker" {
 		// for now only support default name of Dockerfile


### PR DESCRIPTION
# Changes
Fixes:
In whitesourceExcuteScan piper step the buildDescriptorExcludeList parameter is not excluding the npm modules during scanning. To address this, we have implemented the ignoreDirectoryPatterns functionality specifically for NPM modules to exclude the specified modules during the scan.


- [x] Tests
- [ ] Documentation
