### PR TITLE
ci(release): disable scheduled releases

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -10,8 +10,6 @@ on:
         default: false
   repository_dispatch:
     types: perform-release
-  schedule:
-    - cron: '0 9 * * 1'
 
 jobs:
   run_integration_tests:


### PR DESCRIPTION
according to our release strategy, scheduled Monday releases are disabled. Releases will be handled manually.