### PR TITLE
Find dist folder from sources

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -374,7 +374,7 @@ steps:
     stepMessage: 'Do you want to restart?'
   pipelineStashFilesAfterBuild:
     stashIncludes:
-      buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original, dist/**'
+      buildResult: '**/target/*.war, **/target/*.jar, **/*.mtar, **/*.jar.original, **/dist/**'
       checkmarx: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html, **/*.ts'
       checkmarxOne: '**/*.js, **/*.scala, **/*.py, **/*.go, **/*.d, **/*.di, **/*.xml, **/*.html, **/*.ts'
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'


### PR DESCRIPTION
# Changes
This change extends the visibility of **dist** folder produced during the Build stage. Currently it is stashed only if the **dist** folder is on root. With this change, it is stashed from the sub folders of the sources.

- [ ] Tests
- [ ] Documentation
