### PR TITLE
fix(executeATCCheck): correctly escape namespaces

### DIFF
--- a/cmd/gctsExecuteABAPQualityChecks.go
+++ b/cmd/gctsExecuteABAPQualityChecks.go
@@ -759,21 +759,21 @@ func executeATCCheck(config *gctsExecuteABAPQualityChecksOptions, client piperht
 		case "CLAS":
 			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/classes/` + url.QueryEscape(object.Object) + `"/>`
 		case "INTF":
-			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/interfaces/` + object.Object + `"/>`
+			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/oo/interfaces/` + url.QueryEscape(object.Object) + `"/>`
 		case "DEVC":
 			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/repository/informationsystem/virtualfolders?selection=package%3a` + url.QueryEscape(object.Object) + `"/>`
 		case "FUGR":
-			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/functions/groups/` + object.Object + `/source/main"/>`
+			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/functions/groups/` + url.QueryEscape(object.Object) + `/source/main"/>`
 		case "TABL":
-			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/tables/` + object.Object + `/source/main"/>`
+			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/tables/` + url.QueryEscape(object.Object) + `/source/main"/>`
 		case "DTEL":
-			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/dataelements/` + object.Object + `"/>`
+			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/dataelements/` + url.QueryEscape(object.Object) + `"/>`
 		case "DOMA":
-			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/domains/` + object.Object + `"/>`
+			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/ddic/domains/` + url.QueryEscape(object.Object) + `"/>`
 		case "MSAG":
-			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/messageclass/` + object.Object + `"/>`
+			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/messageclass/` + url.QueryEscape(object.Object) + `"/>`
 		case "PROG":
-			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/programs/programs/` + object.Object + `/source/main"/>`
+			innerXml = innerXml + `<adtcore:objectReference adtcore:uri="/sap/bc/adt/programs/programs/` + url.QueryEscape(object.Object) + `/source/main"/>`
 		default:
 			log.Entry().Warning("object Type " + object.Type + " is not supported!")
 


### PR DESCRIPTION
# Description

The ATC check failed when the name of a development object included a namespace. Prior to this change, the generated request body looked like this:

```
  ...
  <adtcore:objectReferences>
    <adtcore:objectReference
      adtcore:uri="/sap/bc/adt/ddic/tables//ABC/MY_TABLE/source/main" />
    <adtcore:objectReference
      adtcore:uri="/sap/bc/adt/oo/interfaces//ABC/MY_INTERFACE" />
  </adtcore:objectReferences>
  ...
```

Due to the unescaped slashes in the namespace, the SAP system failed with a 400 Bad Request error:

> URI-Mapping cannot be performed due to invalid URI: /sap/bc/adt/ddic/tables//ABC/MY_TABLE/source/main

By ensuring the namespaces are properly escaped (e.g. `%2FABC%2FMY_TABLE`) for all object types, the ATC check now works as expected. However, for classes this issue was already fixed in commit 4ff5271c (gCTSExecuteABAPQualityCheck_namespace_objects (#4623), 2023-10-11).

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
