### PR TITLE
chore(renovate): Add ignorePaths for integration test data

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
     "labels": [
         "dependencies"
     ],
-    ignorePaths: [
+    "ignorePaths": [
         "integration/testdata/**",
         "**/node_modules/**", 
         "**/bower_components/**"


### PR DESCRIPTION
# Description

Added ignorePaths to exclude specific directories from Renovate.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
