### PR TITLE
feat(vault): support complex data types in secrets

### DIFF
--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -169,9 +169,19 @@ func (v Client) GetKvSecret(path string) (map[string]string, error) {
 
 	secretData := make(map[string]string, len(data))
 	for k, v := range data {
-		valueStr, ok := v.(string)
-		if ok {
-			secretData[k] = valueStr
+		switch t := v.(type) {
+		case string:
+			secretData[k] = t
+		case int:
+			secretData[k] = fmt.Sprintf("%d", t)
+		default:
+			jsonBytes, err := json.Marshal(t)
+			if err != nil {
+				log.Entry().Warnf("failed to parse Vault secret key %q, error: %s", k, err.Error())
+				continue
+			}
+
+			secretData[k] = string(jsonBytes)
 		}
 	}
 	return secretData, nil


### PR DESCRIPTION
# Changes

Vault support complex types, like objects, array or simple integers as key values. This PR introduces support for these keys, marshalling these types to JSON strings when possible.

- [x] Tests
- [ ] Documentation
