### PR TITLE
fix(ci): disable Code Climate publishing

### DIFF
--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -28,16 +28,19 @@ jobs:
       - name: unit-test
         id: unit-test
         run: go test -tags=unit ./... -coverprofile cover.out
+
+      # Code Climate publishing was disabled due to an error and uncertainty about its necessity.
       # run code coverage upload to code climate on main branch since PR branch will not have access to secret
-      - name: unit-test-code-climate-upload
-        if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: paambaati/codeclimate-action@v5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
-        with:
-          coverageLocations: cover.out:gocov
-          # truncate package name from file paths in report
-          prefix: github.com/SAP/jenkins-library/
+      # - name: unit-test-code-climate-upload
+      #   if: ${{ (github.event_name != 'pull_request') || (github.event.pull_request.head.repo.full_name == github.repository) }}
+      #   uses: paambaati/codeclimate-action@v5
+      #   env:
+      #     CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
+      #   with:
+      #     coverageLocations: cover.out:gocov
+      #     # truncate package name from file paths in report
+      #     prefix: github.com/SAP/jenkins-library/
+          
   format:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Code Climate publishing was disabled due to an error and uncertainty about its necessity.