### PR TITLE
 fix: npmExecuteScripts - omit optional dependencies in cyclonedx-npm BOM generation

### DIFF
--- a/pkg/npm/bom.go
+++ b/pkg/npm/bom.go
@@ -144,7 +144,7 @@ func (exec *Execute) generatePnpmBOMFiles(packageJSONFiles []string, cliPath str
 func (exec *Execute) createNpmBOM(packageJSONFiles []string) error {
 	// Primary attempt with cyclonedx-npm
 	cycloneDxNpmInstallParams := []string{"install", "--no-save", cycloneDxNpmPackageVersion, "--prefix", tmpInstallFolder}
-	cycloneDxNpmRunParams := []string{"--output-format", "XML", "--spec-version", CycloneDxSchemaVersion, "--omit", "dev", "--output-file"}
+	cycloneDxNpmRunParams := []string{"--output-format", "XML", "--spec-version", CycloneDxSchemaVersion, "--omit", "dev", "--omit", "optional", "--output-file"}
 
 	err := exec.createBOMWithParams(cycloneDxNpmInstallParams, cycloneDxNpmRunParams, packageJSONFiles)
 	if err != nil {

--- a/pkg/npm/bom_test.go
+++ b/pkg/npm/bom_test.go
@@ -38,6 +38,8 @@ func TestBom(t *testing.T) {
 			CycloneDxSchemaVersion,
 			"--omit",
 			"dev",
+			"--omit",
+			"optional",
 			"--output-file",
 		}
 
@@ -86,6 +88,7 @@ func TestBom(t *testing.T) {
 			"--output-format", "XML",
 			"--spec-version", CycloneDxSchemaVersion,
 			"--omit", "dev",
+			"--omit", "optional",
 			"--output-file", "bom-npm.xml",
 			"package.json",
 		}, " ")


### PR DESCRIPTION
# Description
 fix: npmExecuteScripts - skip optional dependencies during BOM generation

Since `@cyclonedx/cyclonedx-npm@2.1.0` (introduced in #5693), the tool attempts to resolve `optionalDependencies` and fails with exit code 254 if any cannot be resolved (e.g. local-only dev dependencies).

Adding `--omit optional` alongside the existing `--omit dev` instructs cyclonedx-npm to skip optional dependencies, consistent with how npm itself handles them.

## Root cause
`cyclonedx-npm@2.1.0` changed behavior to include optional dependencies by default. Projects with unresolvable optional dependencies (e.g. platform-specific or local-only packages) now fail SBOM generation.

## Reproduction
Error observed:
npmExecuteScripts failed:
  failed to generate BOM with @cyclonedx/cyclonedx-npm@2.1.0
  running './tmp/node_modules/.bin/cyclonedx-npm' failed: exit status 254

- Failed pipeline (before fix):
  https://github.tools.sap/CALMRun/rum-ui/actions/runs/33428132/job/158190898
- Workaround commit (after fix): https://github.tools.sap/CALMRun/rum-ui/commit/ba4152838e5059d010982c93b17099891070adf6