### PR TITLE
fix: integration_gauge_test.go to keep the container alive

### DIFF
--- a/integration/integration_gauge_test.go
+++ b/integration/integration_gauge_test.go
@@ -48,7 +48,7 @@ cd /test
 
 	reqNode := testcontainers.ContainerRequest{
 		Image: "timbru31/java-node:17-jdk-22",
-		Cmd:   []string{"tail", "-f"},
+		Cmd:   []string{"tail", "-f", "/dev/null"},
 		Mounts: testcontainers.Mounts(
 			testcontainers.BindMount(pwd, "/piperbin"),
 			testcontainers.BindMount(tempDir, "/test"),


### PR DESCRIPTION
# Description
The test uses Cmd: []string{"tail", "-f"} to keep the container alive — but tail -f without a file argument exits immediately on this image (Alpine/Debian behavior varies). The container exits before nodeContainer.Exec(...) runs, causing container is not running.

# Checklist

- [x] Tests
- [x] Documentation
- [ ] Inner source library needs updating
