### PR TITLE
 Feat(CxOne): incremental scans based on another branch

### DIFF
--- a/cmd/checkmarxOneExecuteScan_test.go
+++ b/cmd/checkmarxOneExecuteScan_test.go
@@ -70,11 +70,11 @@ func (sys *checkmarxOneSystemMock) GetScanWorkflow(scanID string) ([]checkmarxOn
 	return []checkmarxOne.WorkflowLog{}, nil
 }
 
-func (sys *checkmarxOneSystemMock) GetLastScans(projectID string, limit int) ([]checkmarxOne.Scan, error) {
+func (sys *checkmarxOneSystemMock) GetLastScans(projectID, branch string, limit int) ([]checkmarxOne.Scan, error) {
 	return []checkmarxOne.Scan{}, nil
 }
 
-func (sys *checkmarxOneSystemMock) GetLastScansByStatus(projectID string, limit int, status []string) ([]checkmarxOne.Scan, error) {
+func (sys *checkmarxOneSystemMock) GetLastScansByStatus(projectID, branch string, limit int, status []string) ([]checkmarxOne.Scan, error) {
 	return []checkmarxOne.Scan{}, nil
 }
 

--- a/pkg/checkmarxone/checkmarxone.go
+++ b/pkg/checkmarxone/checkmarxone.go
@@ -304,8 +304,8 @@ type System interface {
 	GetScanSummary(scanID string) (ScanSummary, error)
 	GetResultsPredicates(SimilarityID int64, ProjectID string) ([]ResultsPredicates, error)
 	GetScanWorkflow(scanID string) ([]WorkflowLog, error)
-	GetLastScans(projectID string, limit int) ([]Scan, error)
-	GetLastScansByStatus(projectID string, limit int, status []string) ([]Scan, error)
+	GetLastScans(projectID, branch string, limit int) ([]Scan, error)
+	GetLastScansByStatus(projectID, branch string, limit int, status []string) ([]Scan, error)
 
 	ScanProject(projectID, sourceUrl, branch, scanType string, settings []ScanConfiguration, tags map[string]string) (Scan, error)
 	ScanProjectZip(projectID, sourceUrl, branch string, settings []ScanConfiguration, tags map[string]string) (Scan, error)
@@ -1142,7 +1142,7 @@ func (sys *SystemInstance) GetScanWorkflow(scanID string) ([]WorkflowLog, error)
 	return workflow, nil
 }
 
-func (sys *SystemInstance) GetLastScans(projectID string, limit int) ([]Scan, error) {
+func (sys *SystemInstance) GetLastScans(projectID, branch string, limit int) ([]Scan, error) {
 	var scanResponse struct {
 		TotalCount         uint64
 		FilteredTotalCount uint64
@@ -1163,6 +1163,7 @@ func (sys *SystemInstance) GetLastScans(projectID string, limit int) ([]Scan, er
 		"offset":     {fmt.Sprintf("%v", 0)},
 		"limit":      {fmt.Sprintf("%v", limit)},
 		"sort":       {sortStr},
+		"branches":   []string{branch},
 	}
 
 	header := http.Header{}
@@ -1177,7 +1178,7 @@ func (sys *SystemInstance) GetLastScans(projectID string, limit int) ([]Scan, er
 	return scanResponse.Scans, err
 }
 
-func (sys *SystemInstance) GetLastScansByStatus(projectID string, limit int, status []string) ([]Scan, error) {
+func (sys *SystemInstance) GetLastScansByStatus(projectID, branch string, limit int, status []string) ([]Scan, error) {
 	var scanResponse struct {
 		TotalCount         uint64
 		FilteredTotalCount uint64
@@ -1199,6 +1200,7 @@ func (sys *SystemInstance) GetLastScansByStatus(projectID string, limit int, sta
 		"limit":      {fmt.Sprintf("%d", limit)},
 		"sort":       {sortStr},
 		"statuses":   status,
+		"branches":   []string{branch},
 	}
 
 	data, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/scans/?%v", body.Encode()), nil, nil, []int{})


### PR DESCRIPTION
This PR leverages a new feature in CxOne that allows to base an incremental scan on a full scan from another branch.
This is especially useful in pull requests in order to get quick feedback. In PRs, Piper will always trigger incremental scans based on the target branch (even if it goes beyond the fullScanCycle value).
Outside pull requests, Piper will use the primary branch set in Checkmarx to try basing the scan on the primary branch.