### PR TITLE
feat: Fix getCoordinates for INI files

### DIFF
--- a/cmd/artifactPrepareVersion_generated.go
+++ b/cmd/artifactPrepareVersion_generated.go
@@ -154,6 +154,7 @@ Define ` + "`" + `buildTool: custom` + "`" + ` as well as ` + "`" + `filePath: <
 **Please note:** ` + "`" + `<path to your file>` + "`" + ` need to point either to a ` + "`" + `*.txt` + "`" + ` file or to a file without extension.
 
 **Warning:** Using a plain version file may lead to issues in later pipeline steps, as some steps expect structured files (ini, yaml, json) for version extraction.
+In addition, no artifact name can be derived from a plain version file, so ` + "`" + `artifactId` + "`" + ` in the commonPipelineEnvironment stays empty. Steps which rely on it (e.g. for artifact download) then require ` + "`" + `artifactId` + "`" + ` to be configured explicitly.
 
 #### ` + "`" + `ini` + "`" + ` file containing the version:
 
@@ -161,13 +162,19 @@ Define ` + "`" + `buildTool: custom` + "`" + `, ` + "`" + `filePath: <path to yo
 
 **Please note:** ` + "`" + `<path to your file>` + "`" + ` need to point either to a ` + "`" + `*.cfg` + "`" + ` or a ` + "`" + `*.ini` + "`" + ` file.
 
+If the file additionally contains a ` + "`" + `name` + "`" + ` field in the same section as the version (` + "`" + `customVersionSection` + "`" + `), its value is published as ` + "`" + `artifactId` + "`" + ` to the commonPipelineEnvironment so that subsequent steps can consume the artifact name. Quotes around the values are not required.
+
 #### ` + "`" + `json` + "`" + ` file containing the version:
 
 Define ` + "`" + `buildTool: custom` + "`" + `, ` + "`" + `filePath: <path to your *.json file>` + "`" + ` as well as parameter ` + "`" + `customVersionField` + "`" + ` to point to the parameter containing the version.
 
+If the file additionally contains a top-level ` + "`" + `name` + "`" + ` field, its value is published as ` + "`" + `artifactId` + "`" + ` to the commonPipelineEnvironment.
+
 #### ` + "`" + `yaml` + "`" + ` file containing the version
 
-Define ` + "`" + `buildTool: custom` + "`" + `, ` + "`" + `filePath: <path to your *.yml/*.yaml file>` + "`" + ` as well as parameter ` + "`" + `customVersionField` + "`" + ` to point to the parameter containing the version.`,
+Define ` + "`" + `buildTool: custom` + "`" + `, ` + "`" + `filePath: <path to your *.yml/*.yaml file>` + "`" + ` as well as parameter ` + "`" + `customVersionField` + "`" + ` to point to the parameter containing the version.
+
+If the file additionally contains a top-level ` + "`" + `ID` + "`" + ` field, its value is published as ` + "`" + `artifactId` + "`" + ` to the commonPipelineEnvironment.`,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			startTime = time.Now()
 			log.SetStepName(STEP_NAME)

--- a/pkg/versioning/inifile.go
+++ b/pkg/versioning/inifile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/SAP/jenkins-library/pkg/log"
 	"gopkg.in/ini.v1"
 )
 
@@ -95,6 +96,8 @@ func (i *INIfile) GetCoordinates() (Coordinates, error) {
 	section := i.content.Section(i.versionSection)
 	if section.HasKey("name") {
 		result.ArtifactID = section.Key("name").String()
+	} else {
+		log.Entry().Debugf("no 'name' field found in section '%v' of file '%v': artifactId remains empty", i.versionSection, i.path)
 	}
 	if version, err := i.GetVersion(); err == nil {
 		result.Version = version

--- a/pkg/versioning/inifile.go
+++ b/pkg/versioning/inifile.go
@@ -86,5 +86,19 @@ func (i *INIfile) SetVersion(version string) error {
 
 // GetCoordinates returns the coordinates
 func (i *INIfile) GetCoordinates() (Coordinates, error) {
-	return Coordinates{}, nil
+	result := Coordinates{}
+	if i.content == nil {
+		if err := i.init(); err != nil {
+			return result, err
+		}
+	}
+	section := i.content.Section(i.versionSection)
+	if section.HasKey("name") {
+		result.ArtifactID = section.Key("name").String()
+	}
+	if version, err := i.GetVersion(); err == nil {
+		result.Version = version
+	}
+
+	return result, nil
 }

--- a/pkg/versioning/inifile_test.go
+++ b/pkg/versioning/inifile_test.go
@@ -51,6 +51,91 @@ func TestINIfileGetVersion(t *testing.T) {
 	})
 }
 
+func TestINIfileGetCoordinates(t *testing.T) {
+	t.Run("success case - quoted values", func(t *testing.T) {
+		inifile := INIfile{
+			path:           "my.cfg",
+			versionField:   "version",
+			versionSection: "general",
+			readFile: func(filename string) ([]byte, error) {
+				return []byte("[general]\nversion=\"1.2.3\"\nname=\"my-artifact\""), nil
+			},
+		}
+		coordinates, err := inifile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Equal(t, "my-artifact", coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
+	})
+
+	t.Run("success case - unquoted values", func(t *testing.T) {
+		inifile := INIfile{
+			path:           "my.cfg",
+			versionField:   "version",
+			versionSection: "general",
+			readFile: func(filename string) ([]byte, error) {
+				return []byte("[general]\nversion=1.2.3\nname=my-artifact"), nil
+			},
+		}
+		coordinates, err := inifile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Equal(t, "my-artifact", coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
+	})
+
+	t.Run("success case - flat file without section", func(t *testing.T) {
+		inifile := INIfile{
+			path:         "my.cfg",
+			versionField: "version",
+			readFile: func(filename string) ([]byte, error) {
+				return []byte("version = 1.2.3\nname = my-artifact"), nil
+			},
+		}
+		coordinates, err := inifile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Equal(t, "my-artifact", coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
+	})
+
+	t.Run("no name field returns empty artifactID without error", func(t *testing.T) {
+		inifile := INIfile{
+			path:           "my.cfg",
+			versionField:   "version",
+			versionSection: "general",
+			readFile: func(filename string) ([]byte, error) {
+				return []byte("[general]\nversion=1.2.3"), nil
+			},
+		}
+		coordinates, err := inifile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Empty(t, coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
+	})
+
+	t.Run("missing version keeps artifactID", func(t *testing.T) {
+		inifile := INIfile{
+			path:           "my.cfg",
+			versionField:   "version",
+			versionSection: "general",
+			readFile: func(filename string) ([]byte, error) {
+				return []byte("[general]\nname=my-artifact"), nil
+			},
+		}
+		coordinates, err := inifile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Equal(t, "my-artifact", coordinates.ArtifactID)
+		assert.Empty(t, coordinates.Version)
+	})
+
+	t.Run("error case - read error", func(t *testing.T) {
+		inifile := INIfile{
+			path:     "my.cfg",
+			readFile: func(filename string) ([]byte, error) { return []byte{}, fmt.Errorf("read error") },
+		}
+		_, err := inifile.GetCoordinates()
+		assert.EqualError(t, err, "failed to read file 'my.cfg': read error")
+	})
+}
+
 func TestINIfileSetVersion(t *testing.T) {
 	t.Run("success case - flat", func(t *testing.T) {
 		var content []byte

--- a/pkg/versioning/jsonfile.go
+++ b/pkg/versioning/jsonfile.go
@@ -50,7 +50,10 @@ func (j *JSONfile) GetVersion() (string, error) {
 		return "", fmt.Errorf("failed to read json content of file '%v': %w", j.content, err)
 	}
 
-	version, _ := j.content.Get(j.versionField)
+	version, exists := j.content.Get(j.versionField)
+	if !exists || version == nil {
+		return "", nil
+	}
 
 	return fmt.Sprint(version), nil
 }
@@ -89,9 +92,9 @@ func (j *JSONfile) GetCoordinates() (Coordinates, error) {
 	if err != nil {
 		return result, err
 	}
-	projectName, _ := j.content.Get("name")
-
-	result.ArtifactID = fmt.Sprint(projectName)
+	if projectName, exists := j.content.Get("name"); exists && projectName != nil {
+		result.ArtifactID = fmt.Sprint(projectName)
+	}
 	result.Version = projectVersion
 
 	return result, nil

--- a/pkg/versioning/jsonfile_test.go
+++ b/pkg/versioning/jsonfile_test.go
@@ -46,8 +46,10 @@ func TestJSONfileGetVersion(t *testing.T) {
 func TestJSONfileGetCoordinates(t *testing.T) {
 	t.Run("success case", func(t *testing.T) {
 		jsonfile := JSONfile{
-			path:     "my.json",
-			readFile: func(filename string) ([]byte, error) { return []byte(`{"name": "my-artifact", "version": "1.2.3"}`), nil },
+			path: "my.json",
+			readFile: func(filename string) ([]byte, error) {
+				return []byte(`{"name": "my-artifact", "version": "1.2.3"}`), nil
+			},
 		}
 		coordinates, err := jsonfile.GetCoordinates()
 		assert.NoError(t, err)

--- a/pkg/versioning/jsonfile_test.go
+++ b/pkg/versioning/jsonfile_test.go
@@ -22,6 +22,16 @@ func TestJSONfileGetVersion(t *testing.T) {
 		assert.Equal(t, "1.2.3", version)
 	})
 
+	t.Run("version field not found returns empty string instead of '<nil>'", func(t *testing.T) {
+		jsonfile := JSONfile{
+			path:     "my.json",
+			readFile: func(filename string) ([]byte, error) { return []byte(`{"name": "my-artifact"}`), nil },
+		}
+		version, err := jsonfile.GetVersion()
+		assert.NoError(t, err)
+		assert.Equal(t, "", version)
+	})
+
 	t.Run("error case", func(t *testing.T) {
 		jsonfile := JSONfile{
 			path:         "my.json",
@@ -30,6 +40,30 @@ func TestJSONfileGetVersion(t *testing.T) {
 		}
 		_, err := jsonfile.GetVersion()
 		assert.EqualError(t, err, "failed to read file 'my.json': read error")
+	})
+}
+
+func TestJSONfileGetCoordinates(t *testing.T) {
+	t.Run("success case", func(t *testing.T) {
+		jsonfile := JSONfile{
+			path:     "my.json",
+			readFile: func(filename string) ([]byte, error) { return []byte(`{"name": "my-artifact", "version": "1.2.3"}`), nil },
+		}
+		coordinates, err := jsonfile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Equal(t, "my-artifact", coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
+	})
+
+	t.Run("missing name returns empty artifactID instead of '<nil>'", func(t *testing.T) {
+		jsonfile := JSONfile{
+			path:     "my.json",
+			readFile: func(filename string) ([]byte, error) { return []byte(`{"version": "1.2.3"}`), nil },
+		}
+		coordinates, err := jsonfile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Empty(t, coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
 	})
 }
 

--- a/pkg/versioning/yamlfile.go
+++ b/pkg/versioning/yamlfile.go
@@ -61,7 +61,11 @@ func (y *YAMLfile) readField(key string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get key %s: %w", key, err)
 	}
-	return strings.TrimSpace(fmt.Sprint(y.content[key])), nil
+	value, exists := y.content[key]
+	if !exists || value == nil {
+		return "", nil
+	}
+	return strings.TrimSpace(fmt.Sprint(value)), nil
 }
 
 // VersioningScheme returns the relevant versioning scheme

--- a/pkg/versioning/yamlfile_test.go
+++ b/pkg/versioning/yamlfile_test.go
@@ -45,6 +45,16 @@ func TestYAMLfileGetArtifactID(t *testing.T) {
 		assert.Equal(t, "artifact-id", artifactID)
 	})
 
+	t.Run("field not found returns empty string instead of '<nil>'", func(t *testing.T) {
+		yamlfile := YAMLfile{
+			path:     "my.yaml",
+			readFile: func(filename string) ([]byte, error) { return []byte(`version: 1.2.3`), nil },
+		}
+		artifactID, err := yamlfile.GetArtifactID()
+		assert.NoError(t, err)
+		assert.Equal(t, "", artifactID)
+	})
+
 	t.Run("error case", func(t *testing.T) {
 		yamlfile := YAMLfile{
 			path:            "my.yaml",
@@ -54,6 +64,30 @@ func TestYAMLfileGetArtifactID(t *testing.T) {
 		artifactID, err := yamlfile.GetArtifactID()
 		assert.EqualError(t, err, "failed to get key theArtifact: failed to read file 'my.yaml': read error")
 		assert.Equal(t, "", artifactID)
+	})
+}
+
+func TestYAMLfileGetCoordinates(t *testing.T) {
+	t.Run("success case", func(t *testing.T) {
+		yamlfile := YAMLfile{
+			path:     "my.yaml",
+			readFile: func(filename string) ([]byte, error) { return []byte("ID: artifact-id\nversion: 1.2.3"), nil },
+		}
+		coordinates, err := yamlfile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Equal(t, "artifact-id", coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
+	})
+
+	t.Run("missing ID returns empty artifactID instead of '<nil>'", func(t *testing.T) {
+		yamlfile := YAMLfile{
+			path:     "my.yaml",
+			readFile: func(filename string) ([]byte, error) { return []byte(`version: 1.2.3`), nil },
+		}
+		coordinates, err := yamlfile.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Empty(t, coordinates.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinates.Version)
 	})
 }
 

--- a/resources/metadata/artifactPrepareVersion.yaml
+++ b/resources/metadata/artifactPrepareVersion.yaml
@@ -57,6 +57,7 @@ metadata:
     **Please note:** `<path to your file>` need to point either to a `*.txt` file or to a file without extension.
 
     **Warning:** Using a plain version file may lead to issues in later pipeline steps, as some steps expect structured files (ini, yaml, json) for version extraction.
+    In addition, no artifact name can be derived from a plain version file, so `artifactId` in the commonPipelineEnvironment stays empty. Steps which rely on it (e.g. for artifact download) then require `artifactId` to be configured explicitly.
 
     #### `ini` file containing the version:
 
@@ -64,13 +65,19 @@ metadata:
 
     **Please note:** `<path to your file>` need to point either to a `*.cfg` or a `*.ini` file.
 
+    If the file additionally contains a `name` field in the same section as the version (`customVersionSection`), its value is published as `artifactId` to the commonPipelineEnvironment so that subsequent steps can consume the artifact name. Quotes around the values are not required.
+
     #### `json` file containing the version:
 
     Define `buildTool: custom`, `filePath: <path to your *.json file>` as well as parameter `customVersionField` to point to the parameter containing the version.
 
+    If the file additionally contains a top-level `name` field, its value is published as `artifactId` to the commonPipelineEnvironment.
+
     #### `yaml` file containing the version
 
     Define `buildTool: custom`, `filePath: <path to your *.yml/*.yaml file>` as well as parameter `customVersionField` to point to the parameter containing the version.
+
+    If the file additionally contains a top-level `ID` field, its value is published as `artifactId` to the commonPipelineEnvironment.
 spec:
   inputs:
     secrets:


### PR DESCRIPTION
# Description

`INIfile.GetCoordinates()` was a stub returning empty `Coordinates`, so for `buildTool: custom` with an `*.ini`/`*.cfg` descriptor the `artifactId` in the commonPipelineEnvironment was always empty. Downstream steps consuming it then built broken artifact URLs (e.g. `.../packages//0.2.0/-0.2.0.tar.gz`) with no error output.

## Changes

- **`INIfile.GetCoordinates()`**: reads the `name` field from the configured version section (`customVersionSection`) and publishes it as `artifactId` to the commonPipelineEnvironment. No new configuration parameters — this mirrors how the json (`name`) and yaml (`ID`) descriptors already behave. Quotes around values are not required (go-ini strips them). Missing `name` keeps `artifactId` empty (backward compatible) and logs a debug message.
- **`YAMLfile.readField()` / `JSONfile`**: a missing field returned the literal string `"<nil>"` (via `fmt.Sprint(nil)`) instead of an empty string — that bogus value ended up in CPE `artifactId`/version and in download URLs. Missing fields now return `""`.
- **Documentation** (`resources/metadata/artifactPrepareVersion.yaml` longDescription): documented `artifactId` extraction for ini/json/yaml custom descriptors and the limitation of plain version files (no artifact name derivable).

## Verification

Ran the built binary against the reporter's exact descriptor and config:

```ini
[general]
version="0.2.0"
name="some-artifact"
```

```
artifactPrepareVersion --buildTool custom --filePath lib_version.ini --versioningType library --customVersionField version --customVersionSection general
```

- quoted values → CPE `artifactId = some-artifact`, `artifactVersion = 0.2.0` (quotes stripped)
- unquoted values → works as well
- descriptor without `name` → `artifactId` stays empty, step still succeeds (no regression)

# Checklist

- [x] Tests
- [x] Documentation
- [ ] Inner source library needs updating