### PR TITLE
fix: url encoding for branch, repo name

### DIFF
--- a/pkg/abaputils/abaputils.go
+++ b/pkg/abaputils/abaputils.go
@@ -379,6 +379,7 @@ type ClientMock struct {
 	NilResponse        bool
 	ErrorInsteadOfDump bool
 	ErrorList          []error
+	RequestedURLs      []string
 }
 
 // SetOptions sets clientOptions for a client mock
@@ -390,7 +391,7 @@ func (c *ClientMock) SendRequest(method, url string, bdy io.Reader, hdr http.Hea
 	if c.NilResponse {
 		return nil, c.Error
 	}
-
+	c.RequestedURLs = append(c.RequestedURLs, url)
 	var body []byte
 	var responseError error
 	if c.Body != "" {

--- a/pkg/abaputils/sap_com_0948.go
+++ b/pkg/abaputils/sap_com_0948.go
@@ -8,8 +8,9 @@ import (
 	"net/http/cookiejar"
 	"reflect"
 	"regexp"
-	"strings"
 	"time"
+
+	"net/url" // add
 
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
@@ -435,12 +436,15 @@ func (api *SAP_COM_0948) setSleepTimeConfig(timeUnit time.Duration, maxSleepTime
 	api.retryMaxSleepTime = maxSleepTime
 }
 
+// git does not allow forward slashes as per convention but
+// software components have slashes like /DMO/REPO/ and so we url encode
 func (api *SAP_COM_0948) getRepoNameForPath() string {
-	return "/" + strings.ReplaceAll(api.repository.Name, "/", "%2F")
+	return "/" + url.PathEscape(api.repository.Name)
 }
 
+// forward slashes are allowed in git branch names
 func (api *SAP_COM_0948) getBranchNameForPath() string {
-	return "/" + api.repository.Branch
+	return "/" + url.PathEscape(api.repository.Branch)
 }
 
 func (api *SAP_COM_0948) getLogProtocolQuery(page int) string {


### PR DESCRIPTION
# Description
Url encoding for branch names in communication with `SAP_COM_0948`. Example checkout branch using `abapEnvironmentCheckoutBranch`
# Checklist

- [x] Tests
- [x] Documentation
- [x] Inner source library needs updating
