### PR TITLE
ABAP AAKaaS Check Namespace provided

### DIFF
--- a/cmd/abapAddonAssemblyKitReserveNextPackages.go
+++ b/cmd/abapAddonAssemblyKitReserveNextPackages.go
@@ -82,6 +82,10 @@ func checkAndCopyFieldsToRepositories(pckgWR []aakaas.PackageWithRepository) ([]
 	var repos []abaputils.Repository
 	var checkFailure error = nil
 	for i := range pckgWR {
+		if pckgWR[i].Package.Status != aakaas.PackageStatusReleased && pckgWR[i].Package.Namespace == "" {
+			checkFailure = errors.New("AAKaaS returned a response with empty Namespace which indicates a configuration error")
+		}
+
 		checkFailure = checkCommitID(pckgWR, i, checkFailure)
 
 		pckgWR[i].Package.CopyFieldsToRepo(&pckgWR[i].Repo)

--- a/cmd/abapAddonAssemblyKitReserveNextPackages_test.go
+++ b/cmd/abapAddonAssemblyKitReserveNextPackages_test.go
@@ -210,6 +210,32 @@ func TestCopyFieldsToRepositoriesPackage(t *testing.T) {
 	})
 }
 
+func TestCheckNamespace(t *testing.T) {
+	pckgWR := []aakaas.PackageWithRepository{
+		{
+			Package: aakaas.Package{
+				ComponentName: "/DRNMSPC/COMP01",
+				VersionYAML:   "1.0.0",
+				PackageName:   "SAPK-001AAINDRNMSPC",
+				Type:          "AOI",
+			},
+			Repo: abaputils.Repository{
+				Name:        "/DRNMSPC/COMP01",
+				VersionYAML: "1.0.0",
+			},
+		},
+	}
+
+	t.Run("test copyFieldsToRepositories Planned success w/o predecessorcommitID", func(t *testing.T) {
+		pckgWR[0].Package.Status = aakaas.PackageStatusPlanned
+		pckgWR[0].Package.PredecessorCommitID = ""
+		pckgWR[0].Repo.CommitID = "something40charslongxxxxxxxxxxxxxxxxxxxx"
+		pckgWR[0].Package.CommitID = "something40charslongxxxxxxxxxxxxxxxxxxxx"
+		_, err := checkAndCopyFieldsToRepositories(pckgWR)
+		assert.ErrorContains(t, err, "AAKaaS returned a response with empty Namespace which indicates a configuration error")
+	})
+}
+
 // ********************* Test reserveNext *******************
 func TestReserveNextPackage(t *testing.T) {
 	t.Run("test reserveNext - success", func(t *testing.T) {


### PR DESCRIPTION
for planned packages the assembly will fail without a namespace. check & fail early.
