### PR TITLE
feat(splunk): enhance error details

### DIFF
--- a/pkg/splunk/data.go
+++ b/pkg/splunk/data.go
@@ -28,6 +28,7 @@ type MonitoringData struct {
 	Duration        string `json:"Duration,omitempty"`
 	ErrorCode       string `json:"ErrorCode,omitempty"`
 	ErrorCategory   string `json:"ErrorCategory,omitempty"`
+	ErrorMessage    string `json:"ErrorMessage,omitempty"`
 	CorrelationID   string `json:"CorrelationId,omitempty"`
 	CommitHash      string `json:"CommitHash,omitempty"`
 	Branch          string `json:"Branch,omitempty"`

--- a/pkg/splunk/splunk_test.go
+++ b/pkg/splunk/splunk_test.go
@@ -465,24 +465,21 @@ func Test_prepareTelemetry_ErrorMessageCapture(t *testing.T) {
 	})
 
 	t.Run("no error message when step succeeds", func(t *testing.T) {
-		// Test data with no error
 		telemetryData := telemetry.Data{
 			BaseData: telemetry.BaseData{
 				Orchestrator: "Jenkins",
 			},
 			CustomData: telemetry.CustomData{
-				ErrorCode: "0", // Success
+				ErrorCode: "0",
 			},
 		}
 
-		// Execute
 		splunkClient := &Splunk{}
 		err := splunkClient.Initialize("test", "url", "token", "index", false)
 		require.NoError(t, err)
 
 		result := splunkClient.prepareTelemetry(telemetryData)
 
-		// Verify no error message
 		assert.Empty(t, result.ErrorMessage)
 	})
 }


### PR DESCRIPTION
# Description
Currently on Splunk we can only check whether an error actually occurred but we don't capture its contents. That makes it hard for us to decide on which common errors we should focus.

# Checklist

- [X] Tests
- [ ] Documentation
- [X] Inner source library needs updating
