### PR TITLE
Modify document generator to include GHA

### DIFF
--- a/pkg/documentation/generator.go
+++ b/pkg/documentation/generator.go
@@ -86,7 +86,7 @@ func main() {
 			OpenDocTemplateFile: openDocTemplateFile,
 			DocFileWriter:       writeFile,
 			OpenFile:            openFile,
-		}, includeAzure)
+		}, includeAzure, includeGHA)
 		checkError(err)
 	}
 }

--- a/pkg/documentation/generator.go
+++ b/pkg/documentation/generator.go
@@ -32,12 +32,13 @@ func main() {
 	var docTemplatePath string
 	var customLibraryStepFile string
 	var customDefaultFiles sliceFlags
-	var includeAzure bool
+	var includeAzure, includeGHA bool
 	flag.StringVar(&metadataPath, "metadataDir", "./resources/metadata", "The directory containing the step metadata. Default points to \\'resources/metadata\\'.")
 	flag.StringVar(&docTemplatePath, "docuDir", "./documentation/docs/steps/", "The directory containing the docu stubs. Default points to \\'documentation/docs/steps/\\'.")
 	flag.StringVar(&customLibraryStepFile, "customLibraryStepFile", "", "")
 	flag.Var(&customDefaultFiles, "customDefaultFile", "Path to a custom default configuration file.")
 	flag.BoolVar(&includeAzure, "includeAzure", false, "Include Azure-specifics in step documentation.")
+	flag.BoolVar(&includeGHA, "includeGHA", false, "Include GitHub Actions-specifics in step documentation.")
 
 	// flags for stage documentation
 	var generateStageConfig bool

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -77,7 +77,7 @@ func createDescriptionSection(stepData *config.StepData) string {
 		description += fmt.Sprintf("%v    uses: SAP/project-piper-action@main\n", spacingTabBox)
 		description += fmt.Sprintf("%v    with:\n", spacingTabBox)
 		description += fmt.Sprintf("%v      step-name: %v\n", spacingTabBox, stepData.Metadata.Name)
-		description += fmt.Sprintf("%v      flags: --anyStepFlag\n", spacingTabBox)
+		description += fmt.Sprintf("%v      flags: --anyStepParameter\n", spacingTabBox)
 		description += fmt.Sprintf("%v```\n\n", spacingTabBox)
 	}
 

--- a/pkg/documentation/generator/description.go
+++ b/pkg/documentation/generator/description.go
@@ -13,7 +13,8 @@ const (
 	headlineUsage           = "## Usage\n\n"
 	headlineJenkinsPipeline = "    === \"Jenkins\"\n\n"
 	headlineCommandLine     = "    === \"Command Line\"\n\n"
-	headlineAzure           = "    === \"Azure\"\n\n"
+	headlineAzure           = "    === \"Azure DevOps\"\n\n"
+	headlineGHA             = "    === \"GitHub Actions\"\n\n"
 	spacingTabBox           = "        "
 )
 
@@ -64,6 +65,19 @@ func createDescriptionSection(stepData *config.StepData) string {
 		description += fmt.Sprintf("%v    name: %v\n", spacingTabBox, stepData.Metadata.Name)
 		description += fmt.Sprintf("%v    inputs:\n", spacingTabBox)
 		description += fmt.Sprintf("%v      stepName: %v\n", spacingTabBox, stepData.Metadata.Name)
+		description += fmt.Sprintf("%v```\n\n", spacingTabBox)
+	}
+
+	// add GiHub Actions specific information if activated
+	if includeGHA {
+		description += headlineGHA
+		description += fmt.Sprintf("%v```\n", spacingTabBox)
+		description += fmt.Sprintf("%vsteps:\n", spacingTabBox)
+		description += fmt.Sprintf("%v  - name: your preferred name for the step\n", spacingTabBox)
+		description += fmt.Sprintf("%v    uses: SAP/project-piper-action@main\n", spacingTabBox)
+		description += fmt.Sprintf("%v    with:\n", spacingTabBox)
+		description += fmt.Sprintf("%v      step-name: %v\n", spacingTabBox, stepData.Metadata.Name)
+		description += fmt.Sprintf("%v      flags: --anyStepFlag\n", spacingTabBox)
 		description += fmt.Sprintf("%v```\n\n", spacingTabBox)
 	}
 

--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -25,7 +25,7 @@ type DocuHelperData struct {
 }
 
 var stepParameterNames []string
-var includeAzure bool
+var includeAzure, includeGHA bool
 
 func readStepConfiguration(stepMetadata config.StepData, customDefaultFiles []string, docuHelperData DocuHelperData) config.StepConfig {
 	filters := stepMetadata.GetParameterFilters()

--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -58,8 +58,9 @@ func readStepConfiguration(stepMetadata config.StepData, customDefaultFiles []st
 }
 
 // GenerateStepDocumentation generates step coding based on step configuration provided in yaml files
-func GenerateStepDocumentation(metadataFiles []string, customDefaultFiles []string, docuHelperData DocuHelperData, azure bool) error {
+func GenerateStepDocumentation(metadataFiles []string, customDefaultFiles []string, docuHelperData DocuHelperData, azure bool, githubAction bool) error {
 	includeAzure = azure
+	includeGHA = githubAction
 	for key := range metadataFiles {
 		stepMetadata := readStepMetadata(metadataFiles[key], docuHelperData)
 


### PR DESCRIPTION
# Description
This PR intends to include "GitHub Actions" tab for all the piper go steps via a flag` --includeGHA`. This flag is then used by piper documentation repository to generate the "GitHb Actions" tab for steps.

Modified the document generator files (generator folder and generator.go) to include flag `--include GHA`

