### PR TITLE
remove obsolete warning for short commit id

### DIFF
--- a/documentation/docs/pipelines/abapEnvironment/stages/build.md
+++ b/documentation/docs/pipelines/abapEnvironment/stages/build.md
@@ -44,10 +44,6 @@ stages:
 
 ### addon.yml
 
-!!! caution "Use Long Commit ID for the commitID fields"
-    Please use the long commit ID in the commit ID field currently if you are using the short commit ID the build process will fail.
-    Go into the Manage Software Components app, navigate to the branch, select the commit in the list of commits, field "Long Commit ID" becomes available.
-
 ```YAML
 ---
 addonProduct: /NAMESPC/PRODUCTX


### PR DESCRIPTION
remove obsolete warning for short commit id

# Description

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
