### PR TITLE
fix(python): correct parameter typo

### DIFF
--- a/cmd/pythonBuild.go
+++ b/cmd/pythonBuild.go
@@ -120,25 +120,25 @@ func buildExecute(config *pythonBuildOptions, utils pythonBuildUtils, pipInstall
 }
 
 func createVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions, virutalEnvironmentPathMap map[string]string) error {
-	virtualEnvironmentFlags := []string{"-m", "venv", config.VirutalEnvironmentName}
+	virtualEnvironmentFlags := []string{"-m", "venv", config.VirtualEnvironmentName}
 	err := utils.RunExecutable("python3", virtualEnvironmentFlags...)
 	if err != nil {
 		return err
 	}
-	err = utils.RunExecutable("bash", "-c", "source "+filepath.Join(config.VirutalEnvironmentName, "bin", "activate"))
+	err = utils.RunExecutable("bash", "-c", "source "+filepath.Join(config.VirtualEnvironmentName, "bin", "activate"))
 	if err != nil {
 		return err
 	}
-	virutalEnvironmentPathMap["pip"] = filepath.Join(config.VirutalEnvironmentName, "bin", "pip")
+	virutalEnvironmentPathMap["pip"] = filepath.Join(config.VirtualEnvironmentName, "bin", "pip")
 	// venv will create symlinks to python3 inside the container
 	virutalEnvironmentPathMap["python"] = "python"
-	virutalEnvironmentPathMap["deactivate"] = filepath.Join(config.VirutalEnvironmentName, "bin", "deactivate")
+	virutalEnvironmentPathMap["deactivate"] = filepath.Join(config.VirtualEnvironmentName, "bin", "deactivate")
 
 	return nil
 }
 
 func removeVirtualEnvironment(utils pythonBuildUtils, config *pythonBuildOptions) error {
-	err := utils.RemoveAll(config.VirutalEnvironmentName)
+	err := utils.RemoveAll(config.VirtualEnvironmentName)
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func runBOMCreationForPy(utils pythonBuildUtils, pipInstallFlags []string, virut
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallCycloneDxFlags...); err != nil {
 		return err
 	}
-	virutalEnvironmentPathMap["cyclonedx"] = filepath.Join(config.VirutalEnvironmentName, "bin", "cyclonedx-py")
+	virutalEnvironmentPathMap["cyclonedx"] = filepath.Join(config.VirtualEnvironmentName, "bin", "cyclonedx-py")
 
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["cyclonedx"], "env", "--output-file", PyBomFilename, "--output-format", "XML", "--spec-version", cycloneDxSchemaVersion); err != nil {
 		return err
@@ -175,7 +175,7 @@ func publishWithTwine(config *pythonBuildOptions, utils pythonBuildUtils, pipIns
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["pip"], pipInstallFlags...); err != nil {
 		return err
 	}
-	virutalEnvironmentPathMap["twine"] = filepath.Join(config.VirutalEnvironmentName, "bin", "twine")
+	virutalEnvironmentPathMap["twine"] = filepath.Join(config.VirtualEnvironmentName, "bin", "twine")
 	if err := utils.RunExecutable(virutalEnvironmentPathMap["twine"], "upload", "--username", config.TargetRepositoryUser,
 		"--password", config.TargetRepositoryPassword, "--repository-url", config.TargetRepositoryURL, "--disable-progress-bar",
 		"dist/*"); err != nil {

--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -27,7 +27,7 @@ type pythonBuildOptions struct {
 	TargetRepositoryUser     string   `json:"targetRepositoryUser,omitempty"`
 	TargetRepositoryURL      string   `json:"targetRepositoryURL,omitempty"`
 	BuildSettingsInfo        string   `json:"buildSettingsInfo,omitempty"`
-	VirutalEnvironmentName   string   `json:"virutalEnvironmentName,omitempty"`
+	VirtualEnvironmentName   string   `json:"virtualEnvironmentName,omitempty"`
 	RequirementsFilePath     string   `json:"requirementsFilePath,omitempty"`
 }
 
@@ -212,7 +212,7 @@ func addPythonBuildFlags(cmd *cobra.Command, stepConfig *pythonBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.TargetRepositoryUser, "targetRepositoryUser", os.Getenv("PIPER_targetRepositoryUser"), "Username for the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment.")
 	cmd.Flags().StringVar(&stepConfig.TargetRepositoryURL, "targetRepositoryURL", os.Getenv("PIPER_targetRepositoryURL"), "URL of the target repository where the compiled binaries shall be uploaded - typically provided by the CI/CD environment.")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the maven build . This information is typically used for compliance related processes.")
-	cmd.Flags().StringVar(&stepConfig.VirutalEnvironmentName, "virutalEnvironmentName", `piperBuild-env`, "name of the virtual environment that will be used for the build")
+	cmd.Flags().StringVar(&stepConfig.VirtualEnvironmentName, "virtualEnvironmentName", `piperBuild-env`, "name of the virtual environment that will be used for the build")
 	cmd.Flags().StringVar(&stepConfig.RequirementsFilePath, "requirementsFilePath", `requirements.txt`, "file path to the requirements.txt file needed for the sbom cycloneDx file creation.")
 
 }
@@ -321,12 +321,12 @@ func pythonBuildMetadata() config.StepData {
 						Default:   os.Getenv("PIPER_buildSettingsInfo"),
 					},
 					{
-						Name:        "virutalEnvironmentName",
+						Name:        "virtualEnvironmentName",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
 						Type:        "string",
 						Mandatory:   false,
-						Aliases:     []config.Alias{},
+						Aliases:     []config.Alias{{Name: "virutalEnvironmentName", Deprecated: true}},
 						Default:     `piperBuild-env`,
 					},
 					{

--- a/cmd/pythonBuild_test.go
+++ b/cmd/pythonBuild_test.go
@@ -36,7 +36,7 @@ func TestRunPythonBuild(t *testing.T) {
 	cpe := pythonBuildCommonPipelineEnvironment{}
 	t.Run("success - build", func(t *testing.T) {
 		config := pythonBuildOptions{
-			VirutalEnvironmentName: "dummy",
+			VirtualEnvironmentName: "dummy",
 		}
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
@@ -62,14 +62,14 @@ func TestRunPythonBuild(t *testing.T) {
 			TargetRepositoryURL:      "https://my.target.repository.local",
 			TargetRepositoryUser:     "user",
 			TargetRepositoryPassword: "password",
-			VirutalEnvironmentName:   "dummy",
+			VirtualEnvironmentName:   "dummy",
 		}
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
 
 		runPythonBuild(&config, &telemetryData, utils, &cpe)
 		assert.Equal(t, "python3", utils.ExecMockRunner.Calls[0].Exec)
-		assert.Equal(t, []string{"-m", "venv", config.VirutalEnvironmentName}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, []string{"-m", "venv", config.VirtualEnvironmentName}, utils.ExecMockRunner.Calls[0].Params)
 		assert.Equal(t, "bash", utils.ExecMockRunner.Calls[1].Exec)
 		assert.Equal(t, []string{"-c", "source " + filepath.Join("dummy", "bin", "activate")}, utils.ExecMockRunner.Calls[1].Params)
 		assert.Equal(t, "python", utils.ExecMockRunner.Calls[2].Exec)
@@ -86,7 +86,7 @@ func TestRunPythonBuild(t *testing.T) {
 		config := pythonBuildOptions{
 			CreateBOM:              true,
 			Publish:                false,
-			VirutalEnvironmentName: "dummy",
+			VirtualEnvironmentName: "dummy",
 		}
 		utils := newPythonBuildTestsUtils()
 		telemetryData := telemetry.CustomData{}
@@ -94,7 +94,7 @@ func TestRunPythonBuild(t *testing.T) {
 		runPythonBuild(&config, &telemetryData, utils, &cpe)
 		// assert.NoError(t, err)
 		assert.Equal(t, "python3", utils.ExecMockRunner.Calls[0].Exec)
-		assert.Equal(t, []string{"-m", "venv", config.VirutalEnvironmentName}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, []string{"-m", "venv", config.VirtualEnvironmentName}, utils.ExecMockRunner.Calls[0].Params)
 		assert.Equal(t, "bash", utils.ExecMockRunner.Calls[1].Exec)
 		assert.Equal(t, []string{"-c", "source " + filepath.Join("dummy", "bin", "activate")}, utils.ExecMockRunner.Calls[1].Params)
 		assert.Equal(t, "python", utils.ExecMockRunner.Calls[2].Exec)
@@ -111,7 +111,7 @@ func TestPythonBuildExecute(t *testing.T) {
 		config := pythonBuildOptions{
 			BuildFlags:             []string{"--verbose"},
 			SetupFlags:             []string{"egg_info", "--tag-build=pr13"},
-			VirutalEnvironmentName: "venv",
+			VirtualEnvironmentName: "venv",
 		}
 
 		utils := pythonBuildMockUtils{

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -89,7 +89,7 @@ spec:
         resourceRef:
           - name: commonPipelineEnvironment
             param: custom/buildSettingsInfo
-      - name: virutalEnvironmentName
+      - name: virtualEnvironmentName
         type: string
         description: name of the virtual environment that will be used for the build
         scope:
@@ -97,6 +97,9 @@ spec:
           - STAGES
           - PARAMETERS
         default: piperBuild-env
+        aliases:
+          - name: virutalEnvironmentName  # typo alias - to be removed in future releases
+            deprecated: true
       - name: requirementsFilePath
         type: string
         description: file path to the requirements.txt file needed for the sbom cycloneDx file creation.


### PR DESCRIPTION
# Description

Fix typo in parameter name `virutalEnvironmentName`

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
