### PR TITLE
feat(cloudFoundryDeploy): add cfTrace param to customize cf log output

### DIFF
--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -577,6 +577,10 @@ func cfDeploy(
 	var err error
 	var loginPerformed bool
 
+	// TODO: remove after testing?
+	log.Entry().Infof("additionalEnvironment '%s'", additionalEnvironment)
+	log.Entry().Infof("config.CfTrace '%s'", config.CfTrace)
+
 	if config.CfTrace {
 		additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+cfLogFile)
 	} else {
@@ -618,7 +622,10 @@ func cfDeploy(
 	}
 
 	// TODO: remove after testing?
-	if fileExists, _ := piperutils.FileExists(cfLogFile); fileExists && !config.CfTrace {
+	fileExists, _ := piperutils.FileExists(cfLogFile);
+	log.Entry().Infof("cfLogFile fileExists? '%s'", fileExists)
+
+	if fileExists && !config.CfTrace {
 		log.Entry().Infof("Removing existing cf log file '%s'", cfLogFile)
 		err = os.Remove(cfLogFile)
 		if err != nil {

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -636,7 +636,7 @@ func cfDeploy(
 	if err != nil || GeneralConfig.Verbose {
 		if config.CfTrace != "" && config.CfTrace != "true" {
 			if e := handleCfCliLog(config.CfTrace); e != nil {
-				log.Entry().WithError(err).Errorf("Error reading cf log file '%s'.", config.CfTrace)
+				log.Entry().WithError(err).Errorf("Error reading cf log file '%s': %v", config.CfTrace, e)
 			}
 		}
 	}

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -579,7 +579,7 @@ func cfDeploy(
 
 	// TODO: remove after testing?
 	log.Entry().Infof("additionalEnvironment '%s'", additionalEnvironment)
-	log.Entry().Infof("config.CfTrace '%s'", config.CfTrace)
+	log.Entry().Infof("config.CfTrace '%v'", config.CfTrace)
 
 	if config.CfTrace {
 		additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+cfLogFile)
@@ -623,7 +623,7 @@ func cfDeploy(
 
 	// TODO: remove after testing?
 	fileExists, _ := piperutils.FileExists(cfLogFile)
-	log.Entry().Infof("cfLogFile fileExists? '%s'", fileExists)
+	log.Entry().Infof("cfLogFile fileExists? '%v'", fileExists)
 
 	if fileExists && !config.CfTrace {
 		log.Entry().Infof("Removing existing cf log file '%s'", cfLogFile)

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -573,11 +573,12 @@ func cfDeploy(
 	additionalEnvironment []string,
 	command command.ExecRunner) error {
 
-	const cfLogFile = "cf.log"
 	var err error
 	var loginPerformed bool
 
-	additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+cfLogFile)
+	if config.CfTrace != "" {
+		additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+config.CfTrace)
+	}
 
 	if len(config.CfHome) > 0 {
 		additionalEnvironment = append(additionalEnvironment, "CF_HOME="+config.CfHome)
@@ -633,9 +634,10 @@ func cfDeploy(
 	}
 
 	if err != nil || GeneralConfig.Verbose {
-		e := handleCfCliLog(cfLogFile)
-		if e != nil {
-			log.Entry().WithError(err).Errorf("Error reading cf log file '%s'.", cfLogFile)
+		if config.CfTrace != "" && config.CfTrace != "true" {
+			if e := handleCfCliLog(config.CfTrace); e != nil {
+				log.Entry().WithError(err).Errorf("Error reading cf log file '%s'.", config.CfTrace)
+			}
 		}
 	}
 

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -573,11 +573,14 @@ func cfDeploy(
 	additionalEnvironment []string,
 	command command.ExecRunner) error {
 
+	const cfLogFile = "cf.log"
 	var err error
 	var loginPerformed bool
 
-	if config.CfTrace != "" {
-		additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+config.CfTrace)
+	if config.CfTrace {
+		additionalEnvironment = append(additionalEnvironment, "CF_TRACE="+cfLogFile)
+	} else {
+		additionalEnvironment = append(additionalEnvironment, "CF_TRACE=true") // Print API request diagnostics to stdout
 	}
 
 	if len(config.CfHome) > 0 {
@@ -634,9 +637,9 @@ func cfDeploy(
 	}
 
 	if err != nil || GeneralConfig.Verbose {
-		if config.CfTrace != "" && config.CfTrace != "true" {
-			if e := handleCfCliLog(config.CfTrace); e != nil {
-				log.Entry().WithError(err).Errorf("Error reading cf log file '%s': %v", config.CfTrace, e)
+		if config.CfTrace {
+			if e := handleCfCliLog(cfLogFile); e != nil {
+				log.Entry().WithError(err).Errorf("Error reading cf log file '%s': %v", cfLogFile, e)
 			}
 		}
 	}

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -617,6 +617,15 @@ func cfDeploy(
 		}
 	}
 
+	// TODO: remove after testing?
+	if fileExists, _ := piperutils.FileExists(cfLogFile); fileExists && !config.CfTrace {
+		log.Entry().Infof("Removing existing cf log file '%s'", cfLogFile)
+		err = os.Remove(cfLogFile)
+		if err != nil {
+			log.Entry().WithError(err).Errorf("Cannot remove existing cf log file '%s'", cfLogFile)
+		}
+	}
+
 	if err == nil {
 		err = command.RunExecutable("cf", cfDeployParams...)
 		if err != nil {

--- a/cmd/cloudFoundryDeploy.go
+++ b/cmd/cloudFoundryDeploy.go
@@ -622,7 +622,7 @@ func cfDeploy(
 	}
 
 	// TODO: remove after testing?
-	fileExists, _ := piperutils.FileExists(cfLogFile);
+	fileExists, _ := piperutils.FileExists(cfLogFile)
 	log.Entry().Infof("cfLogFile fileExists? '%s'", fileExists)
 
 	if fileExists && !config.CfTrace {

--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -26,6 +26,7 @@ type cloudFoundryDeployOptions struct {
 	CfHome                   string                 `json:"cfHome,omitempty"`
 	CfNativeDeployParameters string                 `json:"cfNativeDeployParameters,omitempty"`
 	CfPluginHome             string                 `json:"cfPluginHome,omitempty"`
+	CfTrace                  string                 `json:"cfTrace,omitempty"`
 	DeployDockerImage        string                 `json:"deployDockerImage,omitempty"`
 	DeployTool               string                 `json:"deployTool,omitempty"`
 	BuildTool                string                 `json:"buildTool,omitempty"`
@@ -239,6 +240,7 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.CfHome, "cfHome", os.Getenv("PIPER_cfHome"), "The cf home folder used by the cf cli. If not provided the default assumed by the cf cli is used.")
 	cmd.Flags().StringVar(&stepConfig.CfNativeDeployParameters, "cfNativeDeployParameters", os.Getenv("PIPER_cfNativeDeployParameters"), "Additional parameters passed to cf native deployment command")
 	cmd.Flags().StringVar(&stepConfig.CfPluginHome, "cfPluginHome", os.Getenv("PIPER_cfPluginHome"), "The cf plugin home folder used by the cf cli. If not provided the default assumed by the cf cli is used.")
+	cmd.Flags().StringVar(&stepConfig.CfTrace, "cfTrace", `cf.log`, "Append CF CLI API request diagnostics to a log file. If set to 'true', prints API request diagnostics to stdout.")
 	cmd.Flags().StringVar(&stepConfig.DeployDockerImage, "deployDockerImage", os.Getenv("PIPER_deployDockerImage"), "Docker image deployments are supported [via manifest file in general](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#docker). If no manifest is used, this parameter defines the image to be deployed. The specified name of the image is passed to the `--docker-image` parameter of the cf CLI and must adhere it's naming pattern (e.g. REPO/IMAGE:TAG). See [cf CLI documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html)x`x` for details. Note: The used Docker registry must be visible for the targeted Cloud Foundry instance.")
 	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", os.Getenv("PIPER_deployTool"), "Defines the tool which should be used for deployment. Mandatory if `buildTool` is not found in pipeline environment")
 	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", os.Getenv("PIPER_buildTool"), "Defines the tool which is used for building the artifact. If provided, `deployTool` is automatically derived from it. For MTA projects, `deployTool` defaults to `mtaDeployPlugin`. For other projects `cf_native` will be used.")
@@ -353,6 +355,15 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_cfPluginHome"),
+					},
+					{
+						Name:        "cfTrace",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `cf.log`,
 					},
 					{
 						Name:        "deployDockerImage",

--- a/cmd/cloudFoundryDeploy_generated.go
+++ b/cmd/cloudFoundryDeploy_generated.go
@@ -26,7 +26,7 @@ type cloudFoundryDeployOptions struct {
 	CfHome                   string                 `json:"cfHome,omitempty"`
 	CfNativeDeployParameters string                 `json:"cfNativeDeployParameters,omitempty"`
 	CfPluginHome             string                 `json:"cfPluginHome,omitempty"`
-	CfTrace                  string                 `json:"cfTrace,omitempty"`
+	CfTrace                  bool                   `json:"cfTrace,omitempty"`
 	DeployDockerImage        string                 `json:"deployDockerImage,omitempty"`
 	DeployTool               string                 `json:"deployTool,omitempty"`
 	BuildTool                string                 `json:"buildTool,omitempty"`
@@ -240,7 +240,7 @@ func addCloudFoundryDeployFlags(cmd *cobra.Command, stepConfig *cloudFoundryDepl
 	cmd.Flags().StringVar(&stepConfig.CfHome, "cfHome", os.Getenv("PIPER_cfHome"), "The cf home folder used by the cf cli. If not provided the default assumed by the cf cli is used.")
 	cmd.Flags().StringVar(&stepConfig.CfNativeDeployParameters, "cfNativeDeployParameters", os.Getenv("PIPER_cfNativeDeployParameters"), "Additional parameters passed to cf native deployment command")
 	cmd.Flags().StringVar(&stepConfig.CfPluginHome, "cfPluginHome", os.Getenv("PIPER_cfPluginHome"), "The cf plugin home folder used by the cf cli. If not provided the default assumed by the cf cli is used.")
-	cmd.Flags().StringVar(&stepConfig.CfTrace, "cfTrace", `cf.log`, "Append CF CLI API request diagnostics to a log file. If set to 'true', prints API request diagnostics to stdout.")
+	cmd.Flags().BoolVar(&stepConfig.CfTrace, "cfTrace", true, "Append CF CLI API request diagnostics to a 'cf.log' file. If set to false, just prints API request diagnostics to stdout.")
 	cmd.Flags().StringVar(&stepConfig.DeployDockerImage, "deployDockerImage", os.Getenv("PIPER_deployDockerImage"), "Docker image deployments are supported [via manifest file in general](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#docker). If no manifest is used, this parameter defines the image to be deployed. The specified name of the image is passed to the `--docker-image` parameter of the cf CLI and must adhere it's naming pattern (e.g. REPO/IMAGE:TAG). See [cf CLI documentation](https://docs.cloudfoundry.org/devguide/deploy-apps/push-docker.html)x`x` for details. Note: The used Docker registry must be visible for the targeted Cloud Foundry instance.")
 	cmd.Flags().StringVar(&stepConfig.DeployTool, "deployTool", os.Getenv("PIPER_deployTool"), "Defines the tool which should be used for deployment. Mandatory if `buildTool` is not found in pipeline environment")
 	cmd.Flags().StringVar(&stepConfig.BuildTool, "buildTool", os.Getenv("PIPER_buildTool"), "Defines the tool which is used for building the artifact. If provided, `deployTool` is automatically derived from it. For MTA projects, `deployTool` defaults to `mtaDeployPlugin`. For other projects `cf_native` will be used.")
@@ -360,10 +360,10 @@ func cloudFoundryDeployMetadata() config.StepData {
 						Name:        "cfTrace",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS", "GENERAL"},
-						Type:        "string",
+						Type:        "bool",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     `cf.log`,
+						Default:     true,
 					},
 					{
 						Name:        "deployDockerImage",

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -104,15 +104,15 @@ spec:
           - GENERAL
         mandatory: false
       - name: cfTrace
-        type: string
-        description: "Append CF CLI API request diagnostics to a log file. If set to 'true', prints API request diagnostics to stdout."
+        type: bool
+        description: "Append CF CLI API request diagnostics to a 'cf.log' file. If set to false, just prints API request diagnostics to stdout."
         scope:
           - PARAMETERS
           - STAGES
           - STEPS
           - GENERAL
         mandatory: false
-        default: "cf.log"
+        default: true
       - name: deployDockerImage
         type: string
         description: "Docker image deployments are supported

--- a/resources/metadata/cloudFoundryDeploy.yaml
+++ b/resources/metadata/cloudFoundryDeploy.yaml
@@ -103,6 +103,16 @@ spec:
           - STEPS
           - GENERAL
         mandatory: false
+      - name: cfTrace
+        type: string
+        description: "Append CF CLI API request diagnostics to a log file. If set to 'true', prints API request diagnostics to stdout."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+          - GENERAL
+        mandatory: false
+        default: "cf.log"
       - name: deployDockerImage
         type: string
         description: "Docker image deployments are supported

--- a/vars/karmaExecuteTests.groovy
+++ b/vars/karmaExecuteTests.groovy
@@ -11,10 +11,6 @@ import groovy.transform.Field
 @Field String STEP_NAME = getClass().getName()
 @Field String METADATA_FILE = 'metadata/karmaExecuteTests.yaml'
 
-/**
- * Executes the Karma tests.
- */
-@GenerateDocumentation
 void call(Map parameters = [:]) {
     List credentials = [
         [type: 'usernamePassword', id: 'seleniumHubCredentialsId', env: ['PIPER_SELENIUM_HUB_USER', 'PIPER_SELENIUM_HUB_PASSWORD']],

--- a/vars/karmaExecuteTests.groovy
+++ b/vars/karmaExecuteTests.groovy
@@ -11,6 +11,10 @@ import groovy.transform.Field
 @Field String STEP_NAME = getClass().getName()
 @Field String METADATA_FILE = 'metadata/karmaExecuteTests.yaml'
 
+/**
+ * Executes the Karma tests.
+ */
+@GenerateDocumentation
 void call(Map parameters = [:]) {
     List credentials = [
         [type: 'usernamePassword', id: 'seleniumHubCredentialsId', env: ['PIPER_SELENIUM_HUB_USER', 'PIPER_SELENIUM_HUB_PASSWORD']],


### PR DESCRIPTION
# Description

This PR adds a new param "cfTrace" for **cloudFoundryDeploy** step. Prior to this PR the value we used for CF CLI log output was hardcoded to "cf.log" whilst some users wanted to do not create that log file at all or just print it to the stdout instead.

**cfTrace** set related env var CF_TRACE used by [CF CLI](https://cli.cloudfoundry.org/en-US/v6/).

This change backward compatible with existing Piper pipeline configurations, no changes need.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
