### PR TITLE
refactor(gcp): use CloudEvents SDK Pub/Sub binding for publishing

### DIFF
--- a/cmd/gcpPublishEvent.go
+++ b/cmd/gcpPublishEvent.go
@@ -36,13 +36,13 @@ func gcpPublishEvent(cfg gcpPublishEventOptions, telemetryData *telemetry.Custom
 }
 
 func runGcpPublishEvent(publisher gcp.PubsubClient, cfg *gcpPublishEventOptions) error {
-	data, err := eventing.NewEventFromJSON(cfg.EventType, cfg.EventSource, cfg.EventData, cfg.AdditionalEventData)
+	event, err := eventing.NewEventFromJSON(cfg.EventType, cfg.EventSource, cfg.EventData, cfg.AdditionalEventData)
 	if err != nil {
 		return fmt.Errorf("failed to create event data: %w", err)
 	}
-	log.Entry().Debugf("CloudEvent created: %s", string(data))
+	log.Entry().Debugf("CloudEvent created: %s", event.String())
 
-	if err = publisher.Publish(cfg.Topic, data); err != nil {
+	if err = publisher.Publish(cfg.Topic, event); err != nil {
 		return fmt.Errorf("failed to publish event: %w", err)
 	}
 

--- a/cmd/gcpPublishEvent_test.go
+++ b/cmd/gcpPublishEvent_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +14,7 @@ type mockPubsubClient struct {
 	publishErr error
 }
 
-func (p *mockPubsubClient) Publish(_ string, _ []byte) error {
+func (p *mockPubsubClient) Publish(_ string, _ cloudevents.Event) error {
 	return p.publishErr
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,8 @@ require (
 	github.com/bndr/gojenkins v1.1.1-0.20240109173050-c316119c46d5
 	github.com/buildpacks/lifecycle v0.18.5
 	github.com/cdevents/sdk-go v0.4.1
-	github.com/cloudevents/sdk-go/v2 v2.15.2
+	github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.16.2
+	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/docker/cli v29.3.0+incompatible
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/evanphx/json-patch v5.9.11+incompatible

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,10 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudevents/sdk-go/v2 v2.15.2 h1:54+I5xQEnI73RBhWHxbI1XJcqOFOVJN85vb41+8mHUc=
-github.com/cloudevents/sdk-go/v2 v2.15.2/go.mod h1:lL7kSWAE/V8VI4Wh0jbL2v/jvqsm6tjmaQBSvxcv4uE=
+github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.16.2 h1:hW59aiNnXx+E13iK4pDklnQoBwMG446kbYkxKRyNL0I=
+github.com/cloudevents/sdk-go/protocol/pubsub/v2 v2.16.2/go.mod h1:9ZBrjWKrMIo7fch/dTRbOTmsLqvCJA8Tg/ASVHX3pZM=
+github.com/cloudevents/sdk-go/v2 v2.16.2 h1:ZYDFrYke4FD+jM8TZTJJO6JhKHzOQl2oqpFK1D+NnQM=
+github.com/cloudevents/sdk-go/v2 v2.16.2/go.mod h1:laOcGImm4nVJEU+PHnUrKL56CKmRL65RlQF0kRmW/kg=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/pkg/eventing/cdevent.go
+++ b/pkg/eventing/cdevent.go
@@ -1,19 +1,19 @@
 package eventing
 
 import (
-	"encoding/json"
 	"fmt"
 
 	cdevents "github.com/cdevents/sdk-go/pkg/api"
 	cdeventsv04 "github.com/cdevents/sdk-go/pkg/api/v04"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
-// newPipelineRunStartedCDEvent creates a CDEvents PipelineRunStarted event and returns its JSON-serialized CloudEvent bytes.
+// newPipelineRunStartedCDEvent creates a CDEvents PipelineRunStarted event as a CloudEvent.
 // Custom data fields (commitID, repositoryURL, pipelineRunMode, cumulusInformation) can be added via SetCustomData by the consuming team.
-func newPipelineRunStartedCDEvent(source, pipelineName, pipelineURL string) ([]byte, error) {
+func newPipelineRunStartedCDEvent(source, pipelineName, pipelineURL string) (cloudevents.Event, error) {
 	event, err := cdeventsv04.NewPipelineRunStartedEvent()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CDEvent: %w", err)
+		return cloudevents.Event{}, fmt.Errorf("failed to create CDEvent: %w", err)
 	}
 
 	event.SetSource(source)
@@ -24,21 +24,16 @@ func newPipelineRunStartedCDEvent(source, pipelineName, pipelineURL string) ([]b
 
 	ce, err := cdevents.AsCloudEvent(event)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert CDEvent to CloudEvent: %w", err)
+		return cloudevents.Event{}, fmt.Errorf("failed to convert CDEvent to CloudEvent: %w", err)
 	}
-
-	bytes, err := json.Marshal(ce)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal CloudEvent: %w", err)
-	}
-	return bytes, nil
+	return *ce, nil
 }
 
-// newTaskRunFinishedCDEvent creates a CDEvents TaskRunFinished event and returns its JSON-serialized CloudEvent bytes.
-func newTaskRunFinishedCDEvent(source, taskName, pipelineURL, outcome, stageName string) ([]byte, error) {
+// newTaskRunFinishedCDEvent creates a CDEvents TaskRunFinished event as a CloudEvent.
+func newTaskRunFinishedCDEvent(source, taskName, pipelineURL, outcome, stageName string) (cloudevents.Event, error) {
 	event, err := cdeventsv04.NewTaskRunFinishedEvent()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CDEvent: %w", err)
+		return cloudevents.Event{}, fmt.Errorf("failed to create CDEvent: %w", err)
 	}
 
 	event.SetSource(source)
@@ -51,18 +46,13 @@ func newTaskRunFinishedCDEvent(source, taskName, pipelineURL, outcome, stageName
 	if stageName != "" {
 		customData := map[string]string{"stageName": stageName}
 		if err = event.SetCustomData("application/json", customData); err != nil {
-			return nil, fmt.Errorf("failed to set custom data: %w", err)
+			return cloudevents.Event{}, fmt.Errorf("failed to set custom data: %w", err)
 		}
 	}
 
 	ce, err := cdevents.AsCloudEvent(event)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert CDEvent to CloudEvent: %w", err)
+		return cloudevents.Event{}, fmt.Errorf("failed to convert CDEvent to CloudEvent: %w", err)
 	}
-
-	bytes, err := json.Marshal(ce)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal CloudEvent: %w", err)
-	}
-	return bytes, nil
+	return *ce, nil
 }

--- a/pkg/eventing/cdevent_test.go
+++ b/pkg/eventing/cdevent_test.go
@@ -3,7 +3,6 @@
 package eventing
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,75 +10,59 @@ import (
 
 func TestNewTaskRunFinishedCDEvent(t *testing.T) {
 	t.Run("creates valid CDEvent as CloudEvent", func(t *testing.T) {
-		bytes, err := newTaskRunFinishedCDEvent("test/source", "myTask", "https://example.com/run/1", "success", "Build")
+		event, err := newTaskRunFinishedCDEvent("test/source", "myTask", "https://example.com/run/1", "success", "Build")
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-
-		assert.Equal(t, "1.0", result["specversion"])
-		assert.Contains(t, result["type"], "taskrun")
-		assert.Contains(t, result["type"], "finished")
-		assert.Equal(t, "test/source", result["source"])
-		assert.NotEmpty(t, result["id"])
+		assert.Equal(t, "1.0", event.SpecVersion())
+		assert.Contains(t, event.Type(), "taskrun")
+		assert.Contains(t, event.Type(), "finished")
+		assert.Equal(t, "test/source", event.Source())
+		assert.NotEmpty(t, event.ID())
 	})
 
 	t.Run("includes stageName in customData", func(t *testing.T) {
-		bytes, err := newTaskRunFinishedCDEvent("test/source", "myTask", "", "success", "Build")
+		event, err := newTaskRunFinishedCDEvent("test/source", "myTask", "", "success", "Build")
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-
-		data, ok := result["data"].(map[string]any)
-		assert.True(t, ok)
+		var data map[string]any
+		assert.NoError(t, event.DataAs(&data))
 		customData, ok := data["customData"].(map[string]any)
 		assert.True(t, ok)
 		assert.Equal(t, "Build", customData["stageName"])
 	})
 
 	t.Run("no customData when stageName is empty", func(t *testing.T) {
-		bytes, err := newTaskRunFinishedCDEvent("test/source", "myTask", "", "success", "")
+		event, err := newTaskRunFinishedCDEvent("test/source", "myTask", "", "success", "")
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-
-		data, ok := result["data"].(map[string]any)
-		assert.True(t, ok)
+		var data map[string]any
+		assert.NoError(t, event.DataAs(&data))
 		_, hasCustomData := data["customData"]
 		assert.False(t, hasCustomData)
 	})
 
 	t.Run("outcome failure", func(t *testing.T) {
-		bytes, err := newTaskRunFinishedCDEvent("test/source", "myTask", "", "failure", "")
+		event, err := newTaskRunFinishedCDEvent("test/source", "myTask", "", "failure", "")
 		assert.NoError(t, err)
-		assert.NotEmpty(t, bytes)
+		assert.NotEmpty(t, event.ID())
 	})
 }
 
 func TestNewPipelineRunStartedCDEvent(t *testing.T) {
 	t.Run("creates valid CDEvent as CloudEvent", func(t *testing.T) {
-		bytes, err := newPipelineRunStartedCDEvent("test/source", "myPipeline", "https://example.com/run/1")
+		event, err := newPipelineRunStartedCDEvent("test/source", "myPipeline", "https://example.com/run/1")
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-
-		assert.Equal(t, "1.0", result["specversion"])
-		assert.Contains(t, result["type"], "pipelinerun")
-		assert.Contains(t, result["type"], "started")
-		assert.Equal(t, "test/source", result["source"])
-		assert.NotEmpty(t, result["id"])
+		assert.Equal(t, "1.0", event.SpecVersion())
+		assert.Contains(t, event.Type(), "pipelinerun")
+		assert.Contains(t, event.Type(), "started")
+		assert.Equal(t, "test/source", event.Source())
+		assert.NotEmpty(t, event.ID())
 	})
 
 	t.Run("empty pipeline URL", func(t *testing.T) {
-		bytes, err := newPipelineRunStartedCDEvent("test/source", "myPipeline", "")
+		event, err := newPipelineRunStartedCDEvent("test/source", "myPipeline", "")
 		assert.NoError(t, err)
-		assert.NotEmpty(t, bytes)
+		assert.NotEmpty(t, event.ID())
 	})
 }

--- a/pkg/eventing/event.go
+++ b/pkg/eventing/event.go
@@ -9,9 +9,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// newEvent creates a CloudEvent v1.0 with the given type, source, and data payload,
-// and returns its JSON-serialized bytes.
-func newEvent(eventType, source string, data any) ([]byte, error) {
+// newEvent creates a CloudEvent v1.0 with the given type, source, and data payload.
+func newEvent(eventType, source string, data any) (cloudevents.Event, error) {
 	event := cloudevents.NewEvent("1.0")
 	event.SetID(uuid.New().String())
 	event.SetType(eventType)
@@ -19,30 +18,26 @@ func newEvent(eventType, source string, data any) ([]byte, error) {
 	event.SetTime(time.Now())
 
 	if err := event.SetData(cloudevents.ApplicationJSON, data); err != nil {
-		return nil, fmt.Errorf("failed to set event data: %w", err)
+		return event, fmt.Errorf("failed to set event data: %w", err)
 	}
 
-	bytes, err := json.Marshal(event)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal event: %w", err)
-	}
-	return bytes, nil
+	return event, nil
 }
 
 // NewEventFromJSON creates a CloudEvent v1.0 from JSON string data, optionally merging
-// additional JSON data into the event payload. Returns the serialized CloudEvent bytes.
-func NewEventFromJSON(eventType, source, jsonData, additionalJSON string) ([]byte, error) {
+// additional JSON data into the event payload.
+func NewEventFromJSON(eventType, source, jsonData, additionalJSON string) (cloudevents.Event, error) {
 	var dataMap map[string]any
 	if jsonData != "" {
 		if err := json.Unmarshal([]byte(jsonData), &dataMap); err != nil {
-			return nil, fmt.Errorf("eventData is invalid JSON: %w", err)
+			return cloudevents.Event{}, fmt.Errorf("eventData is invalid JSON: %w", err)
 		}
 	}
 
 	if additionalJSON != "" {
 		var additional map[string]any
 		if err := json.Unmarshal([]byte(additionalJSON), &additional); err != nil {
-			return nil, fmt.Errorf("additionalEventData is invalid JSON: %w", err)
+			return cloudevents.Event{}, fmt.Errorf("additionalEventData is invalid JSON: %w", err)
 		}
 		if dataMap == nil {
 			dataMap = make(map[string]any)

--- a/pkg/eventing/event_test.go
+++ b/pkg/eventing/event_test.go
@@ -3,7 +3,6 @@
 package eventing
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,19 +11,17 @@ import (
 func TestNewEvent(t *testing.T) {
 	t.Run("creates valid CloudEvent with map data", func(t *testing.T) {
 		data := map[string]string{"key": "value"}
-		bytes, err := newEvent("test.type", "test/source", data)
+		event, err := newEvent("test.type", "test/source", data)
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-		assert.Equal(t, "1.0", result["specversion"])
-		assert.Equal(t, "test.type", result["type"])
-		assert.Equal(t, "test/source", result["source"])
-		assert.NotEmpty(t, result["id"])
-		assert.NotEmpty(t, result["time"])
+		assert.Equal(t, "1.0", event.SpecVersion())
+		assert.Equal(t, "test.type", event.Type())
+		assert.Equal(t, "test/source", event.Source())
+		assert.NotEmpty(t, event.ID())
+		assert.NotEmpty(t, event.Time())
 
-		eventData := result["data"].(map[string]any)
+		var eventData map[string]any
+		assert.NoError(t, event.DataAs(&eventData))
 		assert.Equal(t, "value", eventData["key"])
 	})
 
@@ -38,75 +35,63 @@ func TestNewEvent(t *testing.T) {
 			StageName: "dev",
 			Outcome:   "success",
 		}
-		bytes, err := newEvent("test.type", "test/source", payload)
+		event, err := newEvent("test.type", "test/source", payload)
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-
-		eventData := result["data"].(map[string]any)
+		var eventData map[string]any
+		assert.NoError(t, event.DataAs(&eventData))
 		assert.Equal(t, "build", eventData["taskName"])
 		assert.Equal(t, "dev", eventData["stageName"])
 		assert.Equal(t, "success", eventData["outcome"])
 	})
 
 	t.Run("handles nil data", func(t *testing.T) {
-		bytes, err := newEvent("test.type", "test/source", nil)
+		event, err := newEvent("test.type", "test/source", nil)
 		assert.NoError(t, err)
-		assert.NotEmpty(t, bytes)
+		assert.Equal(t, "test.type", event.Type())
 	})
 }
 
 func TestNewEventFromJSON(t *testing.T) {
 	t.Run("creates event from JSON data", func(t *testing.T) {
-		bytes, err := NewEventFromJSON("test.type", "test/source", `{"key":"value"}`, "")
+		event, err := NewEventFromJSON("test.type", "test/source", `{"key":"value"}`, "")
 		assert.NoError(t, err)
+		assert.Equal(t, "test.type", event.Type())
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-		assert.Equal(t, "test.type", result["type"])
-
-		eventData := result["data"].(map[string]any)
+		var eventData map[string]any
+		assert.NoError(t, event.DataAs(&eventData))
 		assert.Equal(t, "value", eventData["key"])
 	})
 
 	t.Run("merges additional JSON data", func(t *testing.T) {
-		bytes, err := NewEventFromJSON("test.type", "test/source",
+		event, err := NewEventFromJSON("test.type", "test/source",
 			`{"key":"value"}`,
 			`{"extra":"data"}`,
 		)
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-
-		eventData := result["data"].(map[string]any)
+		var eventData map[string]any
+		assert.NoError(t, event.DataAs(&eventData))
 		assert.Equal(t, "value", eventData["key"])
 		assert.Equal(t, "data", eventData["extra"])
 	})
 
 	t.Run("additional data overwrites existing keys", func(t *testing.T) {
-		bytes, err := NewEventFromJSON("test.type", "test/source",
+		event, err := NewEventFromJSON("test.type", "test/source",
 			`{"key":"original"}`,
 			`{"key":"overwritten"}`,
 		)
 		assert.NoError(t, err)
 
-		var result map[string]any
-		err = json.Unmarshal(bytes, &result)
-		assert.NoError(t, err)
-
-		eventData := result["data"].(map[string]any)
+		var eventData map[string]any
+		assert.NoError(t, event.DataAs(&eventData))
 		assert.Equal(t, "overwritten", eventData["key"])
 	})
 
 	t.Run("handles empty data strings", func(t *testing.T) {
-		bytes, err := NewEventFromJSON("test.type", "test/source", "", "")
+		event, err := NewEventFromJSON("test.type", "test/source", "", "")
 		assert.NoError(t, err)
-		assert.NotEmpty(t, bytes)
+		assert.Equal(t, "test.type", event.Type())
 	})
 
 	t.Run("returns error on invalid JSON", func(t *testing.T) {

--- a/pkg/eventing/publish.go
+++ b/pkg/eventing/publish.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/config"
 	"github.com/SAP/jenkins-library/pkg/gcp"
 	"github.com/SAP/jenkins-library/pkg/log"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
 const (
@@ -51,7 +52,7 @@ func PublishTaskRunFinishedEvent(tokenProvider gcp.OIDCTokenProvider, generalCon
 		outcome = "success"
 	}
 
-	var fatalError = map[string]any{}
+	fatalError := map[string]any{}
 	rawErrorDetail := log.GetFatalErrorDetail()
 	if ctx.ErrorCode != "0" && rawErrorDetail != nil {
 		// retrieve the error information from the logCollector
@@ -71,14 +72,17 @@ func PublishTaskRunFinishedEvent(tokenProvider gcp.OIDCTokenProvider, generalCon
 		return fmt.Errorf("failed to create event: %w", err)
 	}
 
-	prettyJSON, _ := json.MarshalIndent(json.RawMessage(eventData), "", "  ")
-	log.Entry().Debugf("CloudEvent event payload:\n%s", string(prettyJSON))
+	if prettyJSON, err := json.MarshalIndent(eventData, "", "  "); err != nil {
+		log.Entry().WithError(err).Debug("failed to marshal CloudEvent payload for debug output")
+	} else {
+		log.Entry().Debugf("CloudEvent event payload:\n%s", string(prettyJSON))
+	}
 	log.Entry().Debugf("publishing TaskRunFinished event to GCP Pub/Sub...")
 
 	return publish(tokenProvider, generalConfig, topicPipelineTaskRunFinished, eventData)
 }
 
-func publish(tokenProvider gcp.OIDCTokenProvider, generalConfig *config.GeneralConfigOptions, topic string, eventData []byte) error {
+func publish(tokenProvider gcp.OIDCTokenProvider, generalConfig *config.GeneralConfigOptions, topic string, event cloudevents.Event) error {
 	cfg := generalConfig.HookConfig.GCPPubSubConfig
 	publisher := gcp.NewGcpPubsubClient(
 		tokenProvider,
@@ -88,7 +92,7 @@ func publish(tokenProvider gcp.OIDCTokenProvider, generalConfig *config.GeneralC
 		generalConfig.CorrelationID,
 		generalConfig.HookConfig.OIDCConfig.RoleID,
 	)
-	if err := publisher.Publish(topic, eventData); err != nil {
+	if err := publisher.Publish(topic, event); err != nil {
 		return fmt.Errorf("event publish failed: %w", err)
 	}
 	return nil

--- a/pkg/gcp/pubsub.go
+++ b/pkg/gcp/pubsub.go
@@ -6,6 +6,9 @@ import (
 
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/SAP/jenkins-library/pkg/log"
+	cepubsub "github.com/cloudevents/sdk-go/protocol/pubsub/v2"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/binding"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
@@ -13,7 +16,10 @@ import (
 type OIDCTokenProvider func(roleID string) (string, error)
 
 type PubsubClient interface {
-	Publish(topic string, data []byte) error
+	// Publish encodes the CloudEvent into a Pub/Sub message via the CloudEvents
+	// SDK and sends it to the topic. Callers pass the event directly; no manual
+	// JSON marshaling is required.
+	Publish(topic string, event cloudevents.Event) error
 }
 
 type pubsubClient struct {
@@ -27,23 +33,23 @@ type pubsubClient struct {
 
 func NewGcpPubsubClient(tokenProvider OIDCTokenProvider, projectNumber, pool, provider, orderingKey, oidcRoleId string) PubsubClient {
 	return &pubsubClient{
-		tokenProvider,
-		projectNumber,
-		pool,
-		provider,
-		orderingKey,
-		oidcRoleId,
+		tokenProvider: tokenProvider,
+		projectNumber: projectNumber,
+		pool:          pool,
+		provider:      provider,
+		orderingKey:   orderingKey,
+		oidcRoleId:    oidcRoleId,
 	}
 }
 
-func (cl *pubsubClient) Publish(topic string, data []byte) error {
+func (cl *pubsubClient) Publish(topic string, event cloudevents.Event) error {
 	ctx := context.Background()
 	psClient, err := cl.getAuthorizedGCPClient(ctx)
 	if err != nil {
 		return fmt.Errorf("could not get authorized pubsub client token: %w", err)
 	}
 
-	return cl.publish(ctx, psClient, topic, cl.orderingKey, data)
+	return cl.publish(ctx, psClient, topic, cl.orderingKey, event)
 }
 
 func (cl *pubsubClient) getAuthorizedGCPClient(ctx context.Context) (*pubsub.Client, error) {
@@ -61,14 +67,22 @@ func (cl *pubsubClient) getAuthorizedGCPClient(ctx context.Context) (*pubsub.Cli
 	return pubsub.NewClient(ctx, cl.projectNumber, option.WithTokenSource(staticTokenSource))
 }
 
-func (cl *pubsubClient) publish(ctx context.Context, psClient *pubsub.Client, topic, orderingKey string, data []byte) error {
+func (cl *pubsubClient) publish(ctx context.Context, psClient *pubsub.Client, topic, orderingKey string, event cloudevents.Event) error {
+	msg := &pubsub.Message{
+		Attributes:  map[string]string{},
+		OrderingKey: orderingKey,
+	}
+	if err := cepubsub.WritePubSubMessage(ctx, binding.ToMessage(&event), msg); err != nil {
+		return fmt.Errorf("could not encode CloudEvent into pubsub message: %w", err)
+	}
+
 	t := psClient.Publisher(topic)
 	t.EnableMessageOrdering = true
-	publishResult := t.Publish(ctx, &pubsub.Message{Data: data, OrderingKey: orderingKey})
+	publishResult := t.Publish(ctx, msg)
 
 	// publishResult.Get() will make API call synchronous by awaiting messageId or error.
 	// By removing .Get() method call we can make publishing asynchronous, but without ability to catch errors
-	msgID, err := publishResult.Get(context.Background())
+	msgID, err := publishResult.Get(ctx)
 	if err != nil {
 		return fmt.Errorf("event publish failed: %w", err)
 	}


### PR DESCRIPTION
# Description
Delegate CloudEvent-to-Pub/Sub message encoding to the cloudevents SDK protocol/pubsub binding instead of hand-marshaling events to JSON. The event factory functions now return cloudevents.Event and PubsubClient.Publish accepts it directly, so the SDK owns serialization and attribute mapping. This also eases sending more structured data for future pipeline events.

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
