### PR TITLE
chore: Add explicit permissions to the workflows

### DIFF
--- a/.github/workflows/build-adr.yml
+++ b/.github/workflows/build-adr.yml
@@ -5,6 +5,10 @@ on:
       - main
     paths:
       - 'documentation/adr/**'
+
+permissions:
+  contents: write  # JamesIves/github-pages-deploy-action pushes to the gh-pages branch
+
 jobs:
   build-adr-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write  # peaceiris/actions-gh-pages deploys docs to gh-pages (master push only)
+  actions: write   # styfle/cancel-workflow-action cancels previous runs
+
 jobs:
   Build:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-pr.yml
+++ b/.github/workflows/integration-tests-pr.yml
@@ -6,6 +6,9 @@ on:
       - created
       - edited
 
+permissions:
+  contents: read  # default for all jobs (checkout + artifacts); only `start` overrides for the cancel action
+
 jobs:
   start:
     name: Start
@@ -22,6 +25,9 @@ jobs:
       go_version: ${{ steps.go_version.outputs.go_version }}
       sha: ${{ steps.sha.outputs.sha }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout (status updates use the INTEGRATION_TEST_VOTING_TOKEN secret, not GITHUB_TOKEN)
+      actions: write  # styfle/cancel-workflow-action cancels previous runs
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
       - name: Get pull request URL

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,6 +22,9 @@ on:
         description: "Integration test status (success/failure)"
         value: ${{ jobs.finish.outputs.status }}
 
+permissions:
+  contents: read  # default for all jobs (checkout + artifacts); only `start` overrides for the cancel action
+
 jobs:
   start:
     name: Start
@@ -29,6 +32,9 @@ jobs:
       go_version: ${{ steps.go_version.outputs.go_version }}
       sha: ${{ steps.sha.outputs.sha }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout (status updates use the INTEGRATION_TEST_VOTING_TOKEN secret, not GITHUB_TOKEN)
+      actions: write  # styfle/cancel-workflow-action cancels previous runs
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v4

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - '**/*.md'
 
+permissions:
+  contents: read  # checkout
+  actions: write  # styfle/cancel-workflow-action cancels previous runs
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -30,7 +30,9 @@ jobs:
     if: |
       needs.run_integration_tests.outputs.test_status == 'success' &&
       github.event.inputs.dry_run != 'true'
-    permissions: write-all
+    permissions:
+      contents: write  # githubPublishRelease creates the release + uploads assets; PATCH converts prerelease to release
+      actions: write   # styfle/cancel-workflow-action cancels previous runs
     name: Publish Release
     runs-on: ubuntu-latest
     steps:
@@ -116,6 +118,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish]
     if: always() && github.event.inputs.dry_run != 'true'
+    permissions:
+      contents: read  # baseline
+      actions: read   # martialonline/workflow-status reads the run conclusion
     steps:
       # Check status of the workflow
       - uses: martialonline/workflow-status@v4

--- a/.github/workflows/renovate-integration-tests.yml
+++ b/.github/workflows/renovate-integration-tests.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - 'renovate/**'
 
+permissions:
+  contents: read        # checkout
+  pull-requests: read   # github.rest.pulls.list finds the PR for the branch
+  issues: write         # github.rest.issues.createComment posts the /it-go comment
+
 jobs:
   comment:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  issues: write         # actions/stale labels, comments on and closes stale issues
+  pull-requests: write  # actions/stale labels, comments on and closes stale PRs
+  actions: write        # styfle/cancel-workflow-action cancels previous runs
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-go-dependencies.yml
+++ b/.github/workflows/update-go-dependencies.yml
@@ -5,6 +5,10 @@ on:
   repository_dispatch:
     types: update-dependencies
 
+permissions:
+  contents: write  # `git push` of the gh-action-update-golang-dependencies branch via the checkout token
+  actions: write   # styfle/cancel-workflow-action cancels previous runs
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-go-master.yml
+++ b/.github/workflows/upload-go-master.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write  # githubPublishRelease uploads the master binaries to the GitHub release
+  actions: write   # styfle/cancel-workflow-action cancels previous runs
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-go.yml
+++ b/.github/workflows/verify-go.yml
@@ -11,9 +11,15 @@ on:
 env:
   DEFAULT_GOLANG: '1.25.0'
 
+permissions:
+  contents: read  # default for all jobs (checkout); only `unit` overrides for the cancel action
+
 jobs:
   unit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout
+      actions: write  # styfle/cancel-workflow-action cancels previous runs
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
       - name: 🏗 Set up Golang ${{ env.DEFAULT_GOLANG }}

--- a/.github/workflows/verify-groovy.yml
+++ b/.github/workflows/verify-groovy.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read  # checkout
+  actions: write  # styfle/cancel-workflow-action cancels previous runs
+
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-yaml.yml
+++ b/.github/workflows/verify-yaml.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read  # checkout
+  actions: write  # styfle/cancel-workflow-action cancels previous runs
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
The default GITHUB_TOKEN permission for GitHub Actions was centrally switched from read/write to read-only for `SAP/jenkins-library`

Added explicit permissions: blocks to all 13 workflows (top-level defaults + job-level overrides where only some jobs need write). Notable grants:

- contents: write for the release/publish/gh-pages/dependency-push workflows.
- actions: write for the 9 jobs running styfle/cancel-workflow-action (it cancels prior runs, which requires it).
- issues/pull-requests: write for stale; issues: write + pull-requests: read for the renovate PR-comment job.
- Read-only jobs (lint/test/format) pinned explicitly to contents: read.

  Also tightened release-go.yml's publish job from permissions: write-all to contents: write + actions: write — it only ever creates releases and cancels runs, so write-all was unnecessarily broad on the most sensitive job.
# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
