### PR TITLE
[fix] changing order of sbom cyclone dx sbom creation after go build 

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -194,12 +194,6 @@ func runGolangBuild(config *golangBuildOptions, telemetryData *telemetry.CustomD
 		}
 	}
 
-	if config.CreateBOM {
-		if err := runBOMCreation(utils, sbomFilename); err != nil {
-			return err
-		}
-	}
-
 	ldflags := ""
 
 	if len(config.LdflagsTemplate) > 0 {
@@ -246,6 +240,12 @@ func runGolangBuild(config *golangBuildOptions, telemetryData *telemetry.CustomD
 		log.Entry().Warnf("failed to create build settings info: %v", err)
 	}
 	commonPipelineEnvironment.custom.buildSettingsInfo = buildSettingsInfo
+
+	if config.CreateBOM {
+		if err := runBOMCreation(utils, sbomFilename); err != nil {
+			return err
+		}
+	}
 
 	if config.Publish {
 		if len(config.TargetRepositoryURL) == 0 {


### PR DESCRIPTION
go lang sbom cyclone dx fails since it happens before the main go build, when there are private dependencies cyclone dx can fail due to this order mismatch .

# Description

in this PR we first run golang build, then cyclone dx sbom generation 

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
