### PR TITLE
fix(cloudFoundryDeploy): handle large amount of mta extension credentials

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -436,7 +436,7 @@ func deployMta(config *cloudFoundryDeployOptions, mtarFilePath string, command c
 		if err != nil {
 			return fmt.Errorf("Cannot prepare mta extension files: %w", err)
 		}
-		_, _, err = handleMtaExtensionCredentials(extFile, config.MtaExtensionCredentials)
+		_, _, err = handleMtaExtensionCredentials(config, extFile, config.MtaExtensionCredentials)
 		if err != nil {
 			return fmt.Errorf("Cannot handle credentials inside mta extension files: %w", err)
 		}
@@ -456,7 +456,7 @@ func deployMta(config *cloudFoundryDeployOptions, mtarFilePath string, command c
 	return err
 }
 
-func handleMtaExtensionCredentials(extFile string, credentials map[string]interface{}) (updated, containsUnresolved bool, err error) {
+func handleMtaExtensionCredentials(config *cloudFoundryDeployOptions, extFile string, credentials map[string]interface{}) (updated, containsUnresolved bool, err error) {
 
 	log.Entry().Debugf("Inserting credentials into extension file '%s'", extFile)
 
@@ -497,7 +497,7 @@ func handleMtaExtensionCredentials(extFile string, credentials map[string]interf
 			log.Entry().Debugf("Mta extension credentials handling: Variable '%s' is not used in file '%s'", name, extFile)
 		}
 	}
-	if len(missingCredentials) > 0 {
+	if len(missingCredentials) > 0 && config.checkMissingCredentials {
 		missinCredsEnvVarKeyCompatible := []string{}
 		for _, missingKey := range missingCredentials {
 			missinCredsEnvVarKeyCompatible = append(missinCredsEnvVarKeyCompatible, toEnvVarKey(missingKey))

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -497,7 +497,7 @@ func handleMtaExtensionCredentials(config *cloudFoundryDeployOptions, extFile st
 			log.Entry().Debugf("Mta extension credentials handling: Variable '%s' is not used in file '%s'", name, extFile)
 		}
 	}
-	if len(missingCredentials) > 0 && config.checkMissingCredentials {
+	if len(missingCredentials) > 0 && config.CheckMissingCredentials {
 		missinCredsEnvVarKeyCompatible := []string{}
 		for _, missingKey := range missingCredentials {
 			missinCredsEnvVarKeyCompatible = append(missinCredsEnvVarKeyCompatible, toEnvVarKey(missingKey))

--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -40,6 +40,7 @@ type cloudFoundryDeployOptions struct {
 	MtaDeployParameters      string                 `json:"mtaDeployParameters,omitempty"`
 	MtaExtensionDescriptor   string                 `json:"mtaExtensionDescriptor,omitempty"`
 	MtaExtensionCredentials  map[string]interface{} `json:"mtaExtensionCredentials,omitempty"`
+	CheckMissingCredentials  bool                   `json:"checkMissingCredentials,omitempty"`
 	MtaPath                  string                 `json:"mtaPath,omitempty"`
 	Org                      string                 `json:"org,omitempty"`
 	Password                 string                 `json:"password,omitempty"`
@@ -245,6 +246,7 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.MtaDeployParameters, "mtaDeployParameters", `-f`, "Additional parameters passed to mta deployment command")
 	cmd.Flags().StringVar(&stepConfig.MtaExtensionDescriptor, "mtaExtensionDescriptor", os.Getenv("PIPER_mtaExtensionDescriptor"), "Defines additional extension descriptor file for deployment with the mtaDeployPlugin")
 
+	cmd.Flags().BoolVar(&stepConfig.CheckMissingCredentials, "checkMissingCredentials", true, "If this option is set to false, then Piper will not check for missing mta extension credentials in env vars. Use this option if you have large amount of mtaExtensionCredentials values.")
 	cmd.Flags().StringVar(&stepConfig.MtaPath, "mtaPath", os.Getenv("PIPER_mtaPath"), "Defines the path to *.mtar for deployment with the mtaDeployPlugin")
 	cmd.Flags().StringVar(&stepConfig.Org, "org", os.Getenv("PIPER_org"), "Cloud Foundry target organization.")
 	cmd.Flags().StringVar(&stepConfig.Password, "password", os.Getenv("PIPER_password"), "Password")
@@ -487,6 +489,15 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Type:        "map[string]interface{}",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "cloudFoundry/mtaExtensionCredentials", Deprecated: true}},
+					},
+					{
+						Name:        "checkMissingCredentials",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     true,
 					},
 					{
 						Name: "mtaPath",

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -985,6 +985,7 @@ func TestMtaExtensionCredentials(t *testing.T) {
 	err := filesMock.Chdir("/home/me")
 	assert.NoError(t, err)
 	fileUtils = &filesMock
+	config := cloudFoundryDeployOptions{}
 
 	_environ = func() []string {
 		return []string{
@@ -999,7 +1000,7 @@ func TestMtaExtensionCredentials(t *testing.T) {
 	}()
 
 	t.Run("extension file does not exist", func(t *testing.T) {
-		_, _, err := handleMtaExtensionCredentials("mtaextDoesNotExist.mtaext", map[string]interface{}{})
+		_, _, err := handleMtaExtensionCredentials(&config, "mtaextDoesNotExist.mtaext", map[string]interface{}{})
 		assert.EqualError(t, err, "Cannot handle credentials for mta extension file 'mtaextDoesNotExist.mtaext': could not read 'mtaextDoesNotExist.mtaext'")
 	})
 
@@ -1013,6 +1014,7 @@ func TestMtaExtensionCredentials(t *testing.T) {
 					test-credentials1: "<%= testCred1 %>"
 					test-credentials2: "<%=testCred2%>"`))
 		_, _, err := handleMtaExtensionCredentials(
+			&config,
 			"mtaext.mtaext",
 			map[string]interface{}{
 				"testCred1": "myCredEnvVar1NotDefined",
@@ -1032,6 +1034,7 @@ func TestMtaExtensionCredentials(t *testing.T) {
 					test-credentials1: "<%= testCred1 %>"
 					test-credentials2: "<%=testCred2%>`))
 		_, _, err := handleMtaExtensionCredentials(
+			&config,
 			"mtaext.mtaext",
 			map[string]interface{}{
 				"testCred1":       "myCredEnvVar1",
@@ -1050,7 +1053,9 @@ func TestMtaExtensionCredentials(t *testing.T) {
 				parameters
 					test-credentials1: "<%= testCred1 %>"
 					test-credentials2: "<%=testCred2%>`))
-		_, _, err := handleMtaExtensionCredentials("mtaext.mtaext",
+		_, _, err := handleMtaExtensionCredentials(
+			&config,
+			"mtaext.mtaext",
 			map[string]interface{}{
 				"test.*Cred1": "myCredEnvVar1",
 			},
@@ -1061,7 +1066,7 @@ func TestMtaExtensionCredentials(t *testing.T) {
 	t.Run("unresolved placeholders does not cause an error", func(t *testing.T) {
 		// we emit a log message, but it does not fail
 		filesMock.AddFile("mtaext-unresolved.mtaext", []byte("<%= unresolved %>"))
-		updated, containsUnresolved, err := handleMtaExtensionCredentials("mtaext-unresolved.mtaext", map[string]interface{}{})
+		updated, containsUnresolved, err := handleMtaExtensionCredentials(&config, "mtaext-unresolved.mtaext", map[string]interface{}{})
 		assert.True(t, containsUnresolved)
 		assert.False(t, updated)
 		assert.NoError(t, err)
@@ -1080,6 +1085,7 @@ func TestMtaExtensionCredentials(t *testing.T) {
 				test-credentials4: "<%=testCred2 %>"
 				test-credentials5: "<%=  testCred2    %>"`))
 		updated, containsUnresolved, err := handleMtaExtensionCredentials(
+			&config,
 			mtaFileName,
 			map[string]interface{}{
 				"testCred1": "myCredEnvVar1",

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -55,6 +55,20 @@ func (m manifestMock) WriteManifest() error {
 	return nil
 }
 
+// everything below in the config map annotated with '//default' is a default in the metadata
+// since we don't get injected these values during the tests we set it here.
+defaultConfig := cloudFoundryDeployOptions{
+	Org:                     "myOrg",
+	Space:                   "mySpace",
+	Username:                "me",
+	Password:                "******",
+	APIEndpoint:             "https://examples.sap.com/cf",
+	Manifest:                "manifest.yml", // default
+	MtaDeployParameters:     "-f",           // default
+	DeployType:              "standard",     // default
+	CheckMissingCredentials: true,           // default
+}
+
 func TestCfDeployment(t *testing.T) {
 
 	defer func() {
@@ -67,20 +81,6 @@ func TestCfDeployment(t *testing.T) {
 	err := filesMock.Chdir("/home/me")
 	assert.NoError(t, err)
 	fileUtils = &filesMock
-
-	// everything below in the config map annotated with '//default' is a default in the metadata
-	// since we don't get injected these values during the tests we set it here.
-	defaultConfig := cloudFoundryDeployOptions{
-		Org:                     "myOrg",
-		Space:                   "mySpace",
-		Username:                "me",
-		Password:                "******",
-		APIEndpoint:             "https://examples.sap.com/cf",
-		Manifest:                "manifest.yml", // default
-		MtaDeployParameters:     "-f",           // default
-		DeployType:              "standard",     // default
-		CheckMissingCredentials: true,           // default
-	}
 
 	config := defaultConfig
 
@@ -986,7 +986,7 @@ func TestMtaExtensionCredentials(t *testing.T) {
 	err := filesMock.Chdir("/home/me")
 	assert.NoError(t, err)
 	fileUtils = &filesMock
-	config := cloudFoundryDeployOptions{}
+	config := defaultConfig
 
 	_environ = func() []string {
 		return []string{

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -71,14 +71,15 @@ func TestCfDeployment(t *testing.T) {
 	// everything below in the config map annotated with '//default' is a default in the metadata
 	// since we don't get injected these values during the tests we set it here.
 	defaultConfig := cloudFoundryDeployOptions{
-		Org:                 "myOrg",
-		Space:               "mySpace",
-		Username:            "me",
-		Password:            "******",
-		APIEndpoint:         "https://examples.sap.com/cf",
-		Manifest:            "manifest.yml", // default
-		MtaDeployParameters: "-f",           // default
-		DeployType:          "standard",     // default
+		Org:                     "myOrg",
+		Space:                   "mySpace",
+		Username:                "me",
+		Password:                "******",
+		APIEndpoint:             "https://examples.sap.com/cf",
+		Manifest:                "manifest.yml", // default
+		MtaDeployParameters:     "-f",           // default
+		DeployType:              "standard",     // default
+		CheckMissingCredentials: true,           // default
 	}
 
 	config := defaultConfig

--- a/cmd/cloudFoundryDeploy_test.go
+++ b/cmd/cloudFoundryDeploy_test.go
@@ -57,7 +57,7 @@ func (m manifestMock) WriteManifest() error {
 
 // everything below in the config map annotated with '//default' is a default in the metadata
 // since we don't get injected these values during the tests we set it here.
-defaultConfig := cloudFoundryDeployOptions{
+var defaultConfig = cloudFoundryDeployOptions{
 	Org:                     "myOrg",
 	Space:                   "mySpace",
 	Username:                "me",

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -296,6 +296,15 @@ spec:
         aliases:
           - name: cloudFoundry/mtaExtensionCredentials
             deprecated: true
+      - name: checkMissingCredentials
+        type: bool
+        description: "If this option is set to false, then Piper will not check for missing mta extension credentials in env vars. Use this option if you have large amount of mtaExtensionCredentials values."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        mandatory: false
+        default: true
       - name: mtaPath
         type: string
         description: "Defines the path to *.mtar for deployment with the mtaDeployPlugin"

--- a/test/groovy/CloudFoundryDeployTest.groovy
+++ b/test/groovy/CloudFoundryDeployTest.groovy
@@ -45,6 +45,7 @@ class CloudFoundryDeployTest extends BasePiperTest {
             juStabUtils            : utils,
             useGoStep              : true,
             mtaExtensionCredentials: [myCred: 'Mta.ExtensionCredential~Credential_Id1'],
+            checkMissingCredentials: true,
         ])
 
         assertEquals('cloudFoundryDeploy', calledStep)
@@ -74,7 +75,8 @@ class CloudFoundryDeployTest extends BasePiperTest {
         })
 
         nullScript.commonPipelineEnvironment.configuration = [steps:[cloudFoundryDeploy:[
-            mtaExtensionCredentials: [myCred: 'Mta.ExtensionCredential~Credential_Id1']
+            mtaExtensionCredentials: [myCred: 'Mta.ExtensionCredential~Credential_Id1'],
+            checkMissingCredentials: true,
         ]]]
 
         stepRule.step.cloudFoundryDeploy([

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -17,7 +17,7 @@ void call(Map parameters = [:]) {
     ]
 
     Map mtaExtensionCredentials = parameters.mtaExtensionCredentials ?: script.commonPipelineEnvironment.getStepConfiguration(STEP_NAME, stageName).mtaExtensionCredentials
-    Bool checkMissingCredentials = parameters.checkMissingCredentials ?: script.commonPipelineEnvironment.getStepConfiguration(STEP_NAME, stageName).checkMissingCredentials
+    boolean checkMissingCredentials = parameters.checkMissingCredentials ?: script.commonPipelineEnvironment.getStepConfiguration(STEP_NAME, stageName).checkMissingCredentials
 
     if (mtaExtensionCredentials) {
         if (checkMissingCredentials) {

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -20,7 +20,7 @@ void call(Map parameters = [:]) {
     Bool checkMissingCredentials = parameters.checkMissingCredentials ?: script.commonPipelineEnvironment.getStepConfiguration(STEP_NAME, stageName).checkMissingCredentials
 
     if (mtaExtensionCredentials) {
-        if checkMissingCredentials {
+        if (checkMissingCredentials) {
             mtaExtensionCredentials.each { key, credentialsId ->
             echo "[INFO]${STEP_NAME}] Preparing credential for being used by piper-go. key: ${key}, credentialsId is: ${credentialsId}, exposed as environment variable ${toEnvVarKey(credentialsId)}"
             credentials << [type: 'token', id: credentialsId, env: [toEnvVarKey(credentialsId)], resolveCredentialsId: false]

--- a/vars/cloudFoundryDeploy.groovy
+++ b/vars/cloudFoundryDeploy.groovy
@@ -17,11 +17,14 @@ void call(Map parameters = [:]) {
     ]
 
     Map mtaExtensionCredentials = parameters.mtaExtensionCredentials ?: script.commonPipelineEnvironment.getStepConfiguration(STEP_NAME, stageName).mtaExtensionCredentials
+    Bool checkMissingCredentials = parameters.checkMissingCredentials ?: script.commonPipelineEnvironment.getStepConfiguration(STEP_NAME, stageName).checkMissingCredentials
 
     if (mtaExtensionCredentials) {
-        mtaExtensionCredentials.each { key, credentialsId ->
+        if checkMissingCredentials {
+            mtaExtensionCredentials.each { key, credentialsId ->
             echo "[INFO]${STEP_NAME}] Preparing credential for being used by piper-go. key: ${key}, credentialsId is: ${credentialsId}, exposed as environment variable ${toEnvVarKey(credentialsId)}"
             credentials << [type: 'token', id: credentialsId, env: [toEnvVarKey(credentialsId)], resolveCredentialsId: false]
+            }
         }
     }
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)


### PR DESCRIPTION
# Description

This is PoC PR that about to bypass limitation on large amount of mta extension credentials set in .pipeline/config.yaml for cloudFoundryDeploy step. 

We introduce step parameter "checkMissingCredentials". If this option is set to false, then Piper will not check for missing mta extension credentials in env vars. Use this option if you have large amount of mtaExtensionCredentials values.

# References

[INC10351618 | Blocked service deployment due to failing cloudFoundryDeploy
](https://itsm.services.sap/now/cwf/agent/record/incident/f78b2fa3eb9656504eb9fa05cad0cdf3)

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
