### PR TITLE
Fix loop in function 'getFilterForResourceReferences' in stepmeta.go

### DIFF
--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -476,7 +476,7 @@ func getFilterForResourceReferences(params []StepParameters) []string {
 			reference = param.GetReference("vaultSecretFile")
 		}
 		if reference == nil {
-			return filter
+			continue
 		}
 		if reference.Name != "" {
 			filter = append(filter, reference.Name)

--- a/pkg/config/stepmeta_test.go
+++ b/pkg/config/stepmeta_test.go
@@ -794,3 +794,49 @@ func TestResolveMetadata(t *testing.T) {
 		assert.EqualError(t, err, "either one of stepMetadata or stepName parameter has to be passed")
 	})
 }
+
+func TestGetFilterForResourceReferences(t *testing.T) {
+	t.Run("collects all vault secret reference names", func(t *testing.T) {
+		params := []StepParameters{
+			{Name: "param1", ResourceRef: []ResourceReference{{Name: "vaultRef1", Type: "vaultSecret"}}},
+			{Name: "param2", ResourceRef: []ResourceReference{{Name: "vaultRef2", Type: "vaultSecret"}}},
+		}
+		filter := getFilterForResourceReferences(params)
+		assert.Equal(t, []string{"vaultRef1", "vaultRef2"}, filter)
+	})
+
+	t.Run("skips params without vault references without stopping iteration", func(t *testing.T) {
+		params := []StepParameters{
+			{Name: "noRef"},
+			{Name: "param1", ResourceRef: []ResourceReference{{Name: "vaultRef1", Type: "vaultSecret"}}},
+			{Name: "alsoNoRef"},
+			{Name: "param2", ResourceRef: []ResourceReference{{Name: "vaultRef2", Type: "vaultSecret"}}},
+		}
+		filter := getFilterForResourceReferences(params)
+		assert.Equal(t, []string{"vaultRef1", "vaultRef2"}, filter)
+	})
+
+	t.Run("includes vaultSecretFile references", func(t *testing.T) {
+		params := []StepParameters{
+			{Name: "param1", ResourceRef: []ResourceReference{{Name: "fileRef", Type: "vaultSecretFile"}}},
+			{Name: "noRef"},
+			{Name: "param2", ResourceRef: []ResourceReference{{Name: "secretRef", Type: "vaultSecret"}}},
+		}
+		filter := getFilterForResourceReferences(params)
+		assert.Equal(t, []string{"fileRef", "secretRef"}, filter)
+	})
+
+	t.Run("returns nil when no params have vault references", func(t *testing.T) {
+		params := []StepParameters{
+			{Name: "param1"},
+			{Name: "param2", ResourceRef: []ResourceReference{{Name: "jenkinsRef", Type: "secret"}}},
+		}
+		filter := getFilterForResourceReferences(params)
+		assert.Nil(t, filter)
+	})
+
+	t.Run("returns nil for empty params", func(t *testing.T) {
+		filter := getFilterForResourceReferences([]StepParameters{})
+		assert.Nil(t, filter)
+	})
+}


### PR DESCRIPTION
# Description

Came across an issue where I'm currently not able to set the reference `golangPrivateModulesGitTokenVaultSecret` for parameter `privateModulesGitToken` in the [golangBuild step](https://www.project-piper.io/steps/golangBuild/#privatemodulesgittoken). Expectation was that I can overwrite the default value, but in the end it always tries to use the default value `golang`.

I'm not 100% sure on the mix-in mechanism of Piper, so please have a look on this proposal.

* Disclaimer: Tests generated with Claude Code

# Checklist

- [x] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
