### PR TITLE
fix(golang): handle errors with simple module names

### DIFF
--- a/pkg/versioning/gomodfile.go
+++ b/pkg/versioning/gomodfile.go
@@ -90,7 +90,7 @@ func (m *GoMod) GetCoordinates() (Coordinates, error) {
 	}
 
 	if parsed.Module == nil {
-		return result, errors.Wrap(err, "failed to parse go.mod file")
+		return result, errors.New("failed to parse go.mod file: no module found")
 	}
 
 	// validate module path as defined by golang

--- a/pkg/versioning/gomodfile.go
+++ b/pkg/versioning/gomodfile.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 
 	"github.com/pkg/errors"
 )
@@ -91,16 +92,23 @@ func (m *GoMod) GetCoordinates() (Coordinates, error) {
 	if parsed.Module == nil {
 		return result, errors.Wrap(err, "failed to parse go.mod file")
 	}
-	if parsed.Module.Mod.Path != "" {
-		artifactSplit := strings.Split(parsed.Module.Mod.Path, "/")
-		artifactID := artifactSplit[len(artifactSplit)-1]
-		result.ArtifactID = artifactID
 
-		goModPath := parsed.Module.Mod.Path
-		lastIndex := strings.LastIndex(goModPath, "/")
-		groupID := goModPath[0:lastIndex]
-		result.GroupID = groupID
+	// validate module path as defined by golang
+	if err = module.CheckPath(parsed.Module.Mod.Path); err != nil {
+		return result, errors.Wrap(err, "failed to parse go.mod file")
 	}
+
+	if parsed.Module.Mod.Path != "" {
+		modulePath := parsed.Module.Mod.Path
+		separatorIndex := strings.LastIndex(modulePath, "/")
+		result.ArtifactID = modulePath[separatorIndex+1:]
+
+		// extract groupID from module path
+		if separatorIndex >= 0 {
+			result.GroupID = modulePath[0:separatorIndex]
+		}
+	}
+
 	result.Version = parsed.Module.Mod.Version
 	if result.Version == "" {
 		result.Version = "unspecified"

--- a/pkg/versioning/gomodfile_test.go
+++ b/pkg/versioning/gomodfile_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+// +build unit
+
+package versioning
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGoModGetCoordinates(t *testing.T) {
+	t.Run("simple module name", func(t *testing.T) {
+		// prepare
+		tmpFolder := t.TempDir()
+		goModFilePath := filepath.Join(tmpFolder, "go.mod")
+		os.WriteFile(goModFilePath, []byte("module test\n\ngo 1.24.0"), 0666)
+		gomod := &GoMod{
+			path: goModFilePath,
+		}  
+		// test
+		coordinates, err := gomod.GetCoordinates()
+		// assert
+		assert.NoError(t, err)
+		assert.Equal(t, "test", coordinates.ArtifactID)
+	})
+}

--- a/pkg/versioning/gomodfile_test.go
+++ b/pkg/versioning/gomodfile_test.go
@@ -12,18 +12,54 @@ import (
 )
 
 func TestGoModGetCoordinates(t *testing.T) {
-	t.Run("simple module name", func(t *testing.T) {
+	t.Run("with full module name", func(t *testing.T) {
 		// prepare
-		tmpFolder := t.TempDir()
-		goModFilePath := filepath.Join(tmpFolder, "go.mod")
-		os.WriteFile(goModFilePath, []byte("module test\n\ngo 1.24.0"), 0666)
-		gomod := &GoMod{
-			path: goModFilePath,
-		}  
+		gomod := createTestGoModFile(t, "module github.com/path-to/moduleName\n\ngo 1.24.0")
 		// test
 		coordinates, err := gomod.GetCoordinates()
 		// assert
 		assert.NoError(t, err)
-		assert.Equal(t, "test", coordinates.ArtifactID)
+		assert.Equal(t, "moduleName", coordinates.ArtifactID)
+		assert.Equal(t, "github.com/path-to", coordinates.GroupID)
 	})
+	t.Run("with module name without path", func(t *testing.T) {
+		// prepare
+		gomod := createTestGoModFile(t, "module github.com/moduleName\n\ngo 1.24.0")
+		// test
+		coordinates, err := gomod.GetCoordinates()
+		// assert
+		assert.NoError(t, err)
+		assert.Equal(t, "moduleName", coordinates.ArtifactID)
+		assert.Equal(t, "github.com", coordinates.GroupID)
+	})
+	t.Run("with invalid simple module name", func(t *testing.T) {
+		// prepare
+		gomod := createTestGoModFile(t, "module moduleName\n\ngo 1.24.0")
+		// test
+		coordinates, err := gomod.GetCoordinates()
+		// assert
+		assert.ErrorContains(t, err, "missing dot in first path element")
+		assert.Empty(t, coordinates.ArtifactID)
+		assert.Empty(t, coordinates.GroupID)
+	})
+	t.Run("with invalid full module name", func(t *testing.T) {
+		// prepare
+		gomod := createTestGoModFile(t, "module path/to/test\n\ngo 1.24.0")
+		// test
+		coordinates, err := gomod.GetCoordinates()
+		// assert
+		assert.ErrorContains(t, err, "missing dot in first path element")
+		assert.Empty(t, coordinates.ArtifactID)
+		assert.Empty(t, coordinates.GroupID)
+	})
+}
+
+func createTestGoModFile(t *testing.T, content string) *GoMod {
+	tmpFolder := t.TempDir()
+	goModFilePath := filepath.Join(tmpFolder, "go.mod")
+	os.WriteFile(goModFilePath, []byte(content), 0666)
+	gomod := &GoMod{
+		path: goModFilePath,
+	}
+	return gomod
 }


### PR DESCRIPTION
# Changes

- GOlang module name must comply with the naming conventions as defined per [`golang.org/x/mod/module.CheckPath`](https://pkg.go.dev/golang.org/x/mod/module#CheckPath)
- if module path just consists of a name, `groupID` is not set

## Issue

When a golang module has no `/` in it's name, the code is currently failing.

```
panic: runtime error: slice bounds out of range [:-1]

goroutine 1 [running]:
github.com/SAP/jenkins-library/pkg/versioning.(*GoMod).GetCoordinates(0xc0001612c0)
	/home/runner/work/jenkins-library/jenkins-library/pkg/versioning/gomodfile.go:101 +0x345
github.com/SAP/jenkins-library/cmd.runArtifactPrepareVersion(0xc000c798b8, 0x0?, 0xc000966700, {0x0, 0x0}, {0x3c51288, 0xc00098e3c0}, {0x3c49fd8, 0xc0010b5bc0}, 0x384d8d8)
	/home/runner/work/jenkins-library/jenkins-library/cmd/artifactPrepareVersion.go:249 +0xe0c
github.com/SAP/jenkins-library/cmd.artifactPrepareVersion({{0x5a4c0e0, 0x0, 0x0}, {0x5a4c0e0, 0x0, 0x0}, {0xc00028c5b0, 0x6}, {0xc00028c5c0, 0xd}, ...}, ...)
	/home/runner/work/jenkins-library/jenkins-library/cmd/artifactPrepareVersion.go:103 +0x210
github.com/SAP/jenkins-library/cmd.ArtifactPrepareVersionCommand.func2(0xc000976008?, {0x3615fe5?, 0x4?, 0x3615df5?})
	/home/runner/work/jenkins-library/jenkins-library/cmd/artifactPrepareVersion_generated.go:265 +0x3ad
github.com/spf13/cobra.(*Command).execute(0xc000976008, {0xc000966380, 0x8, 0x8})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0xa7b
github.com/spf13/cobra.(*Command).ExecuteC(0x59e21a0)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/SAP/jenkins-library/cmd.Execute()
	/home/runner/work/jenkins-library/jenkins-library/cmd/piper.go:236 +0x16d1
main.main()
	/home/runner/work/jenkins-library/jenkins-library/main.go:10 +0xf
Error: The process '/opt/actions-runner/_work/test-app-golang-1/test-app-golang-1/v1_435_0/piper' failed with exit code 2
```

