### PR TITLE
fix(hadolintExecute): align default dockerFile pattern with stage activation glob

### DIFF
--- a/cmd/hadolintExecute_generated.go
+++ b/cmd/hadolintExecute_generated.go
@@ -166,7 +166,7 @@ func addHadolintExecuteFlags(cmd *cobra.Command, stepConfig *hadolintExecuteOpti
 	cmd.Flags().StringVar(&stepConfig.ConfigurationURL, "configurationUrl", os.Getenv("PIPER_configurationUrl"), "URL pointing to the .hadolint.yaml exclude configuration to be used for linting. Also have a look at `configurationFile` which could avoid central configuration download in case the file is part of your repository.")
 	cmd.Flags().StringVar(&stepConfig.ConfigurationUsername, "configurationUsername", os.Getenv("PIPER_configurationUsername"), "The username to authenticate")
 	cmd.Flags().StringVar(&stepConfig.ConfigurationPassword, "configurationPassword", os.Getenv("PIPER_configurationPassword"), "The password to authenticate")
-	cmd.Flags().StringVar(&stepConfig.DockerFile, "dockerFile", `./Dockerfile`, "Path or glob pattern of Dockerfile(s) to be used for the assessment. Supports double-star glob patterns (e.g. `**/Dockerfile`, `images/**/Dockerfile`). When a pattern is provided, all matching files are linted in a single hadolint invocation.")
+	cmd.Flags().StringVar(&stepConfig.DockerFile, "dockerFile", `**/Dockerfile`, "Path or glob pattern of Dockerfile(s) to be used for the assessment. Supports double-star glob patterns (e.g. `**/Dockerfile`, `images/**/Dockerfile`). When a pattern is provided, all matching files are linted in a single hadolint invocation.")
 	cmd.Flags().StringVar(&stepConfig.ConfigurationFile, "configurationFile", `.hadolint.yaml`, "Name of the configuration file used locally within the step. If a file with this name is detected as part of your repo downloading the central configuration via `configurationUrl` will be skipped. If you change the file's name make sure your stashing configuration also reflects this.")
 	cmd.Flags().StringVar(&stepConfig.ReportFile, "reportFile", `hadolint.xml`, "Name of the result file used locally within the step.")
 	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List of download links to custom TLS certificates. This is required to ensure trusted connections between Piper and the system where the configuration file is to be downloaded from.")
@@ -245,7 +245,7 @@ func hadolintExecuteMetadata() config.StepData {
 						Type:        "string",
 						Mandatory:   false,
 						Aliases:     []config.Alias{{Name: "dockerfile"}},
-						Default:     `./Dockerfile`,
+						Default:     `**/Dockerfile`,
 					},
 					{
 						Name:        "configurationFile",

--- a/resources/metadata/hadolintExecute.yaml
+++ b/resources/metadata/hadolintExecute.yaml
@@ -65,7 +65,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        default: ./Dockerfile
+        default: "**/Dockerfile"
       - name: configurationFile
         type: string
         description: Name of the configuration file used locally within the step. If a file with this name is detected as part of your repo downloading the central configuration via `configurationUrl` will be skipped. If you change the file's name make sure your stashing configuration also reflects this.


### PR DESCRIPTION
## Changes

Changes the default of the `dockerFile` parameter from `./Dockerfile` to `**/Dockerfile` (metadata + regenerated step code).

## Why

The step is activated in the Build stage via the file pattern `**/Dockerfile`, but executed with the default `./Dockerfile`. A repository whose only Dockerfile lives in a subdirectory (e.g. `terraform/Dockerfile`) therefore activates the step, which then fails with:

no Dockerfiles found for pattern './Dockerfile'

This surfaced after #5821: previously the missing file was passed straight to hadolint and the error was effectively swallowed by the stdout-based error handling; the new empty-glob guard turns it into a hard failure.

Since #5821 the step fully supports double-star globs, so the default can simply match the activation condition.

## Behavior change

Repositories containing a root `Dockerfile` **and** additional nested Dockerfiles will now have all of them linted in a single hadolint invocation (previously only the root one). This may surface new findings in existing pipelines.

## Testing

- `go test ./cmd/ -tags=unit -run Hadolint` — existing tests pass unchanged (they set `dockerFile` explicitly and don't assert the default)
- `**/Dockerfile` matches a root-level `Dockerfile` as well (doublestar: `**/` = zero or more directories), so single-root-Dockerfile repos keep the exact same behavior

# Possible issues

## hadolint now reports findings from Dockerfiles it previously ignored

1. Restore old scope — pin the pattern in .pipeline/config.yml:
```yml
steps:
  hadolintExecute:
    dockerFile: './Dockerfile'      # or 'images/**/Dockerfile' to scope deliberately
```
2. Suppress specific rules — add a .hadolint.yaml to the repo (its presence skips the central configurationUrl download, so include the central rules you still want):
```yml
ignored:
  - DL3008
```
Note: hadolint ignores are rule-scoped, not path-scoped — there's no "exclude this directory", which is why option 1 is usually the right answer for fixture/vendored Dockerfiles. Inline # hadolint ignore=DL3008 comments in the specific Dockerfile are the per-file alternative.

3. Actually fix the findings — for real Dockerfiles that were simply never linted before, the findings are legitimate; that's the point of the change.

4. Repo shouldn't lint at all — deactivate the step:
```yaml
stages:
  Build:
    hadolintExecute: false
```
# Checklist

- [x] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
