### PR TITLE
fix(versioning): use octal file-mode literals instead of decimal

### DIFF
--- a/pkg/documentation/generator/main.go
+++ b/pkg/documentation/generator/main.go
@@ -119,7 +119,7 @@ func generateStepDocumentation(stepData config.StepData, docuHelperData DocuHelp
 	checkError(err)
 
 	// overwrite existing file
-	err = docuHelperData.DocFileWriter(docTemplateFilePath, docContent.Bytes(), 644)
+	err = docuHelperData.DocFileWriter(docTemplateFilePath, docContent.Bytes(), 0644)
 	checkError(err)
 
 	return nil

--- a/pkg/versioning/helm.go
+++ b/pkg/versioning/helm.go
@@ -73,7 +73,7 @@ func (h *HelmChart) SetVersion(version string) error {
 	if err != nil {
 		return fmt.Errorf("failed to create chart content for '%v': %w", h.path, err)
 	}
-	err = h.utils.FileWrite(h.path, content, 666)
+	err = h.utils.FileWrite(h.path, content, 0666)
 	if err != nil {
 		return fmt.Errorf("failed to write file '%v': %w", h.path, err)
 	}

--- a/pkg/versioning/maven.go
+++ b/pkg/versioning/maven.go
@@ -2,16 +2,9 @@ package versioning
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/SAP/jenkins-library/pkg/maven"
 )
-
-type mavenExecRunner interface {
-	Stdout(out io.Writer)
-	Stderr(err io.Writer)
-	RunExecutable(e string, p ...string) error
-}
 
 type mavenRunner interface {
 	Execute(*maven.ExecuteOptions, maven.Utils) (string, error)

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -128,7 +128,6 @@ func GetArtifact(buildTool, buildDescriptorFilePath string, opts *Options, utils
 		switch buildDescriptorFilePath {
 		case "go.mod":
 			artifact = &GoMod{path: buildDescriptorFilePath, fileExists: fileExists}
-			break
 		default:
 			artifact = &Versionfile{path: buildDescriptorFilePath}
 		}


### PR DESCRIPTION
## Changes

**Fix decimal file-mode arguments passed as `os.FileMode`:**

- `pkg/versioning/helm.go`: `FileWrite(h.path, content, 666)` → `0666`. Decimal `666` is `0o1232` — sticky bit set plus wrong permissions (`-w--wx-wT`) instead of the intended `rw-rw-rw-`, so `Chart.yaml` files newly created by `artifactPrepareVersion` got broken permissions.
- `pkg/documentation/generator/main.go`: same mistake with `644` (= `0o1204`) → `0644`. Found via a sweep of `pkg/` and `cmd/` for decimal mode literals; these were the only two occurrences.

**Minor cleanup in `pkg/versioning` (flagged by staticcheck/linters):**

- `versioning.go`: removed redundant `break` in `switch` (S1023).
- `maven.go`: removed unused `mavenExecRunner` interface and the now-unused `io` import.

## Notes

No behavior change for existing files — `FileWrite`/`os.WriteFile` only applies the mode on file creation. Tests: `go test -tags unit ./pkg/versioning/ ./pkg/documentation/...` passes.
