### PR TITLE
Provide log message in case externally provided package list is used.

### DIFF
--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -146,6 +146,7 @@ func (exec *Execute) RunScriptsInAllPackages(runScripts []string, runOptions []s
 
 	if len(packagesList) > 0 {
 		packageJSONFiles = packagesList
+		log.Entry().Info("Using provided package-list: " + strings.Join(packageJSONFiles, ", "))
 	} else {
 		packageJSONFiles, err = exec.FindPackageJSONFilesWithExcludes(excludeList)
 		if err != nil {

--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -146,7 +146,7 @@ func (exec *Execute) RunScriptsInAllPackages(runScripts []string, runOptions []s
 
 	if len(packagesList) > 0 {
 		packageJSONFiles = packagesList
-		log.Entry().Info("Using provided package-list: " + strings.Join(packageJSONFiles, ", "))
+		log.Entry().Infof("Using provided package-list: %s", strings.Join(packageJSONFiles, ", "))
 	} else {
 		packageJSONFiles, err = exec.FindPackageJSONFilesWithExcludes(excludeList)
 		if err != nil {


### PR DESCRIPTION
# Description

We cannot clearly see in the log when a package list provided from outside is used. Hence adding a log-message.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
