### PR TITLE
Exclude README and CONTRIBUTING files from release packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+README.md export-ignore
+CONTRIBUTING.md export-ignore


### PR DESCRIPTION
From the testing it looks like just the attribute file is sufficient to exclude files. 

Tested: https://github.com/D074360/minimal-github-actions

Note: As our workflows are run from composite workflows from other repository this approach might not be sufficient.
