### PR TITLE
fix: updated base image for go version constraint consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.0 AS build-env
+FROM golang:1.25.10 AS build-env
 COPY . /build
 WORKDIR /build
 


### PR DESCRIPTION
# Description
Fixes:
```
$ docker build -t pipertest .
[+] Building 2.9s (8/9)                                                                                                                                                  docker:default
 => [internal] load build definition from Dockerfile                                                                                                                               0.0s
 => => transferring dockerfile: 924B                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/golang:1.24.0                                                                                                                   0.7s
 => [internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                    0.0s
 => [internal] load build context                                                                                                                                                  0.2s
 => => transferring context: 430.53kB                                                                                                                                              0.2s
 => CACHED [1/5] FROM docker.io/library/golang:1.24.0@sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71                                                      0.1s
 => => resolve docker.io/library/golang:1.24.0@sha256:3f7444391c51a11a039bf0359ee81cc64e663c17d787ad0e637a4de1a3f62a71                                                             0.1s
 => [2/5] COPY . /build                                                                                                                                                            1.0s
 => [3/5] WORKDIR /build                                                                                                                                                           0.1s
 => ERROR [4/5] RUN go test ./... -tags=unit -cover                                                                                                                                0.5s
------
 > [4/5] RUN go test ./... -tags=unit -cover:
0.425 go: go.mod requires go >= 1.25.0 (running go 1.24.0; GOTOOLCHAIN=local)
```

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
