### PR TITLE
chore(github-actions): Upgrade actions/upload-artifact v3 to v4

### DIFF
--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -82,7 +82,7 @@ jobs:
         run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o piper -tags release
       - name: Upload Piper binary
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: piper
           path: piper
@@ -110,7 +110,7 @@ jobs:
           echo "matrix=$(go run .github/workflows/parse_integration_test_list.go -file ./integration/github_actions_integration_test_list.yml)" >> "$GITHUB_OUTPUT"
       - name: Upload integration tests binary
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration_tests
           path: integration_tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,7 +53,7 @@ jobs:
         run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o piper -tags release
       - name: Upload Piper binary
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: piper
           path: piper
@@ -82,7 +82,7 @@ jobs:
           echo "matrix=$(go run .github/workflows/parse_integration_test_list.go -file ./integration/github_actions_integration_test_list.yml)" >> "$GITHUB_OUTPUT"
       - name: Upload integration tests binary
         if: success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: integration_tests
           path: integration_tests


### PR DESCRIPTION
# Description

v3 is deprecated, we need to upgrade to v4

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
