### PR TITLE
fix(CxOne) Use ProjectID instead of ScanID in SARIF Configuration ID

### DIFF
--- a/pkg/checkmarxone/cxjson_to_sarif.go
+++ b/pkg/checkmarxone/cxjson_to_sarif.go
@@ -25,6 +25,7 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 	rulesArray := []format.SarifRule{}
 
 	baseURL := serverURL + "/results/" + scanMeta.ScanID + "/" + scanMeta.ProjectID
+	projectBaseURL := serverURL + "/projects/" + scanMeta.ProjectID + "/"
 
 	cweIdsForTaxonomies := make(map[int]int) //use a map to avoid duplicates
 	cweCounter := 0
@@ -261,7 +262,8 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 	sarif.Runs[0].Tool = tool
 
 	//handle automationDetails
-	sarif.Runs[0].AutomationDetails = &format.AutomationDetails{Id: fmt.Sprintf("%v/sast", baseURL)} // Use deeplink to pass a maximum of information
+	// This field corresponds to the configuration category in GitHub Security tab, it is meant to be used for monorepos so that each project can have its own findings
+	sarif.Runs[0].AutomationDetails = &format.AutomationDetails{Id: projectBaseURL}
 
 	//handle taxonomies
 	//Only one exists apparently: CWE. It is fixed


### PR DESCRIPTION
# Description

Using the Scan ID in the field automationDetails.id leads to a huge amount of configurations and unique findings in the Github repository.
This PR is fixing this issue by using the Project ID instead. 
