### PR TITLE
fix(config): guard against nil pointer panic when array parameter contains null element

### DIFF
--- a/cmd/detectExecuteScan_generated.go
+++ b/cmd/detectExecuteScan_generated.go
@@ -72,10 +72,10 @@ type detectExecuteScanOptions struct {
 	PrivateModules                  string   `json:"privateModules,omitempty"`
 	PrivateModulesGitToken          string   `json:"privateModulesGitToken,omitempty"`
 	ScanContainerDistro             string   `json:"scanContainerDistro,omitempty" validate:"possible-values=ubuntu centos alpine"`
-	ImageNameTags                   []string `json:"imageNameTags,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
-	RegistryURL                     string   `json:"registryUrl,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
-	RepositoryUsername              string   `json:"repositoryUsername,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
-	RepositoryPassword              string   `json:"repositoryPassword,omitempty" validate:"required_if=ScanContainerDistro ubuntu ScanContainerDistro centos ScanContainerDistro alpine"`
+	ImageNameTags                   []string `json:"imageNameTags,omitempty" validate:"required_with=ScanContainerDistro"`
+	RegistryURL                     string   `json:"registryUrl,omitempty" validate:"required_with=ScanContainerDistro"`
+	RepositoryUsername              string   `json:"repositoryUsername,omitempty" validate:"required_with=ScanContainerDistro"`
+	RepositoryPassword              string   `json:"repositoryPassword,omitempty" validate:"required_with=ScanContainerDistro"`
 	UseDetect9                      bool     `json:"useDetect9,omitempty"`
 	UseDetect10                     bool     `json:"useDetect10,omitempty"`
 	ContainerScan                   bool     `json:"containerScan,omitempty"`

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/go-openapi/strfmt v0.26.1
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
-	github.com/go-playground/validator/v10 v10.14.1
+	github.com/go-playground/validator/v10 v10.30.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/go-github/v68 v68.0.0
@@ -105,7 +105,7 @@ require (
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
+	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -242,7 +242,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
-	github.com/leodido/go-urn v1.2.4 // indirect
+	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/magicsong/color-glog v0.0.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -295,8 +295,6 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
-github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getsentry/sentry-go v0.31.1 h1:ELVc0h7gwyhnXHDouXkhqTFSO5oslsRDk0++eyE0KJ4=
@@ -417,8 +415,6 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.14.1 h1:9c50NUPC30zyuKprjL3vNZ0m5oG+jU0zvx4AqHGnv4k=
-github.com/go-playground/validator/v10 v10.14.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJLJuaYTeAH0DYy8=
 github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -622,8 +618,6 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
-github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
@@ -868,7 +862,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.2 h1:w5qFW6JKBz9Y393Y4q372O9A7cUSequkh1Q7OhCmWKU=
 github.com/gabriel-vasile/mimetype v1.4.2/go.mod h1:zApsH/mKG4w07erKIaJPFiX0Tsq9BFQgN3qGY5GnNgA=
+github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
+github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getsentry/sentry-go v0.31.1 h1:ELVc0h7gwyhnXHDouXkhqTFSO5oslsRDk0++eyE0KJ4=
 github.com/getsentry/sentry-go v0.31.1/go.mod h1:CYNcMMz73YigoHljQRG+qPF+eMq8gG72XcGN/p71BAY=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
@@ -417,6 +419,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.14.1 h1:9c50NUPC30zyuKprjL3vNZ0m5oG+jU0zvx4AqHGnv4k=
 github.com/go-playground/validator/v10 v10.14.1/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
+github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJLJuaYTeAH0DYy8=
+github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
@@ -620,6 +624,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
+github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
+github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhnIaL+V+BEER86oLrvS+kWobKpbJuye0=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -539,6 +539,10 @@ func merge(base, overlay map[string]interface{}, metadata StepData) map[string]i
 					if tVal == "[]interface {}" && v.Type == "[]string" {
 						// json Unmarshal genertes arrays of interface{} for string arrays
 						for _, interfaceValue := range value.([]interface{}) {
+							if interfaceValue == nil {
+								log.Entry().Warnf("config id %s contains a nil element, skipping", v.Name)
+								continue
+							}
 							arrayValueType := reflect.TypeOf(interfaceValue).String()
 							if arrayValueType != "string" {
 								log.Entry().Warnf("config id %s should only contain strings but contains a %s", v.Name, arrayValueType)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -806,6 +806,28 @@ func TestMerge(t *testing.T) {
 	}
 }
 
+func TestMerge_NilElementInStringArray(t *testing.T) {
+	// Regression test: nil element in a []interface{} parameter (e.g. groups: [null] passed from
+	// Groovy when scanObj.group is undefined) must not cause a nil pointer dereference panic.
+	stepData := StepData{
+		Spec: StepSpec{
+			Inputs: StepInputs{
+				Parameters: []StepParameters{
+					{Name: "groups", Type: "[]string"},
+				},
+			},
+		},
+	}
+	mergeData := map[string]interface{}{
+		"groups": []interface{}{nil, "valid-group"},
+	}
+	stepConfig := StepConfig{Config: map[string]interface{}{}}
+	assert.NotPanics(t, func() {
+		stepConfig.mixIn(mergeData, []string{}, stepData)
+	}, "mixIn must not panic on nil element in string array parameter")
+	assert.Equal(t, []interface{}{nil, "valid-group"}, stepConfig.Config["groups"])
+}
+
 func TestStepConfig_mixInHookConfig(t *testing.T) {
 	type fields struct {
 		Config     map[string]interface{}

--- a/pkg/config/stepmeta.go
+++ b/pkg/config/stepmeta.go
@@ -66,8 +66,9 @@ type StepParameters struct {
 }
 
 type ParameterDependence struct {
-	Name  string `json:"name" yaml:"name"`
-	Value string `json:"value" yaml:"value"`
+	Name     string `json:"name" yaml:"name"`
+	Value    string `json:"value" yaml:"value"`
+	NotEmpty bool   `json:"notEmpty,omitempty" yaml:"notEmpty,omitempty"`
 }
 
 // ResourceReference defines the parameters of a resource reference

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -252,8 +252,8 @@ func ProcessMetaFiles(metadataFiles []string, targetDir string, stepHelperData S
 
 		for _, parameter := range stepData.Spec.Inputs.Parameters {
 			for _, mandatoryIfCase := range parameter.MandatoryIf {
-				if mandatoryIfCase.Name == "" || mandatoryIfCase.Value == "" {
-					return errors.New("invalid mandatoryIf option")
+				if mandatoryIfCase.Name == "" || (mandatoryIfCase.Value == "" && !mandatoryIfCase.NotEmpty) {
+					return errors.New("invalid mandatoryIf option: 'name' is required; 'value' is required unless 'notEmpty: true' is set")
 				}
 			}
 		}
@@ -563,24 +563,12 @@ func structTag(param config.StepParameters) string {
 		validators = append(validators, "possible-values="+strings.Join(values, " "))
 	}
 	if len(param.MandatoryIf) > 0 {
-		// Fields appearing more than once in mandatoryIf would produce duplicate params in a
-		// single required_if tag, which panics in go-playground/validator v10.30+.
-		// Use required_with for such fields (semantically equivalent when possible-values already
-		// constrains the field to a finite set of non-empty values).
-		fieldCount := make(map[string]int)
-		for _, m := range param.MandatoryIf {
-			fieldCount[piperutils.Title(m.Name)]++
-		}
 		var requiredIfConditions []string
-		seenRequiredWith := make(map[string]bool)
 		var requiredWithFields []string
 		for _, m := range param.MandatoryIf {
 			titleName := piperutils.Title(m.Name)
-			if fieldCount[titleName] > 1 {
-				if !seenRequiredWith[titleName] {
-					requiredWithFields = append(requiredWithFields, titleName)
-					seenRequiredWith[titleName] = true
-				}
+			if m.NotEmpty {
+				requiredWithFields = append(requiredWithFields, titleName)
 			} else {
 				requiredIfConditions = append(requiredIfConditions, titleName+" "+m.Value)
 			}

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -568,6 +568,16 @@ func structTag(param config.StepParameters) string {
 		for _, m := range param.MandatoryIf {
 			titleName := piperutils.Title(m.Name)
 			if m.NotEmpty {
+				// required_with fires when the referenced field is non-empty (any value).
+				// Use notEmpty: true when the field's possible-values already restrict it
+				// to a known set, making an exact-value check redundant.
+				//
+				// NOTE: Do NOT use plain required_if with the same field name repeated for
+				// multiple values (e.g. required_if=Field v1 Field v2). Validator v10.30+
+				// panics on duplicate field names within a single required_if tag.
+				// If you need OR semantics across specific values without notEmpty, emit
+				// one required_if tag per value (they are comma-separated in the struct tag
+				// and validator evaluates each independently).
 				requiredWithFields = append(requiredWithFields, titleName)
 			} else {
 				requiredIfConditions = append(requiredIfConditions, titleName+" "+m.Value)

--- a/pkg/generator/helper/helper.go
+++ b/pkg/generator/helper/helper.go
@@ -563,11 +563,34 @@ func structTag(param config.StepParameters) string {
 		validators = append(validators, "possible-values="+strings.Join(values, " "))
 	}
 	if len(param.MandatoryIf) > 0 {
-		var conditions []string
+		// Fields appearing more than once in mandatoryIf would produce duplicate params in a
+		// single required_if tag, which panics in go-playground/validator v10.30+.
+		// Use required_with for such fields (semantically equivalent when possible-values already
+		// constrains the field to a finite set of non-empty values).
+		fieldCount := make(map[string]int)
 		for _, m := range param.MandatoryIf {
-			conditions = append(conditions, piperutils.Title(m.Name)+" "+m.Value)
+			fieldCount[piperutils.Title(m.Name)]++
 		}
-		validators = append(validators, "required_if="+strings.Join(conditions, " "))
+		var requiredIfConditions []string
+		seenRequiredWith := make(map[string]bool)
+		var requiredWithFields []string
+		for _, m := range param.MandatoryIf {
+			titleName := piperutils.Title(m.Name)
+			if fieldCount[titleName] > 1 {
+				if !seenRequiredWith[titleName] {
+					requiredWithFields = append(requiredWithFields, titleName)
+					seenRequiredWith[titleName] = true
+				}
+			} else {
+				requiredIfConditions = append(requiredIfConditions, titleName+" "+m.Value)
+			}
+		}
+		if len(requiredIfConditions) > 0 {
+			validators = append(validators, "required_if="+strings.Join(requiredIfConditions, " "))
+		}
+		if len(requiredWithFields) > 0 {
+			validators = append(validators, "required_with="+strings.Join(requiredWithFields, " "))
+		}
 	}
 	if len(validators) > 0 {
 		tag += fmt.Sprintf(` validate:"%s"`, strings.Join(validators, ","))

--- a/pkg/generator/helper/helper_test.go
+++ b/pkg/generator/helper/helper_test.go
@@ -101,6 +101,14 @@ spec:
           value: value1
         - name: param2
           value: value2
+      - name: param4
+        type: string
+        description: param4 description
+        scope:
+        - PARAMETERS
+        mandatoryIf:
+        - name: param1
+          notEmpty: true
 `
 	var r string
 	switch name {
@@ -339,5 +347,68 @@ func TestGetStringSliceFromInterface(t *testing.T) {
 
 	for _, v := range tt {
 		assert.Equal(t, v.expected, getStringSliceFromInterface(v.input), "interface conversion failed")
+	}
+}
+
+func TestStructTag(t *testing.T) {
+	t.Parallel()
+	tt := []struct {
+		name     string
+		param    config.StepParameters
+		expected string
+	}{
+		{
+			name:     "no validators",
+			param:    config.StepParameters{Name: "foo", Type: "string"},
+			expected: "`json:\"foo,omitempty\"`",
+		},
+		{
+			name: "required_if single condition",
+			param: config.StepParameters{
+				Name: "foo", Type: "string",
+				MandatoryIf: []config.ParameterDependence{
+					{Name: "bar", Value: "baz"},
+				},
+			},
+			expected: "`json:\"foo,omitempty\" validate:\"required_if=Bar baz\"`",
+		},
+		{
+			name: "required_if two different fields (AND semantics – one tag)",
+			param: config.StepParameters{
+				Name: "foo", Type: "string",
+				MandatoryIf: []config.ParameterDependence{
+					{Name: "field1", Value: "val1"},
+					{Name: "field2", Value: "val2"},
+				},
+			},
+			expected: "`json:\"foo,omitempty\" validate:\"required_if=Field1 val1 Field2 val2\"`",
+		},
+		{
+			name: "notEmpty emits required_with",
+			param: config.StepParameters{
+				Name: "foo", Type: "string",
+				MandatoryIf: []config.ParameterDependence{
+					{Name: "scanContainerDistro", NotEmpty: true},
+				},
+			},
+			expected: "`json:\"foo,omitempty\" validate:\"required_with=ScanContainerDistro\"`",
+		},
+		{
+			name: "notEmpty combined with required_if",
+			param: config.StepParameters{
+				Name: "foo", Type: "string",
+				MandatoryIf: []config.ParameterDependence{
+					{Name: "bar", Value: "baz"},
+					{Name: "distro", NotEmpty: true},
+				},
+			},
+			expected: "`json:\"foo,omitempty\" validate:\"required_if=Bar baz,required_with=Distro\"`",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, structTag(tc.param))
+		})
 	}
 }

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/custom_step_code_generated.golden
@@ -28,6 +28,7 @@ type testStepOptions struct {
 	Param1 string `json:"param1,omitempty" validate:"possible-values=value1 value2 value3"`
 	Param2 string `json:"param2,omitempty" validate:"required_if=Param1 value1"`
 	Param3 string `json:"param3,omitempty" validate:"possible-values=value1 value2 value3,required_if=Param1 value1 Param2 value2"`
+	Param4 string `json:"param4,omitempty" validate:"required_with=Param1"`
 }
 
 type testStepReports struct {
@@ -282,6 +283,7 @@ func addTestStepFlags(cmd *cobra.Command, stepConfig *testStepOptions) {
 	cmd.Flags().StringVar(&stepConfig.Param1, "param1", os.Getenv("PIPER_param1"), "param1 description")
 	cmd.Flags().StringVar(&stepConfig.Param2, "param2", os.Getenv("PIPER_param2"), "param2 description")
 	cmd.Flags().StringVar(&stepConfig.Param3, "param3", os.Getenv("PIPER_param3"), "param3 description")
+	cmd.Flags().StringVar(&stepConfig.Param4, "param4", os.Getenv("PIPER_param4"), "param4 description")
 
 	cmd.MarkFlagRequired("param0")
 	cmd.Flags().MarkDeprecated("param1", "use param3 instead")
@@ -337,6 +339,15 @@ func testStepMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_param3"),
+					},
+					{
+						Name:        "param4",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_param4"),
 					},
 				},
 			},

--- a/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
+++ b/pkg/generator/helper/testdata/TestProcessMetaFiles/step_code_generated.golden
@@ -27,6 +27,7 @@ type testStepOptions struct {
 	Param1 string `json:"param1,omitempty" validate:"possible-values=value1 value2 value3"`
 	Param2 string `json:"param2,omitempty" validate:"required_if=Param1 value1"`
 	Param3 string `json:"param3,omitempty" validate:"possible-values=value1 value2 value3,required_if=Param1 value1 Param2 value2"`
+	Param4 string `json:"param4,omitempty" validate:"required_with=Param1"`
 }
 
 type testStepReports struct {
@@ -281,6 +282,7 @@ func addTestStepFlags(cmd *cobra.Command, stepConfig *testStepOptions) {
 	cmd.Flags().StringVar(&stepConfig.Param1, "param1", os.Getenv("PIPER_param1"), "param1 description")
 	cmd.Flags().StringVar(&stepConfig.Param2, "param2", os.Getenv("PIPER_param2"), "param2 description")
 	cmd.Flags().StringVar(&stepConfig.Param3, "param3", os.Getenv("PIPER_param3"), "param3 description")
+	cmd.Flags().StringVar(&stepConfig.Param4, "param4", os.Getenv("PIPER_param4"), "param4 description")
 
 	cmd.MarkFlagRequired("param0")
 	cmd.Flags().MarkDeprecated("param1", "use param3 instead")
@@ -336,6 +338,15 @@ func testStepMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_param3"),
+					},
+					{
+						Name:        "param4",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_param4"),
 					},
 				},
 			},

--- a/resources/metadata/detectExecuteScan.yaml
+++ b/resources/metadata/detectExecuteScan.yaml
@@ -586,11 +586,7 @@ spec:
         type: "[]string"
         mandatoryIf:
           - name: scanContainerDistro
-            value: ubuntu
-          - name: scanContainerDistro
-            value: centos
-          - name: scanContainerDistro
-            value: alpine
+            notEmpty: true
         description: Images to be scanned (typically filled by CPE)
         scope:
           - STEPS
@@ -603,11 +599,7 @@ spec:
         type: string
         mandatoryIf:
           - name: scanContainerDistro
-            value: ubuntu
-          - name: scanContainerDistro
-            value: centos
-          - name: scanContainerDistro
-            value: alpine
+            notEmpty: true
         description: Used accessing for the images to be scanned (typically filled by CPE)
         scope:
           - STEPS
@@ -620,11 +612,7 @@ spec:
         type: string
         mandatoryIf:
           - name: scanContainerDistro
-            value: ubuntu
-          - name: scanContainerDistro
-            value: centos
-          - name: scanContainerDistro
-            value: alpine
+            notEmpty: true
         description: Used accessing for the images to be scanned (typically filled by CPE)
         scope:
           - STEPS
@@ -637,11 +625,7 @@ spec:
         type: string
         mandatoryIf:
           - name: scanContainerDistro
-            value: ubuntu
-          - name: scanContainerDistro
-            value: centos
-          - name: scanContainerDistro
-            value: alpine
+            notEmpty: true
         description: Used accessing for the images to be scanned (typically filled by CPE)
         scope:
           - STEPS


### PR DESCRIPTION
## Problem

When a step parameter of type `[]string` receives an array containing a `null` element (e.g. from a JSON-serialized config), the binary panics with a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference

github.com/SAP/jenkins-library/pkg/config.merge(...)
        pkg/config/config.go:542
```

The crash occurs because `reflect.TypeOf(nil)` returns `nil`, and calling `.String()` on it causes a segfault.

## Fix

Add a nil guard before calling `reflect.TypeOf()` on array elements in the `merge` function. Nil elements are skipped with a warning log instead of crashing.

```go
for _, interfaceValue := range value.([]interface{}) {
    if interfaceValue == nil {
        log.Entry().Warnf("config id %s contains a nil element, skipping", v.Name)
        continue
    }
    arrayValueType := reflect.TypeOf(interfaceValue).String()
    ...
}
```

## Testing

Added regression test `TestMerge_NilElementInStringArray` that passes `[]interface{}{nil, "valid-group"}` into `mixIn` and asserts no panic occurs.