### PR TITLE
fix(mta build): typo in vault lookup path for mtaDeploymentRepositoryPassword

### DIFF
--- a/cmd/mtaBuild_generated.go
+++ b/cmd/mtaBuild_generated.go
@@ -432,7 +432,7 @@ func mtaBuildMetadata() config.StepData {
 							{
 								Name:    "mtaDeploymentRepositoryPasswordFileVaultSecretName",
 								Type:    "vaultSecretFile",
-								Default: "mta-deployment-repository-passowrd",
+								Default: "mta-deployment-repository-password",
 							},
 						},
 						Scope:     []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},

--- a/resources/metadata/mtaBuild.yaml
+++ b/resources/metadata/mtaBuild.yaml
@@ -170,7 +170,7 @@ spec:
             param: custom/repositoryPassword
           - type: vaultSecretFile
             name: mtaDeploymentRepositoryPasswordFileVaultSecretName
-            default: mta-deployment-repository-passowrd
+            default: mta-deployment-repository-password
       - name: mtaDeploymentRepositoryUser
         type: string
         description: User for the alternative deployment repository to which which mtar artifacts will be publised


### PR DESCRIPTION
# Changes

This fixes a typo in the vault lookup path for mtaDeploymentRepositoryPassword parameter.