### PR TITLE
fix(mend): change agentDownload functionality

### DIFF
--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -344,7 +344,7 @@ The step uses the so-called Mend Unified Agent. For details please refer to the 
 }
 
 func addWhitesourceExecuteScanFlags(cmd *cobra.Command, stepConfig *whitesourceExecuteScanOptions) {
-	cmd.Flags().StringVar(&stepConfig.AgentDownloadURL, "agentDownloadUrl", `https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar`, "URL used to download the latest version of the WhiteSource Unified Agent.")
+	cmd.Flags().StringVar(&stepConfig.AgentDownloadURL, "agentDownloadUrl", `https://downloads.mend.io/wss-unified-agent.jar`, "URL used to download the latest version of the WhiteSource Unified Agent.")
 	cmd.Flags().StringVar(&stepConfig.AgentFileName, "agentFileName", `wss-unified-agent.jar`, "Locally used name for the Unified Agent jar file after download.")
 	cmd.Flags().StringSliceVar(&stepConfig.AgentParameters, "agentParameters", []string{}, "[NOT IMPLEMENTED] List of additional parameters passed to the Unified Agent command line.")
 	cmd.Flags().StringVar(&stepConfig.AgentURL, "agentUrl", `https://saas.whitesourcesoftware.com/agent`, "URL to the WhiteSource agent endpoint.")
@@ -442,7 +442,7 @@ func whitesourceExecuteScanMetadata() config.StepData {
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
-						Default:     `https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar`,
+						Default:     `https://downloads.mend.io/wss-unified-agent.jar`,
 					},
 					{
 						Name:        "agentFileName",

--- a/pkg/whitesource/scanUA.go
+++ b/pkg/whitesource/scanUA.go
@@ -213,26 +213,34 @@ func evaluateExitCode(exitCode int) {
 
 // downloadAgent downloads the unified agent jar file if one does not exist
 func downloadAgent(config *ScanOptions, utils Utils) error {
+	// full list of download urls currently (6/27/2025) supported by vendor:
+	// 1) https://unified-agent.s3.amazonaws.com/wss-unified-agent-latest.jar
+	// 2) https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar
+	// 3) https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar
+	// TODO: implement backup download URLs in case the first one fails
 	agentFile := config.AgentFileName
 	exists, err := utils.FileExists(agentFile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to check if file '%s' exists", agentFile)
 	}
 	if !exists {
-		err := utils.DownloadFile(config.AgentDownloadURL, agentFile, nil, nil)
-		if err != nil {
-			// we check if the copy and the unauthorized error occurs and retry the download
-			// if the copy error did not happen, we rerun the whole download mechanism once
-			if strings.Contains(err.Error(), "unable to copy content from url to file") || strings.Contains(err.Error(), "returned with response 404 Not Found") || strings.Contains(err.Error(), "returned with response 403 Forbidden") {
-				// retry the download once again
-				log.Entry().Warnf("[Retry] Previous download failed due to %v", err)
-				err = nil // reset error to nil
-				err = utils.DownloadFile(config.AgentDownloadURL, agentFile, nil, nil)
+		const maxRetries = 3
+		log.Entry().Infof("Downloading Whitesource Unified Agent from %s to %s", config.AgentDownloadURL, agentFile)
+		for i := 0; i < maxRetries; i++ {
+			err = utils.DownloadFile(config.AgentDownloadURL, agentFile, nil, nil)
+			if err == nil {
+				log.Entry().Infof("Successfully downloaded Whitesource Unified Agent to %s", agentFile)
+				break
 			}
-		}
-
-		if err != nil {
-			return errors.Wrapf(err, "failed to download unified agent from URL '%s' to file '%s'", config.AgentDownloadURL, agentFile)
+			log.Entry().Warnf("Failed to download Whitesource Unified Agent: %v", err)
+			if i < maxRetries-1 {
+				log.Entry().Infof("Retrying download in 2 seconds...")
+				time.Sleep(2 * time.Second)
+			} else {
+				log.Entry().Errorf("Failed to download Whitesource Unified Agent after %d attempts", maxRetries)
+				return errors.Wrapf(err, "failed to download unified agent from URL '%s' to file '%s' after %d attempts", config.AgentDownloadURL, agentFile, maxRetries)
+			}
+			log.Entry().Infof("Retrying download of Whitesource Unified Agent, attempt %d/%d", i+2, maxRetries)
 		}
 	}
 	return nil

--- a/resources/metadata/whitesourceExecuteScan.yaml
+++ b/resources/metadata/whitesourceExecuteScan.yaml
@@ -49,7 +49,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        default: https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar
+        default: https://downloads.mend.io/wss-unified-agent.jar
       - name: agentFileName
         type: string
         description: "Locally used name for the Unified Agent jar file after download."


### PR DESCRIPTION
This fix is to change default agentDownloadUrl as well as introduce retry functionality.

1) agentDownloadUrl requires change because starting from couple months ago SAP pipelines experiencing problems downloading UA from the old default agentDownloadUrl which was: https://github.com/whitesource/unified-agent-distribution/releases/latest/download/wss-unified-agent.jar
Vendor explained (Vendor case: 00151418) that we faced some Github limitations because that source was public and shared between everyone. As solution vendor proposed to change default download url to https://downloads.mend.io/wss-unified-agent.jar which they stated is far more reliable.
This change includes only default value for agentDownloadUrl.

2) Additional retry functionality is introduced to at least try to attempt to download form the same url multiple (3) times to cover sporadic issues. Old implementation covered 1 retry attempt for limited failure list which did not always cover failure types we faced in SAP. So, I decided to attempt retry regardless of the type of the error.

3) Multiple backup urls feature was not implemented yet because it requires either to create new parameter to store them or to hardcode additional urls in the code. I opened to other ideas, but we need to implement it as well.
For now, i just left all 3 of them in the code commented.

