### PR TITLE
feat(mtaBuild): Add enableSetTimestamp parameter

### DIFF
--- a/cmd/mtaBuild.go
+++ b/cmd/mtaBuild.go
@@ -180,8 +180,10 @@ func runMtaBuild(config mtaBuildOptions,
 		log.Entry().Infof("\"%s\" file found in project sources", mtaYamlFile)
 	}
 
-	if err = setTimeStamp(mtaYamlFile, utils); err != nil {
-		return err
+	if config.EnableSetTimestamp {
+		if err = setTimeStamp(mtaYamlFile, utils); err != nil {
+			return err
+		}
 	}
 
 	mtarName, isMtarNativelySuffixed, err := getMtarName(config, mtaYamlFile, utils)

--- a/cmd/mtaBuild_generated.go
+++ b/cmd/mtaBuild_generated.go
@@ -43,6 +43,7 @@ type mtaBuildOptions struct {
 	Profiles                        []string `json:"profiles,omitempty"`
 	BuildSettingsInfo               string   `json:"buildSettingsInfo,omitempty"`
 	CreateBOM                       bool     `json:"createBOM,omitempty"`
+	EnableSetTimestamp              bool     `json:"enableSetTimestamp,omitempty"`
 }
 
 type mtaBuildCommonPipelineEnvironment struct {
@@ -245,6 +246,7 @@ func addMtaBuildFlags(cmd *cobra.Command, stepConfig *mtaBuildOptions) {
 	cmd.Flags().StringSliceVar(&stepConfig.Profiles, "profiles", []string{}, "Defines list of maven build profiles to be used. profiles will overwrite existing values in the global settings xml at $M2_HOME/conf/settings.xml")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build . This information is typically used for compliance related processes.")
 	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using CycloneDX plugin.")
+	cmd.Flags().BoolVar(&stepConfig.EnableSetTimestamp, "enableSetTimestamp", false, "Enables setting the timestamp in the `mta.yaml` when it contains `${timestamp}`. Disable this when you want the MTA Deploy Service to do this instead.")
 
 }
 
@@ -494,6 +496,15 @@ func mtaBuildMetadata() config.StepData {
 						Name:        "createBOM",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
+					},
+					{
+						Name:        "enableSetTimestamp",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
 						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},

--- a/cmd/mtaBuild_generated.go
+++ b/cmd/mtaBuild_generated.go
@@ -246,7 +246,7 @@ func addMtaBuildFlags(cmd *cobra.Command, stepConfig *mtaBuildOptions) {
 	cmd.Flags().StringSliceVar(&stepConfig.Profiles, "profiles", []string{}, "Defines list of maven build profiles to be used. profiles will overwrite existing values in the global settings xml at $M2_HOME/conf/settings.xml")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the mta build . This information is typically used for compliance related processes.")
 	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using CycloneDX plugin.")
-	cmd.Flags().BoolVar(&stepConfig.EnableSetTimestamp, "enableSetTimestamp", false, "Enables setting the timestamp in the `mta.yaml` when it contains `${timestamp}`. Disable this when you want the MTA Deploy Service to do this instead.")
+	cmd.Flags().BoolVar(&stepConfig.EnableSetTimestamp, "enableSetTimestamp", true, "Enables setting the timestamp in the `mta.yaml` when it contains `${timestamp}`. Disable this when you want the MTA Deploy Service to do this instead.")
 
 }
 
@@ -508,7 +508,7 @@ func mtaBuildMetadata() config.StepData {
 						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     false,
+						Default:     true,
 					},
 				},
 			},

--- a/cmd/mtaBuild_test.go
+++ b/cmd/mtaBuild_test.go
@@ -1,6 +1,3 @@
-//go:build unit
-// +build unit
-
 package cmd
 
 import (
@@ -98,7 +95,7 @@ func TestMtaBuild(t *testing.T) {
 
 		utilsMock := newMtaBuildTestUtilsBundle()
 
-		options := mtaBuildOptions{ApplicationName: "myApp", Platform: "CF", MtarName: "myName", Source: "./", Target: "./"}
+		options := mtaBuildOptions{ApplicationName: "myApp", Platform: "CF", MtarName: "myName", Source: "./", Target: "./", EnableSetTimestamp: true}
 
 		utilsMock.AddFile("package.json", []byte("{\"name\": \"myName\", \"version\": \"1.2.3\"}"))
 
@@ -149,7 +146,7 @@ func TestMtaBuild(t *testing.T) {
 
 		utilsMock := newMtaBuildTestUtilsBundle()
 
-		options := mtaBuildOptions{ApplicationName: "myApp"}
+		options := mtaBuildOptions{ApplicationName: "myApp", EnableSetTimestamp: true}
 
 		utilsMock.AddFile("package.json", []byte("{\"name\": \"myName\", \"version\": \"1.2.3\"}"))
 		utilsMock.AddFile("mta.yaml", []byte("already there with-${timestamp}"))

--- a/resources/metadata/mtaBuild.yaml
+++ b/resources/metadata/mtaBuild.yaml
@@ -236,6 +236,13 @@ spec:
           - STAGES
           - PARAMETERS
         default: false
+      - name: enableSetTimestamp
+        type: bool
+        description: Enables setting the timestamp in the `mta.yaml` when it contains `${timestamp}`. Disable this when you want the MTA Deploy Service to do this instead.
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
   outputs:
     resources:
       - name: commonPipelineEnvironment

--- a/resources/metadata/mtaBuild.yaml
+++ b/resources/metadata/mtaBuild.yaml
@@ -243,6 +243,7 @@ spec:
           - STEPS
           - STAGES
           - PARAMETERS
+        default: true
   outputs:
     resources:
       - name: commonPipelineEnvironment


### PR DESCRIPTION
# Changes
The step currently always sets the timestamp in the MTA descriptor file. However, the [MTA Deploy Service](https://help.sap.com/docs/btp/sap-business-technology-platform/content-deployment) can do this too, and Piper doing it in the first place can cause issues for users. Therefore this PR makes this behaviour configurable, but keeps the default behaviour as is in order to not affect existing pipelines.

- [x] Tests
- [x] Documentation
