### PR TITLE
fix(splunk): add default value for TemplateName

### DIFF
--- a/pkg/piperutils/strings.go
+++ b/pkg/piperutils/strings.go
@@ -8,3 +8,10 @@ import (
 func Title(in string) string {
 	return cases.Title(language.English, cases.NoLower).String(in)
 }
+
+func StringWithDefault(input, defaultValue string) string {
+	if input == "" {
+		return defaultValue
+	}
+	return input
+}

--- a/pkg/telemetry/data.go
+++ b/pkg/telemetry/data.go
@@ -17,7 +17,7 @@ type BaseData struct {
 	BuildURLHash    string `json:"buildUrlHash"`    // defaults to sha1 of provider.GetJobURL()
 	Orchestrator    string `json:"orchestrator"`    // defaults to provider.OrchestratorType()
 	// TemplateName indicates what template was used to run the pipeline (gpp, oss, ctp or custom)
-	TemplateName string `json:"templateName"` // defaults to os.Getenv("PIPER_PIPELINE_TEMPLATE_NAME")
+	TemplateName string `json:"templateName"` // defaults to os.Getenv("PIPER_PIPELINE_TEMPLATE_NAME") or "custom" if not set.
 }
 
 var baseData BaseData

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/json"
 	"fmt"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"os"
 	"strconv"
 	"time"
@@ -60,7 +61,7 @@ func (t *Telemetry) Initialize(stepName string) {
 
 	t.baseData = BaseData{
 		Orchestrator:    t.provider.OrchestratorType(),
-		TemplateName:    os.Getenv("PIPER_PIPELINE_TEMPLATE_NAME"),
+		TemplateName:    piperutils.StringWithDefault(os.Getenv("PIPER_PIPELINE_TEMPLATE_NAME"), "custom"),
 		StageName:       t.provider.StageName(),
 		URL:             LibraryRepository,
 		ActionName:      actionName,


### PR DESCRIPTION
Splunk is omiting the field if it's an empty string and it doesn't show up in metrics. This PR makes 'custom' as default value.