### PR TITLE
fix: too long string written to cpe git.commitMessage

### DIFF
--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -239,9 +239,11 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 	commonPipelineEnvironment.originalArtifactVersion = version
 
 	gitCommitMessages := strings.Split(gitCommitMessage, "\n")
-	commonPipelineEnvironment.git.commitMessage = gitCommitMessages[0]
+	commitMessage := truncateString(gitCommitMessages[0], 50) // Github recommends to keep commit message title less than 50 chars
 
-	log.Entry().Debug("commonPipelineEnvironment.git.commitMessage:", gitCommitMessages[0])
+	commonPipelineEnvironment.git.commitMessage = commitMessage
+
+	log.Entry().Debug("CPE git commitMessage:", commitMessage)
 
 	// we may replace GetVersion() above with GetCoordinates() at some point ...
 	coordinates, err := artifact.GetCoordinates()
@@ -256,6 +258,15 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 	}
 
 	return nil
+}
+
+func truncateString(str string, maxLength int) string {
+	chars := []rune(str)
+
+	if len(chars) > maxLength {
+		return string(chars[:maxLength]) + "..."
+	}
+	return str
 }
 
 func openGit() (gitRepository, error) {

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -241,6 +241,8 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 	gitCommitMessages := strings.Split(gitCommitMessage, "\n")
 	commonPipelineEnvironment.git.commitMessage = gitCommitMessages[0]
 
+	log.Entry().Debugf("commonPipelineEnvironment.git.commitMessage:", gitCommitMessages[0])
+
 	// we may replace GetVersion() above with GetCoordinates() at some point ...
 	coordinates, err := artifact.GetCoordinates()
 	if err != nil && !config.FetchCoordinates {

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -241,7 +241,7 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 	gitCommitMessages := strings.Split(gitCommitMessage, "\n")
 	commonPipelineEnvironment.git.commitMessage = gitCommitMessages[0]
 
-	log.Entry().Debugf("commonPipelineEnvironment.git.commitMessage:", gitCommitMessages[0])
+	log.Entry().Debug("commonPipelineEnvironment.git.commitMessage:", gitCommitMessages[0])
 
 	// we may replace GetVersion() above with GetCoordinates() at some point ...
 	coordinates, err := artifact.GetCoordinates()

--- a/cmd/artifactPrepareVersion.go
+++ b/cmd/artifactPrepareVersion.go
@@ -237,7 +237,9 @@ func runArtifactPrepareVersion(config *artifactPrepareVersionOptions, telemetryD
 	commonPipelineEnvironment.git.commitID = gitCommitID // this commitID changes and is not necessarily the HEAD commitID
 	commonPipelineEnvironment.artifactVersion = newVersion
 	commonPipelineEnvironment.originalArtifactVersion = version
-	commonPipelineEnvironment.git.commitMessage = gitCommitMessage
+
+	gitCommitMessages := strings.Split(gitCommitMessage, "\n")
+	commonPipelineEnvironment.git.commitMessage = gitCommitMessages[0]
 
 	// we may replace GetVersion() above with GetCoordinates() at some point ...
 	coordinates, err := artifact.GetCoordinates()

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -914,6 +914,6 @@ func TestTruncateString(t *testing.T) {
 
 	t.Run("input string is empty") {
 		outputStr := truncateString("", 5)
-		assertEqual(t, "", "")
+		assertEqual(t, outputStr, "")
 	}
 }

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -909,11 +909,11 @@ func TestTruncateString(t *testing.T) {
 		expected := "パイパーは..."
 
 		outputStr := truncateString(inputStr, 5)
-		assertEqual(t, outputStr, expected)
+		assert.Equal(t, outputStr, expected)
 	})
 
 	t.Run("input string is empty", func(t *testing.T) {
 		outputStr := truncateString("", 5)
-		assertEqual(t, outputStr, "")
+		assert.Equal(t, outputStr, "")
 	})
 }

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -889,31 +889,31 @@ func TestPropagateVersion(t *testing.T) {
 }
 
 func TestTruncateString(t *testing.T) {
-	t.Run("input string longer than maxLength - truncate") {
+	t.Run("input string longer than maxLength - truncate", func(t *testing.T) {
 		inputStr := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
 		expected := "Lorem ipsum dolor sit amet, consectetur adipiscing..."
 
 		outputStr := truncateString(inputStr, 50)
 		assert.Equal(t, outputStr, expected)
-	}
+	})
 
-	t.Run("input string shorter than maxLength - return as is") {
+	t.Run("input string shorter than maxLength - return as is", func(t *testing.T) {
 		inputStr := "Lorem ipsum dolor sit amet"
 		outputStr := truncateString(inputStr, 50)
 
 		assert.Equal(t, outputStr, inputStr)
-	}
+	})
 
-	t.Run("input string contains unicode chars") {
+	t.Run("input string contains unicode chars", func(t *testing.T) {
 		inputStr := "パイパーは素晴らしい図書館です"
 		expected := "パイパーは..."
 
 		outputStr := truncateString(inputStr, 5)
 		assertEqual(t, outputStr, expected)
-	}
+	})
 
-	t.Run("input string is empty") {
+	t.Run("input string is empty", func(t *testing.T) {
 		outputStr := truncateString("", 5)
 		assertEqual(t, outputStr, "")
-	}
+	})
 }

--- a/cmd/artifactPrepareVersion_test.go
+++ b/cmd/artifactPrepareVersion_test.go
@@ -887,3 +887,33 @@ func TestPropagateVersion(t *testing.T) {
 		assert.Contains(t, fmt.Sprint(err), "failed to retrieve artifact")
 	})
 }
+
+func TestTruncateString(t *testing.T) {
+	t.Run("input string longer than maxLength - truncate") {
+		inputStr := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+		expected := "Lorem ipsum dolor sit amet, consectetur adipiscing..."
+
+		outputStr := truncateString(inputStr, 50)
+		assert.Equal(t, outputStr, expected)
+	}
+
+	t.Run("input string shorter than maxLength - return as is") {
+		inputStr := "Lorem ipsum dolor sit amet"
+		outputStr := truncateString(inputStr, 50)
+
+		assert.Equal(t, outputStr, inputStr)
+	}
+
+	t.Run("input string contains unicode chars") {
+		inputStr := "パイパーは素晴らしい図書館です"
+		expected := "パイパーは..."
+
+		outputStr := truncateString(inputStr, 5)
+		assertEqual(t, outputStr, expected)
+	}
+
+	t.Run("input string is empty") {
+		outputStr := truncateString("", 5)
+		assertEqual(t, "", "")
+	}
+}


### PR DESCRIPTION
# Changes

This PR fixes issues when sometimes too long string written to the CPE git.commitMessage

Related task: [HSPIPER-347
](https://jira.tools.sap/browse/HSPIPER-347)

- [ ] Tests
- [ ] Documentation
