### PR TITLE
Update versions-maven-plugin from 2.7 to 2.18.0

### DIFF
--- a/pkg/versioning/maven.go
+++ b/pkg/versioning/maven.go
@@ -123,7 +123,7 @@ func (m *Maven) SetVersion(version string) error {
 		ProjectSettingsFile: m.options.ProjectSettingsFile,
 		GlobalSettingsFile:  m.options.GlobalSettingsFile,
 		M2Path:              m.options.M2Path,
-		Goals:               []string{"org.codehaus.mojo:versions-maven-plugin:2.7:set"},
+		Goals:               []string{"org.codehaus.mojo:versions-maven-plugin:2.18.0:set"},
 		Defines: []string{
 			fmt.Sprintf("-DnewVersion=%v", version),
 			fmt.Sprintf("-DgroupId=%v", groupID),

--- a/pkg/versioning/maven_test.go
+++ b/pkg/versioning/maven_test.go
@@ -88,7 +88,7 @@ func TestMavenSetVersion(t *testing.T) {
 		expectedOptions := maven.ExecuteOptions{
 			PomPath:             "path/to/pom.xml",
 			Defines:             []string{"-DnewVersion=1.2.4", "-DgroupId=testGroup", "-DartifactId=*", "-DoldVersion=*", "-DgenerateBackupPoms=false"},
-			Goals:               []string{"org.codehaus.mojo:versions-maven-plugin:2.7:set"},
+			Goals:               []string{"org.codehaus.mojo:versions-maven-plugin:2.18.0:set"},
 			ProjectSettingsFile: "project-settings.xml",
 			GlobalSettingsFile:  "global-settings.xml",
 			M2Path:              "m2/path",


### PR DESCRIPTION
As rulesets were introduced after 2.13.0, to enable the users the update of plugin is required.
