### PR TITLE
fix(deps): update python to v3.13 for pythonBuild

### DIFF
--- a/cmd/pythonBuild_generated.go
+++ b/cmd/pythonBuild_generated.go
@@ -341,7 +341,7 @@ func pythonBuildMetadata() config.StepData {
 				},
 			},
 			Containers: []config.Container{
-				{Name: "python", Image: "python:3.12"},
+				{Name: "python", Image: "python:3.13"},
 			},
 			Outputs: config.StepOutputs{
 				Resources: []config.StepResources{

--- a/resources/metadata/pythonBuild.yaml
+++ b/resources/metadata/pythonBuild.yaml
@@ -116,4 +116,4 @@ spec:
           - name: custom/buildSettingsInfo
   containers:
     - name: python
-      image: python:3.12
+      image: python:3.13


### PR DESCRIPTION
# Description
Updated pythonBuild default version to 3.13

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
