### PR TITLE
fix(checkmarxOneExecuteScan) Fix API error in 3.30

### DIFF
--- a/pkg/checkmarxone/checkmarxone.go
+++ b/pkg/checkmarxone/checkmarxone.go
@@ -653,6 +653,15 @@ func (sys *SystemInstance) UpdateApplication(app *Application) error {
 func (sys *SystemInstance) UpdateProject(project *Project) error {
 	sys.logger.Debugf("Updating project: %v", project.Name)
 	jsonBody, err := json.Marshal(*project)
+
+	// Remove fields that can cause API errors in Cx1 3.30
+	var filteredMap map[string]interface{}
+	json.Unmarshal(jsonBody, &filteredMap)
+	delete(filteredMap, "applicationIds")
+	delete(filteredMap, "createdAt")
+	delete(filteredMap, "updatedAt")
+	jsonBody, err = json.Marshal(filteredMap)
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

This PR is fixing an error in the PUT /api/projects to update tags.
The API returns a 400 when a query is assigned to the application.
The workaround is to remove the applicationIds from the JSON payload. 