### PR TITLE
feat(helmBuild): generate SBOM on the publish path

### DIFF
--- a/cmd/helmBuild.go
+++ b/cmd/helmBuild.go
@@ -7,12 +7,22 @@ import (
 	"path/filepath"
 
 	"github.com/SAP/jenkins-library/pkg/buildsettings"
+	"github.com/SAP/jenkins-library/pkg/command"
+	"github.com/SAP/jenkins-library/pkg/docker"
+	"github.com/SAP/jenkins-library/pkg/helm"
+	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/kubernetes"
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/SAP/jenkins-library/pkg/syft"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"github.com/SAP/jenkins-library/pkg/versioning"
 )
+
+// helmDockerConfigDir is the directory syft uses to authenticate against the
+// container registry when scanning referenced images.
+const helmDockerConfigDir = "/root/.docker"
 
 func helmBuild(config helmBuildOptions, telemetryData *telemetry.CustomData, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment) {
 	helmConfig := kubernetes.HelmExecuteOptions{
@@ -74,13 +84,21 @@ func helmBuild(config helmBuildOptions, telemetryData *telemetry.CustomData, com
 
 	helmExecutor := kubernetes.NewHelmExecutor(helmConfig, utils, GeneralConfig.Verbose, log.Writer())
 
+	// dependencies required for SBOM generation (syft): a command runner to
+	// execute the syft binary, an http client to download it, and file utils.
+	execRunner := &command.Command{}
+	execRunner.Stdout(log.Writer())
+	execRunner.Stderr(log.Writer())
+	httpClient := &piperhttp.Client{}
+	fileUtils := &piperutils.Files{}
+
 	// error situations should stop execution through log.Entry().Fatal() call which leads to an os.Exit(1) in the end
-	if err := runHelmBuild(config, helmExecutor, utils, commonPipelineEnvironment); err != nil {
+	if err := runHelmBuild(config, helmExecutor, utils, commonPipelineEnvironment, execRunner, fileUtils, httpClient); err != nil {
 		log.Entry().WithError(err).Fatalf("step execution failed: %v", err)
 	}
 }
 
-func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, utils fileHandler, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment) error {
+func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, utils fileHandler, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
 	if config.RenderValuesTemplate {
 		err := parseAndRenderCPETemplate(config, GeneralConfig.EnvRootPath, utils)
 		if err != nil {
@@ -118,8 +136,11 @@ func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor,
 			return fmt.Errorf("failed to execute helm publish: %v", err)
 		}
 		commonPipelineEnvironment.custom.helmChartURL = targetURL
+		if config.CreateBOM {
+			generateSBOMs(config, helmExecutor, execRunner, fileUtils, httpClient)
+		}
 	default:
-		if err := runHelmBuildDefault(config, helmExecutor, commonPipelineEnvironment); err != nil {
+		if err := runHelmBuildDefault(config, helmExecutor, commonPipelineEnvironment, execRunner, fileUtils, httpClient); err != nil {
 			return err
 		}
 	}
@@ -135,6 +156,7 @@ func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor,
 	buildSettingsInfo, err := buildsettings.CreateBuildSettingsInfo(&buildsettings.BuildOptions{
 		DockerImage:       dockerImage,
 		Publish:           config.Publish,
+		CreateBOM:         config.CreateBOM,
 		BuildSettingsInfo: config.BuildSettingsInfo,
 	}, "helmBuild")
 	if err != nil {
@@ -145,7 +167,7 @@ func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor,
 	return nil
 }
 
-func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment) error {
+func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
 	if len(config.Dependency) > 0 {
 		if err := helmExecutor.RunHelmDependency(); err != nil {
 			return fmt.Errorf("failed to execute helm dependency: %v", err)
@@ -162,6 +184,119 @@ func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmEx
 			return fmt.Errorf("failed to execute helm publish: %v", err)
 		}
 		commonPipelineEnvironment.custom.helmChartURL = targetURL
+		if config.CreateBOM {
+			generateSBOMs(config, helmExecutor, execRunner, fileUtils, httpClient)
+		}
+	}
+
+	return nil
+}
+
+// generateSBOMs produces both SBOMs for the published chart, sharing a single
+// discovered image set so the chart BOM and the container BOMs describe the
+// same images. Both are best-effort: a failure is logged but never fails the
+// step.
+func generateSBOMs(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) {
+	images := discoverImages(config, helmExecutor)
+
+	if err := generateContainerSBOMs(config, images, execRunner, fileUtils, httpClient); err != nil {
+		log.Entry().Warnf("container SBOM generation failed: %v", err)
+	}
+
+	if err := helm.GenerateChartSBOM(config.ChartPath, "bom-helm.xml", images, fileUtils); err != nil {
+		log.Entry().Warnf("chart SBOM generation failed: %v", err)
+	} else {
+		log.Entry().Infof("helm SBOM: generated chart SBOM bom-helm.xml for %s", config.ChartPath)
+	}
+}
+
+// generateContainerSBOMs generates a CycloneDX SBOM (bom-docker-<N>.xml) for
+// each of the given container images, using Syft. The registry is derived from
+// each full image reference.
+func generateContainerSBOMs(config helmBuildOptions, imageNameTags []string, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
+	if len(imageNameTags) == 0 {
+		log.Entry().Info("helm SBOM: no container images available, skipping syft scan")
+		return nil
+	}
+
+	registryURL, err := docker.ContainerRegistryFromImage(imageNameTags[0])
+	if err != nil {
+		log.Entry().Infof("helm SBOM: failed to derive registry from image %q: %v", imageNameTags[0], err)
+		return fmt.Errorf("failed to derive registry from image %q: %w", imageNameTags[0], err)
+	}
+
+	images := make([]string, 0, len(imageNameTags))
+	for _, image := range imageNameTags {
+		nameTag, err := docker.ContainerImageNameTagFromImage(image)
+		if err != nil {
+			log.Entry().Infof("helm SBOM: failed to parse image %q: %v", image, err)
+			return fmt.Errorf("failed to parse image %q: %w", image, err)
+		}
+		images = append(images, nameTag)
+	}
+
+	if err := syft.GenerateSBOM(config.SyftDownloadURL, helmDockerConfigDir, execRunner, fileUtils, httpClient, registryURL, images); err != nil {
+		return err
+	}
+
+	// Syft omits the PURL for the root/parent component of an image BOM
+	// (anchore/syft#1408); without it the BOM fails CycloneDX validation with
+	// "Purl is missing for the root component!". Inject a clean docker PURL.
+	return injectContainerBOMPurls()
+}
+
+// discoverImages returns the container images referenced by the chart. It
+// prefers images rendered by `helm template`; if templating fails or yields no
+// images, it falls back to the containerImageNameTags CPE list.
+func discoverImages(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor) []string {
+	manifests, err := helmExecutor.RunHelmTemplate()
+	if err != nil {
+		log.Entry().Warnf("helm SBOM: helm template failed, falling back to CPE image list: %v", err)
+		return config.ContainerImageNameTags
+	}
+
+	images, err := kubernetes.ExtractImagesFromManifests(manifests)
+	if err != nil {
+		log.Entry().Warnf("helm SBOM: failed to parse rendered manifests, falling back to CPE image list: %v", err)
+		return config.ContainerImageNameTags
+	}
+
+	if len(images) == 0 {
+		return config.ContainerImageNameTags
+	}
+	return images
+}
+
+// injectContainerBOMPurls sets a clean, registry-free docker PURL on the root
+// component of every bom-docker-*.xml produced by Syft. Syft does not emit a
+// PURL for the parent component (anchore/syft#1408), which makes the BOM fail
+// CycloneDX validation. Best-effort: individual failures are logged, not fatal.
+func injectContainerBOMPurls() error {
+	files, err := filepath.Glob("bom-docker-*.xml")
+	if err != nil || len(files) == 0 {
+		log.Entry().Debug("helm SBOM: no bom-docker-*.xml files to update with a root PURL")
+		return nil
+	}
+
+	for _, file := range files {
+		component := piperutils.GetComponent(file)
+		if component.Name == "" {
+			log.Entry().Warnf("helm SBOM: unable to read root component from %s, skipping PURL injection", file)
+			continue
+		}
+
+		// Build a clean, registry-free docker PURL (e.g. pkg:docker/nginx@1.25)
+		// for the root component — shared with kaniko (see
+		// piperutils.BuildRegistryFreeDockerPurl).
+		constructedPurl, _, _, _, err := piperutils.BuildRegistryFreeDockerPurl(component.Name, component.Version)
+		if err != nil {
+			log.Entry().Warnf("helm SBOM: %v for %s", err, file)
+			continue
+		}
+
+		if err := piperutils.UpdatePurl(file, constructedPurl); err != nil {
+			log.Entry().Warnf("helm SBOM: unable to update root purl in %s: %v", file, err)
+		}
 	}
 
 	return nil

--- a/cmd/helmBuild.go
+++ b/cmd/helmBuild.go
@@ -6,12 +6,23 @@ import (
 	"path"
 	"path/filepath"
 
+	"github.com/SAP/jenkins-library/pkg/buildsettings"
+	"github.com/SAP/jenkins-library/pkg/command"
+	"github.com/SAP/jenkins-library/pkg/docker"
+	"github.com/SAP/jenkins-library/pkg/helm"
+	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/kubernetes"
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/SAP/jenkins-library/pkg/syft"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"github.com/SAP/jenkins-library/pkg/versioning"
 )
+
+// helmDockerConfigDir is the directory syft uses to authenticate against the
+// container registry when scanning referenced images.
+const helmDockerConfigDir = "/root/.docker"
 
 func helmBuild(config helmBuildOptions, telemetryData *telemetry.CustomData, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment) {
 	helmConfig := kubernetes.HelmExecuteOptions{
@@ -73,13 +84,36 @@ func helmBuild(config helmBuildOptions, telemetryData *telemetry.CustomData, com
 
 	helmExecutor := kubernetes.NewHelmExecutor(helmConfig, utils, GeneralConfig.Verbose, log.Writer())
 
+	// dependencies required for SBOM generation (syft): a command runner to
+	// execute the syft binary, an http client to download it, and file utils.
+	execRunner := &command.Command{}
+	execRunner.Stdout(log.Writer())
+	execRunner.Stderr(log.Writer())
+	httpClient := &piperhttp.Client{}
+	fileUtils := &piperutils.Files{}
+
 	// error situations should stop execution through log.Entry().Fatal() call which leads to an os.Exit(1) in the end
-	if err := runHelmBuild(config, helmExecutor, utils, commonPipelineEnvironment); err != nil {
+	if err := runHelmBuild(config, helmExecutor, utils, commonPipelineEnvironment, execRunner, fileUtils, httpClient); err != nil {
 		log.Entry().WithError(err).Fatalf("step execution failed: %v", err)
 	}
 }
 
-func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, utils fileHandler, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment) error {
+func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, utils fileHandler, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
+	// SLC-29: record build-settings traceability for the step (independent of
+	// the SBOM/publish flow). Best-effort — a failure must not fail the step.
+	dockerImage, _ := GetDockerImageValue("helmBuild")
+	buildSettings := buildsettings.BuildOptions{
+		Publish:           config.Publish,
+		CreateBOM:         config.CreateBOM,
+		BuildSettingsInfo: config.BuildSettingsInfo,
+		DockerImage:       dockerImage,
+	}
+	if info, err := buildsettings.CreateBuildSettingsInfo(&buildSettings, "helmBuild"); err != nil {
+		log.Entry().Warnf("failed to create build settings info: %v", err)
+	} else {
+		commonPipelineEnvironment.custom.buildSettingsInfo = info
+	}
+
 	if config.RenderValuesTemplate {
 		err := parseAndRenderCPETemplate(config, GeneralConfig.EnvRootPath, utils)
 		if err != nil {
@@ -117,8 +151,11 @@ func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor,
 			return fmt.Errorf("failed to execute helm publish: %v", err)
 		}
 		commonPipelineEnvironment.custom.helmChartURL = targetURL
+		if config.CreateBOM {
+			generateSBOMs(config, helmExecutor, execRunner, fileUtils, httpClient)
+		}
 	default:
-		if err := runHelmBuildDefault(config, helmExecutor, commonPipelineEnvironment); err != nil {
+		if err := runHelmBuildDefault(config, helmExecutor, commonPipelineEnvironment, execRunner, fileUtils, httpClient); err != nil {
 			return err
 		}
 	}
@@ -126,7 +163,7 @@ func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor,
 	return nil
 }
 
-func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment) error {
+func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
 	if len(config.Dependency) > 0 {
 		if err := helmExecutor.RunHelmDependency(); err != nil {
 			return fmt.Errorf("failed to execute helm dependency: %v", err)
@@ -143,6 +180,119 @@ func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmEx
 			return fmt.Errorf("failed to execute helm publish: %v", err)
 		}
 		commonPipelineEnvironment.custom.helmChartURL = targetURL
+		if config.CreateBOM {
+			generateSBOMs(config, helmExecutor, execRunner, fileUtils, httpClient)
+		}
+	}
+
+	return nil
+}
+
+// generateSBOMs produces both SBOMs for the published chart, sharing a single
+// discovered image set so the chart BOM and the container BOMs describe the
+// same images. Both are best-effort: a failure is logged but never fails the
+// step.
+func generateSBOMs(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) {
+	images := discoverImages(config, helmExecutor)
+
+	if err := generateContainerSBOMs(config, images, execRunner, fileUtils, httpClient); err != nil {
+		log.Entry().Warnf("container SBOM generation failed: %v", err)
+	}
+
+	if err := helm.GenerateChartSBOM(config.ChartPath, "bom-helm.xml", images, fileUtils); err != nil {
+		log.Entry().Warnf("chart SBOM generation failed: %v", err)
+	} else {
+		log.Entry().Infof("helm SBOM: generated chart SBOM bom-helm.xml for %s", config.ChartPath)
+	}
+}
+
+// generateContainerSBOMs generates a CycloneDX SBOM (bom-docker-<N>.xml) for
+// each of the given container images, using Syft. The registry is derived from
+// each full image reference.
+func generateContainerSBOMs(config helmBuildOptions, imageNameTags []string, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
+	if len(imageNameTags) == 0 {
+		log.Entry().Info("helm SBOM: no container images available, skipping syft scan")
+		return nil
+	}
+
+	registryURL, err := docker.ContainerRegistryFromImage(imageNameTags[0])
+	if err != nil {
+		log.Entry().Infof("helm SBOM: failed to derive registry from image %q: %v", imageNameTags[0], err)
+		return fmt.Errorf("failed to derive registry from image %q: %w", imageNameTags[0], err)
+	}
+
+	images := make([]string, 0, len(imageNameTags))
+	for _, image := range imageNameTags {
+		nameTag, err := docker.ContainerImageNameTagFromImage(image)
+		if err != nil {
+			log.Entry().Infof("helm SBOM: failed to parse image %q: %v", image, err)
+			return fmt.Errorf("failed to parse image %q: %w", image, err)
+		}
+		images = append(images, nameTag)
+	}
+
+	if err := syft.GenerateSBOM(config.SyftDownloadURL, helmDockerConfigDir, execRunner, fileUtils, httpClient, registryURL, images); err != nil {
+		return err
+	}
+
+	// Syft omits the PURL for the root/parent component of an image BOM
+	// (anchore/syft#1408); without it the BOM fails CycloneDX validation with
+	// "Purl is missing for the root component!". Inject a clean docker PURL.
+	return injectContainerBOMPurls()
+}
+
+// discoverImages returns the container images referenced by the chart. It
+// prefers images rendered by `helm template`; if templating fails or yields no
+// images, it falls back to the containerImageNameTags CPE list.
+func discoverImages(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor) []string {
+	manifests, err := helmExecutor.RunHelmTemplate()
+	if err != nil {
+		log.Entry().Warnf("helm SBOM: helm template failed, falling back to CPE image list: %v", err)
+		return config.ContainerImageNameTags
+	}
+
+	images, err := kubernetes.ExtractImagesFromManifests(manifests)
+	if err != nil {
+		log.Entry().Warnf("helm SBOM: failed to parse rendered manifests, falling back to CPE image list: %v", err)
+		return config.ContainerImageNameTags
+	}
+
+	if len(images) == 0 {
+		return config.ContainerImageNameTags
+	}
+	return images
+}
+
+// injectContainerBOMPurls sets a clean, registry-free docker PURL on the root
+// component of every bom-docker-*.xml produced by Syft. Syft does not emit a
+// PURL for the parent component (anchore/syft#1408), which makes the BOM fail
+// CycloneDX validation. Best-effort: individual failures are logged, not fatal.
+func injectContainerBOMPurls() error {
+	files, err := filepath.Glob("bom-docker-*.xml")
+	if err != nil || len(files) == 0 {
+		log.Entry().Debug("helm SBOM: no bom-docker-*.xml files to update with a root PURL")
+		return nil
+	}
+
+	for _, file := range files {
+		component := piperutils.GetComponent(file)
+		if component.Name == "" {
+			log.Entry().Warnf("helm SBOM: unable to read root component from %s, skipping PURL injection", file)
+			continue
+		}
+
+		// Build a clean, registry-free docker PURL (e.g. pkg:docker/nginx@1.25)
+		// for the root component — shared with kaniko (see
+		// piperutils.BuildRegistryFreeDockerPurl).
+		constructedPurl, _, _, _, err := piperutils.BuildRegistryFreeDockerPurl(component.Name, component.Version)
+		if err != nil {
+			log.Entry().Warnf("helm SBOM: %v for %s", err, file)
+			continue
+		}
+
+		if err := piperutils.UpdatePurl(file, constructedPurl); err != nil {
+			log.Entry().Warnf("helm SBOM: unable to update root purl in %s: %v", file, err)
+		}
 	}
 
 	return nil

--- a/cmd/helmBuild_generated.go
+++ b/cmd/helmBuild_generated.go
@@ -6,15 +6,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/SAP/jenkins-library/pkg/config"
 	"github.com/SAP/jenkins-library/pkg/eventing"
+	"github.com/SAP/jenkins-library/pkg/gcs"
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
 	"github.com/SAP/jenkins-library/pkg/splunk"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"github.com/SAP/jenkins-library/pkg/validation"
+	"github.com/bmatcuk/doublestar"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +54,9 @@ type helmBuildOptions struct {
 	TemplateStartDelimiter    string   `json:"templateStartDelimiter,omitempty"`
 	TemplateEndDelimiter      string   `json:"templateEndDelimiter,omitempty"`
 	RenderValuesTemplate      bool     `json:"renderValuesTemplate,omitempty"`
+	CreateBOM                 bool     `json:"createBOM,omitempty"`
+	SyftDownloadURL           string   `json:"syftDownloadUrl,omitempty"`
+	ContainerImageNameTags    []string `json:"containerImageNameTags,omitempty"`
 	BuildSettingsInfo         string   `json:"buildSettingsInfo,omitempty"`
 }
 
@@ -83,6 +90,40 @@ func (p *helmBuildCommonPipelineEnvironment) persist(path, resourceName string) 
 	}
 }
 
+type helmBuildReports struct {
+}
+
+func (p *helmBuildReports) persist(stepConfig helmBuildOptions, gcpJsonKeyFilePath string, gcsBucketId string, gcsFolderPath string, gcsSubFolder string) {
+	if gcsBucketId == "" {
+		log.Entry().Info("persisting reports to GCS is disabled, because gcsBucketId is empty")
+		return
+	}
+	log.Entry().Info("Uploading reports to Google Cloud Storage...")
+	content := []gcs.ReportOutputParam{
+		{FilePattern: "**/bom-*.xml", ParamRef: "", StepResultType: "sbom"},
+	}
+
+	gcsClient, err := gcs.NewClient(gcpJsonKeyFilePath, "")
+	if err != nil {
+		log.Entry().Errorf("creation of GCS client failed: %v", err)
+		return
+	}
+	defer gcsClient.Close()
+	structVal := reflect.ValueOf(&stepConfig).Elem()
+	inputParameters := map[string]string{}
+	for i := 0; i < structVal.NumField(); i++ {
+		field := structVal.Type().Field(i)
+		if field.Type.String() == "string" {
+			paramName := strings.Split(field.Tag.Get("json"), ",")
+			paramValue, _ := structVal.Field(i).Interface().(string)
+			inputParameters[paramName[0]] = paramValue
+		}
+	}
+	if err := gcs.PersistReportsToGCS(gcsClient, content, inputParameters, gcsFolderPath, gcsBucketId, gcsSubFolder, doublestar.Glob, os.Stat); err != nil {
+		log.Entry().Errorf("failed to persist reports: %v", err)
+	}
+}
+
 // HelmBuildCommand Executes helm3 functionality as the package manager for Kubernetes.
 func HelmBuildCommand() *cobra.Command {
 	const STEP_NAME = "helmBuild"
@@ -91,6 +132,7 @@ func HelmBuildCommand() *cobra.Command {
 	var stepConfig helmBuildOptions
 	var startTime time.Time
 	var commonPipelineEnvironment helmBuildCommonPipelineEnvironment
+	var reports helmBuildReports
 	var logCollector *log.CollectorHook
 	var splunkClient *splunk.Splunk
 	telemetryClient := &telemetry.Telemetry{}
@@ -196,6 +238,7 @@ Note: piper supports only helm3 version, since helm2 is deprecated.`,
 			stepTelemetryData.ErrorCode = "1"
 			handler := func() {
 				commonPipelineEnvironment.persist(GeneralConfig.EnvRootPath, "commonPipelineEnvironment")
+				reports.persist(stepConfig, GeneralConfig.GCPJsonKeyFilePath, GeneralConfig.GCSBucketId, GeneralConfig.GCSFolderPath, GeneralConfig.GCSSubFolder)
 				config.RemoveVaultSecretFiles()
 				stepTelemetryData.Duration = fmt.Sprintf("%v", time.Since(startTime).Milliseconds())
 				stepTelemetryData.ErrorCategory = log.GetErrorCategory().String()
@@ -278,6 +321,9 @@ func addHelmBuildFlags(cmd *cobra.Command, stepConfig *helmBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.TemplateStartDelimiter, "templateStartDelimiter", `{{`, "When templating value files, use this start delimiter.")
 	cmd.Flags().StringVar(&stepConfig.TemplateEndDelimiter, "templateEndDelimiter", `}}`, "When templating value files, use this end delimiter.")
 	cmd.Flags().BoolVar(&stepConfig.RenderValuesTemplate, "renderValuesTemplate", true, "A flag to turn templating value files on or off.")
+	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using Syft for referenced container images and a chart-level BOM (bom-helm.xml) in CycloneDX 1.4 format.")
+	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
+	cmd.Flags().StringSliceVar(&stepConfig.ContainerImageNameTags, "containerImageNameTags", []string{}, "List of full names (registry and tag) of the container images referenced by the chart. Used as a fallback source when image discovery via `helm template` yields no results. Typically populated by an upstream kanikoExecute step.")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "Build settings info is typically filled by the step automatically to create information about the build settings that were used during the helm build. This information is typically used for compliance related processes.")
 
 	cmd.MarkFlagRequired("image")
@@ -688,6 +734,38 @@ func helmBuildMetadata() config.StepData {
 						Default:     true,
 					},
 					{
+						Name:        "createBOM",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
+					},
+					{
+						Name:        "syftDownloadUrl",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz`,
+					},
+					{
+						Name: "containerImageNameTags",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/imageNameTags",
+							},
+						},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:      "[]string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   []string{},
+					},
+					{
 						Name: "buildSettingsInfo",
 						ResourceRef: []config.ResourceReference{
 							{
@@ -714,6 +792,13 @@ func helmBuildMetadata() config.StepData {
 						Parameters: []map[string]interface{}{
 							{"name": "custom/helmChartUrl"},
 							{"name": "custom/buildSettingsInfo"},
+						},
+					},
+					{
+						Name: "reports",
+						Type: "reports",
+						Parameters: []map[string]interface{}{
+							{"filePattern": "**/bom-*.xml", "type": "sbom"},
 						},
 					},
 				},

--- a/cmd/helmBuild_generated.go
+++ b/cmd/helmBuild_generated.go
@@ -6,15 +6,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/SAP/jenkins-library/pkg/config"
 	"github.com/SAP/jenkins-library/pkg/eventing"
+	"github.com/SAP/jenkins-library/pkg/gcs"
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
 	"github.com/SAP/jenkins-library/pkg/splunk"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"github.com/SAP/jenkins-library/pkg/validation"
+	"github.com/bmatcuk/doublestar"
 	"github.com/spf13/cobra"
 )
 
@@ -50,11 +54,16 @@ type helmBuildOptions struct {
 	TemplateStartDelimiter    string   `json:"templateStartDelimiter,omitempty"`
 	TemplateEndDelimiter      string   `json:"templateEndDelimiter,omitempty"`
 	RenderValuesTemplate      bool     `json:"renderValuesTemplate,omitempty"`
+	CreateBOM                 bool     `json:"createBOM,omitempty"`
+	SyftDownloadURL           string   `json:"syftDownloadUrl,omitempty"`
+	ContainerImageNameTags    []string `json:"containerImageNameTags,omitempty"`
+	BuildSettingsInfo         string   `json:"buildSettingsInfo,omitempty"`
 }
 
 type helmBuildCommonPipelineEnvironment struct {
 	custom struct {
-		helmChartURL string
+		helmChartURL      string
+		buildSettingsInfo string
 	}
 }
 
@@ -65,6 +74,7 @@ func (p *helmBuildCommonPipelineEnvironment) persist(path, resourceName string) 
 		value    interface{}
 	}{
 		{category: "custom", name: "helmChartUrl", value: p.custom.helmChartURL},
+		{category: "custom", name: "buildSettingsInfo", value: p.custom.buildSettingsInfo},
 	}
 
 	errCount := 0
@@ -80,6 +90,40 @@ func (p *helmBuildCommonPipelineEnvironment) persist(path, resourceName string) 
 	}
 }
 
+type helmBuildReports struct {
+}
+
+func (p *helmBuildReports) persist(stepConfig helmBuildOptions, gcpJsonKeyFilePath string, gcsBucketId string, gcsFolderPath string, gcsSubFolder string) {
+	if gcsBucketId == "" {
+		log.Entry().Info("persisting reports to GCS is disabled, because gcsBucketId is empty")
+		return
+	}
+	log.Entry().Info("Uploading reports to Google Cloud Storage...")
+	content := []gcs.ReportOutputParam{
+		{FilePattern: "**/bom-*.xml", ParamRef: "", StepResultType: "sbom"},
+	}
+
+	gcsClient, err := gcs.NewClient(gcpJsonKeyFilePath, "")
+	if err != nil {
+		log.Entry().Errorf("creation of GCS client failed: %v", err)
+		return
+	}
+	defer gcsClient.Close()
+	structVal := reflect.ValueOf(&stepConfig).Elem()
+	inputParameters := map[string]string{}
+	for i := 0; i < structVal.NumField(); i++ {
+		field := structVal.Type().Field(i)
+		if field.Type.String() == "string" {
+			paramName := strings.Split(field.Tag.Get("json"), ",")
+			paramValue, _ := structVal.Field(i).Interface().(string)
+			inputParameters[paramName[0]] = paramValue
+		}
+	}
+	if err := gcs.PersistReportsToGCS(gcsClient, content, inputParameters, gcsFolderPath, gcsBucketId, gcsSubFolder, doublestar.Glob, os.Stat); err != nil {
+		log.Entry().Errorf("failed to persist reports: %v", err)
+	}
+}
+
 // HelmBuildCommand Executes helm3 functionality as the package manager for Kubernetes.
 func HelmBuildCommand() *cobra.Command {
 	const STEP_NAME = "helmBuild"
@@ -88,6 +132,7 @@ func HelmBuildCommand() *cobra.Command {
 	var stepConfig helmBuildOptions
 	var startTime time.Time
 	var commonPipelineEnvironment helmBuildCommonPipelineEnvironment
+	var reports helmBuildReports
 	var logCollector *log.CollectorHook
 	var splunkClient *splunk.Splunk
 	telemetryClient := &telemetry.Telemetry{}
@@ -193,6 +238,7 @@ Note: piper supports only helm3 version, since helm2 is deprecated.`,
 			stepTelemetryData.ErrorCode = "1"
 			handler := func() {
 				commonPipelineEnvironment.persist(GeneralConfig.EnvRootPath, "commonPipelineEnvironment")
+				reports.persist(stepConfig, GeneralConfig.GCPJsonKeyFilePath, GeneralConfig.GCSBucketId, GeneralConfig.GCSFolderPath, GeneralConfig.GCSSubFolder)
 				config.RemoveVaultSecretFiles()
 				stepTelemetryData.Duration = fmt.Sprintf("%v", time.Since(startTime).Milliseconds())
 				stepTelemetryData.ErrorCategory = log.GetErrorCategory().String()
@@ -275,6 +321,10 @@ func addHelmBuildFlags(cmd *cobra.Command, stepConfig *helmBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.TemplateStartDelimiter, "templateStartDelimiter", `{{`, "When templating value files, use this start delimiter.")
 	cmd.Flags().StringVar(&stepConfig.TemplateEndDelimiter, "templateEndDelimiter", `}}`, "When templating value files, use this end delimiter.")
 	cmd.Flags().BoolVar(&stepConfig.RenderValuesTemplate, "renderValuesTemplate", true, "A flag to turn templating value files on or off.")
+	cmd.Flags().BoolVar(&stepConfig.CreateBOM, "createBOM", false, "Creates the bill of materials (BOM) using Syft for referenced container images and a chart-level BOM (bom-helm.xml) in CycloneDX 1.4 format.")
+	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
+	cmd.Flags().StringSliceVar(&stepConfig.ContainerImageNameTags, "containerImageNameTags", []string{}, "List of full names (registry and tag) of the container images referenced by the chart. Used as a fallback source when image discovery via `helm template` yields no results. Typically populated by an upstream kanikoExecute step.")
+	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "build settings info is typically filled by the step automatically to create information about the build settings that were used during the helm execute. This information is typically used for compliance related processes.")
 
 	cmd.MarkFlagRequired("image")
 }
@@ -683,6 +733,52 @@ func helmBuildMetadata() config.StepData {
 						Aliases:     []config.Alias{},
 						Default:     true,
 					},
+					{
+						Name:        "createBOM",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"GENERAL", "STEPS", "STAGES", "PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
+					},
+					{
+						Name:        "syftDownloadUrl",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     `https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz`,
+					},
+					{
+						Name: "containerImageNameTags",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "container/imageNameTags",
+							},
+						},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:      "[]string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   []string{},
+					},
+					{
+						Name: "buildSettingsInfo",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:  "commonPipelineEnvironment",
+								Param: "custom/buildSettingsInfo",
+							},
+						},
+						Scope:     []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_buildSettingsInfo"),
+					},
 				},
 			},
 			Containers: []config.Container{
@@ -695,6 +791,14 @@ func helmBuildMetadata() config.StepData {
 						Type: "piperEnvironment",
 						Parameters: []map[string]interface{}{
 							{"name": "custom/helmChartUrl"},
+							{"name": "custom/buildSettingsInfo"},
+						},
+					},
+					{
+						Name: "reports",
+						Type: "reports",
+						Parameters: []map[string]interface{}{
+							{"filePattern": "**/bom-*.xml", "type": "sbom"},
 						},
 					},
 				},

--- a/cmd/helmBuild_test.go
+++ b/cmd/helmBuild_test.go
@@ -4,16 +4,21 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
+	"slices"
 	"testing"
 
 	"errors"
 
+	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/kubernetes/mocks"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,7 +77,7 @@ func TestRunHelmUpgrade(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmUpgrade").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -112,7 +117,7 @@ func TestRunHelmLint(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmLint").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -152,7 +157,7 @@ func TestRunHelmInstall(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmInstall").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -191,7 +196,7 @@ func TestRunHelmTest(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmTest").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -230,7 +235,7 @@ func TestRunHelmUninstall(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmUninstall").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -269,7 +274,7 @@ func TestRunHelmDependency(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmDependency").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -310,12 +315,80 @@ func TestRunHelmPush(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmPublish").Return(testCase.methodString, testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
 		})
 
+	}
+}
+
+func TestRunHelmPushSBOM(t *testing.T) {
+	setupConfigOpenFileMock(t)
+	// SBOM behaviour of the explicit "publish" command path in runHelmBuild.
+	testTable := []struct {
+		name       string
+		createBOM  bool
+		expectSyft bool
+		expectPurl bool
+	}{
+		{
+			name:       "createBOM disabled - no syft",
+			createBOM:  false,
+			expectSyft: false,
+			expectPurl: false,
+		},
+		{
+			name:       "createBOM enabled - syft + root purl injected",
+			createBOM:  true,
+			expectSyft: true,
+			expectPurl: true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Arrange
+			utils := newHelmMockUtilsBundle()
+			execRunner := &mock.ExecMockRunner{}
+			client := setupSyftDownloadMock(t)
+
+			cpe := helmBuildCommonPipelineEnvironment{}
+			config := helmBuildOptions{
+				HelmCommand:            "publish",
+				CreateBOM:              testCase.createBOM,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"registry.example.com/foo:1.0.0"},
+			}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			// helm template yields no images → SBOM falls back to the CPE list.
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			// The fake syft binary does not write a BOM, so pre-create the
+			// bom-docker-0.xml (root component without a PURL) syft would produce.
+			require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+			defer os.Remove("bom-docker-0.xml")
+
+			// Act
+			err := runHelmBuild(config, helmExecutor, utils, &cpe, execRunner, &mock.FilesMock{}, client)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectSyft, syftScanInvoked(execRunner),
+				"syft scan invocation must match createBOM=%v", testCase.createBOM)
+
+			updated, err := os.ReadFile("bom-docker-0.xml")
+			require.NoError(t, err)
+			if testCase.expectPurl {
+				assert.Contains(t, string(updated), "<purl>pkg:docker/nginx@1.25</purl>",
+					"root PURL must be injected when createBOM=true")
+			} else {
+				assert.NotContains(t, string(updated), "<purl>",
+					"no PURL must be injected when createBOM=false")
+			}
+		})
 	}
 }
 
@@ -413,7 +486,7 @@ func TestRunHelmDefaultCommand(t *testing.T) {
 			helmExecutor.On("RunHelmLint").Return(testCase.methodLintError)
 			helmExecutor.On("RunHelmPublish").Return(testCase.methodPublishError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &testCase.fileUtils, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &testCase.fileUtils, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -424,6 +497,539 @@ func TestRunHelmDefaultCommand(t *testing.T) {
 		})
 	}
 
+}
+
+func TestRunHelmDefaultCommandSBOM(t *testing.T) {
+	setupConfigOpenFileMock(t)
+	// SBOM behaviour of the default flow (helmCommand='' + publish=true) in
+	// runHelmBuildDefault.
+	testTable := []struct {
+		name       string
+		createBOM  bool
+		expectSyft bool
+		expectPurl bool
+	}{
+		{
+			name:       "createBOM disabled - no syft",
+			createBOM:  false,
+			expectSyft: false,
+			expectPurl: false,
+		},
+		{
+			name:       "createBOM enabled - syft + root purl injected",
+			createBOM:  true,
+			expectSyft: true,
+			expectPurl: true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Arrange
+			utils := newHelmMockUtilsBundle()
+			execRunner := &mock.ExecMockRunner{}
+			client := setupSyftDownloadMock(t)
+
+			cpe := helmBuildCommonPipelineEnvironment{}
+			config := helmBuildOptions{
+				HelmCommand:            "",
+				Publish:                true,
+				CreateBOM:              testCase.createBOM,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"registry.example.com/foo:1.0.0"},
+			}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmLint").Return(nil)
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			// helm template yields no images → SBOM falls back to the CPE list.
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+			defer os.Remove("bom-docker-0.xml")
+
+			// Act
+			err := runHelmBuild(config, helmExecutor, utils, &cpe, execRunner, &mock.FilesMock{}, client)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectSyft, syftScanInvoked(execRunner),
+				"syft scan invocation must match createBOM=%v", testCase.createBOM)
+
+			updated, err := os.ReadFile("bom-docker-0.xml")
+			require.NoError(t, err)
+			if testCase.expectPurl {
+				assert.Contains(t, string(updated), "<purl>pkg:docker/nginx@1.25</purl>",
+					"root PURL must be injected when createBOM=true")
+			} else {
+				assert.NotContains(t, string(updated), "<purl>",
+					"no PURL must be injected when createBOM=false")
+			}
+		})
+	}
+}
+
+// bomWithoutRootPurl is a minimal image BOM as syft emits it: the root/parent
+// component carries a registry-qualified name (with a host:port, the case that
+// reproduces the real validator failure) and NO <purl> (anchore/syft#1408).
+// Used by the SBOM tests to verify the root PURL gets injected, registry-free.
+const bomWithoutRootPurl = `<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name>host.docker.internal:5000/library/nginx</name>
+			<version>1.25</version>
+		</component>
+	</metadata>
+	<components></components>
+</bom>`
+
+// bomEmptyRootName has a root component with no <name>: GetComponent returns an
+// empty name, so injection skips this file (best-effort, no error, no PURL).
+const bomEmptyRootName = `<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name></name>
+			<version>1.25</version>
+		</component>
+	</metadata>
+	<components></components>
+</bom>`
+
+// bomInvalidRootName has a root component whose name is not a valid image
+// reference (spaces/uppercase), so purl.RefToPURL fails and injection skips
+// this file (best-effort, no error, no PURL).
+const bomInvalidRootName = `<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name>Invalid Name</name>
+			<version>1.25</version>
+		</component>
+	</metadata>
+	<components></components>
+</bom>`
+
+// bomWrongRootElement is parseable by the lenient GetComponent (yields a
+// non-empty name) but is rejected by the strict CycloneDX decoder inside
+// UpdatePurl (root element is not <bom>), driving the UpdatePurl error branch.
+const bomWrongRootElement = `<notbom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name>registry.example.com/foo</name>
+			<version>1.0.0</version>
+		</component>
+	</metadata>
+</notbom>`
+
+func TestRunHelmInjectContainerBOMPurls(t *testing.T) {
+	t.Run("injects a clean registry-free docker purl into the root component", func(t *testing.T) {
+		require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+		defer os.Remove("bom-docker-0.xml")
+
+		err := injectContainerBOMPurls()
+
+		require.NoError(t, err)
+		updated, err := os.ReadFile("bom-docker-0.xml")
+		require.NoError(t, err)
+		assert.Contains(t, string(updated), "<purl>pkg:docker/nginx@1.25</purl>",
+			"root component must carry a clean docker PURL after injection")
+		// The injected PURL must not carry the registry host:port. (The component
+		// <name> still holds syft's original registry-qualified name; UpdatePurl
+		// only adds the <purl>, it does not rewrite the name.)
+		assert.NotContains(t, string(updated), "pkg:docker/host.docker.internal",
+			"the injected PURL must not carry the registry host")
+	})
+
+	t.Run("no bom-docker files - no-op, no error", func(t *testing.T) {
+		// Ensure there is no matching file in the working directory.
+		_ = os.Remove("bom-docker-0.xml")
+
+		err := injectContainerBOMPurls()
+		assert.NoError(t, err, "injection must be a no-op when no bom-docker files exist")
+	})
+
+	t.Run("failing BOM is skipped but later BOMs are still processed", func(t *testing.T) {
+		// For each failure mode: bom-docker-0 fails, bom-docker-1 is valid. The
+		// glob is lexicographically sorted, so 0 is processed first; its failure
+		// must not fail the step nor prevent 1 from getting its PURL injected.
+		failingFixtures := []struct {
+			name    string
+			content string
+		}{
+			{name: "empty root name", content: bomEmptyRootName},
+			{name: "invalid image name (RefToPURL fails)", content: bomInvalidRootName},
+			{name: "undecodable BOM (UpdatePurl fails)", content: bomWrongRootElement},
+		}
+		for _, fixture := range failingFixtures {
+			t.Run(fixture.name, func(t *testing.T) {
+				require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(fixture.content), 0o644))
+				defer os.Remove("bom-docker-0.xml")
+				require.NoError(t, os.WriteFile("bom-docker-1.xml", []byte(bomWithoutRootPurl), 0o644))
+				defer os.Remove("bom-docker-1.xml")
+
+				err := injectContainerBOMPurls()
+
+				assert.NoError(t, err, "a per-file failure must not fail the step")
+				failed, err := os.ReadFile("bom-docker-0.xml")
+				require.NoError(t, err)
+				assert.NotContains(t, string(failed), "<purl>", "the failing BOM must be left untouched")
+				succeeded, err := os.ReadFile("bom-docker-1.xml")
+				require.NoError(t, err)
+				assert.Contains(t, string(succeeded), "<purl>",
+					"a later BOM must still get its PURL injected after an earlier failure")
+			})
+		}
+	})
+
+	t.Run("multiple valid BOMs all get a PURL", func(t *testing.T) {
+		require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+		defer os.Remove("bom-docker-0.xml")
+		require.NoError(t, os.WriteFile("bom-docker-1.xml", []byte(bomWithoutRootPurl), 0o644))
+		defer os.Remove("bom-docker-1.xml")
+
+		err := injectContainerBOMPurls()
+
+		assert.NoError(t, err)
+		for _, file := range []string{"bom-docker-0.xml", "bom-docker-1.xml"} {
+			content, err := os.ReadFile(file)
+			require.NoError(t, err)
+			assert.Contains(t, string(content), "<purl>", "%s must get its PURL injected", file)
+		}
+	})
+}
+
+// setupSyftDownloadMock activates httpmock, registers a fake syft tar.gz archive
+// at the test syft download URL, and returns a real http client wired to it.
+// The caller relies on t.Cleanup for deactivation.
+func setupSyftDownloadMock(t *testing.T) *piperhttp.Client {
+	t.Helper()
+	httpmock.Activate()
+	t.Cleanup(httpmock.DeactivateAndReset)
+	fakeArchive, err := (&mock.FilesMock{}).CreateArchive(map[string][]byte{"syft": []byte("test")})
+	require.NoError(t, err)
+	httpmock.RegisterResponder(http.MethodGet, "http://test-syft-url.io", httpmock.NewBytesResponder(http.StatusOK, fakeArchive))
+	client := &piperhttp.Client{}
+	client.SetOptions(piperhttp.ClientOptions{MaxRetries: -1, UseDefaultTransport: true})
+	return client
+}
+
+// syftScanInvoked reports whether a syft "scan" command was executed.
+func syftScanInvoked(execRunner *mock.ExecMockRunner) bool {
+	for _, call := range execRunner.Calls {
+		if slices.Contains(call.Params, "scan") {
+			return true
+		}
+	}
+	return false
+}
+
+// syftScanCalls returns all executed syft "scan" invocations, in order.
+func syftScanCalls(execRunner *mock.ExecMockRunner) []mock.ExecCall {
+	var calls []mock.ExecCall
+	for _, call := range execRunner.Calls {
+		if len(call.Params) > 0 && call.Params[0] == "scan" {
+			calls = append(calls, call)
+		}
+	}
+	return calls
+}
+
+func TestRunHelmGenerateContainerSBOMs(t *testing.T) {
+	// cpeFallbackExecutor returns a HelmExecutor whose `helm template` yields no
+	// images, so generateContainerSBOMs falls back to the CPE image list. These
+	t.Run("empty image list - no syft scan, no error", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+
+		err := generateContainerSBOMs(config, nil, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+		assert.NoError(t, err)
+		assert.False(t, syftScanInvoked(execRunner), "syft must not run when there are no images")
+	})
+
+	t.Run("single image - one syft scan with derived registry and bom-docker-0.xml", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		client := setupSyftDownloadMock(t)
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0"}
+		defer os.Remove("bom-docker-0.xml")
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, client)
+
+		assert.NoError(t, err)
+		scanCalls := syftScanCalls(execRunner)
+		require.Len(t, scanCalls, 1, "one syft scan per image")
+		assert.Contains(t, scanCalls[0].Params, "registry:registry.example.com/foo:1.0.0",
+			"registry must be derived from the full image reference")
+		assert.Contains(t, scanCalls[0].Params, "cyclonedx-xml@1.4=bom-docker-0.xml")
+	})
+
+	t.Run("multiple images - one scan each with indexed bom filenames", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		client := setupSyftDownloadMock(t)
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0", "registry.example.com/bar:2.0.0"}
+		defer os.Remove("bom-docker-0.xml")
+		defer os.Remove("bom-docker-1.xml")
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, client)
+
+		assert.NoError(t, err)
+		scanCalls := syftScanCalls(execRunner)
+		require.Len(t, scanCalls, 2, "one syft scan per image")
+		assert.Contains(t, scanCalls[0].Params, "registry:registry.example.com/foo:1.0.0")
+		assert.Contains(t, scanCalls[0].Params, "cyclonedx-xml@1.4=bom-docker-0.xml")
+		assert.Contains(t, scanCalls[1].Params, "registry:registry.example.com/bar:2.0.0")
+		assert.Contains(t, scanCalls[1].Params, "cyclonedx-xml@1.4=bom-docker-1.xml")
+	})
+
+	t.Run("syft scan fails - error is surfaced", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{
+			ShouldFailOnCommand: map[string]error{".*scan.*": fmt.Errorf("syft boom")},
+		}
+		client := setupSyftDownloadMock(t)
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0"}
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, client)
+
+		require.Error(t, err, "a failing syft scan must surface as an error")
+		assert.Contains(t, err.Error(), "syft boom", "the underlying syft error must be propagated")
+	})
+
+	t.Run("unparseable image reference - fails to derive registry, no scan", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"bad name"}
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+		require.Error(t, err, "an unparseable image reference must surface as an error")
+		assert.Contains(t, err.Error(), "failed to derive registry from image",
+			"the error must come from the registry-derivation step")
+		assert.False(t, syftScanInvoked(execRunner), "syft must not run when the registry cannot be derived")
+	})
+
+	t.Run("unparseable later image - fails to parse image name/tag, no scan", func(t *testing.T) {
+		// The first image derives the registry fine; a later unparseable image
+		// must surface from the name/tag parsing loop, not from registry derivation.
+		execRunner := &mock.ExecMockRunner{}
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0", "bad name"}
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+		require.Error(t, err, "an unparseable later image must surface as an error")
+		assert.Contains(t, err.Error(), "failed to parse image",
+			"the error must come from the image name/tag parsing step")
+		assert.False(t, syftScanInvoked(execRunner), "syft must not run when an image cannot be parsed")
+	})
+}
+
+func TestRunHelmSBOMDiscoverImages(t *testing.T) {
+	const validManifest = "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - image: registry.example.com/chart-app:9.9.9\n"
+
+	tests := []struct {
+		name           string
+		templateReturn []byte
+		templateErr    error
+		cpeImages      []string
+		expected       []string
+	}{
+		{
+			name:        "helm template fails - falls back to CPE list",
+			templateErr: fmt.Errorf("template boom"),
+			cpeImages:   []string{"registry.example.com/cpe:1.0.0"},
+			expected:    []string{"registry.example.com/cpe:1.0.0"},
+		},
+		{
+			name:           "manifest parsing fails - falls back to CPE list",
+			templateReturn: []byte("foo: [unclosed"),
+			cpeImages:      []string{"registry.example.com/cpe:1.0.0"},
+			expected:       []string{"registry.example.com/cpe:1.0.0"},
+		},
+		{
+			name:           "no images rendered - falls back to CPE list",
+			templateReturn: []byte("apiVersion: v1\nkind: ConfigMap\ndata:\n  key: value\n"),
+			cpeImages:      []string{"registry.example.com/cpe:1.0.0"},
+			expected:       []string{"registry.example.com/cpe:1.0.0"},
+		},
+		{
+			name:           "templated images are returned",
+			templateReturn: []byte(validManifest),
+			cpeImages:      nil,
+			expected:       []string{"registry.example.com/chart-app:9.9.9"},
+		},
+		{
+			name:           "templated images take precedence over a non-empty CPE list",
+			templateReturn: []byte(validManifest),
+			cpeImages:      []string{"registry.example.com/stale:0.0.0"},
+			expected:       []string{"registry.example.com/chart-app:9.9.9"},
+		},
+		{
+			name:        "fallback with an empty CPE list yields no images",
+			templateErr: fmt.Errorf("template boom"),
+			cpeImages:   nil,
+			expected:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmTemplate").Return(test.templateReturn, test.templateErr)
+			config := helmBuildOptions{ContainerImageNameTags: test.cpeImages}
+
+			images := discoverImages(config, helmExecutor)
+
+			assert.Equal(t, test.expected, images)
+		})
+	}
+}
+
+func TestRunHelmSBOMFailureIsBestEffort(t *testing.T) {
+	setupConfigOpenFileMock(t)
+	// SBOM generation is best-effort: a failure inside generateContainerSBOMs
+	// (here, an unparseable image that fails registry derivation) must be logged
+	// and swallowed — the publish step itself must still succeed. Covers the
+	// `if err := generateContainerSBOMs(...); err != nil` guards in both the
+	// explicit "publish" command path and the default (publish=true) flow.
+	tests := []struct {
+		name   string
+		config helmBuildOptions
+	}{
+		{
+			name: "explicit publish command path",
+			config: helmBuildOptions{
+				HelmCommand:            "publish",
+				CreateBOM:              true,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"bad name"},
+			},
+		},
+		{
+			name: "default flow with publish=true",
+			config: helmBuildOptions{
+				HelmCommand:            "",
+				Publish:                true,
+				CreateBOM:              true,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"bad name"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			utils := newHelmMockUtilsBundle()
+			execRunner := &mock.ExecMockRunner{}
+			cpe := helmBuildCommonPipelineEnvironment{}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmLint").Return(nil)
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			// helm template yields no images → SBOM falls back to the (bad) CPE list.
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			err := runHelmBuild(test.config, helmExecutor, utils, &cpe, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+			assert.NoError(t, err, "SBOM generation failure must not fail the publish step")
+			assert.False(t, syftScanInvoked(execRunner), "syft must not run when the registry cannot be derived")
+			assert.Equal(t, "https://my.target.repository/foo-1.0.0.tgz", cpe.custom.helmChartURL,
+				"the chart must still be published despite the SBOM failure")
+		})
+	}
+}
+
+func TestRunHelmChartSBOM(t *testing.T) {
+	setupConfigOpenFileMock(t)
+	// The publish flow must produce the chart-level bom-helm.xml (in addition to
+	// the container-image bom-docker-*.xml). Covers both publish entry points.
+	tests := []struct {
+		name   string
+		config helmBuildOptions
+	}{
+		{
+			name: "explicit publish command path",
+			config: helmBuildOptions{
+				HelmCommand:     "publish",
+				ChartPath:       "chart",
+				CreateBOM:       true,
+				SyftDownloadURL: "http://test-syft-url.io",
+			},
+		},
+		{
+			name: "default flow with publish=true",
+			config: helmBuildOptions{
+				HelmCommand:     "",
+				Publish:         true,
+				ChartPath:       "chart",
+				CreateBOM:       true,
+				SyftDownloadURL: "http://test-syft-url.io",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			utils := newHelmMockUtilsBundle()
+			utils.AddFile("chart/Chart.yaml", []byte("apiVersion: v2\nname: foo\nversion: 1.2.3\n"))
+			execRunner := &mock.ExecMockRunner{}
+			cpe := helmBuildCommonPipelineEnvironment{}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmLint").Return(nil)
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			err := runHelmBuild(test.config, helmExecutor, utils, &cpe, execRunner, utils.FilesMock, utils.HttpClientMock)
+
+			require.NoError(t, err)
+			content, err := utils.FileRead("bom-helm.xml")
+			require.NoError(t, err, "bom-helm.xml must be produced on publish")
+			assert.Contains(t, string(content), "pkg:helm/foo@1.2.3")
+		})
+	}
+}
+
+func TestRunHelmPopulatesBuildSettingsInfo(t *testing.T) {
+	setupConfigOpenFileMock(t)
+	// SLC-29: helmExecute must record build-settings traceability into
+	// commonPipelineEnvironment.custom.buildSettingsInfo (non-empty JSON).
+	t.Run("populates valid JSON on success", func(t *testing.T) {
+		utils := newHelmMockUtilsBundle()
+		cpe := helmBuildCommonPipelineEnvironment{}
+		cfg := helmBuildOptions{
+			HelmCommand: "lint",
+			CreateBOM:   true,
+			Publish:     false,
+		}
+		helmExecutor := &mocks.HelmExecutor{}
+		helmExecutor.On("RunHelmLint").Return(nil)
+
+		err := runHelmBuild(cfg, helmExecutor, utils, &cpe, utils.ExecMockRunner, utils.FilesMock, utils.HttpClientMock)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, cpe.custom.buildSettingsInfo, "buildSettingsInfo must be populated")
+		var payload map[string]interface{}
+		assert.NoError(t, json.Unmarshal([]byte(cpe.custom.buildSettingsInfo), &payload),
+			"buildSettingsInfo must be valid JSON")
+	})
+
+	t.Run("build settings failure is best-effort - step still succeeds", func(t *testing.T) {
+		// A malformed inbound BuildSettingsInfo makes CreateBuildSettingsInfo
+		// fail (json.Unmarshal of the existing value). The step must swallow it:
+		// no error returned, and buildSettingsInfo left empty.
+		utils := newHelmMockUtilsBundle()
+		cpe := helmBuildCommonPipelineEnvironment{}
+		cfg := helmBuildOptions{
+			HelmCommand:       "lint",
+			BuildSettingsInfo: "{not-valid-json",
+		}
+		helmExecutor := &mocks.HelmExecutor{}
+		helmExecutor.On("RunHelmLint").Return(nil)
+
+		err := runHelmBuild(cfg, helmExecutor, utils, &cpe, utils.ExecMockRunner, utils.FilesMock, utils.HttpClientMock)
+
+		assert.NoError(t, err, "a build-settings failure must not fail the step")
+		assert.Empty(t, cpe.custom.buildSettingsInfo, "buildSettingsInfo must stay empty on failure")
+	})
 }
 
 func TestParseAndRenderCPETemplate(t *testing.T) {
@@ -585,7 +1191,7 @@ func TestRunHelmBuildSettingsInfo(t *testing.T) {
 			Publish:     true,
 		}
 
-		err := runHelmBuild(config, helmExecutor, &fileHandlerMock{}, &cpe)
+		err := runHelmBuild(config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 		require.NoError(t, err)
 		assert.NotEmpty(t, cpe.custom.buildSettingsInfo)
 		assert.Contains(t, cpe.custom.buildSettingsInfo, "helmBuild")
@@ -602,7 +1208,7 @@ func TestRunHelmBuildSettingsInfo(t *testing.T) {
 			BuildSettingsInfo: `{"mavenBuild":[{"dockerImage":"maven:3.8"}]}`,
 		}
 
-		err := runHelmBuild(config, helmExecutor, &fileHandlerMock{}, &cpe)
+		err := runHelmBuild(config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 		require.NoError(t, err)
 		assert.Contains(t, cpe.custom.buildSettingsInfo, "helmBuild")
 		assert.Contains(t, cpe.custom.buildSettingsInfo, "mavenBuild")
@@ -617,7 +1223,7 @@ func TestRunHelmBuildSettingsInfo(t *testing.T) {
 			HelmCommand: "lint",
 		}
 
-		err := runHelmBuild(config, helmExecutor, &fileHandlerMock{}, &cpe)
+		err := runHelmBuild(config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 		require.NoError(t, err)
 		assert.NotEmpty(t, cpe.custom.buildSettingsInfo)
 		assert.Contains(t, cpe.custom.buildSettingsInfo, "helmBuild")

--- a/cmd/helmBuild_test.go
+++ b/cmd/helmBuild_test.go
@@ -4,16 +4,22 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path"
+	"slices"
 	"testing"
 
 	"errors"
 
+	"github.com/SAP/jenkins-library/pkg/config"
+	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/kubernetes/mocks"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
+	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +39,15 @@ func newHelmMockUtilsBundle() helmMockUtilsBundle {
 		},
 	}
 	return utils
+}
+
+// TestMain wires configOptions.OpenFile once for the whole package so that
+// GetDockerImageValue (reached via runHelmBuild -> buildsettings) can load
+// step config without panicking. Doing it here — rather than per test — avoids
+// a data race between the parallel TestRunHelm* tests all writing the global.
+func TestMain(m *testing.M) {
+	SetConfigOptions(ConfigCommandOptions{OpenFile: config.OpenPiperFile})
+	os.Exit(m.Run())
 }
 
 func TestRunHelmUpgrade(t *testing.T) {
@@ -64,7 +79,7 @@ func TestRunHelmUpgrade(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmUpgrade").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -103,7 +118,7 @@ func TestRunHelmLint(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmLint").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -142,7 +157,7 @@ func TestRunHelmInstall(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmInstall").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -180,7 +195,7 @@ func TestRunHelmTest(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmTest").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -218,7 +233,7 @@ func TestRunHelmUninstall(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmUninstall").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -256,7 +271,7 @@ func TestRunHelmDependency(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmDependency").Return(testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -296,12 +311,79 @@ func TestRunHelmPush(t *testing.T) {
 			helmExecutor := &mocks.HelmExecutor{}
 			helmExecutor.On("RunHelmPublish").Return(testCase.methodString, testCase.methodError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
 		})
 
+	}
+}
+
+func TestRunHelmPushSBOM(t *testing.T) {
+	// SBOM behaviour of the explicit "publish" command path in runHelmBuild.
+	testTable := []struct {
+		name       string
+		createBOM  bool
+		expectSyft bool
+		expectPurl bool
+	}{
+		{
+			name:       "createBOM disabled - no syft",
+			createBOM:  false,
+			expectSyft: false,
+			expectPurl: false,
+		},
+		{
+			name:       "createBOM enabled - syft + root purl injected",
+			createBOM:  true,
+			expectSyft: true,
+			expectPurl: true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Arrange
+			utils := newHelmMockUtilsBundle()
+			execRunner := &mock.ExecMockRunner{}
+			client := setupSyftDownloadMock(t)
+
+			cpe := helmBuildCommonPipelineEnvironment{}
+			config := helmBuildOptions{
+				HelmCommand:            "publish",
+				CreateBOM:              testCase.createBOM,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"registry.example.com/foo:1.0.0"},
+			}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			// helm template yields no images → SBOM falls back to the CPE list.
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			// The fake syft binary does not write a BOM, so pre-create the
+			// bom-docker-0.xml (root component without a PURL) syft would produce.
+			require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+			defer os.Remove("bom-docker-0.xml")
+
+			// Act
+			err := runHelmBuild(config, helmExecutor, utils, &cpe, execRunner, &mock.FilesMock{}, client)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectSyft, syftScanInvoked(execRunner),
+				"syft scan invocation must match createBOM=%v", testCase.createBOM)
+
+			updated, err := os.ReadFile("bom-docker-0.xml")
+			require.NoError(t, err)
+			if testCase.expectPurl {
+				assert.Contains(t, string(updated), "<purl>pkg:docker/nginx@1.25</purl>",
+					"root PURL must be injected when createBOM=true")
+			} else {
+				assert.NotContains(t, string(updated), "<purl>",
+					"no PURL must be injected when createBOM=false")
+			}
+		})
 	}
 }
 
@@ -398,7 +480,7 @@ func TestRunHelmDefaultCommand(t *testing.T) {
 			helmExecutor.On("RunHelmLint").Return(testCase.methodLintError)
 			helmExecutor.On("RunHelmPublish").Return(testCase.methodPublishError)
 
-			err := runHelmBuild(testCase.config, helmExecutor, &testCase.fileUtils, &cpe)
+			err := runHelmBuild(testCase.config, helmExecutor, &testCase.fileUtils, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle())
 			if err != nil {
 				assert.Equal(t, testCase.expectedErrStr, err.Error())
 			}
@@ -409,6 +491,535 @@ func TestRunHelmDefaultCommand(t *testing.T) {
 		})
 	}
 
+}
+
+func TestRunHelmDefaultCommandSBOM(t *testing.T) {
+	// SBOM behaviour of the default flow (helmCommand='' + publish=true) in
+	// runHelmBuildDefault.
+	testTable := []struct {
+		name       string
+		createBOM  bool
+		expectSyft bool
+		expectPurl bool
+	}{
+		{
+			name:       "createBOM disabled - no syft",
+			createBOM:  false,
+			expectSyft: false,
+			expectPurl: false,
+		},
+		{
+			name:       "createBOM enabled - syft + root purl injected",
+			createBOM:  true,
+			expectSyft: true,
+			expectPurl: true,
+		},
+	}
+
+	for _, testCase := range testTable {
+		t.Run(testCase.name, func(t *testing.T) {
+			// Arrange
+			utils := newHelmMockUtilsBundle()
+			execRunner := &mock.ExecMockRunner{}
+			client := setupSyftDownloadMock(t)
+
+			cpe := helmBuildCommonPipelineEnvironment{}
+			config := helmBuildOptions{
+				HelmCommand:            "",
+				Publish:                true,
+				CreateBOM:              testCase.createBOM,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"registry.example.com/foo:1.0.0"},
+			}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmLint").Return(nil)
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			// helm template yields no images → SBOM falls back to the CPE list.
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+			defer os.Remove("bom-docker-0.xml")
+
+			// Act
+			err := runHelmBuild(config, helmExecutor, utils, &cpe, execRunner, &mock.FilesMock{}, client)
+
+			// Assert
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.expectSyft, syftScanInvoked(execRunner),
+				"syft scan invocation must match createBOM=%v", testCase.createBOM)
+
+			updated, err := os.ReadFile("bom-docker-0.xml")
+			require.NoError(t, err)
+			if testCase.expectPurl {
+				assert.Contains(t, string(updated), "<purl>pkg:docker/nginx@1.25</purl>",
+					"root PURL must be injected when createBOM=true")
+			} else {
+				assert.NotContains(t, string(updated), "<purl>",
+					"no PURL must be injected when createBOM=false")
+			}
+		})
+	}
+}
+
+// bomWithoutRootPurl is a minimal image BOM as syft emits it: the root/parent
+// component carries a registry-qualified name (with a host:port, the case that
+// reproduces the real validator failure) and NO <purl> (anchore/syft#1408).
+// Used by the SBOM tests to verify the root PURL gets injected, registry-free.
+const bomWithoutRootPurl = `<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name>host.docker.internal:5000/library/nginx</name>
+			<version>1.25</version>
+		</component>
+	</metadata>
+	<components></components>
+</bom>`
+
+// bomEmptyRootName has a root component with no <name>: GetComponent returns an
+// empty name, so injection skips this file (best-effort, no error, no PURL).
+const bomEmptyRootName = `<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name></name>
+			<version>1.25</version>
+		</component>
+	</metadata>
+	<components></components>
+</bom>`
+
+// bomInvalidRootName has a root component whose name is not a valid image
+// reference (spaces/uppercase), so purl.RefToPURL fails and injection skips
+// this file (best-effort, no error, no PURL).
+const bomInvalidRootName = `<bom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name>Invalid Name</name>
+			<version>1.25</version>
+		</component>
+	</metadata>
+	<components></components>
+</bom>`
+
+// bomWrongRootElement is parseable by the lenient GetComponent (yields a
+// non-empty name) but is rejected by the strict CycloneDX decoder inside
+// UpdatePurl (root element is not <bom>), driving the UpdatePurl error branch.
+const bomWrongRootElement = `<notbom xmlns="http://cyclonedx.org/schema/bom/1.4" version="1">
+	<metadata>
+		<component bom-ref="abc123" type="container">
+			<name>registry.example.com/foo</name>
+			<version>1.0.0</version>
+		</component>
+	</metadata>
+</notbom>`
+
+func TestRunHelmInjectContainerBOMPurls(t *testing.T) {
+	t.Run("injects a clean registry-free docker purl into the root component", func(t *testing.T) {
+		require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+		defer os.Remove("bom-docker-0.xml")
+
+		err := injectContainerBOMPurls()
+
+		require.NoError(t, err)
+		updated, err := os.ReadFile("bom-docker-0.xml")
+		require.NoError(t, err)
+		assert.Contains(t, string(updated), "<purl>pkg:docker/nginx@1.25</purl>",
+			"root component must carry a clean docker PURL after injection")
+		// The injected PURL must not carry the registry host:port. (The component
+		// <name> still holds syft's original registry-qualified name; UpdatePurl
+		// only adds the <purl>, it does not rewrite the name.)
+		assert.NotContains(t, string(updated), "pkg:docker/host.docker.internal",
+			"the injected PURL must not carry the registry host")
+	})
+
+	t.Run("no bom-docker files - no-op, no error", func(t *testing.T) {
+		// Ensure there is no matching file in the working directory.
+		_ = os.Remove("bom-docker-0.xml")
+
+		err := injectContainerBOMPurls()
+		assert.NoError(t, err, "injection must be a no-op when no bom-docker files exist")
+	})
+
+	t.Run("failing BOM is skipped but later BOMs are still processed", func(t *testing.T) {
+		// For each failure mode: bom-docker-0 fails, bom-docker-1 is valid. The
+		// glob is lexicographically sorted, so 0 is processed first; its failure
+		// must not fail the step nor prevent 1 from getting its PURL injected.
+		failingFixtures := []struct {
+			name    string
+			content string
+		}{
+			{name: "empty root name", content: bomEmptyRootName},
+			{name: "invalid image name (RefToPURL fails)", content: bomInvalidRootName},
+			{name: "undecodable BOM (UpdatePurl fails)", content: bomWrongRootElement},
+		}
+		for _, fixture := range failingFixtures {
+			t.Run(fixture.name, func(t *testing.T) {
+				require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(fixture.content), 0o644))
+				defer os.Remove("bom-docker-0.xml")
+				require.NoError(t, os.WriteFile("bom-docker-1.xml", []byte(bomWithoutRootPurl), 0o644))
+				defer os.Remove("bom-docker-1.xml")
+
+				err := injectContainerBOMPurls()
+
+				assert.NoError(t, err, "a per-file failure must not fail the step")
+				failed, err := os.ReadFile("bom-docker-0.xml")
+				require.NoError(t, err)
+				assert.NotContains(t, string(failed), "<purl>", "the failing BOM must be left untouched")
+				succeeded, err := os.ReadFile("bom-docker-1.xml")
+				require.NoError(t, err)
+				assert.Contains(t, string(succeeded), "<purl>",
+					"a later BOM must still get its PURL injected after an earlier failure")
+			})
+		}
+	})
+
+	t.Run("multiple valid BOMs all get a PURL", func(t *testing.T) {
+		require.NoError(t, os.WriteFile("bom-docker-0.xml", []byte(bomWithoutRootPurl), 0o644))
+		defer os.Remove("bom-docker-0.xml")
+		require.NoError(t, os.WriteFile("bom-docker-1.xml", []byte(bomWithoutRootPurl), 0o644))
+		defer os.Remove("bom-docker-1.xml")
+
+		err := injectContainerBOMPurls()
+
+		assert.NoError(t, err)
+		for _, file := range []string{"bom-docker-0.xml", "bom-docker-1.xml"} {
+			content, err := os.ReadFile(file)
+			require.NoError(t, err)
+			assert.Contains(t, string(content), "<purl>", "%s must get its PURL injected", file)
+		}
+	})
+}
+
+// setupSyftDownloadMock activates httpmock, registers a fake syft tar.gz archive
+// at the test syft download URL, and returns a real http client wired to it.
+// The caller relies on t.Cleanup for deactivation.
+func setupSyftDownloadMock(t *testing.T) *piperhttp.Client {
+	t.Helper()
+	httpmock.Activate()
+	t.Cleanup(httpmock.DeactivateAndReset)
+	fakeArchive, err := (&mock.FilesMock{}).CreateArchive(map[string][]byte{"syft": []byte("test")})
+	require.NoError(t, err)
+	httpmock.RegisterResponder(http.MethodGet, "http://test-syft-url.io", httpmock.NewBytesResponder(http.StatusOK, fakeArchive))
+	client := &piperhttp.Client{}
+	client.SetOptions(piperhttp.ClientOptions{MaxRetries: -1, UseDefaultTransport: true})
+	return client
+}
+
+// syftScanInvoked reports whether a syft "scan" command was executed.
+func syftScanInvoked(execRunner *mock.ExecMockRunner) bool {
+	for _, call := range execRunner.Calls {
+		if slices.Contains(call.Params, "scan") {
+			return true
+		}
+	}
+	return false
+}
+
+// syftScanCalls returns all executed syft "scan" invocations, in order.
+func syftScanCalls(execRunner *mock.ExecMockRunner) []mock.ExecCall {
+	var calls []mock.ExecCall
+	for _, call := range execRunner.Calls {
+		if len(call.Params) > 0 && call.Params[0] == "scan" {
+			calls = append(calls, call)
+		}
+	}
+	return calls
+}
+
+func TestRunHelmGenerateContainerSBOMs(t *testing.T) {
+	// cpeFallbackExecutor returns a HelmExecutor whose `helm template` yields no
+	// images, so generateContainerSBOMs falls back to the CPE image list. These
+	t.Run("empty image list - no syft scan, no error", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+
+		err := generateContainerSBOMs(config, nil, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+		assert.NoError(t, err)
+		assert.False(t, syftScanInvoked(execRunner), "syft must not run when there are no images")
+	})
+
+	t.Run("single image - one syft scan with derived registry and bom-docker-0.xml", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		client := setupSyftDownloadMock(t)
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0"}
+		defer os.Remove("bom-docker-0.xml")
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, client)
+
+		assert.NoError(t, err)
+		scanCalls := syftScanCalls(execRunner)
+		require.Len(t, scanCalls, 1, "one syft scan per image")
+		assert.Contains(t, scanCalls[0].Params, "registry:registry.example.com/foo:1.0.0",
+			"registry must be derived from the full image reference")
+		assert.Contains(t, scanCalls[0].Params, "cyclonedx-xml@1.4=bom-docker-0.xml")
+	})
+
+	t.Run("multiple images - one scan each with indexed bom filenames", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		client := setupSyftDownloadMock(t)
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0", "registry.example.com/bar:2.0.0"}
+		defer os.Remove("bom-docker-0.xml")
+		defer os.Remove("bom-docker-1.xml")
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, client)
+
+		assert.NoError(t, err)
+		scanCalls := syftScanCalls(execRunner)
+		require.Len(t, scanCalls, 2, "one syft scan per image")
+		assert.Contains(t, scanCalls[0].Params, "registry:registry.example.com/foo:1.0.0")
+		assert.Contains(t, scanCalls[0].Params, "cyclonedx-xml@1.4=bom-docker-0.xml")
+		assert.Contains(t, scanCalls[1].Params, "registry:registry.example.com/bar:2.0.0")
+		assert.Contains(t, scanCalls[1].Params, "cyclonedx-xml@1.4=bom-docker-1.xml")
+	})
+
+	t.Run("syft scan fails - error is surfaced", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{
+			ShouldFailOnCommand: map[string]error{".*scan.*": fmt.Errorf("syft boom")},
+		}
+		client := setupSyftDownloadMock(t)
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0"}
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, client)
+
+		require.Error(t, err, "a failing syft scan must surface as an error")
+		assert.Contains(t, err.Error(), "syft boom", "the underlying syft error must be propagated")
+	})
+
+	t.Run("unparseable image reference - fails to derive registry, no scan", func(t *testing.T) {
+		execRunner := &mock.ExecMockRunner{}
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"bad name"}
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+		require.Error(t, err, "an unparseable image reference must surface as an error")
+		assert.Contains(t, err.Error(), "failed to derive registry from image",
+			"the error must come from the registry-derivation step")
+		assert.False(t, syftScanInvoked(execRunner), "syft must not run when the registry cannot be derived")
+	})
+
+	t.Run("unparseable later image - fails to parse image name/tag, no scan", func(t *testing.T) {
+		// The first image derives the registry fine; a later unparseable image
+		// must surface from the name/tag parsing loop, not from registry derivation.
+		execRunner := &mock.ExecMockRunner{}
+		config := helmBuildOptions{CreateBOM: true, SyftDownloadURL: "http://test-syft-url.io"}
+		images := []string{"registry.example.com/foo:1.0.0", "bad name"}
+
+		err := generateContainerSBOMs(config, images, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+		require.Error(t, err, "an unparseable later image must surface as an error")
+		assert.Contains(t, err.Error(), "failed to parse image",
+			"the error must come from the image name/tag parsing step")
+		assert.False(t, syftScanInvoked(execRunner), "syft must not run when an image cannot be parsed")
+	})
+}
+
+func TestRunHelmSBOMDiscoverImages(t *testing.T) {
+	const validManifest = "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - image: registry.example.com/chart-app:9.9.9\n"
+
+	tests := []struct {
+		name           string
+		templateReturn []byte
+		templateErr    error
+		cpeImages      []string
+		expected       []string
+	}{
+		{
+			name:        "helm template fails - falls back to CPE list",
+			templateErr: fmt.Errorf("template boom"),
+			cpeImages:   []string{"registry.example.com/cpe:1.0.0"},
+			expected:    []string{"registry.example.com/cpe:1.0.0"},
+		},
+		{
+			name:           "manifest parsing fails - falls back to CPE list",
+			templateReturn: []byte("foo: [unclosed"),
+			cpeImages:      []string{"registry.example.com/cpe:1.0.0"},
+			expected:       []string{"registry.example.com/cpe:1.0.0"},
+		},
+		{
+			name:           "no images rendered - falls back to CPE list",
+			templateReturn: []byte("apiVersion: v1\nkind: ConfigMap\ndata:\n  key: value\n"),
+			cpeImages:      []string{"registry.example.com/cpe:1.0.0"},
+			expected:       []string{"registry.example.com/cpe:1.0.0"},
+		},
+		{
+			name:           "templated images are returned",
+			templateReturn: []byte(validManifest),
+			cpeImages:      nil,
+			expected:       []string{"registry.example.com/chart-app:9.9.9"},
+		},
+		{
+			name:           "templated images take precedence over a non-empty CPE list",
+			templateReturn: []byte(validManifest),
+			cpeImages:      []string{"registry.example.com/stale:0.0.0"},
+			expected:       []string{"registry.example.com/chart-app:9.9.9"},
+		},
+		{
+			name:        "fallback with an empty CPE list yields no images",
+			templateErr: fmt.Errorf("template boom"),
+			cpeImages:   nil,
+			expected:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmTemplate").Return(test.templateReturn, test.templateErr)
+			config := helmBuildOptions{ContainerImageNameTags: test.cpeImages}
+
+			images := discoverImages(config, helmExecutor)
+
+			assert.Equal(t, test.expected, images)
+		})
+	}
+}
+
+func TestRunHelmSBOMFailureIsBestEffort(t *testing.T) {
+	// SBOM generation is best-effort: a failure inside generateContainerSBOMs
+	// (here, an unparseable image that fails registry derivation) must be logged
+	// and swallowed — the publish step itself must still succeed. Covers the
+	// `if err := generateContainerSBOMs(...); err != nil` guards in both the
+	// explicit "publish" command path and the default (publish=true) flow.
+	tests := []struct {
+		name   string
+		config helmBuildOptions
+	}{
+		{
+			name: "explicit publish command path",
+			config: helmBuildOptions{
+				HelmCommand:            "publish",
+				CreateBOM:              true,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"bad name"},
+			},
+		},
+		{
+			name: "default flow with publish=true",
+			config: helmBuildOptions{
+				HelmCommand:            "",
+				Publish:                true,
+				CreateBOM:              true,
+				SyftDownloadURL:        "http://test-syft-url.io",
+				ContainerImageNameTags: []string{"bad name"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			utils := newHelmMockUtilsBundle()
+			execRunner := &mock.ExecMockRunner{}
+			cpe := helmBuildCommonPipelineEnvironment{}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmLint").Return(nil)
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			// helm template yields no images → SBOM falls back to the (bad) CPE list.
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			err := runHelmBuild(test.config, helmExecutor, utils, &cpe, execRunner, &mock.FilesMock{}, &mock.HttpClientMock{})
+
+			assert.NoError(t, err, "SBOM generation failure must not fail the publish step")
+			assert.False(t, syftScanInvoked(execRunner), "syft must not run when the registry cannot be derived")
+			assert.Equal(t, "https://my.target.repository/foo-1.0.0.tgz", cpe.custom.helmChartURL,
+				"the chart must still be published despite the SBOM failure")
+		})
+	}
+}
+
+func TestRunHelmChartSBOM(t *testing.T) {
+	// The publish flow must produce the chart-level bom-helm.xml (in addition to
+	// the container-image bom-docker-*.xml). Covers both publish entry points.
+	tests := []struct {
+		name   string
+		config helmBuildOptions
+	}{
+		{
+			name: "explicit publish command path",
+			config: helmBuildOptions{
+				HelmCommand:     "publish",
+				ChartPath:       "chart",
+				CreateBOM:       true,
+				SyftDownloadURL: "http://test-syft-url.io",
+			},
+		},
+		{
+			name: "default flow with publish=true",
+			config: helmBuildOptions{
+				HelmCommand:     "",
+				Publish:         true,
+				ChartPath:       "chart",
+				CreateBOM:       true,
+				SyftDownloadURL: "http://test-syft-url.io",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			utils := newHelmMockUtilsBundle()
+			utils.AddFile("chart/Chart.yaml", []byte("apiVersion: v2\nname: foo\nversion: 1.2.3\n"))
+			execRunner := &mock.ExecMockRunner{}
+			cpe := helmBuildCommonPipelineEnvironment{}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmLint").Return(nil)
+			helmExecutor.On("RunHelmPublish").Return("https://my.target.repository/foo-1.0.0.tgz", nil)
+			helmExecutor.On("RunHelmTemplate").Return([]byte(nil), nil)
+
+			err := runHelmBuild(test.config, helmExecutor, utils, &cpe, execRunner, utils.FilesMock, utils.HttpClientMock)
+
+			require.NoError(t, err)
+			content, err := utils.FileRead("bom-helm.xml")
+			require.NoError(t, err, "bom-helm.xml must be produced on publish")
+			assert.Contains(t, string(content), "pkg:helm/foo@1.2.3")
+		})
+	}
+}
+
+func TestRunHelmPopulatesBuildSettingsInfo(t *testing.T) {
+	// SLC-29: helmExecute must record build-settings traceability into
+	// commonPipelineEnvironment.custom.buildSettingsInfo (non-empty JSON).
+	t.Run("populates valid JSON on success", func(t *testing.T) {
+		utils := newHelmMockUtilsBundle()
+		cpe := helmBuildCommonPipelineEnvironment{}
+		cfg := helmBuildOptions{
+			HelmCommand: "lint",
+			CreateBOM:   true,
+			Publish:     false,
+		}
+		helmExecutor := &mocks.HelmExecutor{}
+		helmExecutor.On("RunHelmLint").Return(nil)
+
+		err := runHelmBuild(cfg, helmExecutor, utils, &cpe, utils.ExecMockRunner, utils.FilesMock, utils.HttpClientMock)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, cpe.custom.buildSettingsInfo, "buildSettingsInfo must be populated")
+		var payload map[string]interface{}
+		assert.NoError(t, json.Unmarshal([]byte(cpe.custom.buildSettingsInfo), &payload),
+			"buildSettingsInfo must be valid JSON")
+	})
+
+	t.Run("build settings failure is best-effort - step still succeeds", func(t *testing.T) {
+		// A malformed inbound BuildSettingsInfo makes CreateBuildSettingsInfo
+		// fail (json.Unmarshal of the existing value). The step must swallow it:
+		// no error returned, and buildSettingsInfo left empty.
+		utils := newHelmMockUtilsBundle()
+		cpe := helmBuildCommonPipelineEnvironment{}
+		cfg := helmBuildOptions{
+			HelmCommand:       "lint",
+			BuildSettingsInfo: "{not-valid-json",
+		}
+		helmExecutor := &mocks.HelmExecutor{}
+		helmExecutor.On("RunHelmLint").Return(nil)
+
+		err := runHelmBuild(cfg, helmExecutor, utils, &cpe, utils.ExecMockRunner, utils.FilesMock, utils.HttpClientMock)
+
+		assert.NoError(t, err, "a build-settings failure must not fail the step")
+		assert.Empty(t, cpe.custom.buildSettingsInfo, "buildSettingsInfo must stay empty on failure")
+	})
 }
 
 func TestParseAndRenderCPETemplate(t *testing.T) {

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -20,8 +20,6 @@ import (
 	"github.com/SAP/jenkins-library/pkg/syft"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"github.com/SAP/jenkins-library/pkg/versioning"
-	"github.com/moby/buildkit/util/purl"
-	purlParser "github.com/package-url/packageurl-go"
 )
 
 func kanikoExecute(config kanikoExecuteOptions, telemetryData *telemetry.CustomData, commonPipelineEnvironment *kanikoExecuteCommonPipelineEnvironment) {
@@ -472,24 +470,11 @@ func createDockerBuildArtifactMetadata(containerImageNameTags []string, commonPi
 		// syft sbom do not contain purl for the parent component
 		// this is problem since the way we tie back promoted artifact to build
 		// is only via the sbom parent component , until the time https://github.com/anchore/syft/issues/1408
-		// is fixed we are generating a purl and inserting it into the sbom
-		constructedPurl, err := purl.RefToPURL("docker", fmt.Sprintf("%s:%s", parentComponentName, parentComponentVersion), nil)
+		// is fixed we are generating a purl and inserting it into the sbom.
+		// The registry is stripped from the final purl since we don't want to expose it.
+		constructedPurl, registry, name, version, err := piperutils.BuildRegistryFreeDockerPurl(parentComponentName, parentComponentVersion)
 		if err != nil {
-			log.Entry().Warnf("unable to create purl from reference")
-			return nil
-		}
-
-		// this purl contains the docker registry and we remove that from the final purl
-		// and recreate the purl without the registry, and we dont want to expose that
-		registry, name, version, err := parsePurl(constructedPurl)
-		if err != nil {
-			log.Entry().Warnf("unable to parse purl creating build artifact metadata")
-			return nil
-		}
-
-		constructedPurl, err = purl.RefToPURL("docker", fmt.Sprintf("%s:%s", name, version), nil)
-		if err != nil {
-			log.Entry().Warnf("unable to create purl from reference")
+			log.Entry().Warnf("%v, not creating build artifact metadata for: %s", err, file)
 			return nil
 		}
 
@@ -525,31 +510,6 @@ func createDockerBuildArtifactMetadata(containerImageNameTags []string, commonPi
 	}
 
 	return nil
-}
-
-func parsePurl(purlStr string) (registry, name, version string, err error) {
-	p, err := purlParser.FromString(purlStr)
-	if err != nil {
-		return "", "", "", err
-	}
-
-	// Split namespace to extract registry
-	// E.g., namespace = "ghcr.io/my-org"
-	namespace := p.Namespace
-	if namespace == "" {
-		registry = "docker.io"
-	} else {
-		nsParts := strings.Split(namespace, "/")
-		if strings.Contains(nsParts[0], ".") {
-			registry = nsParts[0]
-		} else {
-			registry = "docker.io"
-		}
-	}
-
-	name = p.Name
-	version = p.Version
-	return
 }
 
 func findImageNameTagInPurl(containerImageNameTags []string, purlReference string) string {

--- a/integration/container_helper.go
+++ b/integration/container_helper.go
@@ -22,10 +22,12 @@ import (
 
 // ContainerConfig holds configuration for creating a test container
 type ContainerConfig struct {
-	Image    string // Docker image to use
-	TestData string // Path relative to integration/testdata (e.g., "TestGradleIntegration/java-project")
-	WorkDir  string // Working directory inside container (e.g., "/java-project")
-	User     string // User to run as (optional, defaults to image default)
+	Image          string   // Docker image to use
+	TestData       string   // Path relative to integration/testdata (e.g., "TestGradleIntegration/java-project")
+	WorkDir        string   // Working directory inside container (e.g., "/java-project")
+	User           string   // User to run as (optional, defaults to image default)
+	Networks       []string // Docker networks to attach the container to (optional)
+	NetworkAliases []string // Aliases the container is reachable by on those networks (optional)
 }
 
 // K3dContainerConfig holds configuration for creating a k3d cluster container
@@ -61,6 +63,16 @@ func StartPiperContainer(t *testing.T, cfg ContainerConfig) testcontainers.Conta
 
 	if cfg.User != "" {
 		req.User = cfg.User
+	}
+
+	if len(cfg.Networks) > 0 {
+		req.Networks = cfg.Networks
+		if len(cfg.NetworkAliases) > 0 {
+			req.NetworkAliases = map[string][]string{}
+			for _, network := range cfg.Networks {
+				req.NetworkAliases[network] = cfg.NetworkAliases
+			}
+		}
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/integration/container_helper.go
+++ b/integration/container_helper.go
@@ -21,10 +21,12 @@ import (
 
 // ContainerConfig holds configuration for creating a test container
 type ContainerConfig struct {
-	Image    string // Docker image to use
-	TestData string // Path relative to integration/testdata (e.g., "TestGradleIntegration/java-project")
-	WorkDir  string // Working directory inside container (e.g., "/java-project")
-	User     string // User to run as (optional, defaults to image default)
+	Image          string   // Docker image to use
+	TestData       string   // Path relative to integration/testdata (e.g., "TestGradleIntegration/java-project")
+	WorkDir        string   // Working directory inside container (e.g., "/java-project")
+	User           string   // User to run as (optional, defaults to image default)
+	Networks       []string // Docker networks to attach the container to (optional)
+	NetworkAliases []string // Aliases the container is reachable by on those networks (optional)
 }
 
 // K3dContainerConfig holds configuration for creating a k3d cluster container
@@ -60,6 +62,16 @@ func StartPiperContainer(t *testing.T, cfg ContainerConfig) testcontainers.Conta
 
 	if cfg.User != "" {
 		req.User = cfg.User
+	}
+
+	if len(cfg.Networks) > 0 {
+		req.Networks = cfg.Networks
+		if len(cfg.NetworkAliases) > 0 {
+			req.NetworkAliases = map[string][]string{}
+			for _, network := range cfg.Networks {
+				req.NetworkAliases[network] = cfg.NetworkAliases
+			}
+		}
 	}
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{

--- a/integration/github_actions_integration_test_list.yml
+++ b/integration/github_actions_integration_test_list.yml
@@ -25,5 +25,7 @@ run:
 
   - '"TestKubernetesDeployIntegration"'
 
+  - '"TestHelmIntegration"'
+
   # these are light-weighted tests, so we can use only one pod to reduce resource consumption
   - '"Test(Gauge|GCS|GitHub|GitOps|Influx|NPM|PNPM|Piper|Python|Sonar|Vault|Karma)Integration"'

--- a/integration/integration_helm_test.go
+++ b/integration/integration_helm_test.go
@@ -1,0 +1,103 @@
+//go:build integration
+// +build integration
+
+// can be executed with
+// go test -v -tags integration -run TestHelmIntegration ./integration/...
+
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/google/uuid"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// TestHelmIntegrationPublishWithSBOM exercises the full helmExecute publish path
+// end-to-end (Tier 1): package the chart, publish it via HTTP PUT to a local
+// WebDAV sink, and generate the chart-level SBOM (bom-helm.xml) plus the
+// buildSettingsInfo commonPipelineEnvironment artifact.
+//
+// The fixture chart is intentionally image-free so helmExecute's container-SBOM
+// path skips the syft scan (which would require a network download of the syft
+// binary); only the pure-Go chart BOM is produced.
+func TestHelmIntegrationPublishWithSBOM(t *testing.T) {
+	t.Parallel()
+	assert := NewContainerAssert(t)
+	ctx := context.Background()
+
+	// A user-defined network lets the piper container reach the chart-repo sink
+	// by its alias (targetRepositoryURL: http://chartrepo:80 in the fixture
+	// config). Mirrors the wiring in integration_karma_test.go.
+	networkName := "helm-sbom-" + uuid.New().String()
+	provider, err := testcontainers.ProviderDocker.GetProvider()
+	if err != nil {
+		t.Fatalf("Failed to get docker provider: %v", err)
+	}
+	network, err := provider.CreateNetwork(ctx, testcontainers.NetworkRequest{Name: networkName, CheckDuplicate: true})
+	if err != nil {
+		t.Fatalf("Failed to create network: %v", err)
+	}
+	defer network.Remove(ctx)
+
+	// bytemark/webdav is a tiny PUT-accepting server; helm publish uploads the
+	// chart .tgz via HTTP PUT, matching the Artifactory/Nexus contract.
+	chartRepo, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:          "bytemark/webdav",
+			Env:            map[string]string{"USERNAME": "repouser", "PASSWORD": "repopass"},
+			Networks:       []string{networkName},
+			NetworkAliases: map[string][]string{networkName: {"chartrepo"}},
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to start chart repo container: %v", err)
+	}
+	defer chartRepo.Terminate(ctx)
+
+	// dtzar/helm-kubectl ships the helm CLI that helmExecute shells out to.
+	container := StartPiperContainer(t, ContainerConfig{
+		Image:          "dtzar/helm-kubectl",
+		TestData:       "TestHelmIntegration/chart",
+		WorkDir:        "/chart",
+		Networks:       []string{networkName},
+		NetworkAliases: []string{"helm-runner"},
+	})
+
+	output := RunPiper(t, container, "/chart", "helmExecute")
+
+	// The chart is packaged, published, and the chart SBOM is generated.
+	assert.Contains(output, "publishing artifact:")
+	assert.Contains(output, "generated chart SBOM bom-helm.xml")
+	// The image-free chart means syft is never invoked (no network download).
+	assert.Contains(output, "no container images available, skipping syft scan")
+
+	// Publish artifact, chart SBOM, and buildSettingsInfo CPE file all exist.
+	assert.FileExists(container,
+		"/chart/helm-int-hello-0.1.0.tgz",
+		"/chart/bom-helm.xml",
+		"/chart/.pipeline/commonPipelineEnvironment/custom/buildSettingsInfo",
+	)
+
+	// The chart SBOM is schema-valid CycloneDX 1.4 and describes the chart.
+	bomContent := ReadFile(t, container, "/chart/bom-helm.xml")
+	assert.NoError(piperutils.ValidateBOM(bomContent), "bom-helm.xml should be a valid CycloneDX BOM")
+	schemaVersion, err := piperutils.GetBomSchemaVersionFromContent(bomContent)
+	assert.NoError(err, "bom-helm.xml should carry a CycloneDX schema version")
+	assert.Equal("1.4", schemaVersion, "chart SBOM must be emitted in CycloneDX schema version 1.4")
+	assert.Contains(string(bomContent), "pkg:helm/helm-int-hello@0.1.0", "chart SBOM root component must carry the helm PURL")
+
+	// The container-image SBOM path was skipped: no bom-docker-*.xml produced.
+	code, lsOutput := ExecCommandExpectNonZero(t, container, "/chart", []string{"sh", "-c", "ls bom-docker-*.xml"})
+	assert.NotEqual(0, code, "no bom-docker-*.xml should be produced for an image-free chart; found:\n%s", lsOutput)
+
+	// buildSettingsInfo (SLC-29) is persisted and records the build flags.
+	buildSettings := ReadFile(t, container, "/chart/.pipeline/commonPipelineEnvironment/custom/buildSettingsInfo")
+	assert.NotEmpty(strings.TrimSpace(string(buildSettings)), "buildSettingsInfo must not be empty")
+	assert.Contains(string(buildSettings), "\"createBOM\":true", "buildSettingsInfo should record createBOM=true")
+	assert.Contains(string(buildSettings), "\"publish\":true", "buildSettingsInfo should record publish=true")
+}

--- a/integration/testdata/TestHelmIntegration/chart/.pipeline/config.yml
+++ b/integration/testdata/TestHelmIntegration/chart/.pipeline/config.yml
@@ -1,0 +1,18 @@
+general:
+  buildTool: 'helm'
+
+steps:
+  artifactPrepareVersion:
+    versioningType: cloud_noTag
+
+  helmExecute:
+    createBOM: true
+    chartPath: '.'
+    helmCommand: 'publish'
+    renderValuesTemplate: false
+    publish: true
+    packageDependencyUpdate: false
+    targetRepositoryName: 'helm-int-hello'
+    targetRepositoryURL: 'http://chartrepo:80'
+    targetRepositoryUser: 'repouser'
+    targetRepositoryPassword: 'repopass'

--- a/integration/testdata/TestHelmIntegration/chart/Chart.yaml
+++ b/integration/testdata/TestHelmIntegration/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: helm-int-hello
+description: Minimal image-free Helm chart used by TestHelmIntegration to exercise helmExecute publish + chart SBOM generation.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/integration/testdata/TestHelmIntegration/chart/templates/configmap.yaml
+++ b/integration/testdata/TestHelmIntegration/chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-config
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  greeting: {{ .Values.greeting | quote }}

--- a/integration/testdata/TestHelmIntegration/chart/values.yaml
+++ b/integration/testdata/TestHelmIntegration/chart/values.yaml
@@ -1,0 +1,5 @@
+# Values for the image-free TestHelmIntegration chart.
+# Intentionally references NO container image so helmExecute's SBOM path skips
+# the syft container scan (which would require a network download) and only the
+# pure-Go chart BOM (bom-helm.xml) is produced.
+greeting: "hello from helmExecute integration test"

--- a/pkg/buildsettings/buildSettings.go
+++ b/pkg/buildsettings/buildSettings.go
@@ -14,6 +14,7 @@ type BuildSettings struct {
 	GolangBuild        []BuildOptions `json:"golangBuild,omitempty"`
 	GradleExecuteBuild []BuildOptions `json:"gradleExecuteBuild,omitempty"`
 	HelmExecute        []BuildOptions `json:"helmExecute,omitempty"`
+	HelmBuild          []BuildOptions `json:"helmBuild,omitempty"`
 	KanikoExecute      []BuildOptions `json:"kanikoExecute,omitempty"`
 	MavenBuild         []BuildOptions `json:"mavenBuild,omitempty"`
 	MtaBuild           []BuildOptions `json:"mtaBuild,omitempty"`
@@ -95,6 +96,10 @@ func CreateBuildSettingsInfo(config *BuildOptions, buildTool string) (string, er
 		case "helmExecute":
 			jsonResult, err = json.Marshal(BuildSettings{
 				HelmExecute: settings,
+			})
+		case "helmBuild":
+			jsonResult, err = json.Marshal(BuildSettings{
+				HelmBuild: settings,
 			})
 		case "kanikoExecute":
 			jsonResult, err = json.Marshal(BuildSettings{

--- a/pkg/helm/sbom.go
+++ b/pkg/helm/sbom.go
@@ -1,0 +1,235 @@
+package helm
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/SAP/jenkins-library/pkg/docker"
+	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/SAP/jenkins-library/pkg/versioning"
+	"github.com/google/uuid"
+	"go.yaml.in/yaml/v3"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// cycloneDxSchemaVersion is the CycloneDX schema version the chart SBOM is
+// emitted in. helmExecute standardizes on 1.4 to match the container-image
+// SBOMs produced by Syft (see pkg/syft/syft.go cyclonedxFormatForSyft). It is
+// set explicitly on the BOM rather than relying on the cyclonedx-go default so
+// the version cannot silently change on a library upgrade.
+const cycloneDxSchemaVersion = "1.4"
+
+// GenerateChartSBOM builds a chart-level CycloneDX SBOM (bom-helm.xml) that
+// describes the helm chart artifact itself: the chart as the root component
+// (with a pkg:helm PURL), its sub-chart dependencies, and the referenced
+// container images. Unlike the container-image SBOMs, this is hand-built with
+// the CycloneDX library since Syft has no helm-chart support.
+func GenerateChartSBOM(chartPath, outputPath string, images []string, files piperutils.FileUtils) error {
+	meta, err := readChartMetadata(chartPath, files)
+	if err != nil {
+		return err
+	}
+
+	bom := newChartBOM(meta, chartPath, images, files)
+	return writeBOM(bom, outputPath, files)
+}
+
+// newChartBOM assembles the chart-level CycloneDX BOM: the chart as the root
+// component, its sub-chart dependencies (Chart.lock resolved versions winning
+// over Chart.yaml ranges), and the referenced container images.
+func newChartBOM(meta *versioning.Metadata, chartPath string, images []string, files piperutils.FileUtils) *cdx.BOM {
+	chartRef := fmt.Sprintf("pkg:helm/%s@%s", meta.Name, meta.Version)
+
+	bom := cdx.NewBOM()
+	// Pin the CycloneDX schema version explicitly (1.4) rather than relying on
+	// the cyclonedx-go default, and set the matching XML namespace.
+	bom.SpecVersion = cycloneDxSchemaVersion
+	bom.XMLNS = "http://cyclonedx.org/schema/bom/" + cycloneDxSchemaVersion
+	// The SBOM gateway requires a BOM serialNumber, a metadata timestamp, and a
+	// bom-ref on the root component. cdx.NewBOM sets none of these (Syft-produced
+	// BOMs carry them, which is why only this hand-built BOM was rejected).
+	bom.SerialNumber = "urn:uuid:" + uuid.NewString()
+	bom.Metadata = &cdx.Metadata{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Component: &cdx.Component{
+			BOMRef:     chartRef,
+			Type:       cdx.ComponentTypeApplication,
+			Name:       meta.Name,
+			Version:    meta.Version,
+			PackageURL: chartRef,
+		},
+	}
+
+	var components []cdx.Component
+
+	// Each sub-chart dependency becomes a component with a clean pkg:helm PURL.
+	// The dependency Repository is a URL and is intentionally omitted from the
+	// PURL to keep it purl-spec-valid and deterministic.
+	//
+	// Chart.lock, when present, pins the resolved dependency versions; it wins
+	// over the (possibly ranged) versions declared in Chart.yaml so the SBOM
+	// reflects what is actually packaged.
+	dependencies := meta.Dependencies
+	if locked := readChartLock(chartPath, files); len(locked) > 0 {
+		dependencies = locked
+	}
+	for _, dep := range dependencies {
+		depPurl := fmt.Sprintf("pkg:helm/%s@%s", dep.Name, dep.Version)
+		components = append(components, cdx.Component{
+			BOMRef:     depPurl,
+			Type:       cdx.ComponentTypeLibrary,
+			Name:       dep.Name,
+			Version:    dep.Version,
+			PackageURL: depPurl,
+		})
+	}
+
+	// Each referenced container image becomes a container component with a
+	// pkg:oci PURL of the form pkg:oci/<name>@<tag-or-digest>.
+	for _, image := range images {
+		name, err := docker.ContainerImageNameFromImage(image)
+		if err != nil {
+			log.Entry().Warnf("helm SBOM: skipping unparseable image %q: %v", image, err)
+			continue
+		}
+		// ContainerImageNameFromImage already validated the reference (it parses
+		// via ContainerImageNameTagFromImage internally), so this cannot fail.
+		nameTag, _ := docker.ContainerImageNameTagFromImage(image)
+		// nameTag is "<name>:<tag>" or "<name>@<digest>"; take the part after
+		// the name as the PURL version.
+		version := strings.TrimLeft(strings.TrimPrefix(nameTag, name), ":@")
+		imagePurl := fmt.Sprintf("pkg:oci/%s@%s", name, version)
+		components = append(components, cdx.Component{
+			BOMRef:     imagePurl,
+			Type:       cdx.ComponentTypeContainer,
+			Name:       name,
+			Version:    version,
+			PackageURL: imagePurl,
+		})
+	}
+
+	if len(components) > 0 {
+		bom.Components = &components
+	}
+	return bom
+}
+
+// writeBOM encodes the BOM as pretty CycloneDX XML, validates it against the
+// CycloneDX 1.4 required-field rules, and writes it to outputPath. Validation
+// runs on the marshaled bytes so a non-conforming BOM never reaches disk.
+func writeBOM(bom *cdx.BOM, outputPath string, files piperutils.FileUtils) error {
+	var buf bytes.Buffer
+	encoder := cdx.NewBOMEncoder(&buf, cdx.BOMFileFormatXML)
+	encoder.SetPretty(true)
+	if err := encoder.Encode(bom); err != nil {
+		return fmt.Errorf("failed to encode chart SBOM: %w", err)
+	}
+
+	if err := validateChartBOM(buf.Bytes()); err != nil {
+		return fmt.Errorf("generated chart SBOM is not schema-conformant: %w", err)
+	}
+
+	return files.FileWrite(outputPath, buf.Bytes(), 0o644)
+}
+
+// validateChartBOM checks the marshaled BOM against the CycloneDX 1.4
+// required-field rules enforced by the downstream SBOM gateway, failing fast at
+// build time instead of at upload. This is not a full XSD validation (no
+// pure-Go XSD validator exists and libxml2/cgo would break the CGO_ENABLED=0
+// static build); it codifies the specific constraints the gateway requires:
+// a urn:uuid serialNumber, a metadata timestamp, the 1.4 namespace, and a
+// bom-ref + valid PURL on the root component and every listed component.
+func validateChartBOM(content []byte) error {
+	var bom struct {
+		XMLNS        string `xml:"xmlns,attr"`
+		SerialNumber string `xml:"serialNumber,attr"`
+		Metadata     struct {
+			Timestamp string `xml:"timestamp"`
+			Component struct {
+				BOMRef string `xml:"bom-ref,attr"`
+				Name   string `xml:"name"`
+				Purl   string `xml:"purl"`
+			} `xml:"component"`
+		} `xml:"metadata"`
+		Components []struct {
+			BOMRef string `xml:"bom-ref,attr"`
+			Name   string `xml:"name"`
+			Purl   string `xml:"purl"`
+		} `xml:"components>component"`
+	}
+	if err := xml.Unmarshal(content, &bom); err != nil {
+		return fmt.Errorf("failed to parse generated BOM: %w", err)
+	}
+
+	if want := "http://cyclonedx.org/schema/bom/" + cycloneDxSchemaVersion; bom.XMLNS != want {
+		return fmt.Errorf("unexpected xmlns %q, want %q", bom.XMLNS, want)
+	}
+	if !strings.HasPrefix(bom.SerialNumber, "urn:uuid:") {
+		return fmt.Errorf("serialNumber %q is missing or not a urn:uuid", bom.SerialNumber)
+	}
+	if bom.Metadata.Timestamp == "" {
+		return fmt.Errorf("metadata timestamp is required")
+	}
+	root := bom.Metadata.Component
+	if root.BOMRef == "" || root.Name == "" {
+		return fmt.Errorf("root component must have a bom-ref and a name")
+	}
+	if err := piperutils.ValidatePurl(root.Purl); err != nil {
+		return fmt.Errorf("root component purl: %w", err)
+	}
+	for i, c := range bom.Components {
+		if c.BOMRef == "" || c.Name == "" {
+			return fmt.Errorf("component %d (%q) must have a bom-ref and a name", i, c.Name)
+		}
+		if err := piperutils.ValidatePurl(c.Purl); err != nil {
+			return fmt.Errorf("component %d (%q) purl: %w", i, c.Name, err)
+		}
+	}
+	return nil
+}
+
+// readChartMetadata reads and parses <chartPath>/Chart.yaml into the shared
+// versioning.Metadata model.
+func readChartMetadata(chartPath string, files piperutils.FileUtils) (*versioning.Metadata, error) {
+	chartYamlPath := filepath.Join(chartPath, "Chart.yaml")
+	content, err := files.FileRead(chartYamlPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", chartYamlPath, err)
+	}
+
+	var meta versioning.Metadata
+	if err := yaml.Unmarshal(content, &meta); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", chartYamlPath, err)
+	}
+
+	return &meta, nil
+}
+
+// chartLock models the subset of Chart.lock needed for the SBOM: the resolved
+// dependency list. Chart.lock has the same dependency shape as Chart.yaml.
+type chartLock struct {
+	Dependencies []*chart.Dependency `yaml:"dependencies,omitempty"`
+}
+
+// readChartLock reads <chartPath>/Chart.lock and returns its resolved
+// dependency list. It is best-effort: a missing or unparseable lock yields nil
+// so the caller falls back to the Chart.yaml dependencies.
+func readChartLock(chartPath string, files piperutils.FileUtils) []*chart.Dependency {
+	lockPath := filepath.Join(chartPath, "Chart.lock")
+	content, err := files.FileRead(lockPath)
+	if err != nil {
+		return nil
+	}
+
+	var lock chartLock
+	if err := yaml.Unmarshal(content, &lock); err != nil {
+		return nil
+	}
+	return lock.Dependencies
+}

--- a/pkg/helm/sbom_test.go
+++ b/pkg/helm/sbom_test.go
@@ -1,0 +1,447 @@
+//go:build unit
+// +build unit
+
+package helm
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	cdx "github.com/CycloneDX/cyclonedx-go"
+	"github.com/SAP/jenkins-library/pkg/mock"
+	"github.com/SAP/jenkins-library/pkg/piperutils"
+	"github.com/SAP/jenkins-library/pkg/versioning"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+func TestRunHelmReadChartMetadata(t *testing.T) {
+	t.Run("valid Chart.yaml is parsed", func(t *testing.T) {
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(
+			"apiVersion: v2\nname: foo\nversion: 1.2.3\nappVersion: 4.5.6\n"))
+
+		meta, err := readChartMetadata("chart", files)
+
+		require.NoError(t, err)
+		assert.Equal(t, "foo", meta.Name)
+		assert.Equal(t, "1.2.3", meta.Version)
+		assert.Equal(t, "4.5.6", meta.AppVersion)
+	})
+
+	t.Run("missing Chart.yaml returns a read error", func(t *testing.T) {
+		files := &mock.FilesMock{}
+
+		meta, err := readChartMetadata("chart", files)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read chart/Chart.yaml")
+		assert.Nil(t, meta)
+	})
+
+	t.Run("malformed Chart.yaml returns a parse error", func(t *testing.T) {
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte("name: foo\n  bad: : indentation"))
+
+		meta, err := readChartMetadata("chart", files)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse chart/Chart.yaml")
+		assert.Nil(t, meta)
+	})
+}
+
+func TestRunHelmReadChartLock(t *testing.T) {
+	t.Run("valid Chart.lock returns its resolved dependencies", func(t *testing.T) {
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.lock", []byte(
+			"dependencies:\n"+
+				"  - name: common\n    version: 2.3.1\n    repository: https://charts.example.com\n"+
+				"  - name: postgresql\n    version: 12.1.9\n    repository: https://charts.example.com\n"))
+
+		deps := readChartLock("chart", files)
+
+		require.Len(t, deps, 2)
+		assert.Equal(t, "common", deps[0].Name)
+		assert.Equal(t, "2.3.1", deps[0].Version)
+		assert.Equal(t, "postgresql", deps[1].Name)
+		assert.Equal(t, "12.1.9", deps[1].Version)
+	})
+
+	t.Run("missing Chart.lock returns nil", func(t *testing.T) {
+		files := &mock.FilesMock{}
+
+		assert.Nil(t, readChartLock("chart", files))
+	})
+
+	t.Run("malformed Chart.lock returns nil", func(t *testing.T) {
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.lock", []byte("dependencies: : broken"))
+
+		assert.Nil(t, readChartLock("chart", files))
+	})
+
+	t.Run("Chart.lock with no dependencies returns an empty list", func(t *testing.T) {
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.lock", []byte("dependencies: []\n"))
+
+		assert.Empty(t, readChartLock("chart", files))
+	})
+}
+
+func TestRunHelmNewChartBOM(t *testing.T) {
+	t.Run("root component carries the chart identity and helm PURL", func(t *testing.T) {
+		meta := &versioning.Metadata{Name: "foo", Version: "1.2.3", AppVersion: "4.5.6"}
+
+		bom := newChartBOM(meta, "chart", nil, &mock.FilesMock{})
+
+		require.NotNil(t, bom.Metadata)
+		require.NotNil(t, bom.Metadata.Component)
+		assert.Equal(t, cdx.ComponentTypeApplication, bom.Metadata.Component.Type)
+		assert.Equal(t, "foo", bom.Metadata.Component.Name)
+		assert.Equal(t, "1.2.3", bom.Metadata.Component.Version)
+		assert.Equal(t, "pkg:helm/foo@1.2.3", bom.Metadata.Component.PackageURL)
+		assert.Nil(t, bom.Components, "a chart with no deps/images must have no components")
+	})
+
+	t.Run("gateway-required fields are populated", func(t *testing.T) {
+		meta := &versioning.Metadata{Name: "foo", Version: "1.2.3"}
+
+		bom := newChartBOM(meta, "chart", nil, &mock.FilesMock{})
+
+		// The SBOM gateway requires a serialNumber (urn:uuid), a metadata
+		// timestamp, and a bom-ref on the root component.
+		assert.Regexp(t, `^urn:uuid:[0-9a-f-]{36}$`, bom.SerialNumber)
+		require.NotNil(t, bom.Metadata)
+		assert.NotEmpty(t, bom.Metadata.Timestamp, "metadata timestamp is required")
+		assert.Equal(t, "pkg:helm/foo@1.2.3", bom.Metadata.Component.BOMRef, "root component needs a bom-ref")
+		// The chart SBOM must be pinned to CycloneDX schema version 1.4.
+		assert.Equal(t, "1.4", bom.SpecVersion)
+		assert.Equal(t, "http://cyclonedx.org/schema/bom/1.4", bom.XMLNS)
+	})
+
+	t.Run("dependencies become library components", func(t *testing.T) {
+		meta := &versioning.Metadata{
+			Name: "foo", Version: "1.2.3",
+			Dependencies: []*chart.Dependency{
+				{Name: "common", Version: "2.0.0"},
+				{Name: "postgresql", Version: "12.1.0"},
+			},
+		}
+
+		bom := newChartBOM(meta, "chart", nil, &mock.FilesMock{})
+
+		require.NotNil(t, bom.Components)
+		require.Len(t, *bom.Components, 2)
+		assert.Equal(t, cdx.ComponentTypeLibrary, (*bom.Components)[0].Type)
+		assert.Equal(t, "pkg:helm/common@2.0.0", (*bom.Components)[0].PackageURL)
+		assert.Equal(t, "pkg:helm/postgresql@12.1.0", (*bom.Components)[1].PackageURL)
+	})
+
+	t.Run("Chart.lock resolved versions win over metadata dependencies", func(t *testing.T) {
+		meta := &versioning.Metadata{
+			Name: "foo", Version: "1.2.3",
+			Dependencies: []*chart.Dependency{{Name: "common", Version: "^2.0.0"}},
+		}
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.lock", []byte(
+			"dependencies:\n  - name: common\n    version: 2.3.1\n"))
+
+		bom := newChartBOM(meta, "chart", nil, files)
+
+		require.NotNil(t, bom.Components)
+		require.Len(t, *bom.Components, 1)
+		assert.Equal(t, "pkg:helm/common@2.3.1", (*bom.Components)[0].PackageURL)
+	})
+
+	t.Run("images become container components, unparseable ones skipped", func(t *testing.T) {
+		meta := &versioning.Metadata{Name: "foo", Version: "1.2.3"}
+		images := []string{"registry.example.com/app:9.9.9", "bad name"}
+
+		bom := newChartBOM(meta, "chart", images, &mock.FilesMock{})
+
+		require.NotNil(t, bom.Components)
+		require.Len(t, *bom.Components, 1, "the unparseable image must be skipped")
+		assert.Equal(t, cdx.ComponentTypeContainer, (*bom.Components)[0].Type)
+		assert.Equal(t, "pkg:oci/app@9.9.9", (*bom.Components)[0].PackageURL)
+	})
+}
+
+func TestRunHelmWriteBOM(t *testing.T) {
+	t.Run("encodes a conformant BOM as CycloneDX XML and writes it", func(t *testing.T) {
+		bom := newChartBOM(&versioning.Metadata{Name: "foo", Version: "1.2.3"}, "chart", nil, &mock.FilesMock{})
+		files := &mock.FilesMock{}
+
+		err := writeBOM(bom, "bom-helm.xml", files)
+
+		require.NoError(t, err)
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		assert.Contains(t, string(content), "pkg:helm/foo@1.2.3")
+		assert.Contains(t, string(content), "http://cyclonedx.org/schema/bom/1.4")
+	})
+
+	t.Run("non-conformant BOM is rejected before writing", func(t *testing.T) {
+		// A bare BOM (no serialNumber/timestamp/xmlns) must fail validation and
+		// never reach the filesystem.
+		bom := cdx.NewBOM()
+		bom.Metadata = &cdx.Metadata{Component: &cdx.Component{Name: "foo", Version: "1.2.3"}}
+		files := &mock.FilesMock{}
+
+		err := writeBOM(bom, "bom-helm.xml", files)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not schema-conformant")
+		exists, _ := files.FileExists("bom-helm.xml")
+		assert.False(t, exists, "a non-conformant BOM must not be written to disk")
+	})
+
+	t.Run("write failure is surfaced", func(t *testing.T) {
+		bom := newChartBOM(&versioning.Metadata{Name: "foo", Version: "1.2.3"}, "chart", nil, &mock.FilesMock{})
+		files := &mock.FilesMock{FileWriteError: fmt.Errorf("disk full")}
+
+		err := writeBOM(bom, "bom-helm.xml", files)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "disk full")
+	})
+}
+
+func TestRunHelmValidateChartBOM(t *testing.T) {
+	// A fully conformant BOM built by newChartBOM, serialized, is the baseline.
+	conformant := func() []byte {
+		bom := newChartBOM(&versioning.Metadata{Name: "foo", Version: "1.2.3"}, "chart", nil, &mock.FilesMock{})
+		var buf bytes.Buffer
+		enc := cdx.NewBOMEncoder(&buf, cdx.BOMFileFormatXML)
+		require.NoError(t, enc.Encode(bom))
+		return buf.Bytes()
+	}
+
+	t.Run("accepts a conformant BOM", func(t *testing.T) {
+		assert.NoError(t, validateChartBOM(conformant()))
+	})
+
+	tests := []struct {
+		name    string
+		mutate  func(string) string
+		wantErr string
+	}{
+		{"missing serialNumber", func(s string) string {
+			return regexp.MustCompile(` serialNumber="[^"]*"`).ReplaceAllString(s, "")
+		}, "serialNumber"},
+		{"wrong xmlns", func(s string) string {
+			return strings.Replace(s, "/bom/1.4", "/bom/1.5", 1)
+		}, "unexpected xmlns"},
+		{"missing timestamp", func(s string) string {
+			return regexp.MustCompile(`<timestamp>[^<]*</timestamp>`).ReplaceAllString(s, "")
+		}, "timestamp is required"},
+		{"malformed root purl", func(s string) string {
+			return strings.Replace(s, "<purl>pkg:helm/foo@1.2.3</purl>", "<purl></purl>", 1)
+		}, "purl"},
+		{"not XML", func(s string) string { return "not xml" }, "failed to parse"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateChartBOM([]byte(test.mutate(string(conformant()))))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), test.wantErr)
+		})
+	}
+}
+
+func TestRunHelmGenerateChartSBOM(t *testing.T) {
+	const validChart = "apiVersion: v2\nname: foo\nversion: 1.2.3\nappVersion: 4.5.6\n"
+
+	t.Run("valid chart produces a valid BOM with a helm PURL", func(t *testing.T) {
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(validChart))
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", nil, files)
+
+		require.NoError(t, err)
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		assert.Contains(t, string(content), "pkg:helm/foo@1.2.3")
+		// Gateway-required fields must be serialized into the XML.
+		assert.Contains(t, string(content), "serialNumber=\"urn:uuid:")
+		assert.Contains(t, string(content), "<timestamp>")
+		assert.Contains(t, string(content), "bom-ref=\"pkg:helm/foo@1.2.3\"")
+		// The BOM must be emitted in CycloneDX schema version 1.4.
+		assert.Contains(t, string(content), `xmlns="http://cyclonedx.org/schema/bom/1.4"`)
+	})
+
+	t.Run("sub-chart dependencies become components", func(t *testing.T) {
+		chartWithDeps := "apiVersion: v2\nname: foo\nversion: 1.2.3\n" +
+			"dependencies:\n" +
+			"  - name: common\n    version: 2.0.0\n    repository: https://charts.example.com\n" +
+			"  - name: postgresql\n    version: 12.1.0\n    repository: https://charts.example.com\n"
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(chartWithDeps))
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", nil, files)
+
+		require.NoError(t, err)
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		// The chart itself is the root component.
+		assert.Contains(t, string(content), "pkg:helm/foo@1.2.3")
+		// Each sub-chart dependency is emitted as its own component.
+		assert.Contains(t, string(content), "pkg:helm/common@2.0.0")
+		assert.Contains(t, string(content), "pkg:helm/postgresql@12.1.0")
+	})
+
+	t.Run("Chart.lock resolved versions override Chart.yaml ranges", func(t *testing.T) {
+		// Chart.yaml carries version ranges; Chart.lock pins the resolved
+		// versions. The lock must win so the SBOM reflects what is packaged.
+		chartWithRanges := "apiVersion: v2\nname: foo\nversion: 1.2.3\n" +
+			"dependencies:\n" +
+			"  - name: common\n    version: ^2.0.0\n    repository: https://charts.example.com\n" +
+			"  - name: postgresql\n    version: ~12.0.0\n    repository: https://charts.example.com\n"
+		chartLock := "dependencies:\n" +
+			"  - name: common\n    version: 2.3.1\n    repository: https://charts.example.com\n" +
+			"  - name: postgresql\n    version: 12.1.9\n    repository: https://charts.example.com\n"
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(chartWithRanges))
+		files.AddFile("chart/Chart.lock", []byte(chartLock))
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", nil, files)
+
+		require.NoError(t, err)
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		// Resolved versions from Chart.lock win.
+		assert.Contains(t, string(content), "pkg:helm/common@2.3.1")
+		assert.Contains(t, string(content), "pkg:helm/postgresql@12.1.9")
+		// The unresolved Chart.yaml ranges must not appear.
+		assert.NotContains(t, string(content), "pkg:helm/common@^2.0.0")
+		assert.NotContains(t, string(content), "pkg:helm/postgresql@~12.0.0")
+	})
+
+	t.Run("malformed Chart.lock falls back to Chart.yaml dependencies", func(t *testing.T) {
+		chartWithDeps := "apiVersion: v2\nname: foo\nversion: 1.2.3\n" +
+			"dependencies:\n" +
+			"  - name: common\n    version: 2.0.0\n    repository: https://charts.example.com\n"
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(chartWithDeps))
+		files.AddFile("chart/Chart.lock", []byte("dependencies: : broken"))
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", nil, files)
+
+		require.NoError(t, err, "an unparseable Chart.lock must not fail SBOM generation")
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		// Falls back to the Chart.yaml dependency version.
+		assert.Contains(t, string(content), "pkg:helm/common@2.0.0")
+	})
+
+	t.Run("empty Chart.lock falls back to Chart.yaml dependencies", func(t *testing.T) {
+		chartWithDeps := "apiVersion: v2\nname: foo\nversion: 1.2.3\n" +
+			"dependencies:\n" +
+			"  - name: common\n    version: 2.0.0\n    repository: https://charts.example.com\n"
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(chartWithDeps))
+		files.AddFile("chart/Chart.lock", []byte("dependencies: []\n"))
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", nil, files)
+
+		require.NoError(t, err)
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		// An empty lock dependency list must not suppress the Chart.yaml deps.
+		assert.Contains(t, string(content), "pkg:helm/common@2.0.0")
+	})
+
+	t.Run("referenced images become container components", func(t *testing.T) {
+		const digest = "sha256:0123456789012345678901234567890123456789012345678901234567890123"
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(validChart))
+		images := []string{"registry.example.com/foo:1.0.0", "registry.example.com/bar@" + digest}
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", images, files)
+
+		require.NoError(t, err)
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		// The chart itself is still the root component.
+		assert.Contains(t, string(content), "pkg:helm/foo@1.2.3")
+		// Each referenced image is a container component with a pkg:oci PURL.
+		assert.Contains(t, string(content), `type="container"`)
+		assert.Contains(t, string(content), "pkg:oci/foo@1.0.0")
+		assert.Contains(t, string(content), "pkg:oci/bar@"+digest)
+	})
+
+	t.Run("unparseable image is skipped, valid images still included", func(t *testing.T) {
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(validChart))
+		images := []string{"bad name", "registry.example.com/foo:1.0.0"}
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", images, files)
+
+		require.NoError(t, err, "an unparseable image must not fail SBOM generation")
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+		// The valid image is still emitted; the bad one is silently skipped.
+		assert.Contains(t, string(content), "pkg:oci/foo@1.0.0")
+		assert.NotContains(t, string(content), "bad name")
+	})
+
+	t.Run("deps and images combine into the expected component set", func(t *testing.T) {
+		chartWithDeps := "apiVersion: v2\nname: foo\nversion: 1.2.3\n" +
+			"dependencies:\n" +
+			"  - name: common\n    version: 2.0.0\n    repository: https://charts.example.com\n" +
+			"  - name: postgresql\n    version: 12.1.0\n    repository: https://charts.example.com\n"
+		files := &mock.FilesMock{}
+		files.AddFile("chart/Chart.yaml", []byte(chartWithDeps))
+		images := []string{"registry.example.com/foo:1.0.0", "registry.example.com/baz:2.0.0"}
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", images, files)
+
+		require.NoError(t, err)
+		content, err := files.FileRead("bom-helm.xml")
+		require.NoError(t, err)
+		assert.NoError(t, piperutils.ValidateBOM(content))
+
+		// Exactly 2 dep + 2 image components (the chart itself is the root
+		// metadata component and is not counted here).
+		var bom piperutils.Bom
+		require.NoError(t, xml.Unmarshal(content, &bom))
+		assert.Len(t, bom.Components, 4, "expected 2 sub-chart deps + 2 images")
+		assert.Contains(t, string(content), "pkg:helm/foo@1.2.3")
+		assert.Contains(t, string(content), "pkg:helm/common@2.0.0")
+		assert.Contains(t, string(content), "pkg:helm/postgresql@12.1.0")
+		assert.Contains(t, string(content), "pkg:oci/foo@1.0.0")
+		assert.Contains(t, string(content), "pkg:oci/baz@2.0.0")
+	})
+
+	t.Run("chart metadata read failure is propagated", func(t *testing.T) {
+		files := &mock.FilesMock{} // no Chart.yaml
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", nil, files)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to read chart/Chart.yaml")
+	})
+
+	t.Run("output write failure is surfaced", func(t *testing.T) {
+		files := &mock.FilesMock{FileWriteError: fmt.Errorf("disk full")}
+		files.AddFile("chart/Chart.yaml", []byte(validChart))
+
+		err := GenerateChartSBOM("chart", "bom-helm.xml", nil, files)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "disk full")
+	})
+}

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,6 +23,7 @@ type HelmExecutor interface {
 	RunHelmTest() error
 	RunHelmPublish() (string, error)
 	RunHelmDependency() error
+	RunHelmTemplate() ([]byte, error)
 }
 
 // HelmExecute struct
@@ -348,6 +350,45 @@ func (h *HelmExecute) runHelmPackage() error {
 	}
 
 	return nil
+}
+
+// RunHelmTemplate renders the chart locally (`helm template`) and returns the
+// rendered multi-document manifest YAML captured from stdout. Used for SBOM
+// image discovery. Stdout is temporarily redirected to a buffer for the
+// duration of the call, then restored.
+func (h *HelmExecute) RunHelmTemplate() ([]byte, error) {
+	if len(h.config.ChartPath) == 0 {
+		return nil, fmt.Errorf("there is no ChartPath value. The chartPath value is mandatory")
+	}
+
+	if err := h.runHelmInit(); err != nil {
+		return nil, fmt.Errorf("failed to execute deployments: %v", err)
+	}
+
+	helmParams := []string{
+		"template",
+		h.config.DeploymentName,
+		h.config.ChartPath,
+	}
+	for _, value := range h.config.HelmValues {
+		helmParams = append(helmParams, "--values", value)
+	}
+	if len(h.config.Namespace) > 0 {
+		helmParams = append(helmParams, "--namespace", h.config.Namespace)
+	}
+	if h.verbose {
+		helmParams = append(helmParams, "--debug")
+	}
+
+	var buf bytes.Buffer
+	h.utils.Stdout(&buf)
+	defer h.utils.Stdout(h.stdout)
+
+	if err := h.utils.RunExecutable("helm", helmParams...); err != nil {
+		return nil, fmt.Errorf("failed to execute helm template: %w", err)
+	}
+
+	return buf.Bytes(), nil
 }
 
 // RunHelmTest is used to run tests for a release

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type helmMockUtilsBundle struct {
@@ -469,6 +470,114 @@ func TestRunHelmPackage(t *testing.T) {
 			assert.Equal(t, testCase.expectedExecCalls, utils.Calls)
 		})
 	}
+}
+
+func TestRunHelmTemplate(t *testing.T) {
+	renderedManifests := "apiVersion: apps/v1\nkind: Deployment\nspec:\n  template:\n    spec:\n      containers:\n        - image: registry.example.com/app:1.2.3\n"
+
+	t.Run("argument construction and stdout capture", func(t *testing.T) {
+		testTable := []struct {
+			name           string
+			config         HelmExecuteOptions
+			verbose        bool
+			expectedParams []string
+		}{
+			{
+				name:           "minimal",
+				config:         HelmExecuteOptions{ChartPath: ".", DeploymentName: "testChart"},
+				expectedParams: []string{"template", "testChart", "."},
+			},
+			{
+				name:           "with values files",
+				config:         HelmExecuteOptions{ChartPath: ".", DeploymentName: "testChart", HelmValues: []string{"a.yaml", "b.yaml"}},
+				expectedParams: []string{"template", "testChart", ".", "--values", "a.yaml", "--values", "b.yaml"},
+			},
+			{
+				name:           "with namespace",
+				config:         HelmExecuteOptions{ChartPath: ".", DeploymentName: "testChart", Namespace: "prod"},
+				expectedParams: []string{"template", "testChart", ".", "--namespace", "prod"},
+			},
+			{
+				name:           "verbose adds --debug",
+				config:         HelmExecuteOptions{ChartPath: ".", DeploymentName: "testChart"},
+				verbose:        true,
+				expectedParams: []string{"template", "testChart", ".", "--debug"},
+			},
+			{
+				name:           "all options combined",
+				config:         HelmExecuteOptions{ChartPath: "charts/app", DeploymentName: "testChart", HelmValues: []string{"v.yaml"}, Namespace: "ns"},
+				verbose:        true,
+				expectedParams: []string{"template", "testChart", "charts/app", "--values", "v.yaml", "--namespace", "ns", "--debug"},
+			},
+		}
+
+		for _, testCase := range testTable {
+			t.Run(testCase.name, func(t *testing.T) {
+				utils := helmMockUtilsBundle{
+					ExecMockRunner: &mock.ExecMockRunner{
+						StdoutReturn: map[string]string{"helm template.*": renderedManifests},
+					},
+				}
+				helmExecute := HelmExecute{
+					utils:   utils,
+					config:  testCase.config,
+					verbose: testCase.verbose,
+					stdout:  log.Writer(),
+				}
+
+				out, err := helmExecute.RunHelmTemplate()
+
+				require.NoError(t, err)
+				require.Len(t, utils.Calls, 1)
+				assert.Equal(t, "helm", utils.Calls[0].Exec)
+				assert.Equal(t, testCase.expectedParams, utils.Calls[0].Params)
+				assert.Equal(t, renderedManifests, string(out), "must return the manifests captured from stdout")
+			})
+		}
+	})
+
+	t.Run("missing ChartPath returns an error, no exec", func(t *testing.T) {
+		utils := helmMockUtilsBundle{ExecMockRunner: &mock.ExecMockRunner{}}
+		helmExecute := HelmExecute{utils: utils, config: HelmExecuteOptions{DeploymentName: "testChart"}, stdout: log.Writer()}
+
+		out, err := helmExecute.RunHelmTemplate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chartPath value is mandatory")
+		assert.Nil(t, out)
+		assert.Empty(t, utils.Calls, "helm must not be invoked when ChartPath is missing")
+	})
+
+	t.Run("helm execution failure is surfaced", func(t *testing.T) {
+		utils := helmMockUtilsBundle{
+			ExecMockRunner: &mock.ExecMockRunner{
+				ShouldFailOnCommand: map[string]error{"helm template.*": fmt.Errorf("template boom")},
+			},
+		}
+		helmExecute := HelmExecute{utils: utils, config: HelmExecuteOptions{ChartPath: ".", DeploymentName: "testChart"}, stdout: log.Writer()}
+
+		out, err := helmExecute.RunHelmTemplate()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute helm template")
+		assert.Contains(t, err.Error(), "template boom")
+		assert.Nil(t, out)
+	})
+
+	t.Run("stdout is restored after the call", func(t *testing.T) {
+		utils := helmMockUtilsBundle{
+			ExecMockRunner: &mock.ExecMockRunner{
+				StdoutReturn: map[string]string{"helm template.*": renderedManifests},
+			},
+		}
+		originalStdout := log.Writer()
+		helmExecute := HelmExecute{utils: utils, config: HelmExecuteOptions{ChartPath: ".", DeploymentName: "testChart"}, stdout: originalStdout}
+
+		_, err := helmExecute.RunHelmTemplate()
+
+		require.NoError(t, err)
+		assert.Equal(t, originalStdout, utils.GetStdout(), "the capture buffer must be replaced by the original stdout after the call")
+	})
 }
 
 func TestRunHelmTest(t *testing.T) {

--- a/pkg/kubernetes/manifest.go
+++ b/pkg/kubernetes/manifest.go
@@ -1,0 +1,69 @@
+package kubernetes
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// ExtractImagesFromManifests parses a multi-doc YAML byte stream (as produced
+// by `helm template`) and returns every non-placeholder value of any `image`
+// key, deduplicated in first-seen order. It covers container/initContainer
+// specs at any depth (Deployment, StatefulSet, DaemonSet, Job, CronJob, ...)
+// by recursively walking each document rather than relying on typed structs.
+//
+// Decoding uses yaml.Node so that document/key order is preserved — a plain
+// map[string]interface{} would lose ordering and make the result depend on
+// Go's randomized map iteration.
+func ExtractImagesFromManifests(manifests []byte) ([]string, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(manifests))
+	seen := map[string]struct{}{}
+	var out []string
+	for {
+		var doc yaml.Node
+		if err := dec.Decode(&doc); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		walkNode(&doc, func(value string) {
+			if value == "" || strings.Contains(value, "{{") {
+				return
+			}
+			if _, ok := seen[value]; ok {
+				return
+			}
+			seen[value] = struct{}{}
+			out = append(out, value)
+		})
+	}
+	return out, nil
+}
+
+// walkNode recursively traverses a yaml.Node tree in document order, invoking
+// visitImage for every scalar value held under a mapping key named "image".
+func walkNode(node *yaml.Node, visitImage func(value string)) {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			walkNode(child, visitImage)
+		}
+	case yaml.MappingNode:
+		// Mapping content is a flat [key0, val0, key1, val1, ...] slice.
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := node.Content[i]
+			val := node.Content[i+1]
+			if key.Value == "image" && val.Kind == yaml.ScalarNode {
+				visitImage(val.Value)
+			}
+			walkNode(val, visitImage)
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			walkNode(child, visitImage)
+		}
+	}
+}

--- a/pkg/kubernetes/manifest_test.go
+++ b/pkg/kubernetes/manifest_test.go
@@ -1,0 +1,159 @@
+//go:build unit
+// +build unit
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestRunHelmExtractImagesFromManifests(t *testing.T) {
+	tests := []struct {
+		name      string
+		manifests string
+		expected  []string
+		wantErr   bool
+	}{
+		{
+			name: "deployment with containers and initContainers",
+			manifests: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: registry.example.com/app:1.2.3
+      initContainers:
+        - name: init
+          image: busybox:1.36
+`,
+			expected: []string{"registry.example.com/app:1.2.3", "busybox:1.36"},
+		},
+		{
+			name: "multiple documents are traversed in order and deduplicated",
+			manifests: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: first
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: registry.example.com/app:1.0.0
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: second
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: cron
+              image: registry.example.com/cron:2.0.0
+            - name: app-again
+              image: registry.example.com/app:1.0.0
+`,
+			expected: []string{"registry.example.com/app:1.0.0", "registry.example.com/cron:2.0.0"},
+		},
+		{
+			name: "placeholders, empty values and templated refs are skipped",
+			manifests: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: empty
+          image: ""
+        - name: templated
+          image: "{{ .Values.image }}"
+        - name: real
+          image: registry.example.com/real:1.0.0
+`,
+			expected: []string{"registry.example.com/real:1.0.0"},
+		},
+		{
+			name:      "no image keys yields an empty result",
+			manifests: "apiVersion: v1\nkind: ConfigMap\ndata:\n  key: value\n",
+			expected:  nil,
+		},
+		{
+			name:      "empty input yields an empty result",
+			manifests: "",
+			expected:  nil,
+		},
+		{
+			name:      "malformed YAML returns an error",
+			manifests: "foo: [unclosed",
+			wantErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			images, err := ExtractImagesFromManifests([]byte(test.manifests))
+			if test.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, images)
+		})
+	}
+}
+
+func TestRunHelmWalkNode(t *testing.T) {
+	// collect gathers every image value walkNode visits, in order.
+	collect := func(yamlDoc string) []string {
+		var node yaml.Node
+		require.NoError(t, yaml.Unmarshal([]byte(yamlDoc), &node))
+		var got []string
+		walkNode(&node, func(value string) { got = append(got, value) })
+		return got
+	}
+
+	t.Run("visits image scalars under a mapping in document order", func(t *testing.T) {
+		got := collect(`
+image: a:1
+nested:
+  image: b:2
+list:
+  - image: c:3
+  - image: d:4
+`)
+		assert.Equal(t, []string{"a:1", "b:2", "c:3", "d:4"}, got)
+	})
+
+	t.Run("ignores non-image keys and non-scalar image values", func(t *testing.T) {
+		got := collect(`
+name: notanimage
+image:
+  nested: notvisited
+`)
+		// "image" whose value is a mapping (not a scalar) must not be reported.
+		assert.Empty(t, got)
+	})
+
+	t.Run("a scalar document node is a safe no-op", func(t *testing.T) {
+		got := collect(`justascalar`)
+		assert.Empty(t, got, "unhandled node kinds (scalar/alias) must not panic and yield nothing")
+	})
+
+	t.Run("a nil node is a safe no-op", func(t *testing.T) {
+		var got []string
+		walkNode(&yaml.Node{}, func(value string) { got = append(got, value) })
+		assert.Empty(t, got)
+	})
+}

--- a/pkg/kubernetes/mocks/HelmExecutor.go
+++ b/pkg/kubernetes/mocks/HelmExecutor.go
@@ -342,6 +342,63 @@ func (_c *HelmExecutor_RunHelmUpgrade_Call) RunAndReturn(run func() error) *Helm
 	return _c
 }
 
+// RunHelmTemplate provides a mock function with given fields:
+func (_m *HelmExecutor) RunHelmTemplate() ([]byte, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for RunHelmTemplate")
+	}
+
+	var r0 []byte
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]byte, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []byte); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// HelmExecutor_RunHelmTemplate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RunHelmTemplate'
+type HelmExecutor_RunHelmTemplate_Call struct {
+	*mock.Call
+}
+
+// RunHelmTemplate is a helper method to define mock.On call
+func (_e *HelmExecutor_Expecter) RunHelmTemplate() *HelmExecutor_RunHelmTemplate_Call {
+	return &HelmExecutor_RunHelmTemplate_Call{Call: _e.mock.On("RunHelmTemplate")}
+}
+
+func (_c *HelmExecutor_RunHelmTemplate_Call) Run(run func()) *HelmExecutor_RunHelmTemplate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *HelmExecutor_RunHelmTemplate_Call) Return(_a0 []byte, _a1 error) *HelmExecutor_RunHelmTemplate_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *HelmExecutor_RunHelmTemplate_Call) RunAndReturn(run func() ([]byte, error)) *HelmExecutor_RunHelmTemplate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewHelmExecutor creates a new instance of HelmExecutor. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewHelmExecutor(t interface {

--- a/pkg/piperutils/cyclonedxBom.go
+++ b/pkg/piperutils/cyclonedxBom.go
@@ -9,6 +9,8 @@ import (
 
 	cdx "github.com/CycloneDX/cyclonedx-go"
 	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/moby/buildkit/util/purl"
+	purlParser "github.com/package-url/packageurl-go"
 )
 
 // CycloneDX 1.4 BOM structure
@@ -196,4 +198,64 @@ func UpdatePurl(sbomPath string, newPurl string) error {
 
 	log.Entry().Debugf("SBOM updated successfully for: %s", sbomPath)
 	return nil
+}
+
+// BuildRegistryFreeDockerPurl constructs a clean, registry-free docker PURL of
+// the form pkg:docker/<name>@<version> for the given image name and version.
+//
+// Syft omits the PURL for the parent/root component of a container-image BOM
+// (https://github.com/anchore/syft/issues/1408); callers use this to construct
+// a replacement and inject it via UpdatePurl. The registry (host:port) is
+// stripped so the emitted PURL is deterministic and does not leak the registry
+// host. It also returns the parsed registry, name and version (from the
+// intermediate PURL) so callers that need them — e.g. to build build-artifact
+// coordinates — do not have to parse again.
+func BuildRegistryFreeDockerPurl(name, version string) (registryFreePurl, registry, parsedName, parsedVersion string, err error) {
+	constructedPurl, err := purl.RefToPURL("docker", fmt.Sprintf("%s:%s", name, version), nil)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("unable to create purl from reference: %w", err)
+	}
+
+	registry, parsedName, parsedVersion, err = ParsePurl(constructedPurl)
+	// Defensive: constructedPurl was just produced by RefToPURL, so ParsePurl
+	// cannot realistically fail on it — not reachable by input in a unit test.
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("unable to parse purl: %w", err)
+	}
+
+	registryFreePurl, err = purl.RefToPURL("docker", fmt.Sprintf("%s:%s", parsedName, parsedVersion), nil)
+	// Defensive: parsedName/parsedVersion come from an already-validated PURL, so
+	// this second RefToPURL cannot realistically fail — not reachable by input.
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("unable to create registry-free purl from reference: %w", err)
+	}
+
+	return registryFreePurl, registry, parsedName, parsedVersion, nil
+}
+
+// ParsePurl splits a docker PURL string into its registry, name and version.
+// A PURL without a registry-like namespace defaults the registry to docker.io.
+func ParsePurl(purlStr string) (registry, name, version string, err error) {
+	p, err := purlParser.FromString(purlStr)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	// Split namespace to extract registry
+	// E.g., namespace = "ghcr.io/my-org"
+	namespace := p.Namespace
+	if namespace == "" {
+		registry = "docker.io"
+	} else {
+		nsParts := strings.Split(namespace, "/")
+		if strings.Contains(nsParts[0], ".") {
+			registry = nsParts[0]
+		} else {
+			registry = "docker.io"
+		}
+	}
+
+	name = p.Name
+	version = p.Version
+	return
 }

--- a/pkg/piperutils/cyclonedxbom_test.go
+++ b/pkg/piperutils/cyclonedxbom_test.go
@@ -507,3 +507,91 @@ func TestUpdateBOMPurl(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePurl(t *testing.T) {
+	tests := []struct {
+		name         string
+		purl         string
+		wantRegistry string
+		wantName     string
+		wantVersion  string
+		wantErr      bool
+	}{
+		{
+			name:         "purl with registry namespace",
+			purl:         "pkg:docker/ghcr.io/my-org/nginx@1.25",
+			wantRegistry: "ghcr.io",
+			wantName:     "nginx",
+			wantVersion:  "1.25",
+		},
+		{
+			name:         "purl without namespace defaults to docker.io",
+			purl:         "pkg:docker/nginx@1.25",
+			wantRegistry: "docker.io",
+			wantName:     "nginx",
+			wantVersion:  "1.25",
+		},
+		{
+			name:         "namespace without a dot defaults to docker.io",
+			purl:         "pkg:docker/library/nginx@1.25",
+			wantRegistry: "docker.io",
+			wantName:     "nginx",
+			wantVersion:  "1.25",
+		},
+		{
+			name:    "invalid purl string returns an error",
+			purl:    "not-a-purl",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry, name, version, err := ParsePurl(tt.purl)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRegistry, registry)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantVersion, version)
+		})
+	}
+}
+
+func TestBuildRegistryFreeDockerPurl(t *testing.T) {
+	t.Run("strips the registry and yields a clean docker purl", func(t *testing.T) {
+		purl, registry, name, version, err := BuildRegistryFreeDockerPurl("ghcr.io/my-org/nginx", "1.25")
+
+		require.NoError(t, err)
+		// The registry host is stripped from the final purl.
+		assert.Equal(t, "pkg:docker/nginx@1.25", purl)
+		assert.Equal(t, "ghcr.io", registry)
+		assert.Equal(t, "nginx", name)
+		assert.Equal(t, "1.25", version)
+	})
+
+	t.Run("registry-free image defaults to docker.io registry", func(t *testing.T) {
+		purl, registry, name, version, err := BuildRegistryFreeDockerPurl("nginx", "1.25")
+
+		require.NoError(t, err)
+		assert.Equal(t, "pkg:docker/nginx@1.25", purl)
+		assert.Equal(t, "docker.io", registry)
+		assert.Equal(t, "nginx", name)
+		assert.Equal(t, "1.25", version)
+	})
+
+	t.Run("invalid image reference fails the first purl construction", func(t *testing.T) {
+		// RefToPURL parses the "<name>:<version>" reference; an uppercase name is
+		// an invalid docker reference ("repository name must be lowercase"), so
+		// the first RefToPURL call returns an error. This is the only one of the
+		// three error guards reachable by input: once the first PURL is built,
+		// ParsePurl cannot fail on it and the second RefToPURL runs on an
+		// already-validated name/version, so those two guards are defensive only.
+		_, _, _, _, err := BuildRegistryFreeDockerPurl("UPPER", "1.0")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unable to create purl from reference")
+	})
+}

--- a/resources/metadata/helmBuild.yaml
+++ b/resources/metadata/helmBuild.yaml
@@ -375,6 +375,32 @@ spec:
         scope:
           - STEPS
           - PARAMETERS
+      - name: createBOM
+        type: bool
+        description: Creates the bill of materials (BOM) using Syft for referenced container images and a chart-level BOM (bom-helm.xml) in CycloneDX 1.4 format.
+        default: false
+        scope:
+          - GENERAL
+          - STEPS
+          - STAGES
+          - PARAMETERS
+      - name: syftDownloadUrl
+        type: string
+        description: Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.
+        scope:
+          - PARAMETERS
+          - STEPS
+        default: "https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz"
+      - name: containerImageNameTags
+        type: "[]string"
+        description: "List of full names (registry and tag) of the container images referenced by the chart. Used as a fallback source when image discovery via `helm template` yields no results. Typically populated by an upstream kanikoExecute step."
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/imageNameTags
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
       - name: buildSettingsInfo
         type: string
         description: Build settings info is typically filled by the step automatically to create information about the build settings that were used during the helm build. This information is typically used for compliance related processes.
@@ -398,3 +424,8 @@ spec:
         params:
           - name: custom/helmChartUrl
           - name: custom/buildSettingsInfo
+      - name: reports
+        type: reports
+        params:
+          - filePattern: "**/bom-*.xml"
+            type: sbom

--- a/resources/metadata/helmBuild.yaml
+++ b/resources/metadata/helmBuild.yaml
@@ -375,6 +375,42 @@ spec:
         scope:
           - STEPS
           - PARAMETERS
+      - name: createBOM
+        type: bool
+        description: Creates the bill of materials (BOM) using Syft for referenced container images and a chart-level BOM (bom-helm.xml) in CycloneDX 1.4 format.
+        default: false
+        scope:
+          - GENERAL
+          - STEPS
+          - STAGES
+          - PARAMETERS
+      - name: syftDownloadUrl
+        type: string
+        description: Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.
+        scope:
+          - PARAMETERS
+          - STEPS
+        default: "https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz"
+      - name: containerImageNameTags
+        type: "[]string"
+        description: "List of full names (registry and tag) of the container images referenced by the chart. Used as a fallback source when image discovery via `helm template` yields no results. Typically populated by an upstream kanikoExecute step."
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: container/imageNameTags
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+      - name: buildSettingsInfo
+        type: string
+        description: build settings info is typically filled by the step automatically to create information about the build settings that were used during the helm execute. This information is typically used for compliance related processes.
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
+        resourceRef:
+          - name: commonPipelineEnvironment
+            param: custom/buildSettingsInfo
   containers:
     - image: alpine/k8s:1.33.13
       workingDir: /config
@@ -387,3 +423,9 @@ spec:
         type: piperEnvironment
         params:
           - name: custom/helmChartUrl
+          - name: custom/buildSettingsInfo
+      - name: reports
+        type: reports
+        params:
+          - filePattern: "**/bom-*.xml"
+            type: sbom


### PR DESCRIPTION
# Add CycloneDX SBOM Generation to `helmBuild` Step

## Description

`helmBuild` (formerly `helmExecute`) now generates CycloneDX 1.4 SBOMs when a
chart is published with `createBOM: true`. SBOM generation runs only **after a
successful publish** — a failed publish produces no artifact to describe.

Two SBOMs are produced, sharing a single discovered image set so they describe
the same images:

- **Chart SBOM** (`bom-helm.xml`) — a chart-level BOM with a `pkg:helm` PURL for
  the published chart. Pure-Go, no network.
- **Container SBOMs** (`bom-docker-<N>.xml`) — one per container image referenced
  by the chart, produced with Syft. Images are discovered by rendering the chart
  (`helm template`), falling back to the `containerImageNameTags` CPE list.

Both are **best-effort**: a failure is logged but never fails the step.

### New step parameters

- `createBOM` (bool, default `false`) — enable SBOM generation.
- `syftDownloadUrl` (string) — download URL of the Syft linux amd64 binary.
- `containerImageNameTags` ([]string) — fallback image list, typically from an
  upstream `kanikoExecute` step (`container/imageNameTags` CPE).

Generated BOMs are collected via a `reports` output (`**/bom-*.xml`, type `sbom`).

### Refactoring

- The registry-free docker PURL construction (workaround for
  [anchore/syft#1408](https://github.com/anchore/syft/issues/1408), where Syft
  omits the root component's PURL) is factored out of `kanikoExecute` into
  `piperutils.BuildRegistryFreeDockerPurl` / `ParsePurl` and shared by both steps.

### Tests

- Unit tests for chart/container SBOM generation, image discovery, PURL
  injection, and the shared piperutils helpers.
- A `TestHelmIntegration` integration test that runs a real `helmBuild` publish
  against a WebDAV sidecar and asserts `bom-helm.xml` is produced and passes
  CycloneDX 1.4 validation, with no container images (no Syft download).
- GHA pipelines : test of different use cases using GHA pipeline. SBOM file validation done.
- Jenkins pipeline: execution done with case helm publish=true.
- ADO pipeline: execution done with case helm publish=true.

## Checklist

- [x] Tests
- [ ] Documentation
- [ ] Inner source library needs updating

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.6`

- Correlation ID: `76bc11a0-8b74-11f1-93c3-d9c03e937050`
- Event Trigger: `issue_comment.edited`
</details>
