### PR TITLE
feat(Splunk): add TemplateName field to Splunk data

### DIFF
--- a/pkg/splunk/data.go
+++ b/pkg/splunk/data.go
@@ -19,6 +19,8 @@ type MonitoringData struct {
 	PipelineUrlHash string `json:"PipelineUrlHash,omitempty"`
 	BuildUrlHash    string `json:"BuildUrlHash,omitempty"`
 	Orchestrator    string `json:"Orchestrator,omitempty"`
+	// TemplateName indicates what template was used to run the pipeline (GPP or custom)
+	TemplateName    string `json:"TemplateName,omitempty"`
 	PiperCommitHash string `json:"PiperCommitHash,omitempty"`
 	StageName       string `json:"StageName,omitempty"`
 	StepName        string `json:"StepName,omitempty"`

--- a/pkg/splunk/data.go
+++ b/pkg/splunk/data.go
@@ -19,7 +19,7 @@ type MonitoringData struct {
 	PipelineUrlHash string `json:"PipelineUrlHash,omitempty"`
 	BuildUrlHash    string `json:"BuildUrlHash,omitempty"`
 	Orchestrator    string `json:"Orchestrator,omitempty"`
-	// TemplateName indicates what template was used to run the pipeline (GPP or custom)
+	// TemplateName indicates what template was used to run the pipeline (gpp, oss, ctp or custom)
 	TemplateName    string `json:"TemplateName,omitempty"`
 	PiperCommitHash string `json:"PiperCommitHash,omitempty"`
 	StageName       string `json:"StageName,omitempty"`

--- a/pkg/splunk/splunk.go
+++ b/pkg/splunk/splunk.go
@@ -115,6 +115,7 @@ func (s *Splunk) prepareTelemetry(telemetryData telemetry.Data) MonitoringData {
 		PipelineUrlHash: telemetryData.PipelineURLHash,
 		BuildUrlHash:    telemetryData.BuildURLHash,
 		Orchestrator:    telemetryData.Orchestrator,
+		TemplateName:    telemetryData.TemplateName,
 		PiperCommitHash: telemetryData.PiperCommitHash,
 		StageName:       telemetryData.StageName,
 		StepName:        telemetryData.BaseData.StepName,

--- a/pkg/splunk/splunk_test.go
+++ b/pkg/splunk/splunk_test.go
@@ -356,6 +356,7 @@ func Test_prepareTelemetry(t *testing.T) {
 				telemetryData: telemetry.Data{
 					BaseData: telemetry.BaseData{
 						Orchestrator: "Jenkins",
+						TemplateName: "hyperspace-piper-gpp",
 					},
 					CustomData: telemetry.CustomData{
 						Duration:      "1234",
@@ -368,6 +369,7 @@ func Test_prepareTelemetry(t *testing.T) {
 				PipelineUrlHash: "",
 				BuildUrlHash:    "",
 				Orchestrator:    "Jenkins",
+				TemplateName:    "hyperspace-piper-gpp",
 				StageName:       "",
 				StepName:        "",
 				ExitCode:        "0",

--- a/pkg/telemetry/data.go
+++ b/pkg/telemetry/data.go
@@ -16,6 +16,8 @@ type BaseData struct {
 	PipelineURLHash string `json:"pipelineUrlHash"` // defaults to sha1 of provider.GetBuildURL()
 	BuildURLHash    string `json:"buildUrlHash"`    // defaults to sha1 of provider.GetJobURL()
 	Orchestrator    string `json:"orchestrator"`    // defaults to provider.OrchestratorType()
+	// TemplateName indicates what template was used to run the pipeline (GPP or custom)
+	TemplateName string `json:"templateName"` // defaults to os.Getenv("PIPER_PIPELINE_TEMPLATE_NAME")
 }
 
 var baseData BaseData

--- a/pkg/telemetry/data.go
+++ b/pkg/telemetry/data.go
@@ -16,7 +16,7 @@ type BaseData struct {
 	PipelineURLHash string `json:"pipelineUrlHash"` // defaults to sha1 of provider.GetBuildURL()
 	BuildURLHash    string `json:"buildUrlHash"`    // defaults to sha1 of provider.GetJobURL()
 	Orchestrator    string `json:"orchestrator"`    // defaults to provider.OrchestratorType()
-	// TemplateName indicates what template was used to run the pipeline (GPP or custom)
+	// TemplateName indicates what template was used to run the pipeline (gpp, oss, ctp or custom)
 	TemplateName string `json:"templateName"` // defaults to os.Getenv("PIPER_PIPELINE_TEMPLATE_NAME")
 }
 

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -59,6 +60,7 @@ func (t *Telemetry) Initialize(stepName string) {
 
 	t.baseData = BaseData{
 		Orchestrator:    t.provider.OrchestratorType(),
+		TemplateName:    os.Getenv("PIPER_PIPELINE_TEMPLATE_NAME"),
 		StageName:       t.provider.StageName(),
 		URL:             LibraryRepository,
 		ActionName:      actionName,


### PR DESCRIPTION
# Description
Telemetry data is missing clear distinction between GPP and custom pipelines. This PR will add a field to Splunk data that will be filled during pipeline execution. 
