### PR TITLE
fix(syft): exclude distlib Windows PE stubs from SBOM scan

### DIFF
--- a/cmd/kanikoExecute_test.go
+++ b/cmd/kanikoExecute_test.go
@@ -361,7 +361,7 @@ func TestRunKanikoExecute(t *testing.T) {
 		assert.Equal(t, "https://index.docker.io", commonPipelineEnvironment.container.registryURL)
 
 		assert.Equal(t, "/tmp/syfttest/syft", execRunner.Calls[2].Exec)
-		assert.Equal(t, []string{"scan", "registry:index.docker.io/myImage:tag", "-o", "cyclonedx-xml@1.4=bom-docker-0.xml", "-q"}, execRunner.Calls[2].Params)
+		assert.Equal(t, []string{"scan", "registry:index.docker.io/myImage:tag", "-o", "cyclonedx-xml@1.4=bom-docker-0.xml", "-q", "--exclude=**/{distlib,distlib-*}/**/*.exe"}, execRunner.Calls[2].Params)
 	})
 
 	t.Run("success case - multi image build with root image", func(t *testing.T) {
@@ -519,7 +519,7 @@ func TestRunKanikoExecute(t *testing.T) {
 			found := false
 			for _, expected := range expectedParams {
 				if expected[0] == "scan" {
-					expected = append(expected, fmt.Sprintf("cyclonedx-xml@1.4=bom-docker-%d.xml", index-3), "-q")
+					expected = append(expected, fmt.Sprintf("cyclonedx-xml@1.4=bom-docker-%d.xml", index-3), "-q", "--exclude=**/{distlib,distlib-*}/**/*.exe")
 				}
 				if strings.Join(call.Params, " ") == strings.Join(expected, " ") {
 					found = true
@@ -671,7 +671,7 @@ func TestRunKanikoExecute(t *testing.T) {
 			found := false
 			for _, expected := range expectedParams {
 				if expected[0] == "scan" {
-					expected = append(expected, fmt.Sprintf("cyclonedx-xml@1.4=bom-docker-%d.xml", index-2), "-q")
+					expected = append(expected, fmt.Sprintf("cyclonedx-xml@1.4=bom-docker-%d.xml", index-2), "-q", "--exclude=**/{distlib,distlib-*}/**/*.exe")
 				}
 				if strings.Join(call.Params, " ") == strings.Join(expected, " ") {
 					found = true

--- a/pkg/syft/syft.go
+++ b/pkg/syft/syft.go
@@ -67,7 +67,12 @@ func (s *SyftScanner) ScanImages(dockerConfigDir string, execRunner command.Exec
 			return errors.New("syft: image name must not be empty")
 		}
 		// TrimPrefix needed as syft needs containerRegistry name only
-		args := []string{"scan", fmt.Sprintf("registry:%s/%s", strings.TrimPrefix(registryURL, "https://"), image), "-o", fmt.Sprintf("cyclonedx-xml%s=bom-docker-%v.xml", cyclonedxFormatForSyft, index), "-q"}
+		args := []string{"scan", fmt.Sprintf("registry:%s/%s", strings.TrimPrefix(registryURL, "https://"), image), "-o", fmt.Sprintf("cyclonedx-xml%s=bom-docker-%v.xml", cyclonedxFormatForSyft, index), "-q",
+			// Exclude Windows PE launcher stubs shipped by pip's distlib on Linux images.
+			// These are detected as "Simple Launcher" without a PURL, causing SBOM validation failures.
+			// The glob covers distlib/ and versioned variants (distlib-x.y.z/) at any depth.
+			"--exclude=**/{distlib,distlib-*}/**/*.exe",
+		}
 		args = append(args, s.additionalArgs...)
 		err := execRunner.RunExecutable(s.syftFile, args...)
 		if err != nil {

--- a/pkg/syft/syft_test.go
+++ b/pkg/syft/syft_test.go
@@ -45,17 +45,17 @@ func TestGenerateSBOM(t *testing.T) {
 		assert.Len(t, execMock.Calls, 2)
 		firstCall := execMock.Calls[0]
 		assert.Equal(t, firstCall.Exec, "/tmp/syfttest/syft")
-		assert.Equal(t, firstCall.Params, []string{"scan", "registry:my-registry/image:latest", "-o", "cyclonedx-xml@1.4=bom-docker-0.xml", "-q"})
+		assert.Equal(t, firstCall.Params, []string{"scan", "registry:my-registry/image:latest", "-o", "cyclonedx-xml@1.4=bom-docker-0.xml", "-q", "--exclude=**/{distlib,distlib-*}/**/*.exe"})
 
 		secondCall := execMock.Calls[1]
 		assert.Equal(t, secondCall.Exec, "/tmp/syfttest/syft")
-		assert.Equal(t, secondCall.Params, []string{"scan", "registry:my-registry/image:1.2.3", "-o", "cyclonedx-xml@1.4=bom-docker-1.xml", "-q"})
+		assert.Equal(t, secondCall.Params, []string{"scan", "registry:my-registry/image:1.2.3", "-o", "cyclonedx-xml@1.4=bom-docker-1.xml", "-q", "--exclude=**/{distlib,distlib-*}/**/*.exe"})
 	})
 
 	t.Run("error case: syft execution failed", func(t *testing.T) {
 		execMock = mock.ExecMockRunner{}
 		execMock.ShouldFailOnCommand = map[string]error{
-			"/tmp/syfttest/syft scan registry:my-registry/image:latest -o cyclonedx-xml@1.4=bom-docker-0.xml -q": errors.New("failed"),
+			"/tmp/syfttest/syft scan registry:my-registry/image:latest -o cyclonedx-xml@1.4=bom-docker-0.xml -q --exclude=**/{distlib,distlib-*}/**/*.exe": errors.New("failed"),
 		}
 
 		err := syft.GenerateSBOM("http://test-syft-gh-release.com/syft.tar.gz", "", &execMock, &fileMock, client, "https://my-registry", []string{"image:latest"})


### PR DESCRIPTION
## Summary

Hardcodes `--exclude=**/{distlib,distlib-*}/**/*.exe` in Syft scans run by `kanikoExecute` and `cnbBuild`.

## Motivation

pip's `distlib` ships Windows PE launcher stubs (`t32.exe`, `t64.exe`, `t64-arm.exe`, `w32.exe`, `w64.exe`, `w64-arm.exe`) inside Linux container images such as `dhi-python`. Syft's PE binary cataloger detects these as "Simple Launcher v1.1.0.14" without a PURL, causing `HYPERSPACE-SBOM-VALIDATION` failures for 20+ teams.

The `--exclude` glob targets only the specific `distlib` path, keeping the PE binary cataloger active for any legitimate PE binaries elsewhere in the image.

## Scope note

The exclusion is applied unconditionally to **every** image scanned by `kanikoExecute` and `cnbBuild`, not just Python images. This is intentional: the glob `**/{distlib,distlib-*}/**/*.exe` is specific enough that it only matches pip's distlib stubs, which are always false positives on Linux. On non-Python images the glob matches nothing and `--exclude` is a silent no-op.

## Changes

- `pkg/syft/syft.go` — adds `--exclude=**/{distlib,distlib-*}/**/*.exe` to every Syft scan invocation
- `cmd/kanikoExecute_test.go` / `pkg/syft/syft_test.go` — updated assertions to verify the exclude flag is passed
- `cmd/cnbBuild.go` — restored original `ScanImages` call (no behavioural change)

## Test plan

- [x] `go test -tags=unit ./pkg/syft/...` — assertions verify `--exclude=**/{distlib,distlib-*}/**/*.exe` is present in every scan call
- [x] `go test -tags=unit -run TestRunKanikoExecute ./cmd/...` — all kanikoExecute tests pass
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/...` — clean build