### PR TITLE
Fix: validate app name

### DIFF
--- a/pkg/transportrequest/cts/upload.go
+++ b/pkg/transportrequest/cts/upload.go
@@ -62,7 +62,7 @@ const (
 	abapUserKey           = "ABAP_USER"
 	abapPasswordKey       = "ABAP_PASSWORD"
 	defaultConfigFileName = "ui5-deploy.yaml"
-	pattern               = "^[a-zA-Z0-9_]+$"
+	pattern               = "^(/[A-Za-z0-9_]{3,8}/)?[A-Za-z0-9_]+$"
 )
 
 // WithConnection ...
@@ -194,7 +194,7 @@ func getFioriDeployStatement(
 	if len(app.Name) > 0 {
 		re := regexp.MustCompile(pattern)
 		if !re.MatchString(app.Name) {
-			return "", fmt.Errorf("application name '%s' contains spaces or special characters and is not according to the regex '%s'.", app.Name, pattern)
+			return "", fmt.Errorf("application name '%s' contains spaces or special characters or invalid namespace prefix and is not according to the regex '%s'.", app.Name, pattern)
 		}
 		log.Entry().Debugf("application name '%s' used from piper config", app.Name)
 		cmd = append(cmd, "--name", app.Name)

--- a/pkg/transportrequest/cts/upload_test.go
+++ b/pkg/transportrequest/cts/upload_test.go
@@ -52,7 +52,7 @@ func TestUploadCTS(t *testing.T) {
 			cmd := mock.ShellMockRunner{}
 			action := UploadAction{
 				Connection:  Connection{Endpoint: "https://example.org:8080/cts", Client: "001", User: "me", Password: "******"},
-				Application: Application{Pack: "abapPackage", Name: "appName", Desc: "the Desc"},
+				Application: Application{Pack: "abapPackage", Name: "/0ABCD/appName", Desc: "the Desc"},
 				Node: Node{
 					DeployDependencies: []string{},
 					InstallOpts:        []string{},
@@ -66,7 +66,7 @@ func TestUploadCTS(t *testing.T) {
 			if assert.NoError(t, err) {
 				assert.Regexp(
 					t,
-					"(?m)^fiori deploy --failfast --yes --username ABAP_USER --password ABAP_PASSWORD --description \"the Desc\" --noConfig --url https://example.org:8080/cts --client 001 --transport 12345678 --package abapPackage --name appName$",
+					"(?m)^fiori deploy --failfast --yes --username ABAP_USER --password ABAP_PASSWORD --description \"the Desc\" --noConfig --url https://example.org:8080/cts --client 001 --transport 12345678 --package abapPackage --name /0ABCD/appName",
 					cmd.Calls[0],
 					"Expected fiori deploy command not found",
 				)
@@ -101,11 +101,11 @@ func TestUploadCTS(t *testing.T) {
 			}
 		})
 
-		t.Run("fail in case of  invalid app name", func(t *testing.T) {
+		t.Run("fail in case of invalid app name", func(t *testing.T) {
 			cmd := mock.ShellMockRunner{}
 			action := UploadAction{
 				Connection:  Connection{Endpoint: "https://example.org:8080/cts", Client: "001", User: "me", Password: "******"},
-				Application: Application{Pack: "abapPackage", Name: "app Name", Desc: "the Desc"},
+				Application: Application{Pack: "abapPackage", Name: "/AB/app1", Desc: "the Desc"},
 				Node: Node{
 					DeployDependencies: []string{},
 					InstallOpts:        []string{},
@@ -116,7 +116,7 @@ func TestUploadCTS(t *testing.T) {
 			}
 
 			err := action.Perform(&cmd)
-			expectedErrorMessge := "application name 'app Name' contains spaces or special characters and is not according to the regex '^[a-zA-Z0-9_]+$'."
+			expectedErrorMessge := "application name '/AB/app1' contains spaces or special characters or invalid namespace prefix and is not according to the regex '^(/[A-Za-z0-9_]{3,8}/)?[A-Za-z0-9_]+$'."
 
 			assert.EqualErrorf(t, err, expectedErrorMessge, "invalid app name")
 		})


### PR DESCRIPTION
# Changes
This fix supports passing of namespace prefix to the application name which was not considered with the old PR #5123.
- [ x] Tests
- [ ] Documentation
