### PR TITLE
feat: update TLS verify flag in kubernetesDeploy

### DIFF
--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -263,9 +263,15 @@ func runKubectlDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUti
 	}
 
 	kubeParams := []string{
-		"--insecure-skip-tls-verify=" + strconv.FormatBool(config.InsecureSkipTLSVerify),
 		fmt.Sprintf("--namespace=%v", config.Namespace),
 	}
+
+	// Add CA certificate if provided
+	if len(config.CACertificate) > 0 && !config.InsecureSkipTLSVerify {
+		kubeParams = append(kubeParams, fmt.Sprintf("--certificate-authority=%v", config.CACertificate))
+	}
+
+	kubeParams = append(kubeParams, "--insecure-skip-tls-verify="+strconv.FormatBool(config.InsecureSkipTLSVerify))
 
 	if len(config.KubeConfig) > 0 {
 		log.Entry().Info("Using KUBECONFIG environment for authentication.")

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -263,7 +263,7 @@ func runKubectlDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUti
 	}
 
 	kubeParams := []string{
-		"--insecure-skip-tls-verify=true",
+		"--insecure-skip-tls-verify=" + strconv.FormatBool(config.InsecureSkipTLSVerify),
 		fmt.Sprintf("--namespace=%v", config.Namespace),
 	}
 
@@ -525,7 +525,7 @@ func defineKubeSecretParams(config kubernetesDeployOptions, containerRegistry st
 		config.ContainerRegistrySecret,
 		fmt.Sprintf("--from-file=.dockerconfigjson=%v", targetPath),
 		"--type=kubernetes.io/dockerconfigjson",
-		"--insecure-skip-tls-verify=true",
+		"--insecure-skip-tls-verify=" + strconv.FormatBool(config.InsecureSkipTLSVerify),
 		"--dry-run=client",
 		"--output=json",
 	}

--- a/cmd/kubernetesDeploy.go
+++ b/cmd/kubernetesDeploy.go
@@ -267,7 +267,7 @@ func runKubectlDeploy(config kubernetesDeployOptions, utils kubernetes.DeployUti
 	}
 
 	// Add CA certificate if provided
-	if len(config.CACertificate) > 0 && !config.InsecureSkipTLSVerify {
+	if len(config.CACertificate) > 0 {
 		kubeParams = append(kubeParams, fmt.Sprintf("--certificate-authority=%v", config.CACertificate))
 	}
 

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -56,6 +56,7 @@ type kubernetesDeployOptions struct {
 	VerificationScript         string                 `json:"verificationScript,omitempty"`
 	TeardownScript             string                 `json:"teardownScript,omitempty"`
 	InsecureSkipTLSVerify      bool                   `json:"insecureSkipTLSVerify,omitempty"`
+	CACertificate              string                 `json:"CACertificate,omitempty"`
 }
 
 // KubernetesDeployCommand Deployment to Kubernetes test or production namespace within the specified Kubernetes cluster.
@@ -251,6 +252,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringVar(&stepConfig.VerificationScript, "verificationScript", os.Getenv("PIPER_verificationScript"), "HTTP location of verification script")
 	cmd.Flags().StringVar(&stepConfig.TeardownScript, "teardownScript", os.Getenv("PIPER_teardownScript"), "HTTP location of teardown script")
 	cmd.Flags().BoolVar(&stepConfig.InsecureSkipTLSVerify, "insecureSkipTLSVerify", false, "This disables TLS certificate verification, allowing connections even with self-signed or untrusted certificates.")
+	cmd.Flags().StringVar(&stepConfig.CACertificate, "CACertificate", os.Getenv("PIPER_CACertificate"), "Path to the Kubernetes CA certificate file. If provided, secure connections will be established using this certificate when 'insecureSkipTLSVerify' is false.\n")
 
 	cmd.MarkFlagRequired("containerRegistryUrl")
 	cmd.MarkFlagRequired("deployTool")
@@ -734,6 +736,15 @@ func kubernetesDeployMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     false,
+					},
+					{
+						Name:        "CACertificate",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_CACertificate"),
 					},
 				},
 			},

--- a/cmd/kubernetesDeploy_generated.go
+++ b/cmd/kubernetesDeploy_generated.go
@@ -55,6 +55,7 @@ type kubernetesDeployOptions struct {
 	SetupScript                string                 `json:"setupScript,omitempty"`
 	VerificationScript         string                 `json:"verificationScript,omitempty"`
 	TeardownScript             string                 `json:"teardownScript,omitempty"`
+	InsecureSkipTLSVerify      bool                   `json:"insecureSkipTLSVerify,omitempty"`
 }
 
 // KubernetesDeployCommand Deployment to Kubernetes test or production namespace within the specified Kubernetes cluster.
@@ -249,6 +250,7 @@ func addKubernetesDeployFlags(cmd *cobra.Command, stepConfig *kubernetesDeployOp
 	cmd.Flags().StringVar(&stepConfig.SetupScript, "setupScript", os.Getenv("PIPER_setupScript"), "HTTP location of setup script")
 	cmd.Flags().StringVar(&stepConfig.VerificationScript, "verificationScript", os.Getenv("PIPER_verificationScript"), "HTTP location of verification script")
 	cmd.Flags().StringVar(&stepConfig.TeardownScript, "teardownScript", os.Getenv("PIPER_teardownScript"), "HTTP location of teardown script")
+	cmd.Flags().BoolVar(&stepConfig.InsecureSkipTLSVerify, "insecureSkipTLSVerify", false, "This disables TLS certificate verification, allowing connections even with self-signed or untrusted certificates.")
 
 	cmd.MarkFlagRequired("containerRegistryUrl")
 	cmd.MarkFlagRequired("deployTool")
@@ -723,6 +725,15 @@ func kubernetesDeployMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_teardownScript"),
+					},
+					{
+						Name:        "insecureSkipTLSVerify",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
 					},
 				},
 			},

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -547,6 +547,12 @@ spec:
           - STAGES
           - STEPS
         default: false
+      - name: CACertificate
+        type: string
+        description: |
+          Path to the Kubernetes CA certificate file. If provided, secure connections will be established using this certificate when 'insecureSkipTLSVerify' is false.
+        scope:
+          - PARAMETERS
   containers:
     - image: dtzar/helm-kubectl:3
       workingDir: /config

--- a/resources/metadata/kubernetesDeploy.yaml
+++ b/resources/metadata/kubernetesDeploy.yaml
@@ -539,6 +539,14 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: insecureSkipTLSVerify
+        type: bool
+        description: "This disables TLS certificate verification, allowing connections even with self-signed or untrusted certificates."
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: false
   containers:
     - image: dtzar/helm-kubectl:3
       workingDir: /config

--- a/vars/kubernetesDeploy.groovy
+++ b/vars/kubernetesDeploy.groovy
@@ -10,6 +10,7 @@ void call(Map parameters = [:]) {
         [type: 'token', id: 'kubeTokenCredentialsId', env: ['PIPER_kubeToken']],
         [type: 'usernamePassword', id: 'dockerCredentialsId', env: ['PIPER_containerRegistryUser', 'PIPER_containerRegistryPassword']],
         [type: 'token', id: 'githubTokenCredentialsId', env: ['PIPER_githubToken']],
+        [type: 'file', id: 'CACertificateCredentialsId', env: ['PIPER_CACertificate']],
     ]
     piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
# Description
Added the option to have custom --insecure-skip-tls-verify flag and added a new flag for CA certificates.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
