### PR TITLE
ci(release): update/create dynamic tags with each release

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -98,6 +98,18 @@ jobs:
           ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ steps.release_id.outputs.release_id }}
           -d '{"prerelease": false, "make_latest": true}'
 
+      # We need to download the shell script because reusable workflows execute
+      # within the context of the workflow that calls them
+      - name: Update/create dynamic tags
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SCRIPT_RAW_URL: https://raw.githubusercontent.com/SAP/project-piper-action/refs/heads/main/.github/scripts/update_dynamic_tags.sh
+        run: |
+          curl -s -L "$SCRIPT_RAW_URL" -o update-dynamic-tags.sh
+          chmod +x update-dynamic-tags.sh
+          ./update-dynamic-tags.sh "${{ env.PIPER_version }}"
+        continue-on-error: true
+
       # Workaround for https://github.com/SAP/jenkins-library/issues/1723, build only works with jdk8 currently
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
added a custom script that will update or create dynamic tags which always point to latest release. For example, when v1.2.4 is released, tags v1 and v1.2 will be updated (or created) to point to the same commit as v1.2.4

related pr: https://github.com/SAP/project-piper-action/pull/291