### PR TITLE
Exclude README and CONTRIBUTING files from release packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+README.md export-ignore
+CONTRIBUTING.md export-ignore

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -27,6 +27,21 @@ jobs:
           cp ./piper_master-darwin.arm64 ./piper-darwin.arm64
           npm install semver --quiet
           echo "PIPER_version=v$(node_modules/.bin/semver -i minor $(curl --silent "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest" | jq -r .tag_name))" >> $GITHUB_ENV
+          echo "ARCHIVE_NAME=jenkins-library-${{ env.PIPER_version }}" >> $GITHUB_ENV
+
+      - name: Create ZIP Archive
+        run: git archive --format=zip --output=${{ env.ARCHIVE_NAME }}.zip HEAD
+
+      - name: Create TAR.GZ Archive
+        run: git archive --format=tar.gz --output=${{ env.ARCHIVE_NAME }}.tar.gz HEAD
+
+      - name: Upload Archives
+        uses: actions/upload-release-artifact@v4
+        with:
+          name: release-archives
+          path: |
+            ${{ env.ARCHIVE_NAME }}.zip
+            ${{ env.ARCHIVE_NAME }}.tar.gz
 
       - uses: SAP/project-piper-action@master
         name: Publish prerelease
@@ -39,6 +54,7 @@ jobs:
             --assetPathList ./piper --assetPathList ./piper_master
             --assetPathList ./piper-darwin.x86_64 --assetPathList ./piper_master-darwin.x86_64
             --assetPathList ./piper-darwin.arm64 --assetPathList ./piper_master-darwin.arm64
+            --assetPathList ./${{ env.ARCHIVE_NAME }}.zip --assetPathList ./${{ env.ARCHIVE_NAME }}.tar.gz
 
       - name: Download Piper binary from recently published prerelease
         uses: robinraju/release-downloader@v1


### PR DESCRIPTION
# Description
To fix the license risks these two files should be removed from the releases packages.

# Checklist

- [x] Tests
- [ ] Documentation
- [ ] Inner source library needs updating


tests are done in this repo, check the latest release where README is excluded as per .gitattributes https://github.com/D074360/minimal-github-actions