### PR TITLE
fix(vault): proper retries handling in Vault token lifecycle

### DIFF
--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -80,49 +80,30 @@ func NewClientWithToken(cfg *ClientConfig, token string) (*Client, error) {
 }
 
 func (c *Client) startTokenLifecycleManager(initialLoginDone chan error) {
-	loginDone := false
-	var lastErr error
-	defer func() {
-		log.Entry().Debugf("exiting Vault token lifecycle manager")
-		if !loginDone {
-			initialLoginDone <- lastErr
-			close(initialLoginDone)
-		}
-	}()
+	vaultLoginResp, err := c.login()
+	if err != nil {
+		log.Entry().WithError(err).Warn("Vault authentication failed")
+		initialLoginDone <- err
+		close(initialLoginDone)
+		return
+	}
+	initialLoginDone <- nil
+	close(initialLoginDone)
 
-	retryAttemptDuration := c.vaultApiClient.MinRetryWait()
-	for i := 0; i <= c.vaultApiClient.MaxRetries(); i++ {
-		if i != 0 {
-			log.Entry().WithField("attempt", i).WithField("maxRetries", c.vaultApiClient.MaxRetries()).WithField("retryDelay", retryAttemptDuration.Seconds()).Info("Retrying Vault login")
-			time.Sleep(retryAttemptDuration)
-		}
+	if !vaultLoginResp.Auth.Renewable {
+		log.Entry().Debugf("Vault token is not configured to be renewable.")
+		return
+	}
 
-		vaultLoginResp, err := c.login()
-		if err != nil {
-			lastErr = err
-			if i == 0 {
-				log.Entry().WithError(err).Warn("Vault authentication failed")
-			} else {
-				log.Entry().WithError(err).WithField("attempt", i).Warn("Vault authentication retry failed")
-			}
-			continue
-		}
-
-		if !loginDone {
-			initialLoginDone <- nil
-			close(initialLoginDone)
-			loginDone = true
-		}
-
-		if !vaultLoginResp.Auth.Renewable {
-			log.Entry().Debugf("Vault token is not configured to be renewable.")
+	for {
+		if tokenErr := c.manageTokenLifecycle(vaultLoginResp); tokenErr != nil {
+			log.Entry().Warnf("unable to manage token lifecycle: %v", tokenErr)
 			return
 		}
-
-		tokenErr := c.manageTokenLifecycle(vaultLoginResp)
-		if tokenErr != nil {
-			log.Entry().Warnf("unable to start managing token lifecycle: %v", tokenErr)
-			continue
+		vaultLoginResp, err = c.login()
+		if err != nil {
+			log.Entry().WithError(err).Warn("Vault re-authentication failed")
+			return
 		}
 	}
 }

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -61,12 +61,11 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	}
 	applyApiClientRetryConfiguration(c.vaultApiClient)
 
-	initialLoginDone := make(chan struct{})
-	go c.startTokenLifecycleManager(initialLoginDone) // this goroutine ends with main goroutine
-	// wait for initial login or a failure
-	<-initialLoginDone
-
-	// In case of a failure, the function returns an unauthorized client, which will cause subsequent requests to fail.
+	initialLoginDone := make(chan error)
+	go c.startTokenLifecycleManager(initialLoginDone)
+	if err := <-initialLoginDone; err != nil {
+		return nil, fmt.Errorf("vault authentication failed: %w", err)
+	}
 	return c, nil
 }
 
@@ -80,15 +79,17 @@ func NewClientWithToken(cfg *ClientConfig, token string) (*Client, error) {
 	return c, nil
 }
 
-func (c *Client) startTokenLifecycleManager(initialLoginDone chan struct{}) {
+func (c *Client) startTokenLifecycleManager(initialLoginDone chan error) {
+	loginDone := false
+	var lastErr error
 	defer func() {
-		// make sure to close channel to avoid blocking of the caller
 		log.Entry().Debugf("exiting Vault token lifecycle manager")
-		initialLoginDone <- struct{}{}
-		close(initialLoginDone)
+		if !loginDone {
+			initialLoginDone <- lastErr
+			close(initialLoginDone)
+		}
 	}()
 
-	initialLoginSucceed := false
 	retryAttemptDuration := c.vaultApiClient.MinRetryWait()
 	for i := 0; i <= c.vaultApiClient.MaxRetries(); i++ {
 		if i != 0 {
@@ -98,6 +99,7 @@ func (c *Client) startTokenLifecycleManager(initialLoginDone chan struct{}) {
 
 		vaultLoginResp, err := c.login()
 		if err != nil {
+			lastErr = err
 			if i == 0 {
 				log.Entry().WithError(err).Warn("Vault authentication failed")
 			} else {
@@ -105,9 +107,11 @@ func (c *Client) startTokenLifecycleManager(initialLoginDone chan struct{}) {
 			}
 			continue
 		}
-		if !initialLoginSucceed {
-			initialLoginDone <- struct{}{}
-			initialLoginSucceed = true
+
+		if !loginDone {
+			initialLoginDone <- nil
+			close(initialLoginDone)
+			loginDone = true
 		}
 
 		if !vaultLoginResp.Auth.Renewable {
@@ -117,7 +121,7 @@ func (c *Client) startTokenLifecycleManager(initialLoginDone chan struct{}) {
 
 		tokenErr := c.manageTokenLifecycle(vaultLoginResp)
 		if tokenErr != nil {
-			log.Entry().Warnf("unable to start managing token lifecycle: %v", err)
+			log.Entry().Warnf("unable to start managing token lifecycle: %v", tokenErr)
 			continue
 		}
 	}

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -180,17 +179,18 @@ func applyApiClientRetryConfiguration(vaultApiClient *vaultAPI.Client) {
 			isEOF = true
 		}
 
-		retry, err := vaultAPI.DefaultRetryPolicy(ctx, resp, err)
+		originalErr := err
+		retry, retryPolicyErr := vaultAPI.DefaultRetryPolicy(ctx, resp, err)
 
-		if err != nil || err == io.EOF || isEOF || retry {
+		if retryPolicyErr != nil || isEOF || retry {
 			if resp != nil {
-				if err != nil {
-					log.Entry().Infof("Retrying vault request... %s (err: %v)", resp.Status, err)
+				if originalErr != nil {
+					log.Entry().Infof("Retrying vault request... %s (err was: %v)", resp.Status, originalErr)
 				} else {
 					log.Entry().Infof("Retrying vault request... %s", resp.Status)
 				}
 			} else {
-				log.Entry().Infof("Retrying vault request... (err: %v)", err)
+				log.Entry().Infof("Retrying vault request... (err was: %v)", originalErr)
 			}
 			return true, nil
 		}

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -61,6 +61,7 @@ func NewClient(cfg *ClientConfig) (*Client, error) {
 	applyApiClientRetryConfiguration(c.vaultApiClient)
 
 	initialLoginDone := make(chan error)
+	// No outer retry loop: transient failures are retried at the HTTP layer by applyApiClientRetryConfiguration (up to 3 attempts, 5–90s backoff).
 	go c.startTokenLifecycleManager(initialLoginDone)
 	if err := <-initialLoginDone; err != nil {
 		return nil, fmt.Errorf("vault authentication failed: %w", err)


### PR DESCRIPTION
## Fix vault NewClient returning nil error on failed authentication

### Problem
When all authentication attempts in `startTokenLifecycleManager` failed (e.g. due to timeout), `NewClient` still returned `nil` as the error. The deferred channel send always unblocked the caller regardless of login outcome, making it impossible to distinguish a healthy client from an unauthenticated one.

### Changes
- Changed `initialLoginDone` from `chan struct{}` to `chan error` so login failures are propagated back to `NewClient`, which now returns the error to the caller
- Removed the redundant outer retry loop in `startTokenLifecycleManager` — the Vault API client already retries at the HTTP level (3 attempts with backoff); the outer loop was duplicating this for initial login
- Restructured `startTokenLifecycleManager` into a clear two-phase flow: single login attempt with error propagation, followed by an indefinite token renewal loop
- Fixed a pre-existing bug where `manageTokenLifecycle` warning logged `err` (out of scope) instead of `tokenErr`
