### PR TITLE
fix(systemtrust): elevate log level on token retrieval failure to Warn

### DIFF
--- a/pkg/config/systemtrust.go
+++ b/pkg/config/systemtrust.go
@@ -18,8 +18,7 @@ func resolveAllSystemTrustReferences(config *StepConfig, params []StepParameters
 				log.Entry().Infof("Getting '%s' from System Trust", param.Name)
 				token, err := systemtrust.GetToken(ref.Default, client, systemTrustConfiguration)
 				if err != nil {
-					log.Entry().Info(" failed")
-					log.Entry().WithError(err).Debugf("Couldn't get '%s' token from System Trust", ref.Default)
+					log.Entry().Warnf("System Trust: failed to retrieve '%s' - %v", param.Name, err)
 					continue
 				}
 				log.RegisterSecret(token)

--- a/pkg/config/systemtrust.go
+++ b/pkg/config/systemtrust.go
@@ -18,7 +18,7 @@ func resolveAllSystemTrustReferences(config *StepConfig, params []StepParameters
 				log.Entry().Infof("Getting '%s' from System Trust", param.Name)
 				token, err := systemtrust.GetToken(ref.Default, client, systemTrustConfiguration)
 				if err != nil {
-					log.Entry().Warnf("System Trust: failed to retrieve '%s' - %v", param.Name, err)
+					log.Entry().WithError(err).Warnf("System Trust: failed to retrieve '%s' (key: '%s')", param.Name, ref.Default)
 					continue
 				}
 				log.RegisterSecret(token)


### PR DESCRIPTION
## Summary
- `resolveAllSystemTrustReferences` was logging ST token fetch failures at Info/Debug level, making them invisible in normal step output
- Users would see a downstream Vault step fail with no indication that System Trust was the root cause
- Change to `Warnf` with a single message including the parameter name and error — no control flow change, fallback to Vault is preserved

## Test plan
- [ ] Trigger a step with a `systemTrustSecret` reference while ST is unavailable
- [ ] Confirm `WARN  System Trust: failed to retrieve '<param>' - <error>` appears in step log output