### PR TITLE
fix: do not escape json files when marshaling

### DIFF
--- a/pkg/versioning/jsonfile.go
+++ b/pkg/versioning/jsonfile.go
@@ -1,6 +1,7 @@
 package versioning
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -67,11 +68,14 @@ func (j *JSONfile) SetVersion(version string) error {
 	}
 	j.content.Set(j.versionField, version)
 
-	content, err := json.MarshalIndent(j.content, "", "  ")
-	if err != nil {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(j.content); err != nil {
 		return errors.Wrapf(err, "failed to create json content for '%v'", j.path)
 	}
-	err = j.writeFile(j.path, content, 0700)
+	err := j.writeFile(j.path, buf.Bytes(), 0700)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write file '%v'", j.path)
 	}


### PR DESCRIPTION
# Description
User reports that when artifactPrepareVersion updates package.json with a new version, when writing it escapes some characters which leads to failed linting for the user. This PR changes marshaling logic to not escape characters.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
