### PR TITLE
feat(detect): Add support for Detect 10

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -431,7 +431,7 @@ func getDetectScript(config detectExecuteScanOptions, utils detectUtils) error {
 		if config.UseDetect8 {
 			return utils.DownloadFile("https://detect.blackduck.com/detect8.sh", "detect.sh", nil, nil)
 		} else if config.UseDetect10 {
-			return utils.DownloadFile("https://detect.blackduck.com/detect9.sh", "detect.sh", nil, nil)
+			return utils.DownloadFile("https://detect.blackduck.com/detect10.sh", "detect.sh", nil, nil)
 		}
 		return utils.DownloadFile("https://detect.blackduck.com/detect9.sh", "detect.sh", nil, nil)
 

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -429,9 +429,11 @@ func getDetectScript(config detectExecuteScanOptions, utils detectUtils) error {
 
 	downloadScript := func() error {
 		if config.UseDetect8 {
-			return utils.DownloadFile("https://detect.synopsys.com/detect8.sh", "detect.sh", nil, nil)
+			return utils.DownloadFile("https://detect.blackduck.com/detect8.sh", "detect.sh", nil, nil)
+		} else if config.UseDetect10 {
+			return utils.DownloadFile("https://detect.blackduck.com/detect9.sh", "detect.sh", nil, nil)
 		}
-		return utils.DownloadFile("https://detect.synopsys.com/detect9.sh", "detect.sh", nil, nil)
+		return utils.DownloadFile("https://detect.blackduck.com/detect9.sh", "detect.sh", nil, nil)
 
 	}
 

--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -430,10 +430,10 @@ func getDetectScript(config detectExecuteScanOptions, utils detectUtils) error {
 	downloadScript := func() error {
 		if config.UseDetect8 {
 			return utils.DownloadFile("https://detect.blackduck.com/detect8.sh", "detect.sh", nil, nil)
-		} else if config.UseDetect10 {
-			return utils.DownloadFile("https://detect.blackduck.com/detect10.sh", "detect.sh", nil, nil)
+		} else if config.UseDetect9 {
+			return utils.DownloadFile("https://detect.blackduck.com/detect9.sh", "detect.sh", nil, nil)
 		}
-		return utils.DownloadFile("https://detect.blackduck.com/detect9.sh", "detect.sh", nil, nil)
+		return utils.DownloadFile("https://detect.blackduck.com/detect10.sh", "detect.sh", nil, nil)
 
 	}
 

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -78,7 +78,7 @@ type detectExecuteScanOptions struct {
 	RepositoryUsername              string   `json:"repositoryUsername,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
 	RepositoryPassword              string   `json:"repositoryPassword,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
 	UseDetect8                      bool     `json:"useDetect8,omitempty"`
-	UseDetect10                     bool     `json:"useDetect10,omitempty"`
+	UseDetect9                      bool     `json:"useDetect9,omitempty"`
 }
 
 type detectExecuteScanInflux struct {
@@ -359,7 +359,7 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.RepositoryUsername, "repositoryUsername", os.Getenv("PIPER_repositoryUsername"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryPassword, "repositoryPassword", os.Getenv("PIPER_repositoryPassword"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect Script instead of v9")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect10, "useDetect10", false, "This flag enables the use of the supported version 10 of the Detect Script instead of v9")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect Script instead of v8")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -961,12 +961,12 @@ func detectExecuteScanMetadata() config.StepData {
 						Default:     false,
 					},
 					{
-						Name:        "useDetect10",
+						Name:        "useDetect9",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "detect/useDetect10"}},
+						Aliases:     []config.Alias{{Name: "detect/useDetect9"}},
 						Default:     false,
 					},
 				},

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -359,9 +359,9 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.RegistryURL, "registryUrl", os.Getenv("PIPER_registryUrl"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryUsername, "repositoryUsername", os.Getenv("PIPER_repositoryUsername"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryPassword, "repositoryPassword", os.Getenv("PIPER_repositoryPassword"), "Used accessing for the images to be scanned (typically filled by CPE)")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect Script instead of default version")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect Script instead of default version")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect10, "useDetect10", true, "This flag enables the use of the supported version 10 of the Detect Script")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect script instead of default version")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect script instead of default version")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect10, "useDetect10", true, "This flag enables the use of the supported version 10 of the Detect script")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -78,6 +78,7 @@ type detectExecuteScanOptions struct {
 	RepositoryUsername              string   `json:"repositoryUsername,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
 	RepositoryPassword              string   `json:"repositoryPassword,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
 	UseDetect8                      bool     `json:"useDetect8,omitempty"`
+	UseDetect10                     bool     `json:"useDetect10,omitempty"`
 }
 
 type detectExecuteScanInflux struct {
@@ -358,6 +359,7 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.RepositoryUsername, "repositoryUsername", os.Getenv("PIPER_repositoryUsername"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryPassword, "repositoryPassword", os.Getenv("PIPER_repositoryPassword"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect Script instead of v9")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect10, "useDetect10", false, "This flag enables the use of the supported version 10 of the Detect Script instead of v9")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -956,6 +958,15 @@ func detectExecuteScanMetadata() config.StepData {
 						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "detect/useDetect8"}},
+						Default:     false,
+					},
+					{
+						Name:        "useDetect10",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "detect/useDetect10"}},
 						Default:     false,
 					},
 				},

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -977,7 +977,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "detect/useDetect9"}},
+						Aliases:     []config.Alias{{Name: "detect/useDetect10"}},
 						Default:     true,
 					},
 				},

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -79,7 +79,6 @@ type detectExecuteScanOptions struct {
 	RepositoryPassword              string   `json:"repositoryPassword,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
 	UseDetect8                      bool     `json:"useDetect8,omitempty"`
 	UseDetect9                      bool     `json:"useDetect9,omitempty"`
-	UseDetect10                     bool     `json:"useDetect10,omitempty"`
 }
 
 type detectExecuteScanInflux struct {
@@ -359,9 +358,8 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.RegistryURL, "registryUrl", os.Getenv("PIPER_registryUrl"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryUsername, "repositoryUsername", os.Getenv("PIPER_repositoryUsername"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryPassword, "repositoryPassword", os.Getenv("PIPER_repositoryPassword"), "Used accessing for the images to be scanned (typically filled by CPE)")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect script instead of default version")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect script instead of default version")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect10, "useDetect10", true, "This flag enables the use of the supported version 10 of the Detect script")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect script instead of default version 10")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect script instead of default version 10")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -970,15 +968,6 @@ func detectExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "detect/useDetect9"}},
 						Default:     false,
-					},
-					{
-						Name:        "useDetect10",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "bool",
-						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "detect/useDetect10"}},
-						Default:     true,
 					},
 				},
 			},

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -79,6 +79,7 @@ type detectExecuteScanOptions struct {
 	RepositoryPassword              string   `json:"repositoryPassword,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
 	UseDetect8                      bool     `json:"useDetect8,omitempty"`
 	UseDetect9                      bool     `json:"useDetect9,omitempty"`
+	UseDetect10                     bool     `json:"useDetect10,omitempty"`
 }
 
 type detectExecuteScanInflux struct {
@@ -358,8 +359,9 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.RegistryURL, "registryUrl", os.Getenv("PIPER_registryUrl"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryUsername, "repositoryUsername", os.Getenv("PIPER_repositoryUsername"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryPassword, "repositoryPassword", os.Getenv("PIPER_repositoryPassword"), "Used accessing for the images to be scanned (typically filled by CPE)")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect Script instead of v9")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect Script instead of v8")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect Script instead of default version")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect Script instead of default version")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect10, "useDetect10", true, "This flag enables the use of the supported version 10 of the Detect Script")
 
 	cmd.MarkFlagRequired("token")
 	cmd.MarkFlagRequired("projectName")
@@ -968,6 +970,15 @@ func detectExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "detect/useDetect9"}},
 						Default:     false,
+					},
+					{
+						Name:        "useDetect10",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "detect/useDetect9"}},
+						Default:     true,
 					},
 				},
 			},

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -310,7 +310,7 @@ func TestRunDetect(t *testing.T) {
 		utilsMock.AddFile("detect.sh", []byte(""))
 		err := runDetect(ctx, detectExecuteScanOptions{}, utilsMock, &detectExecuteScanInflux{})
 
-		assert.Equal(t, utilsMock.downloadedFiles["https://detect.blackduck.com/detect9.sh"], "detect.sh")
+		assert.Equal(t, utilsMock.downloadedFiles["https://detect.blackduck.com/detect10.sh"], "detect.sh")
 		assert.True(t, utilsMock.HasRemovedFile("detect.sh"))
 		assert.NoError(t, err)
 		assert.Equal(t, ".", utilsMock.Dir, "Wrong execution directory used")

--- a/cmd/detectExecuteScan_test.go
+++ b/cmd/detectExecuteScan_test.go
@@ -310,7 +310,7 @@ func TestRunDetect(t *testing.T) {
 		utilsMock.AddFile("detect.sh", []byte(""))
 		err := runDetect(ctx, detectExecuteScanOptions{}, utilsMock, &detectExecuteScanInflux{})
 
-		assert.Equal(t, utilsMock.downloadedFiles["https://detect.synopsys.com/detect9.sh"], "detect.sh")
+		assert.Equal(t, utilsMock.downloadedFiles["https://detect.blackduck.com/detect9.sh"], "detect.sh")
 		assert.True(t, utilsMock.HasRemovedFile("detect.sh"))
 		assert.NoError(t, err)
 		assert.Equal(t, ".", utilsMock.Dir, "Wrong execution directory used")

--- a/pkg/whitesource/configHelper.go
+++ b/pkg/whitesource/configHelper.go
@@ -153,7 +153,7 @@ func (c *ConfigOptions) addGeneralDefaults(config *ScanOptions, utils Utils, pro
 		{Name: "forceUpdate", Value: true, Force: true},
 		{Name: "offline", Value: false, Force: true},
 		{Name: "resolveAllDependencies", Value: false, Force: false},
-		{Name: "failErrorLevel", Value: "ALL", Force: true},
+		{Name: "failErrorLevel", Value: "ALL", Force: false},
 		{Name: "case.sensitive.glob", Value: false},
 		{Name: "followSymbolicLinks", Value: true},
 	}...)

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -655,7 +655,7 @@ spec:
             param: container/repositoryPassword
       - name: useDetect8
         description:
-          "This flag enables the use of the supported version 8 of the Detect Script instead of default version"
+          "This flag enables the use of the supported version 8 of the Detect script instead of default version"
         aliases:
           - name: detect/useDetect8
         type: bool
@@ -666,7 +666,7 @@ spec:
         default: false
       - name: useDetect9
         description:
-          "This flag enables the use of the supported version 9 of the Detect Script instead of default version"
+          "This flag enables the use of the supported version 9 of the Detect script instead of default version"
         aliases:
           - name: detect/useDetect9
         type: bool
@@ -677,7 +677,7 @@ spec:
         default: false
       - name: useDetect10
         description:
-          "This flag enables the use of the supported version 10 of the Detect Script"
+          "This flag enables the use of the supported version 10 of the Detect script"
         aliases:
           - name: detect/useDetect10
         type: bool
@@ -685,7 +685,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        default: true 
+        default: true
   outputs:
     resources:
       - name: influx

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -655,7 +655,7 @@ spec:
             param: container/repositoryPassword
       - name: useDetect8
         description:
-          "This flag enables the use of the supported version 8 of the Detect Script instead of v9"
+          "This flag enables the use of the supported version 8 of the Detect Script instead of v10"
         aliases:
           - name: detect/useDetect8
         type: bool
@@ -666,7 +666,7 @@ spec:
         default: false
       - name: useDetect9
         description:
-          "This flag enables the use of the supported version 9 of the Detect Script instead of v8"
+          "This flag enables the use of the supported version 9 of the Detect Script instead of v10"
         aliases:
           - name: detect/useDetect9
         type: bool

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -655,7 +655,7 @@ spec:
             param: container/repositoryPassword
       - name: useDetect8
         description:
-          "This flag enables the use of the supported version 8 of the Detect script instead of default version"
+          "This flag enables the use of the supported version 8 of the Detect script instead of default version 10"
         aliases:
           - name: detect/useDetect8
         type: bool
@@ -666,7 +666,7 @@ spec:
         default: false
       - name: useDetect9
         description:
-          "This flag enables the use of the supported version 9 of the Detect script instead of default version"
+          "This flag enables the use of the supported version 9 of the Detect script instead of default version 10"
         aliases:
           - name: detect/useDetect9
         type: bool
@@ -675,17 +675,6 @@ spec:
           - STAGES
           - STEPS
         default: false
-      - name: useDetect10
-        description:
-          "This flag enables the use of the supported version 10 of the Detect script"
-        aliases:
-          - name: detect/useDetect10
-        type: bool
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
-        default: true
   outputs:
     resources:
       - name: influx

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -664,11 +664,11 @@ spec:
           - STAGES
           - STEPS
         default: false
-      - name: useDetect10
+      - name: useDetect9
         description:
-          "This flag enables the use of the supported version 10 of the Detect Script instead of v9"
+          "This flag enables the use of the supported version 9 of the Detect Script instead of v8"
         aliases:
-          - name: detect/useDetect10
+          - name: detect/useDetect9
         type: bool
         scope:
           - PARAMETERS

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -655,7 +655,7 @@ spec:
             param: container/repositoryPassword
       - name: useDetect8
         description:
-          "This flag enables the use of the supported version 8 of the Detect Script instead of v10"
+          "This flag enables the use of the supported version 8 of the Detect Script instead of default version"
         aliases:
           - name: detect/useDetect8
         type: bool
@@ -666,7 +666,7 @@ spec:
         default: false
       - name: useDetect9
         description:
-          "This flag enables the use of the supported version 9 of the Detect Script instead of v10"
+          "This flag enables the use of the supported version 9 of the Detect Script instead of default version"
         aliases:
           - name: detect/useDetect9
         type: bool
@@ -675,6 +675,17 @@ spec:
           - STAGES
           - STEPS
         default: false
+      - name: useDetect10
+        description:
+          "This flag enables the use of the supported version 10 of the Detect Script"
+        aliases:
+          - name: detect/useDetect10
+        type: bool
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: true 
   outputs:
     resources:
       - name: influx

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -664,6 +664,17 @@ spec:
           - STAGES
           - STEPS
         default: false
+      - name: useDetect10
+        description:
+          "This flag enables the use of the supported version 10 of the Detect Script instead of v9"
+        aliases:
+          - name: detect/useDetect10
+        type: bool
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: false
   outputs:
     resources:
       - name: influx


### PR DESCRIPTION
# Description
Added the detect 10 parameter, user can use useDetect10 field to use the detect version 10 in their scan.
Change the repo name from detect.synopsys.com to detect.blackduck.com as per vendor instruction. 
Changed the  failErrorLevel flag from true to false as by-default.
# Checklist

- [x] Tests
- [x] Documentation
- [ ] Inner source library needs updating
