### PR TITLE
vaultRotateSecretID: Update logging

### DIFF
--- a/cmd/vaultRotateSecretId.go
+++ b/cmd/vaultRotateSecretId.go
@@ -81,11 +81,12 @@ func runVaultRotateSecretID(utils vaultRotateSecretIDUtils) error {
 		return nil
 	}
 
-	log.Entry().Debugf("Your secret ID is about to expire in %.0f", ttl.Round(time.Hour*24).Hours()/24)
+	log.Entry().Infof("Your secret ID is about to expire in %.0f", ttl.Round(time.Hour*24).Hours()/24)
 
 	if ttl > time.Duration(config.DaysBeforeExpiry)*24*time.Hour {
 		return nil
 	}
+	log.Entry().Info("Rotating...")
 
 	newSecretID, err := utils.GenerateNewAppRoleSecret(GeneralConfig.VaultRoleSecretID, roleName)
 


### PR DESCRIPTION
# Changes

This PR 
- changes the log level from Debug to Info - it is helpful to see secret ID expiration time
- adds new Info level log - it helps to see what step does

- [ ] Tests
- [ ] Documentation
