### PR TITLE
checkmarxOneExecuteScan: use branch name from orchestrator if not set in step config

### DIFF
--- a/cmd/checkmarxOneExecuteScan.go
+++ b/cmd/checkmarxOneExecuteScan.go
@@ -448,6 +448,7 @@ func (c *checkmarxOneExecuteScanHelper) CreateScanRequest(incremental bool, uplo
 		sastConfigString = sastConfigString + fmt.Sprintf(", languageMode %v", c.config.LanguageMode)
 	}
 
+	log.Entry().Debugf("branch = %v ; gitBranch = %v", c.config.Branch, c.config.GitBranch)
 	branch := c.config.Branch
 	if len(branch) == 0 && len(c.config.GitBranch) > 0 {
 		branch = c.config.GitBranch

--- a/cmd/checkmarxOneExecuteScan.go
+++ b/cmd/checkmarxOneExecuteScan.go
@@ -450,7 +450,7 @@ func (c *checkmarxOneExecuteScanHelper) CreateScanRequest(incremental bool, uplo
 
 	log.Entry().Debugf("branch = %v ; gitBranch = %v", c.config.Branch, c.config.GitBranch)
 	branch := c.config.Branch
-	if len(branch) == 0 && len(c.config.GitBranch) > 0 {
+	if len(branch) == 0 && len(c.config.GitBranch) > 0 && c.config.GitBranch != "n/a" {
 		branch = c.config.GitBranch
 	} else if len(branch) == 0 && len(c.config.GitBranch) == 0 { // use the branch from the orchestrator by default
 		cicdOrch, err := orchestrator.GetOrchestratorConfigProvider(nil)

--- a/cmd/checkmarxOneExecuteScan.go
+++ b/cmd/checkmarxOneExecuteScan.go
@@ -455,8 +455,13 @@ func (c *checkmarxOneExecuteScanHelper) CreateScanRequest(incremental bool, uplo
 	} else if len(branch) == 0 && (len(c.config.GitBranch) == 0 || c.config.GitBranch == "n/a") { // use the branch from the orchestrator by default
 		cicdOrch, err := orchestrator.GetOrchestratorConfigProvider(nil)
 		if err == nil {
-			branch = cicdOrch.Branch()
-			log.Entry().Infof("CxOne scan branch was automatically set to : %v", branch)
+			cicdBranch := cicdOrch.Branch()
+			if cicdBranch != "n/a" {
+				branch = cicdBranch
+				log.Entry().Infof("CxOne scan branch was automatically set to : %v", branch)
+			} else {
+				log.Entry().Info("Could not retrieve branch name from orchestrator")
+			}
 		} else {
 			log.Entry().Info("Could not identify orchestrator and set the branch")
 		}

--- a/cmd/checkmarxOneExecuteScan.go
+++ b/cmd/checkmarxOneExecuteScan.go
@@ -452,7 +452,7 @@ func (c *checkmarxOneExecuteScanHelper) CreateScanRequest(incremental bool, uplo
 	branch := c.config.Branch
 	if len(branch) == 0 && len(c.config.GitBranch) > 0 && c.config.GitBranch != "n/a" {
 		branch = c.config.GitBranch
-	} else if len(branch) == 0 && len(c.config.GitBranch) == 0 { // use the branch from the orchestrator by default
+	} else if len(branch) == 0 && (len(c.config.GitBranch) == 0 || c.config.GitBranch == "n/a") { // use the branch from the orchestrator by default
 		cicdOrch, err := orchestrator.GetOrchestratorConfigProvider(nil)
 		if err == nil {
 			branch = cicdOrch.Branch()

--- a/cmd/checkmarxOneExecuteScan.go
+++ b/cmd/checkmarxOneExecuteScan.go
@@ -20,6 +20,7 @@ import (
 	piperGithub "github.com/SAP/jenkins-library/pkg/github"
 	piperHttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/orchestrator"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/SAP/jenkins-library/pkg/reporting"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
@@ -450,6 +451,14 @@ func (c *checkmarxOneExecuteScanHelper) CreateScanRequest(incremental bool, uplo
 	branch := c.config.Branch
 	if len(branch) == 0 && len(c.config.GitBranch) > 0 {
 		branch = c.config.GitBranch
+	} else if len(branch) == 0 && len(c.config.GitBranch) == 0 { // use the branch from the orchestrator by default
+		cicdOrch, err := orchestrator.GetOrchestratorConfigProvider(nil)
+		if err == nil {
+			branch = cicdOrch.Branch()
+			log.Entry().Infof("CxOne scan branch was automatically set to : %v", branch)
+		} else {
+			log.Entry().Info("Could not identify orchestrator and set the branch")
+		}
 	}
 	if len(c.config.PullRequestName) > 0 {
 		branch = fmt.Sprintf("%v-%v", c.config.PullRequestName, c.config.Branch)


### PR DESCRIPTION
This PR will make checkmarxOneExecuteScan to set the branch of the scan to the branch that is retrieved from the orchestrator environment. 
If the branch name is set in the step config, it takes precedence. 
If the branch name is not set and it cannot be retrieved, it will be empty. 
