### PR TITLE
fix(config): guard against nil pointer panic when array parameter contains null element

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -539,6 +539,10 @@ func merge(base, overlay map[string]interface{}, metadata StepData) map[string]i
 					if tVal == "[]interface {}" && v.Type == "[]string" {
 						// json Unmarshal genertes arrays of interface{} for string arrays
 						for _, interfaceValue := range value.([]interface{}) {
+							if interfaceValue == nil {
+								log.Entry().Warnf("config id %s contains a nil element, skipping", v.Name)
+								continue
+							}
 							arrayValueType := reflect.TypeOf(interfaceValue).String()
 							if arrayValueType != "string" {
 								log.Entry().Warnf("config id %s should only contain strings but contains a %s", v.Name, arrayValueType)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -806,6 +806,28 @@ func TestMerge(t *testing.T) {
 	}
 }
 
+func TestMerge_NilElementInStringArray(t *testing.T) {
+	// Regression test: nil element in a []interface{} parameter (e.g. groups: [null] passed from
+	// Groovy when scanObj.group is undefined) must not cause a nil pointer dereference panic.
+	stepData := StepData{
+		Spec: StepSpec{
+			Inputs: StepInputs{
+				Parameters: []StepParameters{
+					{Name: "groups", Type: "[]string"},
+				},
+			},
+		},
+	}
+	mergeData := map[string]interface{}{
+		"groups": []interface{}{nil, "valid-group"},
+	}
+	stepConfig := StepConfig{Config: map[string]interface{}{}}
+	assert.NotPanics(t, func() {
+		stepConfig.mixIn(mergeData, []string{}, stepData)
+	}, "mixIn must not panic on nil element in string array parameter")
+	assert.Equal(t, []interface{}{nil, "valid-group"}, stepConfig.Config["groups"])
+}
+
 func TestStepConfig_mixInHookConfig(t *testing.T) {
 	type fields struct {
 		Config     map[string]interface{}


### PR DESCRIPTION
## Problem

When a step parameter of type `[]string` receives an array containing a `null` element (e.g. from a JSON-serialized config), the binary panics with a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference

github.com/SAP/jenkins-library/pkg/config.merge(...)
        pkg/config/config.go:542
```

The crash occurs because `reflect.TypeOf(nil)` returns `nil`, and calling `.String()` on it causes a segfault.

## Fix

Add a nil guard before calling `reflect.TypeOf()` on array elements in the `merge` function. Nil elements are skipped with a warning log instead of crashing.

```go
for _, interfaceValue := range value.([]interface{}) {
    if interfaceValue == nil {
        log.Entry().Warnf("config id %s contains a nil element, skipping", v.Name)
        continue
    }
    arrayValueType := reflect.TypeOf(interfaceValue).String()
    ...
}
```

## Testing

Added regression test `TestMerge_NilElementInStringArray` that passes `[]interface{}{nil, "valid-group"}` into `mixIn` and asserts no panic occurs.