### PR TITLE
Changed the documents link from Synopsys to Blackduck

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -183,7 +183,7 @@ func detectExecuteScan(config detectExecuteScanOptions, _ *telemetry.CustomData,
 }
 
 func runDetect(ctx context.Context, config detectExecuteScanOptions, utils detectUtils, influx *detectExecuteScanInflux) error {
-	// detect execution details, see https://synopsys.atlassian.net/wiki/spaces/INTDOCS/pages/88440888/Sample+Synopsys+Detect+Scan+Configuration+Scenarios+for+Black+Duck
+	// detect execution details, see https://documentation.blackduck.com/bundle/detect/page/runningdetect/basics/runningwithblackduck.html
 	err := getDetectScript(config, utils)
 	if err != nil {
 		return fmt.Errorf("failed to download 'detect.sh' script: %w", err)
@@ -633,7 +633,7 @@ func addDetectArgsImages(args []string, config detectExecuteScanOptions, utils d
 
 	args = append(args, fmt.Sprintf("--detect.docker.tar=./%s", imageTar))
 	args = append(args, "--detect.target.type=IMAGE")
-	// https://community.synopsys.com/s/article/Docker-image-scanning-CLI-examples-and-some-Q-As
+	// https://community.blackduck.com/s/article/Docker-image-scanning-CLI-examples-and-some-Q-As
 	args = append(args, "--detect.tools.excluded=DETECTOR")
 	args = append(args, "--detect.docker.passthrough.shared.dir.path.local=/opt/blackduck/blackduck-imageinspector/shared/")
 	args = append(args, "--detect.docker.passthrough.shared.dir.path.imageinspector=/opt/blackduck/blackduck-imageinspector/shared")

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -174,7 +174,7 @@ func (p *detectExecuteScanReports) persist(stepConfig detectExecuteScanOptions, 
 	}
 }
 
-// DetectExecuteScanCommand Executes Synopsys Detect scan
+// DetectExecuteScanCommand Executes Blackduck Detect scan
 func DetectExecuteScanCommand() *cobra.Command {
 	const STEP_NAME = "detectExecuteScan"
 
@@ -189,9 +189,9 @@ func DetectExecuteScanCommand() *cobra.Command {
 
 	var createDetectExecuteScanCmd = &cobra.Command{
 		Use:   STEP_NAME,
-		Short: "Executes Synopsys Detect scan",
-		Long: `This step executes [Synopsys Detect](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=introduction.html&_LANG=enus) scans.
-Synopsys Detect command line utlity can be used to run various scans including BlackDuck and Polaris scans. This step allows users to run BlackDuck scans by default.
+		Short: "Executes Blackduck Detect scan",
+		Long: `This step executes [Blackduck Detect](https://documentation.blackduck.com/bundle/detect/page/introduction.html) scans.
+Blackduck Detect command line utlity can be used to run various scans including BlackDuck scans. This step allows users to run BlackDuck scans by default.
 Please configure your BlackDuck server Url using the serverUrl parameter and the API token of your user using the apiToken parameter for this step.`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			startTime = time.Now()
@@ -303,15 +303,15 @@ Please configure your BlackDuck server Url using the serverUrl parameter and the
 }
 
 func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScanOptions) {
-	cmd.Flags().StringVar(&stepConfig.Token, "token", os.Getenv("PIPER_token"), "Api token to be used for connectivity with Synopsis Detect server.")
+	cmd.Flags().StringVar(&stepConfig.Token, "token", os.Getenv("PIPER_token"), "Api token to be used for connectivity with Blackduck Detect server.")
 	cmd.Flags().StringVar(&stepConfig.CodeLocation, "codeLocation", os.Getenv("PIPER_codeLocation"), "An override for the name Detect will use for the scan file it creates.")
-	cmd.Flags().StringVar(&stepConfig.ProjectName, "projectName", os.Getenv("PIPER_projectName"), "Name of the Synopsis Detect (formerly BlackDuck) project.")
-	cmd.Flags().StringSliceVar(&stepConfig.Scanners, "scanners", []string{`signature`}, "List of scanners to be used for Synopsis Detect (formerly BlackDuck) scan.")
-	cmd.Flags().StringSliceVar(&stepConfig.ScanPaths, "scanPaths", []string{`.`}, "List of paths which should be scanned by the Synopsis Detect (formerly BlackDuck) scan.")
+	cmd.Flags().StringVar(&stepConfig.ProjectName, "projectName", os.Getenv("PIPER_projectName"), "Name of the Blackduck Detect project.")
+	cmd.Flags().StringSliceVar(&stepConfig.Scanners, "scanners", []string{`signature`}, "List of scanners to be used for Blackduck Detect scan.")
+	cmd.Flags().StringSliceVar(&stepConfig.ScanPaths, "scanPaths", []string{`.`}, "List of paths which should be scanned by the Blackduck Detect scan.")
 	cmd.Flags().StringVar(&stepConfig.DependencyPath, "dependencyPath", `.`, "Absolute Path of the dependency management file of the project. This path represents the folder which contains the pom file, package.json etc. If the project contains multiple pom files, provide the path to the parent pom file or the base folder of the project")
 	cmd.Flags().BoolVar(&stepConfig.Unmap, "unmap", false, "Unmap flag will unmap all previous code locations and keep only the current scan results in the specified project version. Set this parameter to true, when the project version needs to store only the latest scan results.")
-	cmd.Flags().StringSliceVar(&stepConfig.ScanProperties, "scanProperties", []string{`--blackduck.signature.scanner.memory=4096`, `--detect.timeout=6000`, `--blackduck.trust.cert=true`, `--logging.level.detect=DEBUG`, `--detect.maven.excluded.scopes=test`}, "Properties passed to the Synopsis Detect (formerly BlackDuck) scan. You can find details in the [Synopsis Detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fall-properties.html&_LANG=enus)")
-	cmd.Flags().StringVar(&stepConfig.ServerURL, "serverUrl", os.Getenv("PIPER_serverUrl"), "Server URL to the Synopsis Detect (formerly BlackDuck) Server.")
+	cmd.Flags().StringSliceVar(&stepConfig.ScanProperties, "scanProperties", []string{`--blackduck.signature.scanner.memory=4096`, `--detect.timeout=6000`, `--blackduck.trust.cert=true`, `--logging.level.detect=DEBUG`, `--detect.maven.excluded.scopes=test`}, "Properties passed to the Blackduck Detect scan. You can find details in the [Blackduck Detect documentation](https://documentation.blackduck.com/bundle/detect/page/properties/basic-properties.html)")
+	cmd.Flags().StringVar(&stepConfig.ServerURL, "serverUrl", os.Getenv("PIPER_serverUrl"), "Server URL to the Blackduck Detect Server.")
 	cmd.Flags().StringSliceVar(&stepConfig.Groups, "groups", []string{}, "Users groups to be assigned for the Project")
 	cmd.Flags().StringSliceVar(&stepConfig.FailOn, "failOn", []string{`BLOCKER`}, "Mark the current build as fail based on the policy categories applied.")
 	cmd.Flags().StringVar(&stepConfig.VersioningModel, "versioningModel", `major`, "The versioning model used for result reporting (based on the artifact version). Example 1.2.3 using `major` will result in version 1")
@@ -330,13 +330,13 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().BoolVar(&stepConfig.GenerateReportsForEmptyProjects, "generateReportsForEmptyProjects", false, "If enabled, it will generate reports for empty projects. This could be useful to see the compliance reports in Sirius")
 	cmd.Flags().StringVar(&stepConfig.MtaPlatform, "mtaPlatform", `CF`, "The platform of the MTA project")
 	cmd.Flags().StringVar(&stepConfig.PomPath, "pomPath", `pom.xml`, "Path to the pom file which should be installed including all children.")
-	cmd.Flags().StringSliceVar(&stepConfig.IncludedPackageManagers, "includedPackageManagers", []string{}, "The package managers that need to be included for this scan. Providing the package manager names with this parameter will ensure that the build descriptor file of that package manager will be searched in the scan folder For the complete list of possible values for this parameter, please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fdetector.html&_LANG=enus&anchor=detector-types-included-advanced)")
-	cmd.Flags().StringSliceVar(&stepConfig.ExcludedPackageManagers, "excludedPackageManagers", []string{}, "The package managers that need to be excluded for this scan. Providing the package manager names with this parameter will ensure that the build descriptor file of that package manager will be ignored in the scan folder For the complete list of possible values for this parameter, please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fdetector.html&_LANG=enus&anchor=detector-types-excluded-advanced)")
+	cmd.Flags().StringSliceVar(&stepConfig.IncludedPackageManagers, "includedPackageManagers", []string{}, "The package managers that need to be included for this scan. Providing the package manager names with this parameter will ensure that the build descriptor file of that package manager will be searched in the scan folder For the complete list of possible values for this parameter, please refer [Blackduck detect documentation](https://documentation.blackduck.com/bundle/detect/page/properties/configuration/detector.html#ariaid-title5)")
+	cmd.Flags().StringSliceVar(&stepConfig.ExcludedPackageManagers, "excludedPackageManagers", []string{}, "The package managers that need to be excluded for this scan. Providing the package manager names with this parameter will ensure that the build descriptor file of that package manager will be ignored in the scan folder For the complete list of possible values for this parameter, please refer [Blackduck detect documentation](https://documentation.blackduck.com/bundle/detect/page/properties/configuration/detector.html#ariaid-title4)")
 	cmd.Flags().StringSliceVar(&stepConfig.MavenExcludedScopes, "mavenExcludedScopes", []string{}, "The maven scopes that need to be excluded from the scan. For example, setting the value 'test' will exclude all components which are defined with a test scope in maven")
-	cmd.Flags().StringSliceVar(&stepConfig.DetectTools, "detectTools", []string{}, "The type of BlackDuck scanners to include while running the BlackDuck scan. By default All scanners are included. For the complete list of possible values, Please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html&_LANG=enus&anchor=detect-tools-included)")
+	cmd.Flags().StringSliceVar(&stepConfig.DetectTools, "detectTools", []string{}, "The type of BlackDuck scanners to include while running the BlackDuck scan. By default All scanners are included. For the complete list of possible values, Please refer [Blackduck detect documentation](https://documentation.blackduck.com/bundle/detect/page/components/tools.html)")
 	cmd.Flags().BoolVar(&stepConfig.ScanOnChanges, "scanOnChanges", false, "This flag determines if the scan is submitted to the server. If set to true, then the scan request is submitted to the server only when changes are detected in the Open Source Bill of Materials If the flag is set to false, then the scan request is submitted to server regardless of any changes. For more details please refer to the [documentation](https://github.com/blackducksoftware/detect_rescan/blob/master/README.md)")
 	cmd.Flags().BoolVar(&stepConfig.SuccessOnSkip, "successOnSkip", true, "This flag allows forces Black Duck to exit with 0 error code if any step is skipped")
-	cmd.Flags().StringSliceVar(&stepConfig.CustomEnvironmentVariables, "customEnvironmentVariables", []string{}, "A list of environment variables which can be set to prepare the environment to run a BlackDuck scan. This includes a list of environment variables defined by Synopsys. The full list can be found [here](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=configuring%2Fenvvars.html&_LANG=enus) This list affects the detect script downloaded while running the scan. Right now only detect7.sh is available for downloading")
+	cmd.Flags().StringSliceVar(&stepConfig.CustomEnvironmentVariables, "customEnvironmentVariables", []string{}, "A list of environment variables which can be set to prepare the environment to run a BlackDuck scan. This includes a list of environment variables defined by Blackduck. The full list can be found [here](https://documentation.blackduck.com/bundle/detect/page/configuring/envvars.html) This list affects the detect script downloaded while running the scan. Right now only detect7.sh is available for downloading")
 	cmd.Flags().IntVar(&stepConfig.MinScanInterval, "minScanInterval", 0, "[DEPRECATED] This parameter controls the frequency (in number of hours) at which the signature scan is re-submitted for scan. When set to a value greater than 0, the signature scans are skipped until the specified number of hours has elapsed since the last signature scan.")
 	cmd.Flags().StringVar(&stepConfig.GithubToken, "githubToken", os.Getenv("PIPER_githubToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line")
 	cmd.Flags().BoolVar(&stepConfig.CreateResultIssue, "createResultIssue", false, "Activate creation of result issues in GitHub.")
@@ -372,12 +372,12 @@ func detectExecuteScanMetadata() config.StepData {
 		Metadata: config.StepMetadata{
 			Name:        "detectExecuteScan",
 			Aliases:     []config.Alias{},
-			Description: "Executes Synopsys Detect scan",
+			Description: "Executes Blackduck Detect scan",
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
 				Secrets: []config.StepSecrets{
-					{Name: "detectTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing the API token used to authenticate with the Synopsis Detect (formerly BlackDuck) Server.", Type: "jenkins", Aliases: []config.Alias{{Name: "apiTokenCredentialsId", Deprecated: false}}},
+					{Name: "detectTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing the API token used to authenticate with the Blackduck Detect Server.", Type: "jenkins", Aliases: []config.Alias{{Name: "apiTokenCredentialsId", Deprecated: false}}},
 					{Name: "githubTokenCredentialsId", Description: "Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.", Type: "jenkins"},
 					{Name: "golangPrivateModulesGitTokenCredentialsId", Description: "Jenkins 'Username with password' credentials ID containing username/password for http access to your git repos where your go private modules are stored.", Type: "jenkins"},
 				},

--- a/documentation/docs/stages/introduction.md
+++ b/documentation/docs/stages/introduction.md
@@ -142,7 +142,7 @@ You find details about this stage on the page [**Acceptance**](acceptance.md).
 
 ### Security
 
-This stage can run security checks using Checkmarx, Synopsys Detect, Fortify and WhiteSource.
+This stage can run security checks using Checkmarx, Blackduck Detect, Fortify and WhiteSource.
 
 You find details about this stage on the page [**Security**](security.md).
 

--- a/documentation/docs/steps/detectExecuteScan.md
+++ b/documentation/docs/steps/detectExecuteScan.md
@@ -14,7 +14,7 @@ You need to store the API token for the Detect service as _'Secret text'_ creden
 
 ## Rapid scan
 
-In addition to the full scan, Black Duck also offers a faster and easier scan option, called <a href="https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=downloadingandrunning%2Frapidscan.html&_LANG=enus" target="_blank">Rapid Scan</a>.
+In addition to the full scan, Black Duck also offers a faster and easier scan option, called <a href="https://documentation.blackduck.com/bundle/detect/page/runningdetect/rapidscan.html" target="_blank">Rapid Scan</a>.
 Its main advantage is speed. In most cases, the scan is completed in less than 30 seconds. It doesn't save any information on the Black Duck side.
 The result can be found in the pipeline console.
 

--- a/pkg/blackduck/reporting.go
+++ b/pkg/blackduck/reporting.go
@@ -160,7 +160,7 @@ func CreateSarifResultFile(vulns *Vulnerabilities, projectName, projectVersion, 
 		Driver: format.Driver{
 			Name:           "Black Duck",
 			Version:        "unknown",
-			InformationUri: "https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=introduction.html&_LANG=enus",
+			InformationUri: "https://documentation.blackduck.com/bundle/detect/page/introduction.html",
 			Rules:          rules,
 		},
 	}

--- a/pkg/reporting/pullRequestReport.go
+++ b/pkg/reporting/pullRequestReport.go
@@ -96,7 +96,7 @@ type OtherViolation struct {
 const rapidReportMdTemplate = `
  {{if .Success}}:heavy_check_mark: **OSS related checks passed successfully**
   :clipboard: OSS related checks executed by Black Duck - rapid scan passed successfully.
- <h4><a href="https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/runningdetect/rapidscan.html">RAPID SCAN</a></h4>
+ <h4><a href="https://documentation.blackduck.com/bundle/detect/page/runningdetect/rapidscan.html">RAPID SCAN</a></h4>
 
 {{else}} :x: **OSS related checks failed**
   :clipboard: Policies violated by added OSS components

--- a/pkg/reporting/pullRequestReport_test.go
+++ b/pkg/reporting/pullRequestReport_test.go
@@ -139,7 +139,7 @@ func TestCreateMarkdownReport(t *testing.T) {
 			components: &Components{},
 			expectedReport: "\n :heavy_check_mark: **OSS related checks passed successfully**\n  :clipboard: OSS related checks executed by Black Duck " +
 				"- rapid scan passed successfully.\n" +
-				" <h4><a href=\"https://sig-product-docs.synopsys.com/bundle/integrations-detect/page/runningdetect/rapidscan.html\">" +
+				" <h4><a href=\"https://documentation.blackduck.com/bundle/detect/page/runningdetect/rapidscan.html\">" +
 				"RAPID SCAN</a></h4>\n\n\n",
 		},
 	}

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -1,9 +1,9 @@
 metadata:
   name: detectExecuteScan
-  description: Executes Synopsys Detect scan
+  description: Executes Blackduck Detect scan
   longDescription: |
-    This step executes [Synopsys Detect](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=introduction.html&_LANG=enus) scans.
-    Synopsys Detect command line utlity can be used to run various scans including BlackDuck and Polaris scans. This step allows users to run BlackDuck scans by default.
+    This step executes [Blackduck Detect](https://documentation.blackduck.com/bundle/detect/page/introduction.html) scans.
+    Blackduck Detect command line utlity can be used to run various scans including BlackDuck scans. This step allows users to run BlackDuck scans by default.
     Please configure your BlackDuck server Url using the serverUrl parameter and the API token of your user using the apiToken parameter for this step.
 spec:
   inputs:
@@ -16,7 +16,7 @@ spec:
       - name: detectTokenCredentialsId
         aliases:
           - name: apiTokenCredentialsId
-        description: Jenkins 'Secret text' credentials ID containing the API token used to authenticate with the Synopsis Detect (formerly BlackDuck) Server.
+        description: Jenkins 'Secret text' credentials ID containing the API token used to authenticate with the Blackduck Detect Server.
         type: jenkins
       - name: githubTokenCredentialsId
         description: Jenkins 'Secret text' credentials ID containing token to authenticate to GitHub.
@@ -33,7 +33,7 @@ spec:
             deprecated: true
           - name: detect/apiToken
             deprecated: true
-        description: Api token to be used for connectivity with Synopsis Detect server.
+        description: Api token to be used for connectivity with Blackduck Detect server.
         type: string
         mandatory: true
         secret: true
@@ -55,7 +55,7 @@ spec:
           - STAGES
           - STEPS
       - name: projectName
-        description: Name of the Synopsis Detect (formerly BlackDuck) project.
+        description: Name of the Blackduck Detect project.
         aliases:
           - name: detect/projectName
         type: string
@@ -65,7 +65,7 @@ spec:
           - STAGES
           - STEPS
       - name: scanners
-        description: List of scanners to be used for Synopsis Detect (formerly BlackDuck) scan.
+        description: List of scanners to be used for Blackduck Detect scan.
         aliases:
           - name: detect/scanners
         type: "[]string"
@@ -79,7 +79,7 @@ spec:
           - STAGES
           - STEPS
       - name: scanPaths
-        description: List of paths which should be scanned by the Synopsis Detect (formerly BlackDuck) scan.
+        description: List of paths which should be scanned by the Blackduck Detect scan.
         aliases:
           - name: detect/scanPaths
         type: "[]string"
@@ -109,7 +109,7 @@ spec:
           - STAGES
           - STEPS
       - name: scanProperties
-        description: Properties passed to the Synopsis Detect (formerly BlackDuck) scan. You can find details in the [Synopsis Detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fall-properties.html&_LANG=enus)
+        description: Properties passed to the Blackduck Detect scan. You can find details in the [Blackduck Detect documentation](https://documentation.blackduck.com/bundle/detect/page/properties/basic-properties.html)
         aliases:
           - name: detect/scanProperties
         type: "[]string"
@@ -124,7 +124,7 @@ spec:
           - STAGES
           - STEPS
       - name: serverUrl
-        description: Server URL to the Synopsis Detect (formerly BlackDuck) Server.
+        description: Server URL to the Blackduck Detect Server.
         aliases:
           - name: detect/serverUrl
           - name: detectServerUrl
@@ -147,7 +147,7 @@ spec:
         description: Mark the current build as fail based on the policy categories applied.
         longDescription: |
           A list of policies can be provided which will be applied after the scan is completed. These policies if violated will mark the build/scan result as failed.
-          The list of accepted values can be found at [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fproject.html&anchor=fail-on-policy-violation-severities&_LANG=enus)
+          The list of accepted values can be found at [Blackduck detect documentation](https://documentation.blackduck.com/bundle/detect/page/properties/configuration/project.html#fail-on-policy-violation-severities)
         aliases:
           - name: detect/failOn
         type: "[]string"
@@ -328,7 +328,7 @@ spec:
       - name: includedPackageManagers
         description:
           "The package managers that need to be included for this scan. Providing the package manager names with this parameter will ensure that the build descriptor file of that package manager will be searched in the scan folder
-          For the complete list of possible values for this parameter, please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fdetector.html&_LANG=enus&anchor=detector-types-included-advanced)"
+          For the complete list of possible values for this parameter, please refer [Blackduck detect documentation](https://documentation.blackduck.com/bundle/detect/page/properties/configuration/detector.html#ariaid-title5)"
         aliases:
           - name: detect/includedPackageManagers
         type: "[]string"
@@ -339,7 +339,7 @@ spec:
       - name: excludedPackageManagers
         description:
           "The package managers that need to be excluded for this scan. Providing the package manager names with this parameter will ensure that the build descriptor file of that package manager will be ignored in the scan folder
-          For the complete list of possible values for this parameter, please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fdetector.html&_LANG=enus&anchor=detector-types-excluded-advanced)"
+          For the complete list of possible values for this parameter, please refer [Blackduck detect documentation](https://documentation.blackduck.com/bundle/detect/page/properties/configuration/detector.html#ariaid-title4)"
         aliases:
           - name: detect/excludedPackageManagers
         type: "[]string"
@@ -359,7 +359,7 @@ spec:
       - name: detectTools
         description:
           "The type of BlackDuck scanners to include while running the BlackDuck scan. By default All scanners are included.
-          For the complete list of possible values, Please refer [Synopsys detect documentation](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=properties%2Fconfiguration%2Fpaths.html&_LANG=enus&anchor=detect-tools-included)"
+          For the complete list of possible values, Please refer [Blackduck detect documentation](https://documentation.blackduck.com/bundle/detect/page/components/tools.html)"
         aliases:
           - name: detect/detectTools
         type: "[]string"
@@ -394,7 +394,7 @@ spec:
       - name: customEnvironmentVariables
         description:
           "A list of environment variables which can be set to prepare the environment to run a BlackDuck scan. This includes a list of environment variables defined by
-          Synopsys. The full list can be found [here](https://community.synopsys.com/s/document-item?bundleId=integrations-detect&topicId=configuring%2Fenvvars.html&_LANG=enus)
+          Blackduck. The full list can be found [here](https://documentation.blackduck.com/bundle/detect/page/configuring/envvars.html)
           This list affects the detect script downloaded while running the scan. Right now only detect7.sh is available for downloading"
         type: "[]string"
         scope:

--- a/vars/piperPipelineStageSecurity.groovy
+++ b/vars/piperPipelineStageSecurity.groovy
@@ -13,7 +13,7 @@ import static com.sap.piper.Prerequisites.checkScript
 @Field STAGE_STEP_KEYS = [
     /** Executes a Checkmarx scan */
     'checkmarxExecuteScan',
-    /** Executes Synopsys Detect scans */
+    /** Executes Blackduck Detect scans */
     'detectExecuteScan',
     /** Executes a Fortify scan */
     'fortifyExecuteScan',


### PR DESCRIPTION
# Description
This pull request updates the document references for the detectExecuteScan step. Since Synopsys Detect has transitioned to Black Duck domain, the previous links had become invalid. This update includes the correct set of links required for the Black Duck scan.

# Checklist

- [x] Tests
- [x] Documentation
- [ ] Inner source library needs updating
