### PR TITLE
Fixed excluded directories with pattern

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -1124,7 +1124,7 @@ func logConfigInVerboseMode(config detectExecuteScanOptions) {
 }
 
 func handleExcludedDirectories(args *[]string, config *detectExecuteScanOptions) {
-	index := findItemInStringSlice(config.ScanProperties, "detect.excluded.directories")
+	index := findItemInStringSlice(config.ScanProperties, "--detect.excluded.directories=")
 	if index != -1 && !strings.Contains(config.ScanProperties[index], configPath) {
 		config.ScanProperties[index] += "," + configPath
 	} else {


### PR DESCRIPTION
# Changes
Added a precise scan properties pattern to differentiate between two similar detect scan properties(--detect.excluded.directories.defaults.disabled and --detect.excluded.directories).

- [ ] Tests
- [ ] Documentation
