### PR TITLE
feat(buildsettings): add dockerBuild support in CreateBuildSettingsInfo

### DIFF
--- a/documentation/docs/steps/dockerBuild.md
+++ b/documentation/docs/steps/dockerBuild.md
@@ -29,10 +29,16 @@ steps:
 
 ### Building multiple images from sub-directories
 
+`containerRegistryUrl`, `containerRegistryUser`, and `containerRegistryPassword` are required —
+the multi-image build path will fail immediately if `containerRegistryUrl` is empty.
+
 ```yaml
 steps:
   dockerBuild:
     containerImageName: myImage
+    containerRegistryUrl: my.registry.example.com
+    containerRegistryUser: myUser
+    containerRegistryPassword: myPassword
     containerMultiImageBuild: true
 ```
 

--- a/documentation/docs/steps/dockerBuild.md
+++ b/documentation/docs/steps/dockerBuild.md
@@ -1,0 +1,82 @@
+# ${docGenStepName}
+
+## ${docGenDescription}
+
+## Prerequisites
+
+This step is intended for use in **GitHub Actions**, where Docker + BuildKit are natively available on the runner.
+It is not supported on Jenkins or Azure DevOps runners.
+
+When pushing to a container registry, you need to provide credentials via one of these approaches:
+
+* Pass `containerRegistryUser` and `containerRegistryPassword` parameters — the step will write a `config.json` automatically.
+* Provide a pre-existing `config.json` via the `dockerConfigJSON` parameter.
+
+## ${docJenkinsPluginDependencies}
+
+## Example
+
+### Building a single image
+
+```yaml
+steps:
+  dockerBuild:
+    containerImageName: myImage
+    containerRegistryUrl: my.registry.example.com
+    containerRegistryUser: myUser
+    containerRegistryPassword: myPassword
+```
+
+### Building multiple images from sub-directories
+
+```yaml
+steps:
+  dockerBuild:
+    containerImageName: myImage
+    containerMultiImageBuild: true
+```
+
+With the following Dockerfiles present in the repository:
+
+* `sub1/Dockerfile`
+* `sub2/Dockerfile`
+
+The following images will be built and pushed:
+
+* `myImage-sub1`
+* `myImage-sub2`
+
+### Using registry mirrors
+
+```yaml
+steps:
+  dockerBuild:
+    containerImageName: myImage
+    registryMirrors:
+      - mirror.gcr.io
+      - mycompany-docker-virtual.jfrog.io
+```
+
+### Enabling BOM creation
+
+```yaml
+steps:
+  dockerBuild:
+    containerImageName: myImage
+    createBOM: true
+```
+
+### Opting in (replacing kanikoExecute)
+
+By default `kanikoExecute` is active and `dockerBuild` is off. To switch:
+
+```yaml
+stages:
+  Build:
+    dockerBuild: true
+    kanikoExecute: false
+```
+
+## ${docGenParameters}
+
+## ${docGenConfiguration}

--- a/documentation/docs/steps/dockerBuild.md
+++ b/documentation/docs/steps/dockerBuild.md
@@ -1,4 +1,12 @@
+---
+search:
+  exclude: true
+---
+
 # ${docGenStepName}
+
+!!! note
+    This step is in **beta**. Breaking changes may occur before it reaches general availability.
 
 ## ${docGenDescription}
 

--- a/documentation/docs/steps/kanikoExecute.md
+++ b/documentation/docs/steps/kanikoExecute.md
@@ -2,8 +2,10 @@
 
 ## ${docGenDescription}
 
+<!-- beta: uncomment when dockerBuild is GA
 > **Note:** For pipelines running on **GitHub Actions**, consider using the [`dockerBuild`](dockerBuild.md) step instead.
 > It uses Docker BuildKit natively and does not require a Kaniko sidecar container.
+-->
 
 ## Prerequisites
 

--- a/documentation/docs/steps/kanikoExecute.md
+++ b/documentation/docs/steps/kanikoExecute.md
@@ -2,6 +2,9 @@
 
 ## ${docGenDescription}
 
+> **Note:** For pipelines running on **GitHub Actions**, consider using the [`dockerBuild`](dockerBuild.md) step instead.
+> It uses Docker BuildKit natively and does not require a Kaniko sidecar container.
+
 ## Prerequisites
 
 When pushing to a container registry, you need to maintain the respective credentials in your Jenkins credentials store:

--- a/pkg/buildsettings/buildSettings.go
+++ b/pkg/buildsettings/buildSettings.go
@@ -41,12 +41,13 @@ func CreateBuildSettingsInfo(config *BuildOptions, buildTool string) (string, er
 		dockerImage = envDockerImage
 	}
 
+	// BuildSettingsInfo is intentionally omitted to avoid recursive nesting.
 	currentBuildSettingsInfo := BuildOptions{
-		CreateBOM:                   config.CreateBOM,
-		GlobalSettingsFile:          config.GlobalSettingsFile,
-		LogSuccessfulMavenTransfers: config.LogSuccessfulMavenTransfers,
 		Profiles:                    config.Profiles,
 		Publish:                     config.Publish,
+		CreateBOM:                   config.CreateBOM,
+		LogSuccessfulMavenTransfers: config.LogSuccessfulMavenTransfers,
+		GlobalSettingsFile:          config.GlobalSettingsFile,
 		DefaultNpmRegistry:          config.DefaultNpmRegistry,
 		DockerImage:                 dockerImage,
 	}

--- a/pkg/buildsettings/buildSettings.go
+++ b/pkg/buildsettings/buildSettings.go
@@ -10,6 +10,7 @@ import (
 )
 
 type BuildSettings struct {
+	DockerBuild        []BuildOptions `json:"dockerBuild,omitempty"`
 	GolangBuild        []BuildOptions `json:"golangBuild,omitempty"`
 	GradleExecuteBuild []BuildOptions `json:"gradleExecuteBuild,omitempty"`
 	HelmExecute        []BuildOptions `json:"helmExecute,omitempty"`
@@ -78,6 +79,10 @@ func CreateBuildSettingsInfo(config *BuildOptions, buildTool string) (string, er
 		settings = append(settings, currentBuildSettingsInfo)
 		var err error
 		switch buildTool {
+		case "dockerBuild":
+			jsonResult, err = json.Marshal(BuildSettings{
+				DockerBuild: settings,
+			})
 		case "golangBuild":
 			jsonResult, err = json.Marshal(BuildSettings{
 				GolangBuild: settings,

--- a/pkg/buildsettings/buildSettings_test.go
+++ b/pkg/buildsettings/buildSettings_test.go
@@ -69,6 +69,11 @@ func TestCreateBuildSettingsInfo(t *testing.T) {
 				buildTool: "cnbBuild",
 				expected:  "{\"cnbBuild\":[{\"dockerImage\":\"builder:latest\"}]}",
 			},
+			{
+				config:    BuildOptions{DockerImage: "docker:latest"},
+				buildTool: "dockerBuild",
+				expected:  "{\"dockerBuild\":[{\"dockerImage\":\"docker:latest\"}]}",
+			},
 		}
 
 		for _, testCase := range testTableConfig {

--- a/pkg/buildsettings/buildSettings_test.go
+++ b/pkg/buildsettings/buildSettings_test.go
@@ -1,14 +1,19 @@
+//go:build unit
+
 package buildsettings
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateBuildSettingsInfo(t *testing.T) {
+	t.Parallel()
 
-	t.Run("test build settings cpe with no previous and existing values", func(t *testing.T) {
+	t.Run("fresh path - no previous build settings", func(t *testing.T) {
+		t.Parallel()
 		testTableConfig := []struct {
 			config    BuildOptions
 			buildTool string
@@ -17,62 +22,57 @@ func TestCreateBuildSettingsInfo(t *testing.T) {
 			{
 				config:    BuildOptions{CreateBOM: true},
 				buildTool: "golangBuild",
-				expected:  "{\"golangBuild\":[{\"createBOM\":true}]}",
+				expected:  `{"golangBuild":[{"createBOM":true}]}`,
 			},
 			{
 				config:    BuildOptions{DockerImage: "golang:latest"},
 				buildTool: "golangBuild",
-				expected:  "{\"golangBuild\":[{\"dockerImage\":\"golang:latest\"}]}",
+				expected:  `{"golangBuild":[{"dockerImage":"golang:latest"}]}`,
 			},
 			{
 				config:    BuildOptions{CreateBOM: true, DockerImage: "gradle:latest"},
 				buildTool: "gradleExecuteBuild",
-				expected:  "{\"gradleExecuteBuild\":[{\"createBOM\":true,\"dockerImage\":\"gradle:latest\"}]}",
+				expected:  `{"gradleExecuteBuild":[{"createBOM":true,"dockerImage":"gradle:latest"}]}`,
 			},
 			{
 				config:    BuildOptions{Publish: true},
 				buildTool: "helmExecute",
-				expected:  "{\"helmExecute\":[{\"publish\":true}]}",
+				expected:  `{"helmExecute":[{"publish":true}]}`,
 			},
 			{
 				config:    BuildOptions{Publish: true},
 				buildTool: "kanikoExecute",
-				expected:  "{\"kanikoExecute\":[{\"publish\":true}]}",
+				expected:  `{"kanikoExecute":[{"publish":true}]}`,
 			},
 			{
 				config:    BuildOptions{Profiles: []string{"profile1", "profile2"}, CreateBOM: true},
 				buildTool: "mavenBuild",
-				expected:  "{\"mavenBuild\":[{\"profiles\":[\"profile1\",\"profile2\"],\"createBOM\":true}]}",
-			},
-			{
-				config:    BuildOptions{Profiles: []string{"profile1", "profile2"}, CreateBOM: true, BuildSettingsInfo: "{\"mavenBuild\":[{\"createBOM\":true}]}"},
-				buildTool: "mavenBuild",
-				expected:  "{\"mavenBuild\":[{\"createBOM\":true},{\"profiles\":[\"profile1\",\"profile2\"],\"createBOM\":true}]}",
+				expected:  `{"mavenBuild":[{"profiles":["profile1","profile2"],"createBOM":true}]}`,
 			},
 			{
 				config:    BuildOptions{Profiles: []string{"release.build"}, Publish: true, GlobalSettingsFile: "http://nexus.test:8081/nexus/"},
 				buildTool: "mtaBuild",
-				expected:  "{\"mtaBuild\":[{\"profiles\":[\"release.build\"],\"publish\":true,\"globalSettingsFile\":\"http://nexus.test:8081/nexus/\"}]}",
+				expected:  `{"mtaBuild":[{"profiles":["release.build"],"publish":true,"globalSettingsFile":"http://nexus.test:8081/nexus/"}]}`,
 			},
 			{
 				config:    BuildOptions{CreateBOM: true},
 				buildTool: "pythonBuild",
-				expected:  "{\"pythonBuild\":[{\"createBOM\":true}]}",
+				expected:  `{"pythonBuild":[{"createBOM":true}]}`,
 			},
 			{
 				config:    BuildOptions{CreateBOM: true},
 				buildTool: "npmExecuteScripts",
-				expected:  "{\"npmExecuteScripts\":[{\"createBOM\":true}]}",
+				expected:  `{"npmExecuteScripts":[{"createBOM":true}]}`,
 			},
 			{
 				config:    BuildOptions{DockerImage: "builder:latest"},
 				buildTool: "cnbBuild",
-				expected:  "{\"cnbBuild\":[{\"dockerImage\":\"builder:latest\"}]}",
+				expected:  `{"cnbBuild":[{"dockerImage":"builder:latest"}]}`,
 			},
 			{
 				config:    BuildOptions{DockerImage: "docker:latest"},
 				buildTool: "dockerBuild",
-				expected:  "{\"dockerBuild\":[{\"dockerImage\":\"docker:latest\"}]}",
+				expected:  `{"dockerBuild":[{"dockerImage":"docker:latest"}]}`,
 			},
 		}
 
@@ -83,4 +83,85 @@ func TestCreateBuildSettingsInfo(t *testing.T) {
 		}
 	})
 
+	t.Run("fresh path - unsupported buildTool returns empty string without error", func(t *testing.T) {
+		t.Parallel()
+		config := BuildOptions{CreateBOM: true}
+		result, err := CreateBuildSettingsInfo(&config, "unsupportedTool")
+		assert.NoError(t, err)
+		assert.Empty(t, result)
+	})
+}
+
+func TestCreateBuildSettingsInfo_MergePath(t *testing.T) {
+	t.Parallel()
+
+	t.Run("appends to existing key when buildTool already present", func(t *testing.T) {
+		t.Parallel()
+		config := BuildOptions{
+			Profiles:          []string{"profile1", "profile2"},
+			CreateBOM:         true,
+			BuildSettingsInfo: `{"mavenBuild":[{"createBOM":true}]}`,
+		}
+		result, err := CreateBuildSettingsInfo(&config, "mavenBuild")
+		assert.NoError(t, err)
+		assert.Equal(t, `{"mavenBuild":[{"createBOM":true},{"profiles":["profile1","profile2"],"createBOM":true}]}`, result)
+	})
+
+	t.Run("adds new key alongside existing when buildTool not yet present", func(t *testing.T) {
+		t.Parallel()
+		config := BuildOptions{
+			CreateBOM:         true,
+			BuildSettingsInfo: `{"mavenBuild":[{"createBOM":true}]}`,
+		}
+		result, err := CreateBuildSettingsInfo(&config, "golangBuild")
+		assert.NoError(t, err)
+		assert.Contains(t, result, `"mavenBuild":[{"createBOM":true}]`)
+		assert.Contains(t, result, `"golangBuild":[{"createBOM":true}]`)
+	})
+
+	t.Run("returns error on malformed BuildSettingsInfo JSON", func(t *testing.T) {
+		t.Parallel()
+		config := BuildOptions{
+			BuildSettingsInfo: `{not-valid-json`,
+		}
+		_, err := CreateBuildSettingsInfo(&config, "golangBuild")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unmarshal existing build settings json")
+	})
+
+	t.Run("unsupported buildTool silently adds new key in merge path", func(t *testing.T) {
+		t.Parallel()
+		config := BuildOptions{
+			CreateBOM:         true,
+			BuildSettingsInfo: `{"mavenBuild":[{"createBOM":true}]}`,
+		}
+		result, err := CreateBuildSettingsInfo(&config, "unknownTool")
+		assert.NoError(t, err)
+		assert.Contains(t, result, `"mavenBuild"`)
+		assert.Contains(t, result, `"unknownTool"`)
+	})
+}
+
+// Env-override tests are sequential because os.Setenv affects the whole process.
+func TestCreateBuildSettingsInfo_EnvDockerImageOverride(t *testing.T) {
+	t.Run("fresh path - PIPER_dockerImage env overrides config.DockerImage", func(t *testing.T) {
+		os.Setenv("PIPER_dockerImage", "override:fresh")
+		defer os.Unsetenv("PIPER_dockerImage")
+		config := BuildOptions{DockerImage: "original:fresh"}
+		result, err := CreateBuildSettingsInfo(&config, "golangBuild")
+		assert.NoError(t, err)
+		assert.Equal(t, `{"golangBuild":[{"dockerImage":"override:fresh"}]}`, result)
+	})
+
+	t.Run("merge path - PIPER_dockerImage applies to appended entry only, historical entry preserved", func(t *testing.T) {
+		os.Setenv("PIPER_dockerImage", "override:v2")
+		defer os.Unsetenv("PIPER_dockerImage")
+		config := BuildOptions{
+			DockerImage:       "original:v1",
+			BuildSettingsInfo: `{"golangBuild":[{"dockerImage":"original:v1"}]}`,
+		}
+		result, err := CreateBuildSettingsInfo(&config, "golangBuild")
+		assert.NoError(t, err)
+		assert.Equal(t, `{"golangBuild":[{"dockerImage":"original:v1"},{"dockerImage":"override:v2"}]}`, result)
+	})
 }


### PR DESCRIPTION
# Description
dockerBuild was falling through to the default branch, emitting a warning and returning empty buildSettingsInfo. Add it as a first-class supported tool alongside kanikoExecute and cnbBuild
# Checklist

- [X] Tests
- [X] Documentation
- [X] Inner source library needs updating
