### PR TITLE
feat(sonar): Enable trustengine for token retrieval

### DIFF
--- a/cmd/sonarExecuteScan_generated.go
+++ b/cmd/sonarExecuteScan_generated.go
@@ -331,6 +331,12 @@ func sonarExecuteScanMetadata() config.StepData {
 								Name: "sonarTokenCredentialsId",
 								Type: "secret",
 							},
+
+							{
+								Name:    "sonarTrustengineSecretName",
+								Type:    "trustengineSecret",
+								Default: "sonar",
+							},
 						},
 						Scope:     []string{"PARAMETERS"},
 						Type:      "string",

--- a/resources/metadata/sonarExecuteScan.yaml
+++ b/resources/metadata/sonarExecuteScan.yaml
@@ -53,6 +53,9 @@ spec:
             default: sonar
           - name: sonarTokenCredentialsId
             type: secret
+          - type: trustengineSecret
+            name: sonarTrustengineSecretName
+            default: sonar
         aliases:
           - name: sonarToken
       - name: organization


### PR DESCRIPTION
# Changes
Adds trustengine resource reference for the token parameter. This means that the Sonar token will be retrieved from there if it's not found in Vault.

- [x] Tests
- [x] Documentation
