### PR TITLE
fix(CloudFoundryDeploy) : Make "buildTool" non mandatory and align to documentation

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -105,7 +105,7 @@ func runCloudFoundryDeploy(config *cloudFoundryDeployOptions, telemetryData *tel
 }
 
 func validateDeployTool(config *cloudFoundryDeployOptions) {
-	if config.DeployTool != "" || config.BuildTool == "" {
+	if config.DeployTool != "" {
 		return
 	}
 


### PR DESCRIPTION
# Description
In the documentation , buildTool is not mandatory. 
It is only to derive the deployTool.
In order to align to this documentation, we need to remove this condition.
# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
