### PR TITLE
Fix memory leak warning

### DIFF
--- a/vars/dockerExecute.groovy
+++ b/vars/dockerExecute.groovy
@@ -228,7 +228,7 @@ void call(Map parameters = [:], body) {
                 executeInsideDocker = false
             }
 
-            returnCode = sh script: 'docker ps -q > /dev/null', returnStatus: true
+            def returnCode = sh script: 'docker ps -q > /dev/null', returnStatus: true
             if (returnCode != 0) {
                 echo "[WARNING][$STEP_NAME] Cannot connect to docker daemon (command 'docker ps' did not return with '0'). Configured docker image '${config.dockerImage}' will not be used."
                 executeInsideDocker = false


### PR DESCRIPTION
Without the def keyword, we see this warning in the console output of Jenkins: Did you forget the `def` keyword? dockerExecute seems to be setting a field named returnCode (to a value of type Integer) which could lead to memory leaks or other issues.
