### PR TITLE
fix: add missing return value for error

### DIFF
--- a/pkg/transportrequest/cts/upload.go
+++ b/pkg/transportrequest/cts/upload.go
@@ -194,7 +194,7 @@ func getFioriDeployStatement(
 	if len(app.Name) > 0 {
 		re := regexp.MustCompile(pattern)
 		if !re.MatchString(app.Name) {
-			fmt.Errorf("application name '%s' contains spaces or special characters. It is not according to the '%s'", app.Name, pattern)
+			return "", fmt.Errorf("application name '%s' contains spaces or special characters and is not according to the regex '%s'.", app.Name, pattern)
 		}
 		log.Entry().Debugf("application name '%s' used from piper config", app.Name)
 		cmd = append(cmd, "--name", app.Name)

--- a/pkg/transportrequest/cts/upload_test.go
+++ b/pkg/transportrequest/cts/upload_test.go
@@ -4,10 +4,11 @@
 package cts
 
 import (
+	"testing"
+
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestUploadCTS(t *testing.T) {
@@ -98,6 +99,26 @@ func TestUploadCTS(t *testing.T) {
 				)
 				assert.Equal(t, []string{"ABAP_USER=me", "ABAP_PASSWORD=******"}, cmd.Env)
 			}
+		})
+
+		t.Run("fail in case of  invalid app name", func(t *testing.T) {
+			cmd := mock.ShellMockRunner{}
+			action := UploadAction{
+				Connection:  Connection{Endpoint: "https://example.org:8080/cts", Client: "001", User: "me", Password: "******"},
+				Application: Application{Pack: "abapPackage", Name: "app Name", Desc: "the Desc"},
+				Node: Node{
+					DeployDependencies: []string{},
+					InstallOpts:        []string{},
+				},
+				TransportRequestID: "12345678",
+				ConfigFile:         "ui5-deploy.yaml",
+				DeployUser:         "doesNotMatterInThisCase",
+			}
+
+			err := action.Perform(&cmd)
+			expectedErrorMessge := "application name 'app Name' contains spaces or special characters and is not according to the regex '^[a-zA-Z0-9_]+$'."
+
+			assert.EqualErrorf(t, err, expectedErrorMessge, "invalid app name")
 		})
 	})
 


### PR DESCRIPTION
# Changes

The error message from the [previous PR](https://github.com/SAP/jenkins-library/pull/5123) is not caught as expected due to missing return value. This fixes the problem.

- [x ] Tests
- [ ] Documentation
