### PR TITLE
fix: grant actions: write to run_integration_tests job

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/integration-tests.yml
     permissions:
       contents: read
-      actions: read
+      actions: write
       statuses: write  # update commit status via GITHUB_TOKEN in the called workflow
     secrets:
       PIPER_INTEGRATION_GITHUB_TOKEN: ${{ secrets.PIPER_INTEGRATION_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the following workflow validation error:

> The workflow is not valid. `.github/workflows/release-go.yml` (Line: 15, Col: 3): Error calling workflow `SAP/jenkins-library/.github/workflows/integration-tests.yml@920e8536ee0d8ec7b90d132f5a1a3841c3c1a5a2`. The nested job 'start' is requesting `actions: write`, but is only allowed `actions: read`.

The `integration-tests.yml` workflow uses `styfle/cancel-workflow-action` which requires `actions: write`. The caller job `run_integration_tests` in `release-go.yml` was only granting `actions: read`.