### PR TITLE
Unstash class files for Compliance stage (#5192)

### DIFF
--- a/resources/com.sap.piper/pipeline/stashSettings.yml
+++ b/resources/com.sap.piper/pipeline/stashSettings.yml
@@ -31,6 +31,7 @@ Acceptance:
 Compliance:
   unstash:
     - source
+    - classFiles
   stashes: []
 
 Performance:


### PR DESCRIPTION
# Description

Now - as we know more details - we know that unstashing the class files will resolve the sonar issue.
For more details see the [original](https://github.com/SAP/jenkins-library/pull/5192) pull request.

We also discussed that the absense of `sonar-project.properties` could cause the issue. But this file is present. It is unstashed from the `sources`-stash.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
