### PR TITLE
Disable telemetry reporting

### DIFF
--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -420,6 +420,11 @@ func PrepareConfig(cmd *cobra.Command, metadata *config.StepData, stepName strin
 		}
 	}
 
+	// since Pendo has been sunset
+	// disable telemetry reporting in go
+	// follow-up cleanup needed
+	GeneralConfig.NoTelemetry = true
+
 	stepConfig.Config = checkTypes(stepConfig.Config, options)
 	confJSON, _ := json.Marshal(stepConfig.Config)
 	_ = json.Unmarshal(confJSON, &options)


### PR DESCRIPTION
# Changes

This PR disables sendong telemetry data to Pendo, since Pendo subscription has been disabled

same as https://github.com/SAP/jenkins-library/pull/4788

- [ ] Tests
- [ ] Documentation
