### PR TITLE
fix: remove duplicate unknownOrchestrator initialization 

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -132,9 +132,7 @@ func newDetectUtils(client *github.Client) detectUtils {
 	provider, err := orchestrator.GetOrchestratorConfigProvider(nil)
 	if err != nil {
 		log.Entry().WithError(err).Warning(err)
-		provider = &orchestrator.UnknownOrchestratorConfigProvider{}
 	}
-
 	utils.provider = provider
 
 	return &utils

--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -243,7 +243,6 @@ func addRootFlags(rootCmd *cobra.Command) {
 	provider, err := orchestrator.GetOrchestratorConfigProvider(nil)
 	if err != nil {
 		log.Entry().Error(err)
-		provider = &orchestrator.UnknownOrchestratorConfigProvider{}
 	}
 
 	rootCmd.PersistentFlags().StringVar(&GeneralConfig.CorrelationID, "correlationID", provider.BuildURL(), "ID for unique identification of a pipeline run")

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -40,7 +40,6 @@ func (t *Telemetry) Initialize(stepName string) {
 	provider, err := orchestrator.GetOrchestratorConfigProvider(nil)
 	if err != nil {
 		log.Entry().Warningf("could not get orchestrator config provider, leads to insufficient data")
-		provider = &orchestrator.UnknownOrchestratorConfigProvider{}
 	}
 	t.provider = provider
 


### PR DESCRIPTION
# Changes

This removes the unnecessary initialization of an UnknownOrchestrator` as this is [already given by the detect function](https://github.com/SAP/jenkins-library/blob/59055f0b4f9671748620e06c0d885116b1395e55/pkg/orchestrator/orchestrator.go#L95-L101).
