### PR TITLE
fix(vault): retry loop in startTokenLifecycleManager for non-renewable Vault tokens

### DIFF
--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -106,6 +106,11 @@ func (c *Client) startTokenLifecycleManager(initialLoginDone chan struct{}) {
 			initialLoginSucceed = true
 		}
 
+		if !vaultLoginResp.Auth.Renewable {
+			log.Entry().Debugf("Vault token is not configured to be renewable.")
+			return
+		}
+
 		tokenErr := c.manageTokenLifecycle(vaultLoginResp)
 		if tokenErr != nil {
 			log.Entry().Warnf("unable to start managing token lifecycle: %v", err)
@@ -117,11 +122,6 @@ func (c *Client) startTokenLifecycleManager(initialLoginDone chan struct{}) {
 // Starts token lifecycle management. Returns only fatal errors as errors,
 // otherwise returns nil, so we can attempt login again.
 func (c *Client) manageTokenLifecycle(authResp *vaultAPI.Secret) error {
-	if !authResp.Auth.Renewable {
-		log.Entry().Debugf("Token is not configured to be renewable. Re-attempting login.")
-		return nil
-	}
-
 	watcher, err := c.vaultApiClient.NewLifetimeWatcher(&vaultAPI.LifetimeWatcherInput{Secret: authResp})
 	if err != nil {
 		return fmt.Errorf("unable to initialize new lifetime watcher for renewing auth token: %w", err)


### PR DESCRIPTION
# What’s Changed

Improved the `startTokenLifecycleManager()` logic to prevent unnecessary Vault login retries when both `login()` and `manageTokenLifecycle()` succeed.

**Key changes:**
- The retry loop now exits immediately after a successful login if the token is not configured to be renewable.

# Why It Matters

Previously, the function would continue retrying Vault logins even if both `login()` and `manageTokenLifecycle()` completed successfully. This caused:
- Pipeline take ages
- Excessive login attempts (up to MaxRetries)
- Misleading log entries such as Retrying to login to Vault...
- Unnecessary load on Vault in environments with frequent restarts.

## Example: Problem Before the Fix
Even with `err == nil` and `tokenErr == nil`, login attempts would still repeat when Vault returned a non-renewable token:

<img width="1203" alt="Screenshot 2025-06-16 at 18 13 30" src="https://github.com/user-attachments/assets/974c2590-0dcc-461b-ae6a-48e76a814419" />

## After the Fix: Non-Renewable Token
Condition was moved to prevent redundant login attempts when a token is not renewable:

<img width="1705" alt="Screenshot 2025-06-16 at 18 14 14" src="https://github.com/user-attachments/assets/d3a3785f-7222-472d-b630-6b1c7cf46dc9" />

