### PR TITLE
fix(cmd/abapEnvironmentRunATCCheck): handle abort state correctly

### DIFF
--- a/cmd/abapEnvironmentRunATCCheck.go
+++ b/cmd/abapEnvironmentRunATCCheck.go
@@ -376,8 +376,14 @@ func pollATCRun(details abaputils.ConnectionDetailsHTTP, body []byte, client pip
 		if x.Status == "Completed" {
 			return x.Link[0].Key, err
 		}
+		if x.Status == "Aborted" {
+			return "", fmt.Errorf("ATC run was aborted")
+		}
 		if x.Status == "" {
 			return "", fmt.Errorf("Could not get any response from ATC poll: %v", errors.New("Status from ATC run is empty. Either it's not an ABAP system or ATC run hasn't started"))
+		}
+		if x.Status != "Running" {
+			return "", fmt.Errorf("ATC run ended with unexpected status: %s", x.Status)
 		}
 		time.Sleep(5 * time.Second)
 	}

--- a/cmd/abapEnvironmentRunATCCheck_test.go
+++ b/cmd/abapEnvironmentRunATCCheck_test.go
@@ -175,7 +175,7 @@ func TestFetchXcsrfToken(t *testing.T) {
 }
 
 func TestPollATCRun(t *testing.T) {
-	t.Run("ATC run Poll Test", func(t *testing.T) {
+	t.Run("ATC run Poll Test - empty status", func(t *testing.T) {
 		tokenExpected := "myToken"
 
 		client := &abaputils.ClientMock{
@@ -192,8 +192,22 @@ func TestPollATCRun(t *testing.T) {
 		if err != nil {
 			assert.Equal(t, "", resp)
 			assert.EqualError(t, err, "Could not get any response from ATC poll: Status from ATC run is empty. Either it's not an ABAP system or ATC run hasn't started")
-
 		}
+	})
+
+	t.Run("ATC run Poll Test - aborted status", func(t *testing.T) {
+		client := &abaputils.ClientMock{
+			Body: `<?xml version="1.0" encoding="utf-8"?><run status="Aborted"></run>`,
+		}
+
+		con := abaputils.ConnectionDetailsHTTP{
+			User:     "Test",
+			Password: "Test",
+			URL:      "https://api.endpoint.com/Entity/",
+		}
+		resp, err := pollATCRun(con, []byte(client.Body), client)
+		assert.Equal(t, "", resp)
+		assert.EqualError(t, err, "ATC run was aborted")
 	})
 }
 


### PR DESCRIPTION
# Description
Correct ATC polling status. Currently, polling ATC status doesn't stop, when status switches to "Aborted". Polling happens until the pipeline is being killed.

# Checklist

- [x] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
