### PR TITLE
fix(CxOne): Fix incremental scan count and full scan cycle handling

### DIFF
--- a/cmd/checkmarxOneExecuteScan_test.go
+++ b/cmd/checkmarxOneExecuteScan_test.go
@@ -54,6 +54,10 @@ func (sys *checkmarxOneSystemMock) GetScanMetadata(scanID string) (checkmarxOne.
 	return checkmarxOne.ScanMetadata{}, nil
 }
 
+func (sys *checkmarxOneSystemMock) GetScanMetadatas(scanID []string) ([]checkmarxOne.ScanMetadata, error) {
+	return []checkmarxOne.ScanMetadata{}, nil
+}
+
 func (sys *checkmarxOneSystemMock) GetScanResults(scanID string, limit uint64) ([]checkmarxOne.ScanResult, error) {
 	return []checkmarxOne.ScanResult{}, nil
 }


### PR DESCRIPTION
# Description

Fixes:
- full scans were incorrectly counted as incremental because the API response was not containing the actual scan type but the requested type
- incremental scans based on the primary branch were not following the full scan cycle parameter
- default branch name will be the cxone default: .unknown (instead of "n/a")
 

