### PR TITLE
feat(influx): add collectInfluxTelemetry option to disable Influx data collection

### DIFF
--- a/vars/influxWriteData.groovy
+++ b/vars/influxWriteData.groovy
@@ -12,7 +12,12 @@ import groovy.transform.Field
 
 @Field def STEP_NAME = getClass().getName()
 
-@Field Set GENERAL_CONFIG_KEYS = []
+@Field Set GENERAL_CONFIG_KEYS = [
+    /**
+     * Defines if Influx telemetry data should be collected and written. Set to `false` to disable all Influx data collection.
+     */
+    'collectInfluxTelemetry'
+]
 @Field Set STEP_CONFIG_KEYS = GENERAL_CONFIG_KEYS.plus([
     /**
      * Defines the version of the current artifact. Defaults to `commonPipelineEnvironment.getArtifactVersion()`
@@ -95,6 +100,11 @@ void call(Map parameters = [:]) {
             .addIfNull('customDataMap', InfluxData.getInstance().getFields().findAll({ it.key != 'jenkins_custom_data' }))
             .addIfNull('customDataMapTags', InfluxData.getInstance().getTags().findAll({ it.key != 'jenkins_custom_data' }))
             .use()
+
+        if (config.collectInfluxTelemetry == false) {
+            echo "[${STEP_NAME}] collectInfluxTelemetry is disabled -> skipping Influx data collection"
+            return
+        }
 
         if (!config.artifactVersion)  {
             //this takes care that terminated builds due to milestone-locking do not cause an error

--- a/vars/piperExecuteBin.groovy
+++ b/vars/piperExecuteBin.groovy
@@ -99,7 +99,12 @@ void call(Map parameters = [:], String stepName, String metadataFile, List crede
                            readPipelineEnv(script: script, piperGoPath: piperGoPath)
                         }
                     } finally {
-                        InfluxData.readFromDisk(script)
+                        def rawConfig = script.commonPipelineEnvironment.configuration
+                        def collectInfluxTelemetry = rawConfig?.get('general')?.collectInfluxTelemetry
+                            ?: rawConfig?.get('steps')?.get('influxWriteData')?.collectInfluxTelemetry
+                        if (collectInfluxTelemetry != false) {
+                            InfluxData.readFromDisk(script)
+                        }
                         utils.stash name: 'pipelineStepReports', includes: '.pipeline/stepReports/**', allowEmpty: true
                     }
                 }


### PR DESCRIPTION
## Summary

- Adds `collectInfluxTelemetry` as a general config key in `influxWriteData`
- When set to `false`, `influxWriteData` exits early before reading or writing any data
- When set to `false`, `piperExecuteBin` skips `InfluxData.readFromDisk` to avoid unnecessary disk I/O

## Usage

```yaml
general:
  collectInfluxTelemetry: false
```
