### PR TITLE
fix: do not scan all package.json in checkIfStepActive

### DIFF
--- a/pkg/config/evaluation.go
+++ b/pkg/config/evaluation.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"slices"
 	"strings"
 
@@ -11,6 +10,30 @@ import (
 	"github.com/SAP/jenkins-library/pkg/orchestrator"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 )
+
+// npmScriptsPackageJSONExcludesKey is the StepConfig key used to extend the default
+// list of glob patterns that are excluded from package.json discovery when the
+// `npmScripts` step-activation condition is evaluated.
+//
+// The value may be supplied at any scope that resolves into StepConfig (general,
+// stages, steps, or the step itself). A typical use case is excluding test
+// fixtures that intentionally contain invalid JSON, e.g.:
+//
+//	general:
+//	  npmScriptsPackageJSONExcludes:
+//	    - "test_fixtures/**"
+//	    - "tests/**"
+const npmScriptsPackageJSONExcludesKey = "npmScriptsPackageJSONExcludes"
+
+// defaultNpmScriptsPackageJSONExcludes mirrors the default exclusion patterns
+// used by pkg/npm.Execute.FindPackageJSONFilesWithExcludes so that step
+// activation evaluation discovers the same set of package.json files as the
+// npm steps that will eventually run.
+var defaultNpmScriptsPackageJSONExcludes = []string{
+	"**/node_modules/**",
+	"**/gen/**",
+	"**/tmp/**",
+}
 
 const (
 	configCondition                = "config"
@@ -127,7 +150,6 @@ func (s *StepCondition) evaluateV1(
 	envRootPath string,
 	runSteps map[string]bool,
 ) (bool, error) {
-
 	// only the first condition will be evaluated.
 	// if multiple conditions should be checked they need to provided via the Conditions list
 	if s.Config != nil {
@@ -236,7 +258,8 @@ func getCPEEntry(param string, value interface{}, metadata *StepData, stepName s
 		dataType = "string"
 	}
 	metadata.Spec.Inputs.Parameters = []StepParameters{
-		{Name: stepName,
+		{
+			Name:        stepName,
 			Type:        dataType,
 			ResourceRef: []ResourceReference{{Name: "commonPipelineEnvironment", Param: param}},
 		},
@@ -261,24 +284,21 @@ func checkForNpmScriptsInPackagesV1(npmScript string, config StepConfig, utils p
 	if err != nil {
 		return false, fmt.Errorf("failed to check if file-exists: %w", err)
 	}
-	for _, pack := range packages {
-		packDirs := strings.Split(path.Dir(pack), "/")
-		isNodeModules := false
-		for _, dir := range packDirs {
-			if dir == "node_modules" {
-				isNodeModules = true
-				break
-			}
-		}
-		if isNodeModules {
-			continue
-		}
 
+	excludes := append([]string{}, defaultNpmScriptsPackageJSONExcludes...)
+	excludes = append(excludes, npmScriptsPackageJSONExcludesFromConfig(config)...)
+
+	packages, err = piperutils.ExcludeFiles(packages, excludes)
+	if err != nil {
+		return false, fmt.Errorf("failed to apply package.json excludes: %w", err)
+	}
+
+	for _, pack := range packages {
 		jsonFile, err := utils.FileRead(pack)
 		if err != nil {
 			return false, fmt.Errorf("failed to open file %s: %v", pack, err)
 		}
-		packageJSON := map[string]interface{}{}
+		packageJSON := map[string]any{}
 		if err := json.Unmarshal(jsonFile, &packageJSON); err != nil {
 			return false, fmt.Errorf("failed to unmarshal json file %s: %v", pack, err)
 		}
@@ -286,7 +306,7 @@ func checkForNpmScriptsInPackagesV1(npmScript string, config StepConfig, utils p
 		if !ok {
 			continue
 		}
-		scriptsMap, ok := npmScripts.(map[string]interface{})
+		scriptsMap, ok := npmScripts.(map[string]any)
 		if !ok {
 			return false, fmt.Errorf("failed to read scripts from package.json: %T", npmScripts)
 		}
@@ -295,6 +315,29 @@ func checkForNpmScriptsInPackagesV1(npmScript string, config StepConfig, utils p
 		}
 	}
 	return false, nil
+}
+
+func npmScriptsPackageJSONExcludesFromConfig(config StepConfig) []string {
+	raw, ok := config.Config[npmScriptsPackageJSONExcludesKey]
+	if !ok || raw == nil {
+		return nil
+	}
+
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		excludes := make([]string, 0, len(v))
+		for _, entry := range v {
+			if pattern, ok := entry.(string); ok && pattern != "" {
+				excludes = append(excludes, pattern)
+			}
+		}
+		return excludes
+	default:
+		log.Entry().Warnf("ignoring %s: expected []string, got %T", npmScriptsPackageJSONExcludesKey, raw)
+		return nil
+	}
 }
 
 // anyOtherStepIsActive loops through previous steps active states and returns true

--- a/pkg/config/evaluation_test.go
+++ b/pkg/config/evaluation_test.go
@@ -68,121 +68,138 @@ func TestRunConfigV1EvaluateConditionsV1(t *testing.T) {
 	}{
 		{
 			name: "all steps in stage are inactive",
-			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{{DisplayName: "Test Stage 1",
-				Steps: []Step{{
-					Name:                "step1",
-					NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
-				}, {
-					Name: "step2",
-				}, {
-					Name:                "step3",
-					NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
-				}},
-			},
+			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{
+				{
+					DisplayName: "Test Stage 1",
+					Steps: []Step{{
+						Name:                "step1",
+						NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
+					}, {
+						Name: "step2",
+					}, {
+						Name:                "step3",
+						NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
+					}},
+				},
 			}}},
 			wantRunSteps: map[string]map[string]bool{
 				"Test Stage 1": {
 					"step1": false,
 					"step2": false,
 					"step3": false,
-				}},
+				},
+			},
 			wantRunStages: map[string]bool{"Test Stage 1": false},
 		},
 		{
 			name: "simple stepActive conditions",
-			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{{DisplayName: "Test Stage 1",
-				Steps: []Step{{
-					Name:       "step3",
-					Conditions: []StepCondition{{ConfigKey: "testKey"}},
-				}, {
-					Name:       "step4",
-					Conditions: []StepCondition{{ConfigKey: "notExistentKey"}},
-				}},
-			},
+			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{
+				{
+					DisplayName: "Test Stage 1",
+					Steps: []Step{{
+						Name:       "step3",
+						Conditions: []StepCondition{{ConfigKey: "testKey"}},
+					}, {
+						Name:       "step4",
+						Conditions: []StepCondition{{ConfigKey: "notExistentKey"}},
+					}},
+				},
 			}}},
 			wantRunSteps: map[string]map[string]bool{
 				"Test Stage 1": {
 					"step3": true,
 					"step4": false,
-				}},
+				},
+			},
 			wantRunStages: map[string]bool{"Test Stage 1": true},
 		},
 		{
 			name: "explicit active/deactivate over stepActiveCondition",
-			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{{DisplayName: "Test Stage 1",
-				Steps: []Step{{
-					Name:       "step1",
-					Conditions: []StepCondition{{ConfigKey: "notExistentKey"}},
-				}, {
-					Name:       "step2",
-					Conditions: []StepCondition{{ConfigKey: "testKey"}},
-				}},
-			},
+			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{
+				{
+					DisplayName: "Test Stage 1",
+					Steps: []Step{{
+						Name:       "step1",
+						Conditions: []StepCondition{{ConfigKey: "notExistentKey"}},
+					}, {
+						Name:       "step2",
+						Conditions: []StepCondition{{ConfigKey: "testKey"}},
+					}},
+				},
 			}}},
 			wantRunSteps: map[string]map[string]bool{
 				"Test Stage 1": {
 					"step1": true,
 					"step2": false,
-				}},
+				},
+			},
 			wantRunStages: map[string]bool{"Test Stage 1": true},
 		},
 		{
 			name: "stepNotActiveCondition over stepActiveCondition",
-			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{{DisplayName: "Test Stage 1",
-				Steps: []Step{{
-					Name:                "step3",
-					Conditions:          []StepCondition{{ConfigKey: "testKey"}},
-					NotActiveConditions: []StepCondition{{ConfigKey: "testKey2"}},
-				}, {
-					// false notActive condition
-					Name:                "step4",
-					Conditions:          []StepCondition{{ConfigKey: "testKey"}},
-					NotActiveConditions: []StepCondition{{ConfigKey: "notExistentKey"}},
-				}},
-			},
+			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{
+				{
+					DisplayName: "Test Stage 1",
+					Steps: []Step{{
+						Name:                "step3",
+						Conditions:          []StepCondition{{ConfigKey: "testKey"}},
+						NotActiveConditions: []StepCondition{{ConfigKey: "testKey2"}},
+					}, {
+						// false notActive condition
+						Name:                "step4",
+						Conditions:          []StepCondition{{ConfigKey: "testKey"}},
+						NotActiveConditions: []StepCondition{{ConfigKey: "notExistentKey"}},
+					}},
+				},
 			}}},
 			wantRunSteps: map[string]map[string]bool{
 				"Test Stage 1": {
 					"step3": false,
 					"step4": true,
-				}},
+				},
+			},
 			wantRunStages: map[string]bool{"Test Stage 1": true},
 		},
 		{
 			name: "stepNotActiveCondition over explicitly activated step",
-			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{{DisplayName: "Test Stage 1",
-				Steps: []Step{{
-					Name:                "step1",
-					NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
-				}, {
-					Name:                "step5",
-					NotActiveConditions: []StepCondition{{ConfigKey: "notExistentKey"}},
-				}},
-			},
+			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{
+				{
+					DisplayName: "Test Stage 1",
+					Steps: []Step{{
+						Name:                "step1",
+						NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
+					}, {
+						Name:                "step5",
+						NotActiveConditions: []StepCondition{{ConfigKey: "notExistentKey"}},
+					}},
+				},
 			}}},
 			wantRunSteps: map[string]map[string]bool{
 				"Test Stage 1": {
 					"step1": false,
 					"step5": true,
-				}},
+				},
+			},
 			wantRunStages: map[string]bool{"Test Stage 1": true},
 		},
 		{
 			name: "deactivate if only active step in stage",
-			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{{DisplayName: "Test Stage 1",
-				Steps: []Step{{
-					Name:                "step1",
-					NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
-				}, {
-					Name: "step2",
-				}, {
-					Name:                "step3",
-					NotActiveConditions: []StepCondition{{OnlyActiveStepInStage: true}},
-				}, {
-					Name:       "step4",
-					Conditions: []StepCondition{{ConfigKey: "keyNotExist"}},
-				}},
-			},
+			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{
+				{
+					DisplayName: "Test Stage 1",
+					Steps: []Step{{
+						Name:                "step1",
+						NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
+					}, {
+						Name: "step2",
+					}, {
+						Name:                "step3",
+						NotActiveConditions: []StepCondition{{OnlyActiveStepInStage: true}},
+					}, {
+						Name:       "step4",
+						Conditions: []StepCondition{{ConfigKey: "keyNotExist"}},
+					}},
+				},
 			}}},
 			wantRunSteps: map[string]map[string]bool{
 				"Test Stage 1": {
@@ -190,26 +207,29 @@ func TestRunConfigV1EvaluateConditionsV1(t *testing.T) {
 					"step2": false,
 					"step3": false,
 					"step4": false,
-				}},
+				},
+			},
 			wantRunStages: map[string]bool{"Test Stage 1": false},
 		},
 		{
 			name: "OnlyActiveStepInStage: one of the next steps is active",
-			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{{DisplayName: "Test Stage 1",
-				Steps: []Step{{
-					Name:                "step1",
-					NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
-				}, {
-					Name: "step2",
-				}, {
-					Name:                "step3",
-					Conditions:          []StepCondition{{ConfigKey: "testKey"}},
-					NotActiveConditions: []StepCondition{{OnlyActiveStepInStage: true}},
-				}, {
-					Name:       "step4",
-					Conditions: []StepCondition{{ConfigKey: "testKey2"}},
-				}},
-			},
+			pipelineConfig: PipelineDefinitionV1{Spec: Spec{Stages: []Stage{
+				{
+					DisplayName: "Test Stage 1",
+					Steps: []Step{{
+						Name:                "step1",
+						NotActiveConditions: []StepCondition{{ConfigKey: "testKey"}},
+					}, {
+						Name: "step2",
+					}, {
+						Name:                "step3",
+						Conditions:          []StepCondition{{ConfigKey: "testKey"}},
+						NotActiveConditions: []StepCondition{{OnlyActiveStepInStage: true}},
+					}, {
+						Name:       "step4",
+						Conditions: []StepCondition{{ConfigKey: "testKey2"}},
+					}},
+				},
 			}}},
 			wantRunSteps: map[string]map[string]bool{
 				"Test Stage 1": {
@@ -217,7 +237,8 @@ func TestRunConfigV1EvaluateConditionsV1(t *testing.T) {
 					"step2": false,
 					"step3": true,
 					"step4": true,
-				}},
+				},
+			},
 			wantRunStages: map[string]bool{"Test Stage 1": true},
 		},
 	}
@@ -424,12 +445,12 @@ func TestEvaluateV1(t *testing.T) {
 	dir := t.TempDir()
 
 	cpeDir := filepath.Join(dir, "commonPipelineEnvironment")
-	err := os.MkdirAll(filepath.Join(cpeDir, "custom"), 0700)
+	err := os.MkdirAll(filepath.Join(cpeDir, "custom"), 0o700)
 	if err != nil {
 		t.Fatal("Failed to create sub directories")
 	}
-	os.WriteFile(filepath.Join(cpeDir, "myCpeTrueFile"), []byte("myTrueValue"), 0700)
-	os.WriteFile(filepath.Join(cpeDir, "custom", "myCpeTrueFile"), []byte("myTrueValue"), 0700)
+	os.WriteFile(filepath.Join(cpeDir, "myCpeTrueFile"), []byte("myTrueValue"), 0o700)
+	os.WriteFile(filepath.Join(cpeDir, "custom", "myCpeTrueFile"), []byte("myTrueValue"), 0o700)
 
 	for _, test := range tt {
 		t.Run(test.name, func(t *testing.T) {
@@ -496,6 +517,157 @@ func TestAnyOtherStepIsActive(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, anyOtherStepIsActive(targetStep, tt.runSteps), "anyOtherStepIsActive(%v, %v)", targetStep, tt.runSteps)
+		})
+	}
+}
+
+func TestCheckForNpmScriptsInPackagesV1(t *testing.T) {
+	const validPkg = `{"scripts": {"build": "echo build"}}`
+	const invalidPkg = `not a json`
+
+	tests := []struct {
+		name        string
+		files       map[string]string
+		npmScript   string
+		config      StepConfig
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:      "node_modules excluded by default",
+			files:     map[string]string{"node_modules/foo/package.json": validPkg},
+			npmScript: "build",
+			expected:  false,
+		},
+		{
+			name:      "gen excluded by default",
+			files:     map[string]string{"gen/foo/package.json": validPkg},
+			npmScript: "build",
+			expected:  false,
+		},
+		{
+			name:      "tmp excluded by default",
+			files:     map[string]string{"tmp/foo/package.json": validPkg},
+			npmScript: "build",
+			expected:  false,
+		},
+		{
+			name:        "invalid package.json without exclude returns error",
+			files:       map[string]string{"test_fixtures/package.json": invalidPkg},
+			npmScript:   "build",
+			expectError: true,
+		},
+		{
+			name: "invalid package.json under custom exclude is skipped",
+			files: map[string]string{
+				"package.json":               validPkg,
+				"test_fixtures/package.json": invalidPkg,
+			},
+			npmScript: "build",
+			config: StepConfig{Config: map[string]any{
+				"npmScriptsPackageJSONExcludes": []any{"test_fixtures/**"},
+			}},
+			expected: true,
+		},
+		{
+			name: "custom exclude accepts []string",
+			files: map[string]string{
+				"package.json":               validPkg,
+				"test_fixtures/package.json": invalidPkg,
+			},
+			npmScript: "build",
+			config: StepConfig{Config: map[string]any{
+				"npmScriptsPackageJSONExcludes": []string{"test_fixtures/**"},
+			}},
+			expected: true,
+		},
+		{
+			name:      "missing script returns false",
+			files:     map[string]string{"package.json": validPkg},
+			npmScript: "nonexistent",
+			expected:  false,
+		},
+		{
+			name: "non-string entries in exclude list are ignored",
+			files: map[string]string{
+				"package.json":               validPkg,
+				"test_fixtures/package.json": invalidPkg,
+			},
+			npmScript: "build",
+			config: StepConfig{Config: map[string]any{
+				"npmScriptsPackageJSONExcludes": []any{42, "test_fixtures/**", nil},
+			}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := mock.FilesMock{}
+			for path, content := range tt.files {
+				files.AddFile(path, []byte(content))
+			}
+
+			result, err := checkForNpmScriptsInPackagesV1(tt.npmScript, tt.config, &files)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNpmScriptsPackageJSONExcludesFromConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   StepConfig
+		expected []string
+	}{
+		{
+			name:     "missing key returns nil",
+			config:   StepConfig{Config: map[string]any{}},
+			expected: nil,
+		},
+		{
+			name:     "nil value returns nil",
+			config:   StepConfig{Config: map[string]any{"npmScriptsPackageJSONExcludes": nil}},
+			expected: nil,
+		},
+		{
+			name: "[]string passthrough",
+			config: StepConfig{Config: map[string]any{
+				"npmScriptsPackageJSONExcludes": []string{"a/**", "b/**"},
+			}},
+			expected: []string{"a/**", "b/**"},
+		},
+		{
+			name: "[]any of strings is converted",
+			config: StepConfig{Config: map[string]any{
+				"npmScriptsPackageJSONExcludes": []any{"a/**", "b/**"},
+			}},
+			expected: []string{"a/**", "b/**"},
+		},
+		{
+			name: "empty strings dropped, non-strings ignored",
+			config: StepConfig{Config: map[string]any{
+				"npmScriptsPackageJSONExcludes": []any{"", "a/**", 7, nil, "b/**"},
+			}},
+			expected: []string{"a/**", "b/**"},
+		},
+		{
+			name: "unsupported type returns nil",
+			config: StepConfig{Config: map[string]any{
+				"npmScriptsPackageJSONExcludes": "a/**",
+			}},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, npmScriptsPackageJSONExcludesFromConfig(tt.config))
 		})
 	}
 }


### PR DESCRIPTION
# Description
checkIfStepActive step reads ALL package.json files in the project, ignoring only the ones under “node_modules” dir.

This is a blocking issue for users who intentionally have invalid package.json files in their tests folder (due to some unit test cases). 

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
