### PR TITLE
Add support for sonar.projectBaseDir

### DIFF
--- a/pkg/sonar/sonar.go
+++ b/pkg/sonar/sonar.go
@@ -30,7 +30,7 @@ func ReadTaskReport(workspace string) (result TaskReportData, err error) {
 		subdirs, _ := os.ReadDir(workspace)
 		for _, dir := range subdirs {
 			if dir.IsDir() {
-				reportFile = filepath.Join(workspace, dir.Name(), ".scannerwork", "report-task.txt")
+				reportFile = filepath.Join(workspace, dir.Name(), "report-task.txt")
 				reportContent, err = properties.LoadFile(reportFile, properties.UTF8)
 				if err == nil {
 					break


### PR DESCRIPTION
When configuring the `sonar.projectBaseDir` parameter, the scan places the report file in said folder.
It is necessary when using the `executeBuild` step's parameter `xMakeDownloadDownstreamsProjectArchives`, as it will create subfolders with the name of the downstream xmake jobs instead of placing the files back in the workspace root folder. This code will look through these folders to see if the report file is there if it isn't in the `~/.scannerwork/` folder

Haven't tested the changes myself.

# Changes

- [ ] Tests
- [ ] Documentation
