### PR TITLE
set custom User-Agent header for BlackDuck API requests

### DIFF
--- a/cmd/detectExecuteScan.go
+++ b/cmd/detectExecuteScan.go
@@ -141,6 +141,11 @@ func newBlackduckSystem(config detectExecuteScanOptions) *blackduckSystem {
 	sys := blackduckSystem{
 		Client: bd.NewClient(config.Token, config.ServerURL, &piperhttp.Client{}),
 	}
+	commitShortSHA := "unknown"
+	if len(GitCommit) >= 7 {
+		commitShortSHA = GitCommit[:7]
+	}
+	sys.Client.UserAgent = fmt.Sprintf("piper-detectExecuteScan-%s", commitShortSHA)
 	return &sys
 }
 

--- a/pkg/blackduck/blackduck.go
+++ b/pkg/blackduck/blackduck.go
@@ -250,6 +250,7 @@ type Client struct {
 	httpClient                  piperhttp.Sender
 	serverURL                   string
 	projectVersion              *ProjectVersion
+	UserAgent                   string
 }
 
 // NewClient creates a new BlackDuck client
@@ -597,6 +598,10 @@ func (b *Client) sendRequest(method, apiEndpoint string, params map[string]strin
 
 	if len(b.BearerToken) > 0 {
 		header.Add("Authorization", fmt.Sprintf("Bearer %v", b.BearerToken))
+	}
+
+	if b.UserAgent != "" {
+		header.Set("User-Agent", b.UserAgent)
 	}
 
 	response, err := b.httpClient.SendRequest(method, blackDuckAPIUrl.String(), nil, header, nil)

--- a/pkg/blackduck/blackduck.go
+++ b/pkg/blackduck/blackduck.go
@@ -250,7 +250,7 @@ type Client struct {
 	httpClient                  piperhttp.Sender
 	serverURL                   string
 	projectVersion              *ProjectVersion
-	UserAgent                   string
+	UserAgent                   string `json:"-"`
 }
 
 // NewClient creates a new BlackDuck client


### PR DESCRIPTION
# Description

This chang sets a custom User-Agent header to BlackDuck API requests so the server can identify that piper is calling it and which step. The User-Agent follows the format piper-<step-name>-<commit-short-sha>, for example piper-detectExecuteScan-6bda91c.

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
