### PR TITLE
feat(githubPublishRelease): make GitHub API timeout configurable

### DIFF
--- a/cmd/githubPublishRelease.go
+++ b/cmd/githubPublishRelease.go
@@ -31,8 +31,7 @@ type githubIssueClient interface {
 
 func githubPublishRelease(config githubPublishReleaseOptions, telemetryData *telemetry.CustomData) {
 	// TODO provide parameter for trusted certs
-	ctx, client, err := piperGithub.
-		NewClientBuilder(config.Token, config.APIURL).
+	ctx, client, err := piperGithub.NewClientBuilder(config.Token, config.APIURL).
 		WithTimeout(45 * time.Second).
 		WithUploadURL(config.UploadURL).
 		Build()

--- a/cmd/githubPublishRelease.go
+++ b/cmd/githubPublishRelease.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
@@ -32,7 +33,9 @@ func githubPublishRelease(config githubPublishReleaseOptions, telemetryData *tel
 	// TODO provide parameter for trusted certs
 	ctx, client, err := piperGithub.
 		NewClientBuilder(config.Token, config.APIURL).
-		WithUploadURL(config.UploadURL).Build()
+		WithTimeout(45 * time.Second).
+		WithUploadURL(config.UploadURL).
+		Build()
 	if err != nil {
 		log.Entry().WithError(err).Fatal("Failed to get GitHub client.")
 	}

--- a/cmd/githubPublishRelease.go
+++ b/cmd/githubPublishRelease.go
@@ -32,7 +32,7 @@ type githubIssueClient interface {
 func githubPublishRelease(config githubPublishReleaseOptions, telemetryData *telemetry.CustomData) {
 	// TODO provide parameter for trusted certs
 	ctx, client, err := piperGithub.NewClientBuilder(config.Token, config.APIURL).
-		WithTimeout(45 * time.Second).
+		WithTimeout(60 * time.Second).
 		WithUploadURL(config.UploadURL).
 		Build()
 	if err != nil {

--- a/cmd/githubPublishRelease.go
+++ b/cmd/githubPublishRelease.go
@@ -32,7 +32,7 @@ type githubIssueClient interface {
 func githubPublishRelease(config githubPublishReleaseOptions, telemetryData *telemetry.CustomData) {
 	// TODO provide parameter for trusted certs
 	ctx, client, err := piperGithub.NewClientBuilder(config.Token, config.APIURL).
-		WithTimeout(60 * time.Second).
+		WithTimeout(time.Duration(config.GithubAPITimeout) * time.Second).
 		WithUploadURL(config.UploadURL).
 		Build()
 	if err != nil {

--- a/cmd/githubPublishRelease_generated.go
+++ b/cmd/githubPublishRelease_generated.go
@@ -20,6 +20,7 @@ type githubPublishReleaseOptions struct {
 	AddClosedIssues       bool     `json:"addClosedIssues,omitempty"`
 	AddDeltaToLastRelease bool     `json:"addDeltaToLastRelease,omitempty"`
 	APIURL                string   `json:"apiUrl,omitempty"`
+	GithubAPITimeout      int      `json:"githubApiTimeout,omitempty"`
 	AssetPath             string   `json:"assetPath,omitempty"`
 	AssetPathList         []string `json:"assetPathList,omitempty"`
 	Commitish             string   `json:"commitish,omitempty"`
@@ -169,6 +170,7 @@ func addGithubPublishReleaseFlags(cmd *cobra.Command, stepConfig *githubPublishR
 	cmd.Flags().BoolVar(&stepConfig.AddClosedIssues, "addClosedIssues", false, "If set to `true`, closed issues and merged pull-requests since the last release will added below the `releaseBodyHeader`")
 	cmd.Flags().BoolVar(&stepConfig.AddDeltaToLastRelease, "addDeltaToLastRelease", false, "If set to `true`, a link will be added to the release information that brings up all commits since the last release.")
 	cmd.Flags().StringVar(&stepConfig.APIURL, "apiUrl", `https://api.github.com`, "Set the GitHub API url.")
+	cmd.Flags().IntVar(&stepConfig.GithubAPITimeout, "githubApiTimeout", 30, "Set HTTP timeout for GitHub API calls.")
 	cmd.Flags().StringVar(&stepConfig.AssetPath, "assetPath", os.Getenv("PIPER_assetPath"), "Path to a release asset which should be uploaded to the list of release assets.")
 	cmd.Flags().StringSliceVar(&stepConfig.AssetPathList, "assetPathList", []string{}, "List of paths to a release asset which should be uploaded to the list of release assets.")
 	cmd.Flags().StringVar(&stepConfig.Commitish, "commitish", `master`, "Target git commitish for the release")
@@ -233,6 +235,15 @@ func githubPublishReleaseMetadata() config.StepData {
 						Mandatory:   true,
 						Aliases:     []config.Alias{{Name: "githubApiUrl"}},
 						Default:     `https://api.github.com`,
+					},
+					{
+						Name:        "githubApiTimeout",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
+						Type:        "int",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     30,
 					},
 					{
 						Name:        "assetPath",

--- a/cmd/githubPublishRelease_generated.go
+++ b/cmd/githubPublishRelease_generated.go
@@ -170,7 +170,7 @@ func addGithubPublishReleaseFlags(cmd *cobra.Command, stepConfig *githubPublishR
 	cmd.Flags().BoolVar(&stepConfig.AddClosedIssues, "addClosedIssues", false, "If set to `true`, closed issues and merged pull-requests since the last release will added below the `releaseBodyHeader`")
 	cmd.Flags().BoolVar(&stepConfig.AddDeltaToLastRelease, "addDeltaToLastRelease", false, "If set to `true`, a link will be added to the release information that brings up all commits since the last release.")
 	cmd.Flags().StringVar(&stepConfig.APIURL, "apiUrl", `https://api.github.com`, "Set the GitHub API url.")
-	cmd.Flags().IntVar(&stepConfig.GithubAPITimeout, "githubApiTimeout", 30, "Set HTTP timeout for GitHub API calls.")
+	cmd.Flags().IntVar(&stepConfig.GithubAPITimeout, "githubApiTimeout", 30, "Set HTTP timeout for GitHub API calls (in seconds)")
 	cmd.Flags().StringVar(&stepConfig.AssetPath, "assetPath", os.Getenv("PIPER_assetPath"), "Path to a release asset which should be uploaded to the list of release assets.")
 	cmd.Flags().StringSliceVar(&stepConfig.AssetPathList, "assetPathList", []string{}, "List of paths to a release asset which should be uploaded to the list of release assets.")
 	cmd.Flags().StringVar(&stepConfig.Commitish, "commitish", `master`, "Target git commitish for the release")

--- a/resources/metadata/githubPublishRelease.yaml
+++ b/resources/metadata/githubPublishRelease.yaml
@@ -47,6 +47,15 @@ spec:
         type: string
         default: https://api.github.com
         mandatory: true
+      - name: githubApiTimeout
+        description: Set HTTP timeout for GitHub API calls.
+        scope:
+          - GENERAL
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        type: int
+        default: 30
       - name: assetPath
         description: Path to a release asset which should be uploaded to the list of release assets.
         scope:

--- a/resources/metadata/githubPublishRelease.yaml
+++ b/resources/metadata/githubPublishRelease.yaml
@@ -48,7 +48,7 @@ spec:
         default: https://api.github.com
         mandatory: true
       - name: githubApiTimeout
-        description: Set HTTP timeout for GitHub API calls.
+        description: Set HTTP timeout for GitHub API calls (in seconds)
         scope:
           - GENERAL
           - PARAMETERS


### PR DESCRIPTION
# Description
When uploading large asset or in case of slow network, the step fails to get the response headers due to timeout:
`net/http: timeout awaiting response headers`

Increasing timeout should solve that issue.
