### PR TITLE
fix( npmExecuteScripts.yaml ): correct lock file extension

### DIFF
--- a/resources/metadata/npmExecuteScripts.yaml
+++ b/resources/metadata/npmExecuteScripts.yaml
@@ -7,7 +7,7 @@ metadata:
     ### Lock file detection:
 
       - If `package-lock.json` is found → runs `npm ci`
-      - If `yarn.lock.json` is found → runs `yarn install --frozen-lockfile`
+      - If `yarn.lock` is found → runs `yarn install --frozen-lockfile`
       - If `pnpm-lock.yaml` is found → runs `pnpm install --frozen-lockfile`
       - If no lock file is found → defaults to `npm install` and continues execution
 


### PR DESCRIPTION
# Description
Corrected the description to have only 'yarn.lock' which is the correct lock file , than 'yarn.lock.json'
# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
