### PR TITLE
Skipping python build integration test

### DIFF
--- a/integration/integration_python_test.go
+++ b/integration/integration_python_test.go
@@ -20,6 +20,7 @@ import (
 
 func TestPythonIntegrationBuildProject(t *testing.T) {
 	// t.Parallel()
+	t.Skip("Skipping test due to setuptools issue of artifact name change, should be enabled once the issue is fixed.")
 	ctx := context.Background()
 	pwd, err := os.Getwd()
 	assert.NoError(t, err, "Getting current working directory failed.")


### PR DESCRIPTION
The setuptools version above 77.0.3, https://setuptools.pypa.io/en/stable/history.html

Official change log for 78.0.0: Setuptools no longer accepts options containing uppercase or dash characters in setup.cfg. 
Please ensure to write the options in setup.cfg using the lower_snake_case convention (e.g. Name =>name, install-requires => install_requires). 

python Build step creates artifacts with "_" but the Download Artifact step tries to download the artifact with "-" due to fixed format.