### PR TITLE
deprecate 'useDetect8'

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -443,19 +443,18 @@ func exitCodeMapping(exitCodeKey int) string {
 
 func getDetectScript(config detectExecuteScanOptions, utils detectUtils) error {
 	if config.ScanOnChanges {
-		log.Entry().Infof("The scanOnChanges option is deprecated")
+		log.Entry().Info("The scanOnChanges option is deprecated")
 	}
 
 	log.Entry().Infof("Downloading Detect Script")
 
 	downloadScript := func() error {
 		if config.UseDetect8 {
-			return utils.DownloadFile("https://detect.blackduck.com/detect8.sh", "detect.sh", nil, nil)
+			log.Entry().Warn("The useDetect8 option is deprecated")
 		} else if config.UseDetect9 {
 			return utils.DownloadFile("https://detect.blackduck.com/detect9.sh", "detect.sh", nil, nil)
 		}
 		return utils.DownloadFile("https://detect.blackduck.com/detect10.sh", "detect.sh", nil, nil)
-
 	}
 
 	if err := downloadScript(); err != nil {

--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -355,7 +355,7 @@ func addDetectExecuteScanFlags(cmd *cobra.Command, stepConfig *detectExecuteScan
 	cmd.Flags().StringVar(&stepConfig.RegistryURL, "registryUrl", os.Getenv("PIPER_registryUrl"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryUsername, "repositoryUsername", os.Getenv("PIPER_repositoryUsername"), "Used accessing for the images to be scanned (typically filled by CPE)")
 	cmd.Flags().StringVar(&stepConfig.RepositoryPassword, "repositoryPassword", os.Getenv("PIPER_repositoryPassword"), "Used accessing for the images to be scanned (typically filled by CPE)")
-	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "This flag enables the use of the supported version 8 of the Detect script instead of default version 10")
+	cmd.Flags().BoolVar(&stepConfig.UseDetect8, "useDetect8", false, "DEPRECATED: This flag enables the use of the supported version 8 of the Detect script instead of default version 10")
 	cmd.Flags().BoolVar(&stepConfig.UseDetect9, "useDetect9", false, "This flag enables the use of the supported version 9 of the Detect script instead of default version 10")
 	cmd.Flags().BoolVar(&stepConfig.ContainerScan, "containerScan", false, "When set to true, Container Scanning will be used instead of Docker Inspector as the Detect tool for scanning images, and all other detect tools will be ignored in the scan")
 
@@ -946,7 +946,7 @@ func detectExecuteScanMetadata() config.StepData {
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
 						Type:        "bool",
 						Mandatory:   false,
-						Aliases:     []config.Alias{{Name: "detect/useDetect8"}},
+						Aliases:     []config.Alias{{Name: "detect/useDetect8", Deprecated: true}},
 						Default:     false,
 					},
 					{

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -653,6 +653,7 @@ spec:
           - STAGES
           - STEPS
         default: false
+        deprecated: true
       - name: useDetect9
         description:
           "This flag enables the use of the supported version 9 of the Detect script instead of default version 10"

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -644,9 +644,10 @@ spec:
             param: container/repositoryPassword
       - name: useDetect8
         description:
-          "This flag enables the use of the supported version 8 of the Detect script instead of default version 10"
+          "DEPRECATED: This flag enables the use of the supported version 8 of the Detect script instead of default version 10"
         aliases:
           - name: detect/useDetect8
+            deprecated: true
         type: bool
         scope:
           - PARAMETERS


### PR DESCRIPTION
# Description
Deprecate `useDetect8` flag for `detectExecuteScan` command. In case it's used step will default to `detect10.sh` download.


# Checklist

- [x] Tests
- [x] Documentation
- [ ] Inner source library needs updating
