### PR TITLE
[golangBuild] Reset logging of `utils` after `isMainPackage` and `runGolangciLint`

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -568,6 +568,11 @@ func isMainPackage(utils golangBuildUtils, pkg string) (bool, error) {
 	outBuffer := bytes.NewBufferString("")
 	utils.Stdout(outBuffer)
 	utils.Stderr(outBuffer)
+	defer func() {
+		// Reset routing command output to logging framework
+		utils.Stdout(log.Writer())
+		utils.Stderr(log.Writer())
+	}
 	err := utils.RunExecutable("go", "list", "-f", "{{ .Name }}", pkg)
 	if err != nil {
 		return false, fmt.Errorf("%w: %s", err, outBuffer.String())

--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -402,7 +402,6 @@ func reportGolangTestCoverage(config *golangBuildOptions, utils golangBuildUtils
 			log.SetErrorCategory(log.ErrorTest)
 			return fmt.Errorf("failed to convert coverage data to cobertura format: %w", err)
 		}
-		utils.Stdout(log.Writer())
 
 		err = utils.FileWrite("cobertura-coverage.xml", coverageOutput.Bytes(), 0o666)
 		if err != nil {
@@ -438,6 +437,7 @@ func runGolangciLint(utils golangBuildUtils, golangciLintDir string, failOnError
 
 	var outputBuffer bytes.Buffer
 	utils.Stdout(&outputBuffer)
+	defer utils.Stdout(log.Writer())
 	err := utils.RunExecutable(binaryPath, "run", "--out-format", lintSettings["reportStyle"])
 	if err != nil && utils.GetExitCode() != 1 {
 		return fmt.Errorf("running golangci-lint failed: %w", err)

--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -393,6 +393,7 @@ func reportGolangTestCoverage(config *golangBuildOptions, utils golangBuildUtils
 
 		coverageOutput := bytes.Buffer{}
 		utils.Stdout(&coverageOutput)
+		defer utils.Stdout(log.Writer())
 		options := []string{}
 		if config.ExcludeGeneratedFromCoverage {
 			options = append(options, "-ignore-gen-files")
@@ -572,7 +573,7 @@ func isMainPackage(utils golangBuildUtils, pkg string) (bool, error) {
 		// Reset routing command output to logging framework
 		utils.Stdout(log.Writer())
 		utils.Stderr(log.Writer())
-	}
+	}()
 	err := utils.RunExecutable("go", "list", "-f", "{{ .Name }}", pkg)
 	if err != nil {
 		return false, fmt.Errorf("%w: %s", err, outBuffer.String())


### PR DESCRIPTION
# Description

Various methods in `golangBuild` change the `Stdout` and `Stderr` of the `golangBuildUtils` to a BufferString.

Unfortunately, some of them never reset this, so when later actions call binaries, their outputs are not logged anymore. This change implements resetting `Stdout` and `Stderr` to `log.Writer()` via `defer`, as done during initialization of the `golangBuildUtils`.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
