### PR TITLE
fix: pin node version to 22 rather than lts

### DIFF
--- a/cmd/batsExecuteTests_generated.go
+++ b/cmd/batsExecuteTests_generated.go
@@ -262,7 +262,7 @@ func batsExecuteTestsMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "bats", Image: "node:lts-bookworm", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "outputFormat", Value: "junit"}}}}},
+				{Name: "bats", Image: "node:22-bookworm", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "outputFormat", Value: "junit"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/gaugeExecuteTests_generated.go
+++ b/cmd/gaugeExecuteTests_generated.go
@@ -308,7 +308,7 @@ func gaugeExecuteTestsMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "gauge", Image: "node:lts-bookworm", EnvVars: []config.EnvVar{{Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}}, WorkingDir: "/home/node"},
+				{Name: "gauge", Image: "node:22-bookworm", EnvVars: []config.EnvVar{{Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}}, WorkingDir: "/home/node"},
 			},
 			Sidecars: []config.Container{
 				{Name: "selenium", Image: "selenium/standalone-chrome", EnvVars: []config.EnvVar{{Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}, {Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}}},

--- a/cmd/karmaExecuteTests_generated.go
+++ b/cmd/karmaExecuteTests_generated.go
@@ -266,7 +266,7 @@ func karmaExecuteTestsMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "karma", Image: "node:lts-bookworm", EnvVars: []config.EnvVar{{Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}, {Name: "PIPER_SELENIUM_HOSTNAME", Value: "karma"}, {Name: "PIPER_SELENIUM_WEBDRIVER_HOSTNAME", Value: "selenium"}, {Name: "PIPER_SELENIUM_WEBDRIVER_PORT", Value: "4444"}}, WorkingDir: "/home/node"},
+				{Name: "karma", Image: "node:22-bookworm", EnvVars: []config.EnvVar{{Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}, {Name: "PIPER_SELENIUM_HOSTNAME", Value: "karma"}, {Name: "PIPER_SELENIUM_WEBDRIVER_HOSTNAME", Value: "selenium"}, {Name: "PIPER_SELENIUM_WEBDRIVER_PORT", Value: "4444"}}, WorkingDir: "/home/node"},
 			},
 			Sidecars: []config.Container{
 				{Name: "selenium", Image: "selenium/standalone-chrome", EnvVars: []config.EnvVar{{Name: "NO_PROXY", Value: "localhost,karma,$NO_PROXY"}, {Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}}},

--- a/cmd/newmanExecute_generated.go
+++ b/cmd/newmanExecute_generated.go
@@ -337,7 +337,7 @@ func newmanExecuteMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "newman", Image: "node:lts-bookworm", WorkingDir: "/home/node"},
+				{Name: "newman", Image: "node:22-bookworm", WorkingDir: "/home/node"},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/npmExecuteLint_generated.go
+++ b/cmd/npmExecuteLint_generated.go
@@ -234,7 +234,7 @@ func npmExecuteLintMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "node", Image: "node:lts-bookworm"},
+				{Name: "node", Image: "node:22-bookworm"},
 			},
 		},
 	}

--- a/cmd/npmExecuteScripts_generated.go
+++ b/cmd/npmExecuteScripts_generated.go
@@ -535,7 +535,7 @@ func npmExecuteScriptsMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "node", Image: "node:lts-bookworm"},
+				{Name: "node", Image: "node:22-bookworm"},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/cmd/npmExecuteTests_generated.go
+++ b/cmd/npmExecuteTests_generated.go
@@ -363,7 +363,7 @@ func npmExecuteTestsMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "node", Image: "node:lts-bookworm", EnvVars: []config.EnvVar{{Name: "BASE_URL", Value: "${{params.baseUrl}}"}, {Name: "CREDENTIALS_ID", Value: "${{params.credentialsId}}"}, {Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}}, WorkingDir: "/home/node"},
+				{Name: "node", Image: "node:22-bookworm", EnvVars: []config.EnvVar{{Name: "BASE_URL", Value: "${{params.baseUrl}}"}, {Name: "CREDENTIALS_ID", Value: "${{params.credentialsId}}"}, {Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}}, WorkingDir: "/home/node"},
 			},
 			Sidecars: []config.Container{
 				{Name: "selenium", Image: "selenium/standalone-chrome", EnvVars: []config.EnvVar{{Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}, {Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}}},

--- a/cmd/shellExecute_generated.go
+++ b/cmd/shellExecute_generated.go
@@ -247,7 +247,7 @@ func shellExecuteMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "shell", Image: "node:lts-bookworm", WorkingDir: "/home/node"},
+				{Name: "shell", Image: "node:22-bookworm", WorkingDir: "/home/node"},
 			},
 		},
 	}

--- a/cmd/uiVeri5ExecuteTests_generated.go
+++ b/cmd/uiVeri5ExecuteTests_generated.go
@@ -271,7 +271,7 @@ func uiVeri5ExecuteTestsMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "uiVeri5", Image: "node:lts-bookworm", EnvVars: []config.EnvVar{{Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}}, WorkingDir: "/home/node"},
+				{Name: "uiVeri5", Image: "node:22-bookworm", EnvVars: []config.EnvVar{{Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}, {Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}}, WorkingDir: "/home/node"},
 			},
 			Sidecars: []config.Container{
 				{Name: "selenium", Image: "selenium/standalone-chrome", EnvVars: []config.EnvVar{{Name: "NO_PROXY", Value: "localhost,selenium,$NO_PROXY"}, {Name: "no_proxy", Value: "localhost,selenium,$no_proxy"}}},

--- a/cmd/whitesourceExecuteScan_generated.go
+++ b/cmd/whitesourceExecuteScan_generated.go
@@ -1142,9 +1142,9 @@ func whitesourceExecuteScanMetadata() config.StepData {
 				{Image: "gradle", WorkingDir: "/home/gradle", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "gradle"}}}}},
 				{Image: "hseeberger/scala-sbt:8u181_2.12.8_1.2.8", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "sbt"}}}}},
 				{Image: "maven:3.5-jdk-8", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "maven"}}}}},
-				{Image: "node:lts-bookworm", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "npm"}}}}},
+				{Image: "node:22-bookworm", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "npm"}}}}},
 				{Image: "python:3.6-stretch", WorkingDir: "/tmp", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "pip"}}}}},
-				{Image: "node:lts-bookworm", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "yarn"}}}}},
+				{Image: "node:22-bookworm", WorkingDir: "/home/node", Conditions: []config.Condition{{ConditionRef: "strings-equal", Params: []config.Param{{Name: "buildTool", Value: "yarn"}}}}},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/resources/metadata/batsExecuteTests.yaml
+++ b/resources/metadata/batsExecuteTests.yaml
@@ -60,7 +60,7 @@ spec:
                 type: bool
   containers:
     - name: bats
-      image: node:lts-bookworm
+      image: node:22-bookworm
       workingDir: /home/node
       conditions:
         - conditionRef: strings-equal

--- a/resources/metadata/gaugeExecuteTests.yaml
+++ b/resources/metadata/gaugeExecuteTests.yaml
@@ -75,7 +75,7 @@ spec:
             type: delivery-mapping
   containers:
     - name: gauge
-      image: node:lts-bookworm
+      image: node:22-bookworm
       env:
         - name: no_proxy
           value: localhost,selenium,$no_proxy

--- a/resources/metadata/karmaExecuteTests.yaml
+++ b/resources/metadata/karmaExecuteTests.yaml
@@ -75,7 +75,7 @@ spec:
             type: requirement-mapping
   containers:
     - name: karma
-      image: node:lts-bookworm
+      image: node:22-bookworm
       env:
         - name: no_proxy
           value: localhost,selenium,$no_proxy

--- a/resources/metadata/newmanExecute.yaml
+++ b/resources/metadata/newmanExecute.yaml
@@ -100,5 +100,5 @@ spec:
             type: delivery-mapping
   containers:
     - name: newman
-      image: node:lts-bookworm
+      image: node:22-bookworm
       workingDir: /home/node

--- a/resources/metadata/npmExecuteLint.yaml
+++ b/resources/metadata/npmExecuteLint.yaml
@@ -71,4 +71,4 @@ spec:
           - name: npm/outputFormat
   containers:
     - name: node
-      image: node:lts-bookworm
+      image: node:22-bookworm

--- a/resources/metadata/npmExecuteScripts.yaml
+++ b/resources/metadata/npmExecuteScripts.yaml
@@ -254,4 +254,4 @@ spec:
             type: cucumber
   containers:
     - name: node
-      image: node:lts-bookworm
+      image: node:22-bookworm

--- a/resources/metadata/npmExecuteTests.yaml
+++ b/resources/metadata/npmExecuteTests.yaml
@@ -133,7 +133,7 @@ spec:
             type: end-to-end-test
   containers:
     - name: node
-      image: node:lts-bookworm
+      image: node:22-bookworm
       env:
         - name: BASE_URL
           value: ${{params.baseUrl}}

--- a/resources/metadata/shellExecute.yaml
+++ b/resources/metadata/shellExecute.yaml
@@ -79,5 +79,5 @@ spec:
         mandatory: false
   containers:
     - name: shell
-      image: node:lts-bookworm
+      image: node:22-bookworm
       workingDir: /home/node

--- a/resources/metadata/uiVeri5ExecuteTests.yaml
+++ b/resources/metadata/uiVeri5ExecuteTests.yaml
@@ -74,7 +74,7 @@ spec:
             type: delivery-mapping
   containers:
     - name: uiVeri5
-      image: node:lts-bookworm
+      image: node:22-bookworm
       env:
         - name: no_proxy
           value: localhost,selenium,$no_proxy

--- a/resources/metadata/whitesourceExecuteScan.yaml
+++ b/resources/metadata/whitesourceExecuteScan.yaml
@@ -806,7 +806,7 @@ spec:
           params:
             - name: buildTool
               value: maven
-    - image: node:lts-bookworm
+    - image: node:22-bookworm
       workingDir: /home/node
       env: []
       conditions:
@@ -822,7 +822,7 @@ spec:
           params:
             - name: buildTool
               value: pip
-    - image: node:lts-bookworm
+    - image: node:22-bookworm
       workingDir: /home/node
       env: []
       conditions:


### PR DESCRIPTION
# Description
1. October 28, 2025 - Node.js v24.11.0 was released and entered LTS status: https://nodejs.org/en/blog/release/v24.11.0
2. Within the last few hours - Docker Hub updated the node:lts-bookworm tag:
- Before: node:lts-bookworm → Node v22.21.0 + npm 10.9.4 
- After: node:lts-bookworm → Node v24.11.0 + npm 11.6.1 
3. Builds started failing because:
- npm 11 enforces --tag requirement for prerelease versions
- Version 0.0.2-20251029010307 is a prerelease (has hyphen + identifier)
- The jenkins-library doesn't add --tag to the publish command

Last passing:  node:lts-bookworm → v22.21.0 + npm 10.9.4
First failing: node:lts-bookworm → v24.11.0 + npm 11.6.1

Solution:
Pin Docker image to a specific Node.js version that works

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
