### PR TITLE
fix(stash): exclude node_modules from buildResult stash

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -380,7 +380,7 @@ steps:
       classFiles: '**/target/classes/**/*.class, **/target/test-classes/**/*.class'
       sonar: '**/jacoco*.exec, **/sonar-project.properties'
     stashExcludes:
-      buildResult: ''
+      buildResult: '**/node_modules/**, **/*.mockserver.js, **/*-preload.js, **/target/coverage/**'
       checkmarx: '**/*.mockserver.js, node_modules/**/*.js'
       checkmarxOne: '**/*.mockserver.js, node_modules/**/*.js'
       classFiles: ''


### PR DESCRIPTION
## Summary

- The `buildResult` stash includes `**/dist/**`, which matches `dist/` folders inside `node_modules` packages
- Projects with npm dependencies can have 40,000–100,000+ unneeded files stashed, costing several minutes per build
- Adds the same excludes class already used by `checkmarx`/`checkmarxOne` to `buildResult`

**Pattern added:**
```
**/node_modules/**, **/*.mockserver.js, **/*-preload.js, **/target/coverage/**
```

## Performance impact (measured on AdminUIService, build #9894)

| Source | Files |
|---|---|
| `webCore/node_modules/**/dist/**` | 20,089 |
| `webDevOps/node_modules/**/dist/**` | 21,194 |
| Total `buildResult` stash | 112,688 (2m 58s) |
| `pipelineStashFilesAfterBuild` total | 3m 44s |

Reference build log: `https://gkecpspipeline2.jaas-gcp.cloud.sap.corp/job/CPServices/job/AdminUIService/job/dev/9894/console`

## Test plan

- [ ] Verify `buildResult` stash no longer includes `node_modules/**/dist/**` files on a project with npm dependencies
- [ ] Confirm `.war`, `.jar`, `.mtar`, and project-owned `dist/` artifacts are still stashed correctly
- [ ] Check that projects without `node_modules` are unaffected