### PR TITLE
fix(deps):update python to v3.10 for pythonBuild

### DIFF
--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -330,7 +330,7 @@ func pythonBuildMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "python", Image: "python:3.9"},
+				{Name: "python", Image: "python:3.10"},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/integration/integration_python_test.go
+++ b/integration/integration_python_test.go
@@ -40,7 +40,7 @@ func TestPythonIntegrationBuildProject(t *testing.T) {
 	os.WriteFile(filepath.Join(tempDir, "runPiper.sh"), []byte(testScript), 0700)
 
 	reqNode := testcontainers.ContainerRequest{
-		Image: "python:3.9",
+		Image: "python:3.10",
 		Cmd:   []string{"tail", "-f"},
 		Mounts: testcontainers.Mounts(
 			testcontainers.BindMount(pwd, "/piperbin"),

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -113,4 +113,4 @@ spec:
           - name: custom/buildSettingsInfo
   containers:
     - name: python
-      image: python:3.9
+      image: python:3.10


### PR DESCRIPTION
# Description

This updates the Python version used in `pythonBuild` step to `v3.10` as the current version is reaching [EOL](https://devguide.python.org/versions/).

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
