### PR TITLE
chore(renovate): enable 'go mod tidy' and updating imports for PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,8 @@
         "integration/testdata/**",
         "test/resources/**"
     ],
-    "postUpdateOptions": ["gomodTidy"]
+    "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+    ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,5 +6,6 @@
     "ignorePaths": [
         "integration/testdata/**",
         "test/resources/**"
-    ]
+    ],
+    "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
# Description

By default  'go mod tidy' and updating imports for PRs (in case of major module version upgrade) are disabled, so we had to do it on our own. This PR enables those features.

# Reference

* https://github.com/renovatebot/renovate/blob/main/docs/usage/golang.md#how-it-works
* https://docs.renovatebot.com/configuration-options/#postupdateoptions

