### PR TITLE
fix(documentation): check param for jenkinsParams before appending Jenkins-specific text

### DIFF
--- a/pkg/documentation/generator/parameters.go
+++ b/pkg/documentation/generator/parameters.go
@@ -17,6 +17,9 @@ const (
 	deprecatedBadge  = "![deprecated](https://img.shields.io/badge/-deprecated-red)"
 )
 
+var jenkinsParams = []string{"containerCommand", "containerName", "containerShell", "dockerVolumeBind", "dockerWorkspace", "sidecarReadyCommand", "sidecarWorkspace", "stashContent"}
+
+
 // Replaces the Parameters placeholder with the content from the yaml
 func createParametersSection(stepData *config.StepData) string {
 
@@ -97,7 +100,6 @@ func parameterFurtherInfo(paramName string, stepData *config.StepData, execution
 	}
 
 	// handle non-step parameters (e.g. Jenkins-specific parameters as well as execution environment parameters)
-	jenkinsParams := []string{"containerCommand", "containerName", "containerShell", "dockerVolumeBind", "dockerWorkspace", "sidecarReadyCommand", "sidecarWorkspace", "stashContent"}
 	if !contains(stepParameterNames, paramName) {
 		for _, secret := range stepData.Spec.Inputs.Secrets {
 			if paramName == secret.Name && secret.Type == "jenkins" {
@@ -161,7 +163,7 @@ func createParameterDetails(stepData *config.StepData) string {
 	for _, param := range stepData.Spec.Inputs.Parameters {
 		details += fmt.Sprintf("#### %v\n\n", param.Name)
 
-		if !contains(stepParameterNames, param.Name) {
+		if !contains(stepParameterNames, param.Name) && contains(jenkinsParams, param.Name) {
 			details += "**Jenkins-specific:** Used for proper environment setup.\n\n"
 		}
 
@@ -200,7 +202,7 @@ func createParameterDetails(stepData *config.StepData) string {
 	for _, secret := range stepData.Spec.Inputs.Secrets {
 		details += fmt.Sprintf("#### %v\n\n", secret.Name)
 
-		if !contains(stepParameterNames, secret.Name) {
+		if !contains(stepParameterNames, secret.Name) && contains(jenkinsParams, secret.Name) {
 			details += "**Jenkins-specific:** Used for proper environment setup. See *[using credentials](https://www.jenkins.io/doc/book/using/using-credentials/)* for details.\n\n"
 		}
 

--- a/pkg/documentation/generator/parameters.go
+++ b/pkg/documentation/generator/parameters.go
@@ -19,7 +19,6 @@ const (
 
 var jenkinsParams = []string{"containerCommand", "containerName", "containerShell", "dockerVolumeBind", "dockerWorkspace", "sidecarReadyCommand", "sidecarWorkspace", "stashContent"}
 
-
 // Replaces the Parameters placeholder with the content from the yaml
 func createParametersSection(stepData *config.StepData) string {
 


### PR DESCRIPTION
# Description

"Jenkins-specific" text label has been incorrectly set for all the steps parameters (details) not defined in related step metadata yml files. This fix explicitly checks if the param/secret name in jenkinsParams before adding such text label.

# References

https://jira.tools.sap/browse/HSPIPER-237

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
