### PR TITLE
docs(detectExecuteScan): restructure and expand step documentation

### DIFF
--- a/documentation/docs/steps/detectExecuteScan.md
+++ b/documentation/docs/steps/detectExecuteScan.md
@@ -6,39 +6,68 @@
 
 You need to store the API token for the Detect service as _'Secret text'_ credential in your Jenkins system.
 
-## ${docJenkinsPluginDependencies}
+## Scan Types & Configuration
 
-## ${docGenParameters}
+| Scan Type | Description | Parameter | Default |
+|---|---|---|---|
+| **Signature Scan** | Scans file signatures to identify open-source components by matching against the BlackDuck KnowledgeBase. | `scanners: [signature]` | ✅ Enabled by default |
+| **Source Scan** | Scans actual source code content to find code-level matches beyond what signature scanning detects. | `scanners: [source]` | ❌ Disabled by default |
+| **Container Image Scan** | Downloads and scans Docker container images for vulnerabilities in OS packages and libraries. | `scanContainerDistro` or `containerScan: true` | ❌ Disabled by default |
 
-## ${docGenConfiguration}
+## Scan Modes
 
-## Rapid scan
+| Mode | When it activates | Behavior |
+|---|---|---|
+| **FULL** (default) | Normal branch builds | Complete scan. Results are persisted on the BlackDuck server. Required for production deployments and releases. |
+| **RAPID** | Automatically on Pull Requests | Fast scan (~30 seconds). No data saved on BlackDuck server. Suitable for early detection during development, but not for production. |
 
-In addition to the full scan, Black Duck also offers a faster and easier scan option, called <a href="https://documentation.blackduck.com/bundle/detect/page/runningdetect/rapidscan.html" target="_blank">Rapid Scan</a>.
-Its main advantage is speed. In most cases, the scan is completed in less than 30 seconds. It doesn't save any information on the Black Duck side.
-The result can be found in the pipeline console.
+> **Note:** Rapid scan mode is not a separate scan type — it is a mode modifier that applies to whichever scan types are configured. The switch from FULL to RAPID happens automatically when the orchestrator detects a Pull Request.
 
-- **Note**
-  By default, Black Duck scans run in 'FULL' mode. Although rapid scans do appropriate security checks for early detection of issues during daily developments, they are not sufficient for production deployment and releases: Only use 'FULL' scans for production deployment and releases.
+## Combination Rules
 
-### Running rapid scans on pull requests
+### Rule 1: Signature + Source scan
+Signature and source scanners run together within a **single** `detect.sh` invocation (the main scan).
 
-If you have configured your orchestrator to detect pull requests, then the `detecExecuationScan` step in the Piper pipeline can recognize this and change the Black Duck scan mode from 'FULL' to 'RAPID'. This does not affect the usual branch scans.
+```yaml
+steps:
+  detectExecuteScan:
+    serverUrl: 'https://your-blackduck-server.com/'
+    scanners:
+      - signature
+      - source
+```
 
-- **Note**
-  * This functionality is not applicable to the GPP (General Purpose Pipeline)
-  * This can only be used for custom pipelines based on the Jenkins piper library
+### Rule 2: Main scan + Container image scan (via `scanContainerDistro`)
+The main scan (signature **or** source) runs first, then container image scans run separately — one `detect.sh` execution per image.
+
+```yaml
+steps:
+  detectExecuteScan:
+    serverUrl: 'https://your-blackduck-server.com/'
+    scanContainerDistro: 'ubuntu'
+```
+
+### Rule 3: Container image scan only (via `containerScan: true`)
+The main scan (signature/source) is **skipped entirely**. Only container image scans execute.
+
+```yaml
+steps:
+  detectExecuteScan:
+    serverUrl: 'https://your-blackduck-server.com/'
+    containerScan: true
+```
+
+### Rule 4: Rapid scan on Pull Requests
+No additional configuration required. When a Pull Request is detected by the orchestrator, the scan mode automatically switches to RAPID. Optionally provide GitHub credentials to post results as a PR comment.
+
+> **Note:** Rapid scan functionality is not applicable to GPP (General Purpose Pipeline). It can only be used with custom pipelines based on the Jenkins Piper library.
 
 #### How to run rapid scans
 
-1. Specify all the required parameters for the detectExecution step in .pipeline/config.yml
-   Optionally you can specify `githubApi` and `githubToken` in the detectExecution step to get the result in the pull request comment.
-   For example:
+1. Specify all the required parameters for the `detectExecuteScan` step in `.pipeline/config.yml`. Optionally specify `githubApiUrl` and `githubToken` to get the result posted as a pull request comment.
 
-    ```
-    ...
+    ```yaml
     steps:
-      ...
       detectExecuteScan:
         serverUrl: 'https://sap-staging.app.blackduck.com/'
         detectTokenCredentialsId: 'JenkinsCredentialsIdForBlackDuckToken'
@@ -46,33 +75,33 @@ If you have configured your orchestrator to detect pull requests, then the `dete
         version: 'v1.0'
         githubApiUrl: 'https://github.wdf.sap.corp/api/v3'
         githubToken: 'JenkinsCredentialsIdForGithub'
-      ...
-    ...
     ```
 
-2. Enable detecExecuationScan in the orchestrator.
-  For example:
-
-    ```
-    @Library('piper-lib') _
-    @Library('piper-lib-os') __
-
-    node {
-      stage('Init') {
-        checkout scm
-        setupPipelineEnvironment script: this
-      }
-      stage('detectExecuteScan') {
-         detectExecuteScan script: this
-      }
-      ...
-    }
-    ```
+2. Enable `detectExecuteScan` in your chosen orchestrator via config
 
 3. To run the rapid scan, open a pull request with your changes to the main branch.
 
 #### Result of the rapid scan
 
-If you provide `githubApi` and `githubToken`, then the pipeline adds the scan result to the comment of the opened pull request.
+If you provide `githubApiUrl` and `githubToken`, the pipeline adds the scan result to the pull request comment.
 
 ![blackDuckPullRequestComment](../images/BDRapidScanPrs.png)
+
+## Summary Table
+
+| Configuration | Main Scan (Signature/Source) | Container Image Scan | Mode | Total Executions |
+|---|:---:|:---:|:---:|:---:|
+| Default | ✅ Signature | ❌ | FULL | 1 |
+| `scanners: [signature, source]` | ✅ Signature + Source | ❌ | FULL | 1 |
+| `scanContainerDistro: ubuntu` | ✅ Signature (default) | ✅ | FULL | 1 + N |
+| `scanners: [signature, source]` + `scanContainerDistro` | ✅ Signature + Source | ✅ | FULL | 1 + N |
+| `containerScan: true` | ❌ Skipped | ✅ | FULL | N |
+| Any of the above + Pull Request detected | Same as above | Same as above | RAPID | Same as above |
+
+*N = number of container images in `imageNameTags`*
+
+## ${docJenkinsPluginDependencies}
+
+## ${docGenParameters}
+
+## ${docGenConfiguration}


### PR DESCRIPTION
## Summary

- Replaced the loose `## Rapid scan` section with structured reference content covering scan types, scan modes, and combination rules
- Added a **Scan Types & Configuration** table documenting Signature, Source, and Container Image scans with their parameters and defaults
- Added a **Scan Modes** table (FULL vs RAPID) with a note clarifying that RAPID is a mode modifier, not a separate scan type
- Added **Combination Rules** (4 rules) covering every valid scan configuration and when each applies
- Merged the existing step-by-step rapid scan guide and PR screenshot into Rule 4 to consolidate all rapid scan content in one place
- Added a **Summary Table** mapping each configuration to execution counts
- Fixed typos: `detecExecuationScan` → `detectExecuteScan`