### PR TITLE
chore(Splunk): expose orchestrator to Splunk

### DIFF
--- a/pkg/splunk/data.go
+++ b/pkg/splunk/data.go
@@ -18,6 +18,7 @@ type Details struct {
 type MonitoringData struct {
 	PipelineUrlHash string `json:"PipelineUrlHash,omitempty"`
 	BuildUrlHash    string `json:"BuildUrlHash,omitempty"`
+	Orchestrator    string `json:"Orchestrator,omitempty"`
 	StageName       string `json:"StageName,omitempty"`
 	StepName        string `json:"StepName,omitempty"`
 	ExitCode        string `json:"ExitCode,omitempty"`

--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -114,6 +114,7 @@ func (s *Splunk) prepareTelemetry(telemetryData telemetry.Data) MonitoringData {
 	monitoringData := MonitoringData{
 		PipelineUrlHash: telemetryData.PipelineURLHash,
 		BuildUrlHash:    telemetryData.BuildURLHash,
+		Orchestrator:    telemetryData.Orchestrator,
 		StageName:       telemetryData.StageName,
 		StepName:        telemetryData.BaseData.StepName,
 		ExitCode:        telemetryData.CustomData.ErrorCode,

--- a/pkg/splunk/splunk_test.go
+++ b/pkg/splunk/splunk_test.go
@@ -367,7 +367,7 @@ func Test_prepareTelemetry(t *testing.T) {
 			want: MonitoringData{
 				PipelineUrlHash: "",
 				BuildUrlHash:    "",
-				Orchestrator:	 "Jenkins",
+				Orchestrator:    "Jenkins",
 				StageName:       "",
 				StepName:        "",
 				ExitCode:        "0",

--- a/pkg/splunk/splunk_test.go
+++ b/pkg/splunk/splunk_test.go
@@ -354,7 +354,9 @@ func Test_prepareTelemetry(t *testing.T) {
 		{name: "Testing prepare telemetry information",
 			args: args{
 				telemetryData: telemetry.Data{
-					BaseData: telemetry.BaseData{},
+					BaseData: telemetry.BaseData{
+						Orchestrator: "Jenkins",
+					},
 					CustomData: telemetry.CustomData{
 						Duration:      "1234",
 						ErrorCode:     "0",
@@ -365,6 +367,7 @@ func Test_prepareTelemetry(t *testing.T) {
 			want: MonitoringData{
 				PipelineUrlHash: "",
 				BuildUrlHash:    "",
+				Orchestrator:	 "Jenkins",
 				StageName:       "",
 				StepName:        "",
 				ExitCode:        "0",


### PR DESCRIPTION
# Changes

This exposes the used orchestrator to the telemetry data sent to Splunk.