### PR TITLE
chore(renovate): add rule to update python Docker image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -118,6 +118,20 @@
             "datasourceTemplate": "docker",
             "extractVersionTemplate": "(?<version>.*)",
             "autoReplaceStringTemplate": "image: {{depName}}:{{newValue}}"
+        },
+        {
+            "customType": "regex",
+            "matchStringsStrategy": "any",
+            "managerFilePatterns": [
+                "cmd/pythonBuild_generated.go"
+            ],
+            "matchStrings": [
+                "Image: \"(?<depName>python):(?<currentValue>.*)\""
+            ],
+            "depTypeTemplate": "dependencies",
+            "datasourceTemplate": "docker",
+            "extractVersionTemplate": "(?<version>.*)",
+            "autoReplaceStringTemplate": "Image: \"{{depName}}:{{newValue}}\""
         }
     ],
     "postUpdateOptions": [


### PR DESCRIPTION
# Description

This rule is meant to watch the Docker image used in the `pythonBuild` step.

# Checklist

- [x] Tests
  - https://github.com/CCFenner/jenkins-library/pull/10
  - https://github.com/CCFenner/jenkins-library/blob/master/.github/renovate.json
- [ ] Documentation
- [ ] Inner source library needs updating
