### PR TITLE
feat: add ability to pass flags to setup.py in pythonBuild step

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -52,7 +52,6 @@ func pythonBuild(config pythonBuildOptions, telemetryData *telemetry.CustomData,
 }
 
 func runPythonBuild(config *pythonBuildOptions, telemetryData *telemetry.CustomData, utils pythonBuildUtils, commonPipelineEnvironment *pythonBuildCommonPipelineEnvironment) error {
-
 	pipInstallFlags := []string{"install", "--upgrade"}
 	virutalEnvironmentPathMap := make(map[string]string)
 
@@ -106,10 +105,11 @@ func runPythonBuild(config *pythonBuildOptions, telemetryData *telemetry.CustomD
 }
 
 func buildExecute(config *pythonBuildOptions, utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string) error {
-
 	var flags []string
 	flags = append(flags, config.BuildFlags...)
-	flags = append(flags, "setup.py", "sdist", "bdist_wheel")
+	flags = append(flags, "setup.py")
+	flags = append(flags, config.SetupFlags...)
+	flags = append(flags, "sdist", "bdist_wheel")
 
 	log.Entry().Info("starting building python project:")
 	err := utils.RunExecutable(virutalEnvironmentPathMap["python"], flags...)

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -20,6 +20,7 @@ import (
 
 type pythonBuildOptions struct {
 	BuildFlags               []string `json:"buildFlags,omitempty"`
+	SetupFlags               []string `json:"setupFlags,omitempty"`
 	CreateBOM                bool     `json:"createBOM,omitempty"`
 	Publish                  bool     `json:"publish,omitempty"`
 	TargetRepositoryPassword string   `json:"targetRepositoryPassword,omitempty"`
@@ -192,7 +193,8 @@ and are exposed are environment variables that must be present in the environmen
 }
 
 func addPythonBuildFlags(cmd *cobra.Command, stepConfig *pythonBuildOptions) {
-	cmd.Flags().StringSliceVar(&stepConfig.BuildFlags, "buildFlags", []string{}, "Defines list of build flags to be used.")
+	cmd.Flags().StringSliceVar(&stepConfig.BuildFlags, "buildFlags", []string{}, "Defines list of build flags passed to python binary.")
+	cmd.Flags().StringSliceVar(&stepConfig.SetupFlags, "setupFlags", []string{}, "Defines list of flags passed to setup.py.")
 	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using CycloneDX plugin.")
 	cmd.Flags().BoolVar(&stepConfig.Publish, "publish", false, "Configures the build to publish artifacts to a repository.")
 	cmd.Flags().StringVar(&stepConfig.TargetRepositoryPassword, "targetRepositoryPassword", os.Getenv("PIPER_targetRepositoryPassword"), "Password for the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment.")
@@ -217,6 +219,15 @@ func pythonBuildMetadata() config.StepData {
 				Parameters: []config.StepParameters{
 					{
 						Name:        "buildFlags",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "[]string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     []string{},
+					},
+					{
+						Name:        "setupFlags",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "[]string",

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -105,3 +105,34 @@ func TestRunPythonBuild(t *testing.T) {
 		assert.Equal(t, []string{"--e", "--output", "bom-pip.xml", "--format", "xml", "--schema-version", "1.4"}, utils.ExecMockRunner.Calls[4].Params)
 	})
 }
+
+func TestPythonBuildExecute(t *testing.T) {
+	t.Run("Test build with flags", func(t *testing.T) {
+		config := pythonBuildOptions{
+			BuildFlags:             []string{"--verbose"},
+			SetupFlags:             []string{"egg_info", "--tag-build=pr13"},
+			VirutalEnvironmentName: "venv",
+		}
+
+		utils := pythonBuildMockUtils{
+			ExecMockRunner: &mock.ExecMockRunner{},
+		}
+
+		virutalEnvironmentPathMap := map[string]string{
+			"python": "python",
+		}
+
+		err := buildExecute(&config, &utils, []string{}, virutalEnvironmentPathMap)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "python", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{
+			"--verbose",
+			"setup.py",
+			"egg_info",
+			"--tag-build=pr13",
+			"sdist",
+			"bdist_wheel",
+		}, utils.ExecMockRunner.Calls[0].Params)
+	})
+}

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -18,7 +18,14 @@ spec:
     params:
       - name: buildFlags
         type: "[]string"
-        description: Defines list of build flags to be used.
+        description: Defines list of build flags passed to python binary.
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+      - name: setupFlags
+        type: "[]string"
+        description: Defines list of flags passed to setup.py.
         scope:
           - PARAMETERS
           - STAGES


### PR DESCRIPTION
# Description
Adds ability for users to pass parameters to `setup.py` rather than only the `python` binary.

# Checklist

- [X] Tests
- [X] Documentation
- [ ] Inner source library needs updating
