### PR TITLE
fix(maven build): typo in vault lookup path for altDeploymentRepositoryPassword

### DIFF
--- a/cmd/mavenBuild_generated.go
+++ b/cmd/mavenBuild_generated.go
@@ -420,7 +420,7 @@ func mavenBuildMetadata() config.StepData {
 							{
 								Name:    "altDeploymentRepositoryPasswordFileVaultSecretName",
 								Type:    "vaultSecretFile",
-								Default: "alt-deployment-repository-passowrd",
+								Default: "alt-deployment-repository-password",
 							},
 						},
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},

--- a/resources/metadata/mavenBuild.yaml
+++ b/resources/metadata/mavenBuild.yaml
@@ -157,7 +157,7 @@ spec:
             type: secret
           - type: vaultSecretFile
             name: altDeploymentRepositoryPasswordFileVaultSecretName
-            default: alt-deployment-repository-passowrd
+            default: alt-deployment-repository-password
       - name: altDeploymentRepositoryUser
         type: string
         description: User for the alternative deployment repository to which the project artifacts should be deployed ( other than those specified in <distributionManagement> ). This user will be updated in settings.xml . When no settings.xml is provided a new one is created corresponding with <servers> tag


### PR DESCRIPTION
# Changes

This fixes a typo in the vault lookup path for `altDeploymentRepositoryPassword` parameter.
