### PR TITLE
fix(pythonBuild): check creds and url before publishing

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -172,8 +172,7 @@ func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virut
 
 func publishWithTwine(config *pythonBuildOptions, utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string) error {
 	if config.TargetRepositoryUser == "" || config.TargetRepositoryPassword == "" || config.TargetRepositoryURL == "" {
-		log.Entry().Info("Publishing enabled, but skipped due to missing credentials or repository URL.")
-		return nil
+		return fmt.Errorf("publishing enabled, but missing credentials or repository URL")
 	}
 
 	pipInstallFlags = append(pipInstallFlags, "twine")

--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -171,6 +171,11 @@ func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virut
 }
 
 func publishWithTwine(config *pythonBuildOptions, utils pythonBuildUtils, pipInstallFlags []string, virutalEnvironmentPathMap map[string]string) error {
+	if config.TargetRepositoryUser == "" || config.TargetRepositoryPassword == "" || config.TargetRepositoryURL == "" {
+		log.Entry().Info("Publishing enabled, but skipped due to missing credentials or repository URL.")
+		return nil
+	}
+
 	pipInstallFlags = append(pipInstallFlags, "twine")
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallFlags...); err != nil {
 		return err


### PR DESCRIPTION
# Description
The step tries to upload an artifact even if creds and url are empty. In case of empty url `twine` tool uses the default `https://upload.pypi.org/legacy/` which is a public repository and an the step tries to publish artifact there


