### PR TITLE
(fix): Add missed opts used by versioning.GetArtifact

### DIFF
--- a/cmd/mavenBuild.go
+++ b/cmd/mavenBuild.go
@@ -240,6 +240,8 @@ func createBuildArtifactsMetadata(config *mavenBuildOptions, commonPipelineEnvir
 	buildCoordinates := []versioning.Coordinates{}
 	options := versioning.Options{
 		ProjectSettingsFile: config.ProjectSettingsFile,
+		GlobalSettingsFile:  config.GlobalSettingsFile,
+		M2Path:              config.M2Path,
 	}
 	var utils versioning.Utils
 


### PR DESCRIPTION
# Description

`versioning.GetArtifact` for maven build [refers to some opts](https://github.com/SAP/jenkins-library/blob/f376166c7fe79772303365a89c11c86bfdefb07c/pkg/versioning/versioning.go#L141-L155) for `maven.EvaluateOptions` that later [used](https://github.com/SAP/jenkins-library/blob/f376166c7fe79772303365a89c11c86bfdefb07c/pkg/maven/maven.go#L108-L110) by `maven.Evaluate`.

This PR adds missed opts so they could be used by maven.Evaluate and other methods.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
