### PR TITLE
fix(sonar): Fix null value for errors entry in sonarscan report

### DIFF
--- a/cmd/sonarExecuteScan.go
+++ b/cmd/sonarExecuteScan.go
@@ -252,7 +252,7 @@ func runSonar(config sonarExecuteScanOptions, client piperhttp.Downloader, runne
 	}
 	// fetch number of issues by severity
 	issueService := SonarUtils.NewIssuesService(serverUrl, config.Token, taskReport.ProjectKey, config.Organization, config.BranchName, config.ChangeID, apiClient)
-	var categories []SonarUtils.Severity
+	var categories = make([]SonarUtils.Severity, 0)
 	influx.sonarqube_data.fields.blocker_issues, err = issueService.GetNumberOfBlockerIssues(&categories)
 	if err != nil {
 		return err

--- a/cmd/sonarExecuteScan_test.go
+++ b/cmd/sonarExecuteScan_test.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -180,8 +181,15 @@ func TestRunSonar(t *testing.T) {
 		defer os.Setenv("SONAR_SCANNER_OPTS", "")
 		// test
 		err := runSonar(options, &mockDownloadClient, &mockRunner, apiClient, &mock.FilesMock{}, &sonarExecuteScanInflux{})
-		// assert
 		assert.NoError(t, err)
+		// locad sonarscan report file
+		reportFile, err := os.ReadFile(filepath.Join(tmpFolder, "sonarscan.json"))
+		assert.NoError(t, err)
+		var reportData SonarUtils.ReportData
+		err = json.Unmarshal(reportFile, &reportData)
+		assert.NoError(t, err)
+		// assert
+		assert.NotNil(t, reportData.Errors)
 		assert.Contains(t, sonar.options, "-Dsonar.projectVersion=1")
 		assert.Contains(t, sonar.options, "-Dsonar.organization=SAP")
 		assert.Contains(t, sonar.environment, "SONAR_HOST_URL="+sonarServerURL)

--- a/cmd/sonarExecuteScan_test.go
+++ b/cmd/sonarExecuteScan_test.go
@@ -182,7 +182,7 @@ func TestRunSonar(t *testing.T) {
 		// test
 		err := runSonar(options, &mockDownloadClient, &mockRunner, apiClient, &mock.FilesMock{}, &sonarExecuteScanInflux{})
 		assert.NoError(t, err)
-		// locad sonarscan report file
+		// load sonarscan report file
 		reportFile, err := os.ReadFile(filepath.Join(tmpFolder, "sonarscan.json"))
 		assert.NoError(t, err)
 		var reportData SonarUtils.ReportData


### PR DESCRIPTION
The categories has been initialized to refer an empty list.

# Description
In case of no issues detected at static code check the
sonarscan report should contains empty list for Errors entry
instead of null value.

# Checklist

- [ ] Tests
