### PR TITLE
Add the possibility to fetch jsonCredentialsAzure from Vault

### DIFF
--- a/cmd/azureBlobUpload_generated.go
+++ b/cmd/azureBlobUpload_generated.go
@@ -146,6 +146,12 @@ func azureBlobUploadMetadata() config.StepData {
 						Name: "jsonCredentialsAzure",
 						ResourceRef: []config.ResourceReference{
 							{
+								Name:    "azureDevOpsVaultSecretName",
+								Type:    "vaultSecret",
+								Default: "azure-dev-ops",
+							},
+
+							{
 								Name: "azureCredentialsId",
 								Type: "secret",
 							},

--- a/resources/metadata/azureBlobUpload.yaml
+++ b/resources/metadata/azureBlobUpload.yaml
@@ -19,8 +19,11 @@ spec:
           - PARAMETERS
         secret: true
         resourceRef:
-          - name: azureCredentialsId
-            type: secret
+          - type: vaultSecret
+            name: azureDevOpsVaultSecretName
+            default: azure-dev-ops
+          - type: secret
+            name: azureCredentialsId
       - name: filePath
         resourceRef:
           - name: commonPipelineEnvironment


### PR DESCRIPTION
# Changes

This PR adds the possibility to fetch jsonCredentialsAzure from Vault for the azureBlobUpload step.

- [x] Tests
- [x] Documentation
