### PR TITLE
ft(CxOne) Add IaC support

### DIFF
--- a/cmd/checkmarxOneExecuteScan.go
+++ b/cmd/checkmarxOneExecuteScan.go
@@ -43,15 +43,17 @@ type checkmarxOneExecuteScanUtils interface {
 }
 
 type checkmarxOneExecuteScanHelper struct {
-	ctx     context.Context
-	config  checkmarxOneExecuteScanOptions
-	sys     checkmarxOne.System
-	influx  *checkmarxOneExecuteScanInflux
-	utils   checkmarxOneExecuteScanUtils
-	Project *checkmarxOne.Project
-	Group   *checkmarxOne.Group
-	App     *checkmarxOne.Application
-	reports []piperutils.Path
+	ctx      context.Context
+	config   checkmarxOneExecuteScanOptions
+	sys      checkmarxOne.System
+	influx   *checkmarxOneExecuteScanInflux
+	utils    checkmarxOneExecuteScanUtils
+	Project  *checkmarxOne.Project
+	Group    *checkmarxOne.Group
+	App      *checkmarxOne.Application
+	ScanSAST bool
+	ScanIAC  bool
+	reports  []piperutils.Path
 }
 
 type checkmarxOneExecuteScanUtilsBundle struct {
@@ -76,6 +78,18 @@ func checkmarxOneExecuteScan(config checkmarxOneExecuteScanOptions, _ *telemetry
 
 func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteScanInflux, cx1sh *checkmarxOneExecuteScanHelper) error {
 	err := error(nil)
+
+	// if this is an IaC scan, load the help links from json
+	if cx1sh.ScanIAC {
+		if config.IacHelpLinks == "" {
+			log.Entry().Infof("No iacHelpLinks parameter provided - will use the backend API. Please consider providing this parameter to reduce server load.")
+		} else {
+			if err = cx1sh.sys.LoadIACHelpLinks(config.IacHelpLinks); err != nil {
+				log.Entry().WithError(err).Errorf("failed to load IAC help links from %s, will use the backend API.", config.IacHelpLinks)
+			}
+		}
+	}
+
 	if len(cx1sh.config.ProjectID) == 0 {
 		cx1sh.Project, err = cx1sh.GetProjectByName()
 		if err != nil && err.Error() != "project not found" {
@@ -126,9 +140,9 @@ func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteS
 		}
 	}
 
-	err = cx1sh.SetProjectPreset()
+	err = cx1sh.SetProjectPresetsAndFilters()
 	if err != nil {
-		return fmt.Errorf("failed to set preset: %s", err)
+		return fmt.Errorf("failed to set configuration: %s", err)
 	}
 
 	// update project's tags
@@ -174,7 +188,7 @@ func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteS
 		return fmt.Errorf("failed to determine incremental or full scan configuration: %s", err)
 	}
 
-	if config.Incremental {
+	if config.Incremental && cx1sh.ScanSAST {
 		log.Entry().Info("If you change your file filter pattern it is recommended to run a Full scan instead of an incremental, to ensure full code coverage.")
 	}
 
@@ -227,7 +241,7 @@ func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteS
 
 	// TODO: how to provide other scan parameters like engineConfiguration?
 	// TODO: potential to persist file exclusions for git?
-	err = cx1sh.PollScanStatus(scan)
+	scan, err = cx1sh.PollScanStatus(scan)
 	if err != nil {
 		return fmt.Errorf("failed while polling scan status: %s", err)
 	}
@@ -248,7 +262,6 @@ func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteS
 
 func Authenticate(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteScanInflux) (checkmarxOneExecuteScanHelper, error) {
 	client := &piperHttp.Client{}
-
 	ctx, ghClient, err := piperGithub.NewClientBuilder(config.GithubToken, config.GithubAPIURL).Build()
 	if err != nil {
 		log.Entry().WithError(err).Warning("Failed to get GitHub client")
@@ -260,8 +273,22 @@ func Authenticate(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExe
 	influx.step_data.fields.checkmarxOne = false
 
 	utils := newcheckmarxOneExecuteScanUtilsBundle("./", ghClient)
+	sastScan := false
+	iacScan := false
+	for _, engine := range config.Engines {
+		if strings.EqualFold(engine, "sast") {
+			sastScan = true
+		}
+		if strings.EqualFold(engine, "iac") {
+			iacScan = true
+		}
+	}
 
-	return checkmarxOneExecuteScanHelper{ctx, config, sys, influx, utils, nil, nil, nil, []piperutils.Path{}}, nil
+	if !sastScan && !iacScan {
+		return checkmarxOneExecuteScanHelper{}, fmt.Errorf("at least one scan engine must be set in the engines configuration (sast iac)")
+	}
+
+	return checkmarxOneExecuteScanHelper{ctx, config, sys, influx, utils, nil, nil, nil, sastScan, iacScan, []piperutils.Path{}}, nil
 }
 
 func (c *checkmarxOneExecuteScanHelper) GetProjectByName() (*checkmarxOne.Project, error) {
@@ -321,7 +348,7 @@ func (c *checkmarxOneExecuteScanHelper) GetApplicationByID(applicationId string)
 }
 
 func (c *checkmarxOneExecuteScanHelper) CreateProject() (*checkmarxOne.Project, error) {
-	if len(c.config.Preset) == 0 {
+	if c.ScanSAST && len(c.config.SastPreset) == 0 {
 		return nil, fmt.Errorf("Preset is required to create a project")
 	}
 
@@ -346,19 +373,33 @@ func (c *checkmarxOneExecuteScanHelper) CreateProject() (*checkmarxOne.Project, 
 	log.Entry().Infof("Project %v created", project.ProjectID)
 
 	// new project, set the defaults per pipeline config
-	err = c.sys.SetProjectPreset(project.ProjectID, c.config.Preset, true)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to set preset for project %v to %v: %s", project.ProjectID, c.config.Preset, err)
-	}
-	log.Entry().Infof("Project preset updated to %v", c.config.Preset)
-
-	if len(c.config.LanguageMode) != 0 {
-		err = c.sys.SetProjectLanguageMode(project.ProjectID, c.config.LanguageMode, true)
+	if c.ScanSAST {
+		err = c.sys.SetProjectSASTPreset(project.ProjectID, c.config.SastPreset, true)
 		if err != nil {
-
-			return nil, fmt.Errorf("Unable to set languageMode for project %v to %v: %s", project.ProjectID, c.config.LanguageMode, err)
+			return nil, fmt.Errorf("Unable to set SAST preset for project %v to %v: %s", project.ProjectID, c.config.SastPreset, err)
 		}
-		log.Entry().Infof("Project languageMode updated to %v", c.config.LanguageMode)
+		log.Entry().Infof("Project SAST preset updated to %v", c.config.SastPreset)
+
+		// TODO: set sast defaults even for non-sast scan?
+		if len(c.config.LanguageMode) != 0 {
+			err = c.sys.SetProjectLanguageMode(project.ProjectID, c.config.LanguageMode, true)
+			if err != nil {
+
+				return nil, fmt.Errorf("Unable to set SAST languageMode for project %v to %v: %s", project.ProjectID, c.config.LanguageMode, err)
+			}
+			log.Entry().Infof("Project languageMode updated to %v", c.config.LanguageMode)
+		}
+	}
+
+	if c.ScanIAC {
+		if c.config.IacPreset != "" {
+			err = c.sys.SetProjectIACPreset(project.ProjectID, c.config.IacPreset, true)
+
+			if err != nil {
+				return nil, fmt.Errorf("Unable to set IAC preset for project %v to %v: %s", project.ProjectID, c.config.IacPreset, err)
+			}
+			log.Entry().Infof("Project IAC preset updated to %v", c.config.IacPreset)
+		}
 	}
 
 	return &project, nil
@@ -381,59 +422,122 @@ func (c *checkmarxOneExecuteScanHelper) UpdateProjectTags() error {
 	return nil
 }
 
-func (c *checkmarxOneExecuteScanHelper) SetProjectPreset() error {
+func (c *checkmarxOneExecuteScanHelper) SetProjectPresetsAndFilters() error {
 	projectConf, err := c.sys.GetProjectConfiguration(c.Project.ProjectID)
 
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve current project configuration: %s", err)
+		return fmt.Errorf("failed to retrieve current project configuration: %s", err)
 	}
 
-	currentPreset := ""
+	currentSASTPreset := ""
+	currentSASTFilter := ""
+	currentIACPreset := ""
+	currentIACFilter := ""
 	currentLanguageMode := "multi" // piper default
 	for _, conf := range projectConf {
-		if conf.Key == "scan.config.sast.presetName" {
-			currentPreset = conf.Value
-		}
-		if conf.Key == "scan.config.sast.languageMode" {
+		switch conf.Key {
+		case checkmarxOne.ConfigurationKeys.SAST.PresetName:
+			currentSASTPreset = conf.Value
+		case checkmarxOne.ConfigurationKeys.SAST.LanguageMode:
 			currentLanguageMode = conf.Value
+		case checkmarxOne.ConfigurationKeys.SAST.FileFilter:
+			currentSASTFilter = conf.Value
+		case checkmarxOne.ConfigurationKeys.IAC.FileFilter:
+			currentIACFilter = conf.Value
+		case checkmarxOne.ConfigurationKeys.IAC.PresetID:
+			iacPresetName, err := c.sys.GetIACPresetNameByID(conf.Value)
+			if err != nil {
+				return err
+			}
+			currentIACPreset = iacPresetName
 		}
+
 	}
 
-	if c.config.LanguageMode == "" || strings.EqualFold(c.config.LanguageMode, "multi") { // default multi if blank
-		if currentLanguageMode != "multi" {
-			log.Entry().Info("Pipeline yaml requests multi-language scan - updating project configuration")
-			c.sys.SetProjectLanguageMode(c.Project.ProjectID, "multi", true)
+	if c.ScanSAST {
+		if c.config.LanguageMode == "" || strings.EqualFold(c.config.LanguageMode, "multi") { // default multi if blank
+			if currentLanguageMode != "multi" {
+				log.Entry().Info("Pipeline yaml requests multi-language scan - updating project configuration")
+				c.sys.SetProjectLanguageMode(c.Project.ProjectID, "multi", true)
+
+				if c.config.Incremental {
+					log.Entry().Warn("Pipeline yaml requests incremental scan, but switching from 'primary' to 'multi' language mode requires a full scan - switching from incremental to full")
+					c.config.Incremental = false
+				}
+			}
+		} else { // primary language mode
+			if currentLanguageMode != "primary" {
+				log.Entry().Info("Pipeline yaml requests primary-language scan - updating project configuration")
+				c.sys.SetProjectLanguageMode(c.Project.ProjectID, "primary", true)
+				// no need to switch incremental to full here (multi-language scan includes single-language scan coverage)
+			}
+		}
+
+		if c.config.SastPreset == "" {
+			if currentSASTPreset == "" {
+				return fmt.Errorf("must specify the SAST preset in either the pipeline yaml or in the CheckmarxOne project configuration")
+			} else {
+				log.Entry().Infof("Pipeline yaml does not specify a SAST preset, will use project configuration (%v).", currentSASTPreset)
+			}
+			c.config.SastPreset = currentSASTPreset
+		} else if currentSASTPreset != c.config.SastPreset {
+			log.Entry().Infof("Project configured SAST preset (%v) does not match pipeline yaml (%v) - updating project configuration.", currentSASTPreset, c.config.SastPreset)
+			c.sys.SetProjectSASTPreset(c.Project.ProjectID, c.config.SastPreset, true)
 
 			if c.config.Incremental {
-				log.Entry().Warn("Pipeline yaml requests incremental scan, but switching from 'primary' to 'multi' language mode requires a full scan - switching from incremental to full")
+				log.Entry().Warn("Changing project settings requires a full scan to take effect - switching from incremental to full")
 				c.config.Incremental = false
 			}
 		}
-	} else { // primary language mode
-		if currentLanguageMode != "primary" {
-			log.Entry().Info("Pipeline yaml requests primary-language scan - updating project configuration")
-			c.sys.SetProjectLanguageMode(c.Project.ProjectID, "primary", true)
-			// no need to switch incremental to full here (multi-language scan includes single-language scan coverage)
+
+		filterStr := currentSASTFilter
+		if filterStr == "" {
+			filterStr = "no filter"
+		}
+
+		if c.config.SastFilterPattern == "" {
+			log.Entry().Infof("Pipeline yaml does not specify a SAST file filter, will use project configuration (%v).", filterStr)
+			c.config.SastFilterPattern = currentSASTFilter
+		} else if currentSASTFilter != c.config.SastFilterPattern {
+			log.Entry().Infof("Project configured SAST file filter (%v) does not match pipeline yaml (%v) - updating project configuration.", currentSASTFilter, c.config.SastFilterPattern)
+			c.sys.SetProjectSASTFileFilter(c.Project.ProjectID, c.config.SastFilterPattern, true)
+
+			if c.config.Incremental {
+				log.Entry().Warn("Changing project settings requires a full scan to take effect - switching from incremental to full")
+				c.config.Incremental = false
+			}
 		}
 	}
 
-	if c.config.Preset == "" {
-		if currentPreset == "" {
-			return fmt.Errorf("must specify the preset in either the pipeline yaml or in the CheckmarxOne project configuration")
-		} else {
-			log.Entry().Infof("Pipeline yaml does not specify a preset, will use project configuration (%v).", currentPreset)
+	if c.ScanIAC {
+		presetStr := currentIACPreset
+		if presetStr == "" {
+			presetStr = "all checks"
 		}
-		c.config.Preset = currentPreset
-	} else if currentPreset != c.config.Preset {
-		log.Entry().Infof("Project configured preset (%v) does not match pipeline yaml (%v) - updating project configuration.", currentPreset, c.config.Preset)
-		c.sys.SetProjectPreset(c.Project.ProjectID, c.config.Preset, true)
+		if c.config.IacPreset == "" {
+			if currentIACPreset == "" {
+				//return fmt.Errorf("must specify the IAC preset in either the pipeline yaml or in the CheckmarxOne project configuration")
+				log.Entry().Infof("No IAC preset is set - using default (%s)", checkmarxOne.IACDefaultBlankPreset)
+			} else {
+				log.Entry().Infof("Pipeline yaml does not specify a IAC preset, will use project configuration (%v).", presetStr)
+			}
+			c.config.IacPreset = currentIACPreset
+		} else if currentIACPreset != c.config.IacPreset {
+			log.Entry().Infof("Project configured IAC preset (%v) does not match pipeline yaml (%v) - updating project configuration.", currentIACPreset, c.config.IacPreset)
+			c.sys.SetProjectIACPreset(c.Project.ProjectID, c.config.IacPreset, true)
+		}
 
-		if c.config.Incremental {
-			log.Entry().Warn("Changing project settings requires a full scan to take effect - switching from incremental to full")
-			c.config.Incremental = false
+		filterStr := currentIACFilter
+		if filterStr == "" {
+			filterStr = "no filter"
 		}
-	} else {
-		log.Entry().Infof("Project is already configured to use pipeline preset %v", currentPreset)
+		if c.config.IacFilterPattern == "" {
+			log.Entry().Infof("Pipeline yaml does not specify a IAC file filter, will use project configuration (%v).", filterStr)
+			c.config.IacFilterPattern = currentIACFilter
+		} else if currentIACFilter != c.config.IacFilterPattern {
+			log.Entry().Infof("Project configured IAC file filter (%v) does not match pipeline yaml (%v) - updating project configuration.", currentIACFilter, c.config.IacFilterPattern)
+			c.sys.SetProjectIACFileFilter(c.Project.ProjectID, c.config.IacFilterPattern, true)
+		}
 	}
 	return nil
 }
@@ -464,7 +568,7 @@ func (c *checkmarxOneExecuteScanHelper) IncrementalOrFull(scans []checkmarxOne.S
 		scanIds = append(scanIds, scan.ScanID)
 	}
 
-	scanMetadatas, err := c.sys.GetScanMetadatas(scanIds)
+	scanMetadatas, err := c.sys.GetScanSASTMetadatas(scanIds)
 	if err != nil {
 		return false, false, 0, fmt.Errorf("failed to fetch metadata for scans: %w", err)
 	}
@@ -488,7 +592,12 @@ func (c *checkmarxOneExecuteScanHelper) IncrementalOrFull(scans []checkmarxOne.S
 	return incremental, fullScanExists, contiguousIncrementalScans, nil
 }
 
+const defaultZipFilterPattern = `!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go, **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts`
+
 func (c *checkmarxOneExecuteScanHelper) ZipFiles() (*os.File, error) {
+	if c.ScanIAC && c.config.FilterPattern == defaultZipFilterPattern {
+		log.Entry().Warn("Zip file filter pattern is SAST-specific, but IaC scan is enabled. Verify that the IaC files are included in the filterPattern, otherwise no files will be scanned.")
+	}
 	zipFile, err := c.zipWorkspaceFiles(c.config.FilterPattern, c.utils)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to zip workspace files")
@@ -541,31 +650,67 @@ func (c *checkmarxOneExecuteScanHelper) GetScanBranch() (string, bool, string) {
 }
 
 func (c *checkmarxOneExecuteScanHelper) CreateScanRequest(incremental bool, uploadLink string, baseBranch string) (*checkmarxOne.Scan, error) {
-	sastConfigString := ""
-	sastConfig := checkmarxOne.ScanConfiguration{}
-	sastConfig.ScanType = "sast"
-
-	sastConfig.Values = make(map[string]string, 0)
-	sastConfig.Values["incremental"] = strconv.FormatBool(incremental)
-	sastConfig.Values["presetName"] = c.config.Preset // always set, either coming from config or coming from Cx1 configuration
-	if incremental && len(baseBranch) > 0 {           // base the incremental scan on the specified base branch
-		sastConfig.Values["baseBranch"] = baseBranch
-		sastConfigString = fmt.Sprintf("baseBranch: %v, ", baseBranch)
-	}
-	sastConfigString = fmt.Sprintf("%vincremental %v, preset %v", sastConfigString, strconv.FormatBool(incremental), c.config.Preset)
-
-	if len(c.config.LanguageMode) > 0 {
-		sastConfig.Values["languageMode"] = c.config.LanguageMode
-		sastConfigString = sastConfigString + fmt.Sprintf(", languageMode %v", c.config.LanguageMode)
-	}
+	configs := []checkmarxOne.ScanConfiguration{}
 
 	branch, _, _ := c.GetScanBranch()
+	generalConfigString := fmt.Sprintf("Cx1 Branch name %v", branch)
+	configStrings := []string{generalConfigString}
 
-	sastConfigString = fmt.Sprintf("Cx1 Branch name %v, ", branch) + sastConfigString
+	if c.ScanSAST {
+		sastConfigString := "SAST: "
+		sastConfig := checkmarxOne.ScanConfiguration{}
+		sastConfig.ScanType = "sast"
 
-	log.Entry().Infof("Will run a scan with the following configuration: %v", sastConfigString)
+		sastConfig.Values = make(map[string]string, 0)
+		sastConfig.Values["incremental"] = strconv.FormatBool(incremental)
+		sastConfig.Values["presetName"] = c.config.SastPreset // always set, either coming from config or coming from Cx1 configuration
+		if incremental && len(baseBranch) > 0 {               // base the incremental scan on the specified base branch
+			sastConfig.Values["baseBranch"] = baseBranch
+			sastConfigString = fmt.Sprintf("baseBranch: %v, ", baseBranch)
+		}
+		sastConfigString = fmt.Sprintf("%vincremental %v, preset %v", sastConfigString, strconv.FormatBool(incremental), c.config.SastPreset)
 
-	configs := []checkmarxOne.ScanConfiguration{sastConfig}
+		if len(c.config.LanguageMode) > 0 {
+			sastConfig.Values["languageMode"] = c.config.LanguageMode
+			sastConfigString = sastConfigString + fmt.Sprintf(", languageMode %v", c.config.LanguageMode)
+		}
+
+		if c.config.SastFilterPattern != "" {
+			sastConfigString += fmt.Sprintf(", file filter <%s>", c.config.SastFilterPattern)
+		} else {
+			sastConfigString += ", no files filtered"
+		}
+
+		configs = append(configs, sastConfig)
+		configStrings = append(configStrings, sastConfigString)
+	}
+
+	if c.ScanIAC {
+		iacConfigString := "IAC: "
+		iacConfig := checkmarxOne.ScanConfiguration{}
+		iacConfig.ScanType = "kics"
+
+		iacConfig.Values = make(map[string]string, 0)
+		presetId, err := c.sys.GetIACPresetIDByName(c.config.IacPreset)
+		if err != nil {
+			return nil, err
+		}
+		if presetId != "" {
+			iacConfig.Values["presetId"] = presetId
+		}
+		iacConfigString += fmt.Sprintf("preset %s", c.config.IacPreset)
+
+		if c.config.IacFilterPattern != "" {
+			iacConfigString += fmt.Sprintf(", file filter <%s>", c.config.IacFilterPattern)
+		} else {
+			iacConfigString += ", no files filtered"
+		}
+
+		configs = append(configs, iacConfig)
+		configStrings = append(configStrings, iacConfigString)
+	}
+
+	log.Entry().Infof("Will run a scan with the following configuration: %s", strings.Join(configStrings, "; "))
 
 	// add scan's tags
 	tags := make(map[string]string, 0)
@@ -588,22 +733,24 @@ func (c *checkmarxOneExecuteScanHelper) CreateScanRequest(incremental bool, uplo
 	return &scan, nil
 }
 
-func (c *checkmarxOneExecuteScanHelper) PollScanStatus(scan *checkmarxOne.Scan) error {
+func (c *checkmarxOneExecuteScanHelper) PollScanStatus(scan *checkmarxOne.Scan) (*checkmarxOne.Scan, error) {
 	statusDetails := "Scan phase: New"
 	pastStatusDetails := statusDetails
 	log.Entry().Info(statusDetails)
 	status := "New"
+	var scan_refresh checkmarxOne.Scan
+	var err error
 	for {
-		scan_refresh, err := c.sys.GetScan(scan.ScanID)
+		scan_refresh, err = c.sys.GetScan(scan.ScanID)
 
 		if err != nil {
-			return fmt.Errorf("Error while polling scan %v: %s", scan.ScanID, err)
+			return nil, fmt.Errorf("Error while polling scan %v: %s", scan.ScanID, err)
 		}
 
 		status = scan_refresh.Status
 		workflow, err := c.sys.GetScanWorkflow(scan.ScanID)
 		if err != nil {
-			return fmt.Errorf("Error while getting workflow for scan %v: %s", scan.ScanID, err)
+			return nil, fmt.Errorf("Error while getting workflow for scan %v: %s", scan.ScanID, err)
 		}
 
 		statusDetails = workflow[len(workflow)-1].Info
@@ -628,12 +775,12 @@ func (c *checkmarxOneExecuteScanHelper) PollScanStatus(scan *checkmarxOne.Scan) 
 	}
 	if status == "Canceled" {
 		log.SetErrorCategory(log.ErrorCustom)
-		return fmt.Errorf("Scan %v canceled via web interface", scan.ScanID)
+		return nil, fmt.Errorf("Scan %v canceled via web interface", scan.ScanID)
 	}
 	if status == "Failed" {
-		return fmt.Errorf("Checkmarx One scan failed with the following error: %v", statusDetails)
+		return nil, fmt.Errorf("Checkmarx One scan failed with the following error: %v", statusDetails)
 	}
-	return nil
+	return &scan_refresh, nil
 }
 
 func (c *checkmarxOneExecuteScanHelper) PostScanSummaryInPullRequest(detailedResults *map[string]interface{}, insecure bool) error {
@@ -844,10 +991,13 @@ func (c *checkmarxOneExecuteScanHelper) CheckCompliance(scan *checkmarxOne.Scan,
 	return nil
 }
 
-func (c *checkmarxOneExecuteScanHelper) GetReportPDF(scan *checkmarxOne.Scan) error {
+func (c *checkmarxOneExecuteScanHelper) GetReportPDF(scan *checkmarxOne.Scan, engines []string) error {
+	if len(engines) == 0 {
+		return fmt.Errorf("cannot generate a report for 0 engines")
+	}
 	if c.config.GeneratePdfReport {
-		pdfReportName := c.createReportName(c.utils.GetWorkspace(), "Cx1_SASTReport_%v.pdf")
-		err := c.downloadAndSaveReport(pdfReportName, scan, "pdf")
+		pdfReportName := c.createReportName(c.utils.GetWorkspace(), "Cx1_"+strings.ToUpper(engines[0])+"Report_%v.pdf")
+		err := c.downloadAndSaveReport(pdfReportName, scan, "pdf", engines)
 		if err != nil {
 			return fmt.Errorf("Report download failed: %s", err)
 		} else {
@@ -860,25 +1010,48 @@ func (c *checkmarxOneExecuteScanHelper) GetReportPDF(scan *checkmarxOne.Scan) er
 	return nil
 }
 
-func (c *checkmarxOneExecuteScanHelper) GetReportSARIF(scan *checkmarxOne.Scan, scanmeta *checkmarxOne.ScanMetadata, results *[]checkmarxOne.ScanResult) error {
+func (c *checkmarxOneExecuteScanHelper) GetReportSASTSARIF(scan *checkmarxOne.Scan, scanmeta *checkmarxOne.ScanMetadata, results *[]checkmarxOne.ScanResult) error {
 	if c.config.ConvertToSarif {
-		log.Entry().Info("Calling conversion to SARIF function.")
-		sarif, err := checkmarxOne.ConvertCxJSONToSarif(c.sys, c.config.ServerURL, results, scanmeta, scan)
-		if err != nil {
-			return fmt.Errorf("Failed to generate SARIF: %s", err)
+		if scanmeta.SAST != nil {
+			log.Entry().Info("Calling SAST JSON conversion to SARIF function.")
+			sarif, err := checkmarxOne.ConvertCxSASTJSONToSarif(c.sys, c.config.ServerURL, results, scan)
+			if err != nil {
+				return fmt.Errorf("Failed to generate SARIF: %s", err)
+			}
+			paths, err := checkmarxOne.WriteSASTSarif(sarif)
+			if err != nil {
+				return fmt.Errorf("Failed to write SARIF: %s", err)
+			}
+			c.reports = append(c.reports, paths...)
 		}
-		paths, err := checkmarxOne.WriteSarif(sarif)
-		if err != nil {
-			return fmt.Errorf("Failed to write SARIF: %s", err)
-		}
-		c.reports = append(c.reports, paths...)
 	}
 	return nil
 }
 
-func (c *checkmarxOneExecuteScanHelper) GetReportJSON(scan *checkmarxOne.Scan) error {
-	jsonReportName := c.createReportName(c.utils.GetWorkspace(), "Cx1_SASTReport_%v.json")
-	err := c.downloadAndSaveReport(jsonReportName, scan, "json")
+func (c *checkmarxOneExecuteScanHelper) GetReportIACSARIF(scan *checkmarxOne.Scan, scanmeta *checkmarxOne.ScanMetadata, results *[]checkmarxOne.ScanResult) error {
+	if c.config.ConvertToSarif {
+		if scanmeta.IAC != nil {
+			log.Entry().Info("Calling IAC JSON conversion to SARIF function.")
+			sarif, err := checkmarxOne.ConvertCxIACJSONToSarif(c.sys, c.config.ServerURL, results, scan)
+			if err != nil {
+				return fmt.Errorf("Failed to generate SARIF: %s", err)
+			}
+			paths, err := checkmarxOne.WriteIACSarif(sarif)
+			if err != nil {
+				return fmt.Errorf("Failed to write SARIF: %s", err)
+			}
+			c.reports = append(c.reports, paths...)
+		}
+	}
+	return nil
+}
+
+func (c *checkmarxOneExecuteScanHelper) GetReportJSON(scan *checkmarxOne.Scan, engines []string) error {
+	if len(engines) == 0 {
+		return fmt.Errorf("cannot generate a report for 0 engines")
+	}
+	jsonReportName := c.createReportName(c.utils.GetWorkspace(), "Cx1_"+strings.ToUpper(engines[0])+"Report_%v.json")
+	err := c.downloadAndSaveReport(jsonReportName, scan, "json", engines)
 	if err != nil {
 		return fmt.Errorf("Report download failed: %s", err)
 	} else {
@@ -903,7 +1076,7 @@ func (c *checkmarxOneExecuteScanHelper) GetHeaderReportJSON(detailedResults *map
 func (c *checkmarxOneExecuteScanHelper) ParseResults(scan *checkmarxOne.Scan) (map[string]interface{}, error) {
 	var detailedResults map[string]interface{}
 
-	scanmeta, err := c.sys.GetScanMetadata(scan.ScanID)
+	scanmeta, err := c.sys.GetScanMetadata(scan)
 	if err != nil {
 		return detailedResults, fmt.Errorf("Unable to fetch scan metadata for scan %v: %s", scan.ScanID, err)
 	}
@@ -928,18 +1101,36 @@ func (c *checkmarxOneExecuteScanHelper) ParseResults(scan *checkmarxOne.Scan) (m
 		return detailedResults, fmt.Errorf("Unable to fetch detailed results for scan %v: %s", scan.ScanID, err)
 	}
 
-	err = c.GetReportJSON(scan)
-	if err != nil {
-		log.Entry().WithError(err).Warnf("Failed to get JSON report")
+	if c.ScanSAST {
+		err = c.GetReportJSON(scan, []string{"sast"})
+		if err != nil {
+			log.Entry().WithError(err).Warnf("Failed to get JSON SAST report")
+		}
+		err = c.GetReportPDF(scan, []string{"sast"})
+		if err != nil {
+			log.Entry().WithError(err).Warnf("Failed to get PDF SAST report")
+		}
+		err = c.GetReportSASTSARIF(scan, &scanmeta, &results)
+		if err != nil {
+			log.Entry().WithError(err).Warnf("Failed to get SARIF SAST report")
+		}
 	}
-	err = c.GetReportPDF(scan)
-	if err != nil {
-		log.Entry().WithError(err).Warnf("Failed to get PDF report")
+
+	if c.ScanIAC {
+		err = c.GetReportJSON(scan, []string{"iac"})
+		if err != nil {
+			log.Entry().WithError(err).Warnf("Failed to get JSON IAC report")
+		}
+		err = c.GetReportPDF(scan, []string{"iac"})
+		if err != nil {
+			log.Entry().WithError(err).Warnf("Failed to get PDF IAC report")
+		}
+		err = c.GetReportIACSARIF(scan, &scanmeta, &results)
+		if err != nil {
+			log.Entry().WithError(err).Warnf("Failed to get SARIF IAC report")
+		}
 	}
-	err = c.GetReportSARIF(scan, &scanmeta, &results)
-	if err != nil {
-		log.Entry().WithError(err).Warnf("Failed to get SARIF report")
-	}
+
 	err = c.GetHeaderReportJSON(&detailedResults)
 	if err != nil {
 		log.Entry().WithError(err).Warnf("Failed to generate JSON Header report")
@@ -963,8 +1154,8 @@ func (c *checkmarxOneExecuteScanHelper) createReportName(workspace, reportFileNa
 	return filepath.Join(workspace, fmt.Sprintf(reportFileNameTemplate, regExpFileName.ReplaceAllString(string(timeStamp), "_")))
 }
 
-func (c *checkmarxOneExecuteScanHelper) downloadAndSaveReport(reportFileName string, scan *checkmarxOne.Scan, reportType string) error {
-	report, err := c.generateAndDownloadReport(scan, reportType)
+func (c *checkmarxOneExecuteScanHelper) downloadAndSaveReport(reportFileName string, scan *checkmarxOne.Scan, reportType string, engines []string) error {
+	report, err := c.generateAndDownloadReport(scan, reportType, engines)
 	if err != nil {
 		return fmt.Errorf("failed to download the report: %w", err)
 	}
@@ -972,10 +1163,10 @@ func (c *checkmarxOneExecuteScanHelper) downloadAndSaveReport(reportFileName str
 	return c.utils.WriteFile(reportFileName, report, 0o700)
 }
 
-func (c *checkmarxOneExecuteScanHelper) generateAndDownloadReport(scan *checkmarxOne.Scan, reportType string) ([]byte, error) {
+func (c *checkmarxOneExecuteScanHelper) generateAndDownloadReport(scan *checkmarxOne.Scan, reportType string, engines []string) ([]byte, error) {
 	var finalStatus checkmarxOne.ReportStatus
 
-	report, err := c.sys.RequestNewReport(scan.ScanID, scan.ProjectID, scan.Branch, reportType)
+	report, err := c.sys.RequestNewReport(scan.ScanID, scan.ProjectID, scan.Branch, reportType, engines)
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to request new report: %w", err)
 	}
@@ -1049,9 +1240,6 @@ func (c *checkmarxOneExecuteScanHelper) getDetailedResults(scan *checkmarxOne.Sc
 		}
 	}
 
-	resultMap["LinesOfCodeScanned"] = scanmeta.LOC
-	resultMap["FilesScanned"] = scanmeta.FileCount
-
 	version, err := c.sys.GetVersion()
 	if err != nil {
 		resultMap["ToolVersion"] = "Error fetching current version"
@@ -1059,13 +1247,33 @@ func (c *checkmarxOneExecuteScanHelper) getDetailedResults(scan *checkmarxOne.Sc
 		resultMap["ToolVersion"] = fmt.Sprintf("CxOne: %v, SAST: %v, KICS: %v", version.CxOne, version.SAST, version.KICS)
 	}
 
-	if scanmeta.IsIncremental {
-		resultMap["ScanType"] = "Incremental"
+	if scanmeta.SAST != nil {
+		resultMap["SastPreset"] = scanmeta.SAST.PresetName
+		if !scanmeta.SAST.IsIncremental {
+			resultMap["ScanType"] = "Full"
+		} else {
+			resultMap["ScanType"] = "Incremental"
+		}
+
+		resultMap["LinesOfCodeScanned"] = scanmeta.SAST.LOC
+		resultMap["FilesScanned"] = scanmeta.SAST.FileCount
 	} else {
 		resultMap["ScanType"] = "Full"
+		resultMap["SastPreset"] = "n/a"
+
+		resultMap["LinesOfCodeScanned"] = 0
+		resultMap["FilesScanned"] = 0
 	}
 
-	resultMap["Preset"] = scanmeta.PresetName
+	if scanmeta.IAC != nil {
+		resultMap["IacPreset"] = scanmeta.IAC.PresetName
+		resultMap["IacLinesOfCodeScanned"] = scanmeta.IAC.IACLOC
+		resultMap["IacFilesScanned"] = scanmeta.IAC.FileCount
+	} else {
+		resultMap["IacPreset"] = "n/a"
+		resultMap["IacLinesOfCodeScanned"] = 0
+		resultMap["IacFilesScanned"] = 0
+	}
 	resultMap["DeepLink"] = fmt.Sprintf("%v/projects/%v/overview?branch=%v", c.config.ServerURL, c.Project.ProjectID, url.QueryEscape(scan.Branch))
 	resultMap["ReportCreationTime"] = time.Now().String()
 	resultMap["Critical"] = map[string]int{}
@@ -1177,14 +1385,14 @@ func (c *checkmarxOneExecuteScanHelper) zipWorkspaceFiles(filterPattern string, 
 	}
 	defer zipFile.Close()
 
-	err = c.zipFolder(utils.GetWorkspace(), zipFile, patterns, utils)
+	err = c.zipFolder(utils.GetWorkspace(), zipFile, patterns, zipFileName, utils)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compact folder: %w", err)
 	}
 	return zipFile, nil
 }
 
-func (c *checkmarxOneExecuteScanHelper) zipFolder(source string, zipFile io.Writer, patterns []string, utils checkmarxOneExecuteScanUtils) error {
+func (c *checkmarxOneExecuteScanHelper) zipFolder(source string, zipFile io.Writer, patterns []string, zipFileName string, utils checkmarxOneExecuteScanUtils) error {
 	archive := zip.NewWriter(zipFile)
 	defer archive.Close()
 
@@ -1200,6 +1408,13 @@ func (c *checkmarxOneExecuteScanHelper) zipFolder(source string, zipFile io.Writ
 		baseDir = filepath.Base(source)
 	}
 
+	// resolve the output archive's absolute path so it can be skipped during the walk,
+	// otherwise the archive would recursively include itself and inflate indefinitely
+	absZipFileName, absZipErr := filepath.Abs(zipFileName)
+	if absZipErr != nil {
+		absZipFileName = filepath.Clean(zipFileName)
+	}
+
 	fileCount := 0
 	err = filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -1207,6 +1422,15 @@ func (c *checkmarxOneExecuteScanHelper) zipFolder(source string, zipFile io.Writ
 		}
 
 		if !info.Mode().IsRegular() || info.Size() == 0 {
+			return nil
+		}
+
+		// skip the output archive itself to avoid recursively zipping it into itself
+		absPath, absErr := filepath.Abs(path)
+		if absErr != nil {
+			absPath = filepath.Clean(path)
+		}
+		if absPath == absZipFileName {
 			return nil
 		}
 
@@ -1550,7 +1774,8 @@ func (c *checkmarxOneExecuteScanHelper) reportToInflux(results *map[string]inter
 	c.influx.checkmarxOne_data.fields.tool_version = (*results)["ToolVersion"].(string)
 
 	c.influx.checkmarxOne_data.fields.scan_type = (*results)["ScanType"].(string)
-	c.influx.checkmarxOne_data.fields.preset = (*results)["Preset"].(string)
+	c.influx.checkmarxOne_data.fields.preset = (*results)["SastPreset"].(string)
+	c.influx.checkmarxOne_data.fields.iac_preset = (*results)["IacPreset"].(string)
 	c.influx.checkmarxOne_data.fields.deep_link = (*results)["DeepLink"].(string)
 	c.influx.checkmarxOne_data.fields.report_creation_time = (*results)["ReportCreationTime"].(string)
 }

--- a/cmd/checkmarxOneExecuteScan_generated.go
+++ b/cmd/checkmarxOneExecuteScan_generated.go
@@ -25,23 +25,28 @@ import (
 type checkmarxOneExecuteScanOptions struct {
 	Assignees                            []string `json:"assignees,omitempty"`
 	AvoidDuplicateProjectScans           bool     `json:"avoidDuplicateProjectScans,omitempty"`
+	Engines                              []string `json:"engines,omitempty"`
 	FilterPattern                        string   `json:"filterPattern,omitempty"`
 	FullScanCycle                        string   `json:"fullScanCycle,omitempty"`
 	FullScansScheduled                   bool     `json:"fullScansScheduled,omitempty"`
 	GeneratePdfReport                    bool     `json:"generatePdfReport,omitempty"`
 	GithubAPIURL                         string   `json:"githubApiUrl,omitempty"`
 	GithubToken                          string   `json:"githubToken,omitempty"`
+	IacHelpLinks                         string   `json:"iacHelpLinks,omitempty"`
+	IacFilterPattern                     string   `json:"iacFilterPattern,omitempty"`
+	IacPreset                            string   `json:"iacPreset,omitempty"`
 	ScanSummaryInPullRequest             bool     `json:"scanSummaryInPullRequest,omitempty"`
 	Incremental                          bool     `json:"incremental,omitempty"`
 	Owner                                string   `json:"owner,omitempty"`
 	GitBranch                            string   `json:"gitBranch,omitempty"`
 	ClientSecret                         string   `json:"clientSecret,omitempty"`
 	APIKey                               string   `json:"APIKey,omitempty"`
-	Preset                               string   `json:"preset,omitempty"`
 	LanguageMode                         string   `json:"languageMode,omitempty"`
 	ProjectCriticality                   string   `json:"projectCriticality,omitempty"`
 	ProjectName                          string   `json:"projectName,omitempty"`
 	ProjectTags                          string   `json:"projectTags,omitempty"`
+	SastFilterPattern                    string   `json:"sastFilterPattern,omitempty"`
+	SastPreset                           string   `json:"sastPreset,omitempty"`
 	ScanTags                             string   `json:"scanTags,omitempty"`
 	Branch                               string   `json:"branch,omitempty"`
 	PullRequestName                      string   `json:"pullRequestName,omitempty"`
@@ -129,6 +134,7 @@ type checkmarxOneExecuteScanInflux struct {
 			tool_version                         string
 			scan_type                            string
 			preset                               string
+			iac_preset                           string
 			deep_link                            string
 			report_creation_time                 string
 		}
@@ -194,6 +200,7 @@ func (i *checkmarxOneExecuteScanInflux) persist(path, resourceName string) {
 		{valType: config.InfluxField, measurement: "checkmarxOne_data", name: "tool_version", value: i.checkmarxOne_data.fields.tool_version},
 		{valType: config.InfluxField, measurement: "checkmarxOne_data", name: "scan_type", value: i.checkmarxOne_data.fields.scan_type},
 		{valType: config.InfluxField, measurement: "checkmarxOne_data", name: "preset", value: i.checkmarxOne_data.fields.preset},
+		{valType: config.InfluxField, measurement: "checkmarxOne_data", name: "iac_preset", value: i.checkmarxOne_data.fields.iac_preset},
 		{valType: config.InfluxField, measurement: "checkmarxOne_data", name: "deep_link", value: i.checkmarxOne_data.fields.deep_link},
 		{valType: config.InfluxField, measurement: "checkmarxOne_data", name: "report_creation_time", value: i.checkmarxOne_data.fields.report_creation_time},
 	}
@@ -403,23 +410,28 @@ thresholds instead of ` + "`" + `percentage` + "`" + ` whereas we strongly recom
 func addCheckmarxOneExecuteScanFlags(cmd *cobra.Command, stepConfig *checkmarxOneExecuteScanOptions) {
 	cmd.Flags().StringSliceVar(&stepConfig.Assignees, "assignees", []string{``}, "Defines the assignees for the Github Issue created/updated with the results of the scan as a list of login names. [Not yet supported]")
 	cmd.Flags().BoolVar(&stepConfig.AvoidDuplicateProjectScans, "avoidDuplicateProjectScans", true, "Whether duplicate scans of the same project state shall be avoided or not  [Not yet supported]")
-	cmd.Flags().StringVar(&stepConfig.FilterPattern, "filterPattern", `!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go, **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts`, "The filter pattern used to zip the files relevant for scanning, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory")
+	cmd.Flags().StringSliceVar(&stepConfig.Engines, "engines", []string{`sast`}, "The scan engines to trigger for this scan. Can be: sast, iac")
+	cmd.Flags().StringVar(&stepConfig.FilterPattern, "filterPattern", `!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go, **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts`, "The filter pattern used to zip the files relevant for scanning, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory. For multiple-engine scans, this filter should include all files applicable to all engines - per-engine filters should be set separately through sastFileFilter and iacFileFilter.")
 	cmd.Flags().StringVar(&stepConfig.FullScanCycle, "fullScanCycle", `5`, "Indicates how often a full scan should happen between the incremental scans when activated")
 	cmd.Flags().BoolVar(&stepConfig.FullScansScheduled, "fullScansScheduled", true, "Whether full scans are to be scheduled or not. Should be used in relation with `incremental` and `fullScanCycle`")
 	cmd.Flags().BoolVar(&stepConfig.GeneratePdfReport, "generatePdfReport", true, "Whether to generate a PDF report of the analysis results or not")
 	cmd.Flags().StringVar(&stepConfig.GithubAPIURL, "githubApiUrl", `https://api.github.com`, "Set the GitHub API URL.")
 	cmd.Flags().StringVar(&stepConfig.GithubToken, "githubToken", os.Getenv("PIPER_githubToken"), "GitHub personal access token as per https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line")
+	cmd.Flags().StringVar(&stepConfig.IacHelpLinks, "iacHelpLinks", ``, "A path to a json file (remote if http/https, local otherwise) containing a map of IAC_query_id:help_url")
+	cmd.Flags().StringVar(&stepConfig.IacFilterPattern, "iacFilterPattern", ``, "The pattern to filter the files relevant for scanning in IAC, patterns can be negated by setting an exclamation mark in front i.e. `!**/*.yaml` would avoid adding any yaml files located in the test directory")
+	cmd.Flags().StringVar(&stepConfig.IacPreset, "iacPreset", os.Getenv("PIPER_iacPreset"), "The preset to use for IAC scanning, if not set explicitly the step will attempt to look up the project's setting based on the availability of `checkmarxOneCredentialsId`")
 	cmd.Flags().BoolVar(&stepConfig.ScanSummaryInPullRequest, "scanSummaryInPullRequest", true, "Whether the scan summary shall be added to the pull request as a comment or not. This is only applied if the step is executed in a pull request context. githubToken and githubApiUrl parameters must be set to allow the step to create the comment.")
 	cmd.Flags().BoolVar(&stepConfig.Incremental, "incremental", true, "Whether incremental scans are to be applied which optimizes the scan time but might reduce detection capabilities. Therefore full scans are still required from time to time and should be scheduled via `fullScansScheduled` and `fullScanCycle`")
 	cmd.Flags().StringVar(&stepConfig.Owner, "owner", os.Getenv("PIPER_owner"), "Set the GitHub organization.")
 	cmd.Flags().StringVar(&stepConfig.GitBranch, "gitBranch", os.Getenv("PIPER_gitBranch"), "Set the GitHub repository branch.")
 	cmd.Flags().StringVar(&stepConfig.ClientSecret, "clientSecret", os.Getenv("PIPER_clientSecret"), "The clientSecret to authenticate using a service account")
 	cmd.Flags().StringVar(&stepConfig.APIKey, "APIKey", os.Getenv("PIPER_APIKey"), "The APIKey to authenticate")
-	cmd.Flags().StringVar(&stepConfig.Preset, "preset", os.Getenv("PIPER_preset"), "The preset to use for scanning, if not set explicitly the step will attempt to look up the project's setting based on the availability of `checkmarxOneCredentialsId`")
 	cmd.Flags().StringVar(&stepConfig.LanguageMode, "languageMode", `multi`, "Specifies whether the scan should be run for a 'single' language or 'multi' language, default 'multi'")
 	cmd.Flags().StringVar(&stepConfig.ProjectCriticality, "projectCriticality", `3`, "The criticality of the checkmarxOne project, used during project creation")
 	cmd.Flags().StringVar(&stepConfig.ProjectName, "projectName", os.Getenv("PIPER_projectName"), "The name of the checkmarxOne project to scan into")
 	cmd.Flags().StringVar(&stepConfig.ProjectTags, "projectTags", os.Getenv("PIPER_projectTags"), "Used to tag a project with a JSON string, e.g., {\"key\":\"value\", \"keywithoutvalue\":\"\"}")
+	cmd.Flags().StringVar(&stepConfig.SastFilterPattern, "sastFilterPattern", ``, "The pattern to filter the files relevant for scanning in SAST, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory")
+	cmd.Flags().StringVar(&stepConfig.SastPreset, "sastPreset", os.Getenv("PIPER_sastPreset"), "The preset to use for SAST scanning, if not set explicitly the step will attempt to look up the project's setting based on the availability of `checkmarxOneCredentialsId`")
 	cmd.Flags().StringVar(&stepConfig.ScanTags, "scanTags", os.Getenv("PIPER_scanTags"), "Used to tag a scan with a JSON string, e.g., {\"key\":\"value\", \"keywithoutvalue\":\"\"}")
 	cmd.Flags().StringVar(&stepConfig.Branch, "branch", os.Getenv("PIPER_branch"), "Used to supply the branch scanned in the repository, or a friendly-name set by the user")
 	cmd.Flags().StringVar(&stepConfig.PullRequestName, "pullRequestName", os.Getenv("PIPER_pullRequestName"), "Used to supply the name for the newly created PR project branch when being used in pull request scenarios. This is supplied by the orchestrator.")
@@ -508,6 +520,15 @@ func checkmarxOneExecuteScanMetadata() config.StepData {
 						Default:     true,
 					},
 					{
+						Name:        "engines",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "[]string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     []string{`sast`},
+					},
+					{
 						Name:        "filterPattern",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
@@ -571,6 +592,33 @@ func checkmarxOneExecuteScanMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{{Name: "access_token"}},
 						Default:   os.Getenv("PIPER_githubToken"),
+					},
+					{
+						Name:        "iacHelpLinks",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     ``,
+					},
+					{
+						Name:        "iacFilterPattern",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     ``,
+					},
+					{
+						Name:        "iacPreset",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     os.Getenv("PIPER_iacPreset"),
 					},
 					{
 						Name:        "scanSummaryInPullRequest",
@@ -661,15 +709,6 @@ func checkmarxOneExecuteScanMetadata() config.StepData {
 						Default:   os.Getenv("PIPER_APIKey"),
 					},
 					{
-						Name:        "preset",
-						ResourceRef: []config.ResourceReference{},
-						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
-						Type:        "string",
-						Mandatory:   false,
-						Aliases:     []config.Alias{},
-						Default:     os.Getenv("PIPER_preset"),
-					},
-					{
 						Name:        "languageMode",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
@@ -704,6 +743,24 @@ func checkmarxOneExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     os.Getenv("PIPER_projectTags"),
+					},
+					{
+						Name:        "sastFilterPattern",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     ``,
+					},
+					{
+						Name:        "sastPreset",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "string",
+						Mandatory:   false,
+						Aliases:     []config.Alias{{Name: "preset"}},
+						Default:     os.Getenv("PIPER_sastPreset"),
 					},
 					{
 						Name:        "scanTags",
@@ -975,7 +1032,7 @@ func checkmarxOneExecuteScanMetadata() config.StepData {
 						Type: "influx",
 						Parameters: []map[string]interface{}{
 							{"name": "step_data", "fields": []map[string]string{{"name": "checkmarxOne"}}},
-							{"name": "checkmarxOne_data", "fields": []map[string]string{{"name": "critical_issues"}, {"name": "critical_not_false_postive"}, {"name": "critical_not_exploitable"}, {"name": "critical_confirmed"}, {"name": "critical_urgent"}, {"name": "critical_proposed_not_exploitable"}, {"name": "critical_to_verify"}, {"name": "high_issues"}, {"name": "high_not_false_postive"}, {"name": "high_not_exploitable"}, {"name": "high_confirmed"}, {"name": "high_urgent"}, {"name": "high_proposed_not_exploitable"}, {"name": "high_to_verify"}, {"name": "medium_issues"}, {"name": "medium_not_false_postive"}, {"name": "medium_not_exploitable"}, {"name": "medium_confirmed"}, {"name": "medium_urgent"}, {"name": "medium_proposed_not_exploitable"}, {"name": "medium_to_verify"}, {"name": "low_issues"}, {"name": "low_not_false_postive"}, {"name": "low_not_exploitable"}, {"name": "low_confirmed"}, {"name": "low_urgent"}, {"name": "low_proposed_not_exploitable"}, {"name": "low_to_verify"}, {"name": "information_issues"}, {"name": "information_not_false_postive"}, {"name": "information_not_exploitable"}, {"name": "information_confirmed"}, {"name": "information_urgent"}, {"name": "information_proposed_not_exploitable"}, {"name": "information_to_verify"}, {"name": "lines_of_code_scanned"}, {"name": "files_scanned"}, {"name": "initiator_name"}, {"name": "owner"}, {"name": "scan_id"}, {"name": "project_id"}, {"name": "projectName"}, {"name": "group"}, {"name": "group_full_path_on_report_date"}, {"name": "scan_start"}, {"name": "scan_time"}, {"name": "tool_version"}, {"name": "scan_type"}, {"name": "preset"}, {"name": "deep_link"}, {"name": "report_creation_time"}}},
+							{"name": "checkmarxOne_data", "fields": []map[string]string{{"name": "critical_issues"}, {"name": "critical_not_false_postive"}, {"name": "critical_not_exploitable"}, {"name": "critical_confirmed"}, {"name": "critical_urgent"}, {"name": "critical_proposed_not_exploitable"}, {"name": "critical_to_verify"}, {"name": "high_issues"}, {"name": "high_not_false_postive"}, {"name": "high_not_exploitable"}, {"name": "high_confirmed"}, {"name": "high_urgent"}, {"name": "high_proposed_not_exploitable"}, {"name": "high_to_verify"}, {"name": "medium_issues"}, {"name": "medium_not_false_postive"}, {"name": "medium_not_exploitable"}, {"name": "medium_confirmed"}, {"name": "medium_urgent"}, {"name": "medium_proposed_not_exploitable"}, {"name": "medium_to_verify"}, {"name": "low_issues"}, {"name": "low_not_false_postive"}, {"name": "low_not_exploitable"}, {"name": "low_confirmed"}, {"name": "low_urgent"}, {"name": "low_proposed_not_exploitable"}, {"name": "low_to_verify"}, {"name": "information_issues"}, {"name": "information_not_false_postive"}, {"name": "information_not_exploitable"}, {"name": "information_confirmed"}, {"name": "information_urgent"}, {"name": "information_proposed_not_exploitable"}, {"name": "information_to_verify"}, {"name": "lines_of_code_scanned"}, {"name": "files_scanned"}, {"name": "initiator_name"}, {"name": "owner"}, {"name": "scan_id"}, {"name": "project_id"}, {"name": "projectName"}, {"name": "group"}, {"name": "group_full_path_on_report_date"}, {"name": "scan_start"}, {"name": "scan_time"}, {"name": "tool_version"}, {"name": "scan_type"}, {"name": "preset"}, {"name": "iac_preset"}, {"name": "deep_link"}, {"name": "report_creation_time"}}},
 						},
 					},
 					{

--- a/cmd/checkmarxOneExecuteScan_test.go
+++ b/cmd/checkmarxOneExecuteScan_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"archive/zip"
 	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +28,7 @@ func (sys *checkmarxOneSystemMock) GetReportStatus(reportID string) (checkmarxOn
 	return checkmarxOne.ReportStatus{}, nil
 }
 
-func (sys *checkmarxOneSystemMock) RequestNewReport(scanID, projectID, branch, reportType string) (string, error) {
+func (sys *checkmarxOneSystemMock) RequestNewReport(scanID, projectID, branch, reportType string, engines []string) (string, error) {
 	return "", nil
 }
 
@@ -49,12 +52,24 @@ func (sys *checkmarxOneSystemMock) GetScan(scanID string) (checkmarxOne.Scan, er
 	return checkmarxOne.Scan{}, nil
 }
 
-func (sys *checkmarxOneSystemMock) GetScanMetadata(scanID string) (checkmarxOne.ScanMetadata, error) {
+func (sys *checkmarxOneSystemMock) GetScanMetadata(scan *checkmarxOne.Scan) (checkmarxOne.ScanMetadata, error) {
 	return checkmarxOne.ScanMetadata{}, nil
 }
 
-func (sys *checkmarxOneSystemMock) GetScanMetadatas(scanID []string) ([]checkmarxOne.ScanMetadata, error) {
-	return []checkmarxOne.ScanMetadata{}, nil
+func (sys *checkmarxOneSystemMock) GetScanSASTMetadata(scanID string) (checkmarxOne.ScanSASTMetadata, error) {
+	return checkmarxOne.ScanSASTMetadata{}, nil
+}
+
+func (sys *checkmarxOneSystemMock) GetScanIACMetadata(scanID string) (checkmarxOne.ScanIACMetadata, error) {
+	return checkmarxOne.ScanIACMetadata{}, nil
+}
+
+func (sys *checkmarxOneSystemMock) GetScanSASTMetadatas(scanID []string) ([]checkmarxOne.ScanSASTMetadata, error) {
+	return []checkmarxOne.ScanSASTMetadata{}, nil
+}
+
+func (sys *checkmarxOneSystemMock) GetScanConfiguration(_, _ string) (map[string]string, error) {
+	return map[string]string{}, nil
 }
 
 func (sys *checkmarxOneSystemMock) GetScanResults(scanID string, limit uint64) ([]checkmarxOne.ScanResult, error) {
@@ -216,6 +231,25 @@ func (sys *checkmarxOneSystemMock) GetGroupByName(groupName string) (checkmarxOn
 	return group, fmt.Errorf("No group matching %v", groupName)
 }
 
+func (sys *checkmarxOneSystemMock) GetIACPresetNameByID(_ string) (string, error) {
+	return "my-iac-preset", nil
+}
+
+func (sys *checkmarxOneSystemMock) GetIACPresetIDByName(_ string) (string, error) {
+	return "a-b-c-d", nil
+}
+
+func (sys *checkmarxOneSystemMock) GetIACFindingInfo(_ checkmarxOne.ScanResult) (checkmarxOne.IACFindingInfo, error) {
+	return checkmarxOne.IACFindingInfo{
+		Cwe: 0,
+		URL: "Test",
+	}, nil
+}
+
+func (sys *checkmarxOneSystemMock) LoadIACHelpLinks(_ string) error {
+	return nil
+}
+
 func (sys *checkmarxOneSystemMock) GetGroupByID(groupID string) (checkmarxOne.Group, error) {
 	return checkmarxOne.Group{}, nil
 }
@@ -224,15 +258,23 @@ func (sys *checkmarxOneSystemMock) SetProjectBranch(projectID, branch string, al
 	return nil
 }
 
-func (sys *checkmarxOneSystemMock) SetProjectPreset(projectID, presetName string, allowOverride bool) error {
-	return nil
-}
-
 func (sys *checkmarxOneSystemMock) SetProjectLanguageMode(projectID, languageMode string, allowOverride bool) error {
 	return nil
 }
 
-func (sys *checkmarxOneSystemMock) SetProjectFileFilter(projectID, filter string, allowOverride bool) error {
+func (sys *checkmarxOneSystemMock) SetProjectSASTPreset(projectID, presetName string, allowOverride bool) error {
+	return nil
+}
+
+func (sys *checkmarxOneSystemMock) SetProjectIACPreset(projectID, presetName string, allowOverride bool) error {
+	return nil
+}
+
+func (sys *checkmarxOneSystemMock) SetProjectSASTFileFilter(projectID, filter string, allowOverride bool) error {
+	return nil
+}
+
+func (sys *checkmarxOneSystemMock) SetProjectIACFileFilter(projectID, filter string, allowOverride bool) error {
 	return nil
 }
 
@@ -270,9 +312,9 @@ func TestGetProjectByName(t *testing.T) {
 	t.Run("project name not found", func(t *testing.T) {
 		t.Parallel()
 
-		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba_notexist", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "CheckmarxDefault", GroupName: "TestGroup", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
+		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba_notexist", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, SastPreset: "CheckmarxDefault", GroupName: "TestGroup", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
 
-		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, nil}
+		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, true, false, nil}
 
 		_, err := cx1sh.GetProjectByName()
 
@@ -281,9 +323,9 @@ func TestGetProjectByName(t *testing.T) {
 	t.Run("project name exists", func(t *testing.T) {
 		t.Parallel()
 
-		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba-github", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "CheckmarxDefault", GroupName: "TestGroup", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
+		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba-github", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, SastPreset: "CheckmarxDefault", GroupName: "TestGroup", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
 
-		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, nil}
+		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, true, false, nil}
 
 		project, err := cx1sh.GetProjectByName()
 		assert.NoError(t, err, "Error occurred but none expected")
@@ -301,9 +343,9 @@ func TestGetGroup(t *testing.T) {
 	t.Run("group ID and group name is not provided", func(t *testing.T) {
 		t.Parallel()
 
-		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "CheckmarxDefault" /*GroupName: "NotProvided",*/, VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
+		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, SastPreset: "CheckmarxDefault" /*GroupName: "NotProvided",*/, VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
 
-		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, nil}
+		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, true, false, nil}
 		_, err := cx1sh.GetGroup()
 		assert.Contains(t, fmt.Sprint(err), "No group name specified in configuration")
 	})
@@ -311,9 +353,9 @@ func TestGetGroup(t *testing.T) {
 	t.Run("group name not found", func(t *testing.T) {
 		t.Parallel()
 
-		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "CheckmarxDefault", GroupName: "GroupNotExist", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
+		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, SastPreset: "CheckmarxDefault", GroupName: "GroupNotExist", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
 
-		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, nil}
+		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, true, false, nil}
 
 		_, err := cx1sh.GetGroup()
 		assert.Contains(t, fmt.Sprint(err), "Failed to get Checkmarx One group by Name GroupNotExist: No group matching GroupNotExist")
@@ -322,9 +364,9 @@ func TestGetGroup(t *testing.T) {
 	t.Run("group name exists", func(t *testing.T) {
 		t.Parallel()
 
-		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba-github", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "CheckmarxDefault", GroupName: "Group2", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
+		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba-github", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, SastPreset: "CheckmarxDefault", GroupName: "Group2", VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
 
-		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, nil}
+		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, true, false, nil}
 
 		group, err := cx1sh.GetGroup()
 		assert.NoError(t, err, "Error occurred but none expected")
@@ -341,9 +383,9 @@ func TestUpdateProjectTags(t *testing.T) {
 	t.Run("project tags are not provided", func(t *testing.T) {
 		t.Parallel()
 
-		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "CheckmarxDefault" /*GroupName: "NotProvided",*/, VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
+		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, SastPreset: "CheckmarxDefault" /*GroupName: "NotProvided",*/, VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant"}
 
-		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, nil}
+		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, nil, nil, nil, true, false, nil}
 		err := cx1sh.UpdateProjectTags()
 		assert.NoError(t, err, "Error occurred but none expected")
 	})
@@ -366,9 +408,9 @@ func TestUpdateProjectTags(t *testing.T) {
 		var project checkmarxOne.Project
 		_ = json.Unmarshal([]byte(projectJson), &project)
 
-		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, Preset: "CheckmarxDefault" /*GroupName: "NotProvided",*/, VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant", ProjectTags: `{"key3":"value3", "key2":"value5", "keywithoutvalue2":""}`}
+		options := checkmarxOneExecuteScanOptions{ProjectName: "ssba", VulnerabilityThresholdUnit: "absolute", FullScanCycle: "2", Incremental: true, FullScansScheduled: true, SastPreset: "CheckmarxDefault" /*GroupName: "NotProvided",*/, VulnerabilityThresholdEnabled: true, GeneratePdfReport: true, APIKey: "testAPIKey", ServerURL: "testURL", IamURL: "testIamURL", Tenant: "testTenant", ProjectTags: `{"key3":"value3", "key2":"value5", "keywithoutvalue2":""}`}
 
-		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, &project, nil, nil, nil}
+		cx1sh := checkmarxOneExecuteScanHelper{nil, options, sys, nil, nil, &project, nil, nil, true, false, nil}
 		err := cx1sh.UpdateProjectTags()
 		assert.NoError(t, err, "Error occurred but none expected")
 
@@ -388,5 +430,45 @@ func TestUpdateProjectTags(t *testing.T) {
 		maps.Copy(oldTags, newTags)
 
 		assert.Equal(t, project.Tags, oldTags) // project's tags must be merged
+	})
+}
+
+func TestCheckmarxOneZipFolder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("output archive is not zipped into itself", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		err := os.WriteFile(filepath.Join(dir, "abcd.go"), []byte("abcd.go"), 0o700)
+		assert.NoError(t, err)
+		err = os.Mkdir(filepath.Join(dir, "somepath"), 0o700)
+		assert.NoError(t, err)
+		err = os.WriteFile(filepath.Join(dir, "somepath", "abcd.txt"), []byte("somepath/abcd.txt"), 0o700)
+		assert.NoError(t, err)
+
+		// the output archive lives inside the folder being zipped, exactly like workspace.zip
+		zipFileName := filepath.Join(dir, "workspace.zip")
+		zipFile, err := os.Create(zipFileName)
+		assert.NoError(t, err)
+		defer zipFile.Close()
+
+		cx1sh := checkmarxOneExecuteScanHelper{}
+		utils := newcheckmarxOneExecuteScanUtilsBundle(dir, nil)
+
+		// no filter pattern - every file is a candidate, including the output archive itself
+		err = cx1sh.zipFolder(dir, zipFile, []string{}, zipFileName, utils)
+		assert.NoError(t, err)
+
+		zipInfo, err := zipFile.Stat()
+		assert.NoError(t, err)
+		reader, err := zip.NewReader(zipFile, zipInfo.Size())
+		assert.NoError(t, err)
+
+		for _, f := range reader.File {
+			assert.NotEqual(t, "workspace.zip", filepath.Base(f.Name), "the output archive must not be zipped into itself")
+		}
+		// only the two regular source files must be archived, never the output archive
+		assert.Len(t, reader.File, 2)
 	})
 }

--- a/pkg/checkmarxone/checkmarxone.go
+++ b/pkg/checkmarxone/checkmarxone.go
@@ -23,6 +23,7 @@ import (
 // ReportsDirectory defines the subfolder for the Checkmarx reports which are generated
 const ReportsDirectory = "checkmarxOne"
 const cxOrigin = ""
+const IACDefaultBlankPreset = "all checks"
 
 // AuthToken - Structure to store OAuth2 token
 // Updated for Cx1
@@ -147,10 +148,22 @@ type ScanConfiguration struct {
 	Values   map[string]string `json:"value"`
 }
 
-/*
-{"scanId":"bef5d38b-7eb9-4138-b74b-2639fcf49e2e","projectId":"ad34ade3-9bf3-4b5a-91d7-3ad67eca7852","loc":137,"fileCount":12,"isIncremental":false,"isIncrementalCanceled":false,"queryPreset":"ASA Premium"}
-*/
 type ScanMetadata struct {
+	IAC  *ScanIACMetadata
+	SAST *ScanSASTMetadata
+}
+
+type ScanIACMetadata struct {
+	ScanID     string
+	ProjectID  string
+	LOC        int
+	FileCount  int
+	IACLOC     int `json:"kicsLoc"`
+	PresetName string
+	PresetID   string
+}
+
+type ScanSASTMetadata struct {
 	ScanID                string
 	ProjectID             string
 	LOC                   int
@@ -160,19 +173,23 @@ type ScanMetadata struct {
 	PresetName            string `json:"queryPreset"`
 }
 
-type ScanMetadataList struct {
-	TotalCount int
-	Scans      []ScanMetadata
-	Missing    []string
+type scanresultQueryID struct {
+	Value any // uint64 for sast, string for iac
 }
 
 type ScanResultData struct {
-	QueryID      uint64
-	QueryName    string
-	Group        string
-	ResultHash   string
-	LanguageName string
-	Nodes        []ScanResultNodes
+	QueryID      scanresultQueryID
+	QueryName    string            // SAST and IaC
+	Group        string            // SAST and IaC
+	ResultHash   string            // only SAST
+	LanguageName string            // only SAST
+	Nodes        []ScanResultNodes // only SAST
+
+	Platform      string // only IAC
+	Line          int    // only IAC
+	Filename      string // only IAC
+	Value         string // only IAC
+	ExpectedValue string // only IAC
 }
 
 type ScanResultNodes struct {
@@ -194,7 +211,8 @@ type ScanResultNodes struct {
 type ScanResult struct {
 	Type                 string
 	ResultID             string `json:"id"`
-	SimilarityID         int64  `json:"similarityId,string"`
+	AlternateID          string
+	SimilarityID         string
 	Status               string
 	State                string
 	Severity             string
@@ -208,8 +226,13 @@ type ScanResult struct {
 }
 
 type ScanResultDetails struct {
-	CweId       int
+	CweId       int // empty for kics results, pending case 283343
 	Compliances []string
+}
+
+type IACFindingInfo struct {
+	Cwe int
+	URL string
 }
 
 // Cx1: StatusDetails - details of each engine type's scan status for a multi-engine scan
@@ -223,38 +246,41 @@ type ScanStatusDetails struct {
 type ScanSummary struct {
 	TenantID     string
 	ScanID       string
-	SASTCounters struct {
-		//QueriesCounters           []?
-		//SinkFileCounters          []?
-		LanguageCounters []struct {
-			Language string
-			Counter  uint64
-		}
-		ComplianceCounters []struct {
-			Compliance string
-			Counter    uint64
-		}
-		SeverityCounters []struct {
-			Severity string
-			Counter  uint64
-		}
-		StatusCounters []struct {
-			Status  string
-			Counter uint64
-		}
-		StateCounters []struct {
-			State   string
-			Counter uint64
-		}
-		TotalCounter        uint64
-		FilesScannedCounter uint64
-	}
+	SASTCounters ScanSummaryCounters
+	IACCounters  ScanSummaryCounters `json:"kicsCounters"`
 	// ignoring the other counters
 	// KICSCounters
 	// SCACounters
 	// SCAPackagesCounters
 	// SCAContainerCounters
 	// APISecCounters
+}
+
+type ScanSummaryCounters struct {
+	//QueriesCounters           []?
+	//SinkFileCounters          []?
+	LanguageCounters []struct {
+		Language string
+		Counter  uint64
+	}
+	ComplianceCounters []struct {
+		Compliance string
+		Counter    uint64
+	}
+	SeverityCounters []struct {
+		Severity string
+		Counter  uint64
+	}
+	StatusCounters []struct {
+		Status  string
+		Counter uint64
+	}
+	StateCounters []struct {
+		State   string
+		Counter uint64
+	}
+	TotalCounter        uint64
+	FilesScannedCounter uint64
 }
 
 // Status - Status Structure
@@ -282,6 +308,37 @@ type Group struct {
 	Name    string `json:"name"`
 }
 
+// this is a convenience object to facilitate accessing SAST configuration settings from the code
+type sastConfigKeys struct {
+	PresetName   string
+	Incremental  string
+	LanguageMode string
+	FileFilter   string
+}
+
+// this is a convenience object to facilitate accessing IAC configuration settings from the code
+type iacConfigKeys struct {
+	PresetID   string
+	FileFilter string
+}
+
+// this is a convenience object to facilitate accessing configuration settings from the code
+var ConfigurationKeys = struct {
+	SAST sastConfigKeys
+	IAC  iacConfigKeys
+}{
+	SAST: sastConfigKeys{
+		PresetName:   "scan.config.sast.presetName",
+		Incremental:  "scan.config.sast.incremental",
+		LanguageMode: "scan.config.sast.languageMode",
+		FileFilter:   "scan.config.sast.filter",
+	},
+	IAC: iacConfigKeys{
+		PresetID:   "scan.config.kics.presetId",
+		FileFilter: "scan.config.kics.filter",
+	},
+}
+
 // SystemInstance is the client communicating with the Checkmarx backend
 type SystemInstance struct {
 	serverURL           string
@@ -292,13 +349,15 @@ type SystemInstance struct {
 	oauth_client_secret string //separate from APIKey
 	client              piperHttp.Uploader
 	logger              *logrus.Entry
+	version             *VersionInfo              // stored after first fetch
+	iacQueryCache       map[string]IACFindingInfo // map of query-id to finding info, retrieved from the preset-manager api
 }
 
 // System is the interface abstraction of a specific SystemIns
 type System interface {
 	DownloadReport(reportID string) ([]byte, error)
 	GetReportStatus(reportID string) (ReportStatus, error)
-	RequestNewReport(scanID, projectID, branch, reportType string) (string, error)
+	RequestNewReport(scanID, projectID, branch, reportType string, engines []string) (string, error)
 
 	CreateApplication(appname string) (Application, error)
 	GetApplicationByName(appname string) (Application, error)
@@ -306,8 +365,11 @@ type System interface {
 	UpdateApplication(app *Application) error
 
 	GetScan(scanID string) (Scan, error)
-	GetScanMetadata(scanID string) (ScanMetadata, error)
-	GetScanMetadatas(scanIDs []string) ([]ScanMetadata, error)
+	GetScanConfiguration(projectID, scanID string) (map[string]string, error)
+	GetScanMetadata(scan *Scan) (ScanMetadata, error)
+	GetScanSASTMetadata(scanID string) (ScanSASTMetadata, error)
+	GetScanSASTMetadatas(scanIDs []string) ([]ScanSASTMetadata, error)
+	GetScanIACMetadata(scanID string) (ScanIACMetadata, error)
 	GetScanResults(scanID string, limit uint64) ([]ScanResult, error)
 	GetScanSummary(scanID string) (ScanSummary, error)
 	GetResultsPredicates(SimilarityID int64, ProjectID string) ([]ResultsPredicates, error)
@@ -323,7 +385,7 @@ type System interface {
 	UploadProjectSourceCode(projectID string, zipFile string) (string, error)
 	CreateProject(projectName string, groupIDs []string) (Project, error)
 	CreateProjectInApplication(projectName, applicationID string, groupIDs []string) (Project, error)
-	GetPresets() ([]Preset, error)
+	//GetPresets() ([]Preset, error)
 	GetProjectByID(projectID string) (Project, error)
 	GetProjectsByName(projectName string) ([]Project, error)
 	GetProjectsByNameAndGroup(projectName, groupID string) ([]Project, error)
@@ -333,11 +395,18 @@ type System interface {
 	GetGroups() ([]Group, error)
 	GetGroupByName(groupName string) (Group, error)
 	GetGroupByID(groupID string) (Group, error)
-	SetProjectBranch(projectID, branch string, allowOverride bool) error
-	SetProjectPreset(projectID, presetName string, allowOverride bool) error
-	SetProjectLanguageMode(projectID, languageMode string, allowOverride bool) error
-	SetProjectFileFilter(projectID, filter string, allowOverride bool) error
 
+	SetProjectBranch(projectID, branch string, allowOverride bool) error
+	SetProjectLanguageMode(projectID, languageMode string, allowOverride bool) error
+	SetProjectSASTPreset(projectID, presetName string, allowOverride bool) error
+	SetProjectSASTFileFilter(projectID, filter string, allowOverride bool) error
+	SetProjectIACPreset(projectID, presetName string, allowOverride bool) error
+	SetProjectIACFileFilter(projectID, filter string, allowOverride bool) error
+
+	GetIACPresetNameByID(presetID string) (string, error)
+	GetIACPresetIDByName(presetName string) (string, error)
+	GetIACFindingInfo(r ScanResult) (IACFindingInfo, error)
+	LoadIACHelpLinks(url string) error
 	GetProjectConfiguration(projectID string) ([]ProjectConfigurationSetting, error)
 	UpdateProjectConfiguration(projectID string, settings []ProjectConfigurationSetting) error
 
@@ -357,6 +426,7 @@ func NewSystemInstance(client piperHttp.Uploader, serverURL, iamURL, tenant, API
 		oauth_client_secret: client_secret,
 		client:              client,
 		logger:              loggerInstance,
+		iacQueryCache:       make(map[string]IACFindingInfo),
 	}
 
 	var token string
@@ -1017,6 +1087,7 @@ func (sys *SystemInstance) ScanProject(projectID, sourceUrl, branch, scanType st
 	return Scan{}, errors.New("Invalid scanType provided, must be 'upload' or 'git'")
 }
 
+/*
 func (sys *SystemInstance) GetPresets() ([]Preset, error) {
 	sys.logger.Debug("Getting Presets...")
 	var presets []Preset
@@ -1029,6 +1100,160 @@ func (sys *SystemInstance) GetPresets() ([]Preset, error) {
 
 	err = json.Unmarshal(data, &presets)
 	return presets, err
+}
+*/
+
+func (sys *SystemInstance) GetIACPresetIDByName(name string) (string, error) {
+	if name == IACDefaultBlankPreset {
+		return "", nil
+	}
+	type IACPreset struct {
+		PresetID string `json:"id"`
+		Name     string
+	}
+	var preset_response struct {
+		TotalCount uint64      `json:"totalCount"`
+		Presets    []IACPreset `json:"presets"`
+	}
+
+	params := url.Values{
+		"offset":          {"0"},
+		"limit":           {"1"},
+		"exact-match":     {"true"},
+		"include-details": {"true"},
+		"search-term":     {name},
+	}
+
+	response, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/preset-manager/iac/presets?%v", params.Encode()), nil, http.Header{}, nil)
+	if err != nil {
+		return "", err
+	}
+
+	err = json.Unmarshal(response, &preset_response)
+
+	if err != nil {
+		return "", err
+	}
+	if len(preset_response.Presets) == 0 {
+		return "", fmt.Errorf("no such preset %v found", name)
+	}
+	if len(preset_response.Presets) > 1 {
+		return "", fmt.Errorf("%d presets found matching %v", len(preset_response.Presets), name)
+	}
+	return preset_response.Presets[0].PresetID, nil
+}
+
+func (sys *SystemInstance) GetIACPresetNameByID(id string) (string, error) {
+	if id == "" {
+		return IACDefaultBlankPreset, nil
+	}
+	var preset struct {
+		PresetID string `json:"id"`
+		Name     string
+	}
+
+	response, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/preset-manager/iac/presets/%v", id), nil, http.Header{}, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get preset %v: %s", id, err)
+	}
+
+	err = json.Unmarshal(response, &preset)
+	return preset.Name, err
+}
+
+func (sys *SystemInstance) GetIACFindingInfo(r ScanResult) (IACFindingInfo, error) {
+	if queryId, ok := r.Data.QueryID.Value.(string); ok {
+		if info, ok := sys.iacQueryCache[queryId]; ok {
+			return info, nil
+		} else {
+			family, err := sys.GetIACQueryFamily(strings.ToLower(r.Data.Platform))
+			if err != nil {
+				return IACFindingInfo{}, err
+			}
+			for id, info := range family {
+				sys.iacQueryCache[id] = info
+			}
+
+			if info, ok := sys.iacQueryCache[queryId]; ok {
+				return info, nil
+			} else {
+				return IACFindingInfo{}, fmt.Errorf("query with id %s not found", queryId)
+			}
+		}
+	} else {
+		return IACFindingInfo{}, fmt.Errorf("failed to get IAC query ID from: %+v", r.Data.QueryID)
+	}
+}
+
+func (sys *SystemInstance) LoadIACHelpLinks(path string) error {
+	var data []byte
+	var err error
+
+	if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
+		response, err := sys.client.SendRequest(http.MethodGet, path, nil, nil, nil)
+		if err != nil {
+			return fmt.Errorf("failed to load IAC help links from %s: %s", path, err)
+		}
+		if response != nil && response.Body != nil {
+			data, _ = io.ReadAll(response.Body)
+			response.Body.Close()
+		} else {
+			return fmt.Errorf("no content returned from %s", path)
+		}
+	} else {
+		data, err = os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+	}
+	err = json.Unmarshal(data, &sys.iacQueryCache)
+	return err
+}
+
+func (sys *SystemInstance) GetIACQueryFamily(family string) (map[string]IACFindingInfo, error) {
+	response, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/preset-manager/iac/query-families/%v/queries", family), nil, http.Header{}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	type iacQueryFamilyLeaf struct {
+		Key  string
+		Data struct {
+			Cwe int
+			URL string
+		}
+	}
+	type iacQueryFamily struct {
+		// Title string
+		// Key string
+		Children []struct {
+			// Title string // group
+			// Key string
+			Children []iacQueryFamilyLeaf
+		}
+	}
+
+	var iacQueryFamilies []iacQueryFamily
+	if err = json.Unmarshal(response, &iacQueryFamilies); err != nil {
+		return nil, err
+	}
+
+	iacFindings := make(map[string]IACFindingInfo)
+
+	for i := range iacQueryFamilies {
+		iacQueries := &iacQueryFamilies[i]
+		for i := range iacQueries.Children {
+			group := &iacQueries.Children[i]
+			for i := range group.Children {
+				query := &group.Children[i]
+				iacFindings[query.Key] = IACFindingInfo{
+					Cwe: query.Data.Cwe,
+					URL: query.Data.URL,
+				}
+			}
+		}
+	}
+	return iacFindings, nil
 }
 
 func (sys *SystemInstance) GetProjectConfiguration(projectID string) ([]ProjectConfigurationSetting, error) {
@@ -1082,10 +1307,22 @@ func (sys *SystemInstance) SetProjectBranch(projectID, branch string, allowOverr
 	return sys.UpdateProjectConfiguration(projectID, []ProjectConfigurationSetting{setting})
 }
 
-func (sys *SystemInstance) SetProjectPreset(projectID, presetName string, allowOverride bool) error {
+func (sys *SystemInstance) SetProjectSASTPreset(projectID, presetName string, allowOverride bool) error {
 	var setting ProjectConfigurationSetting
-	setting.Key = "scan.config.sast.presetName"
+	setting.Key = ConfigurationKeys.SAST.PresetName
 	setting.Value = presetName
+	setting.AllowOverride = allowOverride
+
+	return sys.UpdateProjectConfiguration(projectID, []ProjectConfigurationSetting{setting})
+}
+func (sys *SystemInstance) SetProjectIACPreset(projectID, presetName string, allowOverride bool) error {
+	var setting ProjectConfigurationSetting
+	setting.Key = ConfigurationKeys.IAC.PresetID
+	presetId, err := sys.GetIACPresetIDByName(presetName)
+	if err != nil {
+		return err
+	}
+	setting.Value = presetId
 	setting.AllowOverride = allowOverride
 
 	return sys.UpdateProjectConfiguration(projectID, []ProjectConfigurationSetting{setting})
@@ -1093,21 +1330,29 @@ func (sys *SystemInstance) SetProjectPreset(projectID, presetName string, allowO
 
 func (sys *SystemInstance) SetProjectLanguageMode(projectID, languageMode string, allowOverride bool) error {
 	var setting ProjectConfigurationSetting
-	setting.Key = "scan.config.sast.languageMode"
+	setting.Key = ConfigurationKeys.SAST.LanguageMode
 	setting.Value = languageMode
 	setting.AllowOverride = allowOverride
 
 	return sys.UpdateProjectConfiguration(projectID, []ProjectConfigurationSetting{setting})
 }
 
-func (sys *SystemInstance) SetProjectFileFilter(projectID, filter string, allowOverride bool) error {
+func (sys *SystemInstance) SetProjectSASTFileFilter(projectID, filter string, allowOverride bool) error {
 	var setting ProjectConfigurationSetting
-	setting.Key = "scan.config.sast.filter"
+	setting.Key = ConfigurationKeys.SAST.FileFilter
 	setting.Value = filter
 	setting.AllowOverride = allowOverride
 
-	// TODO - apply the filter across all languages? set up separate calls per engine? engine as param?
+	// TODO - apply the filter across all languages?
 
+	return sys.UpdateProjectConfiguration(projectID, []ProjectConfigurationSetting{setting})
+}
+
+func (sys *SystemInstance) SetProjectIACFileFilter(projectID, filter string, allowOverride bool) error {
+	var setting ProjectConfigurationSetting
+	setting.Key = ConfigurationKeys.IAC.FileFilter
+	setting.Value = filter
+	setting.AllowOverride = allowOverride
 	return sys.UpdateProjectConfiguration(projectID, []ProjectConfigurationSetting{setting})
 }
 
@@ -1125,35 +1370,135 @@ func (sys *SystemInstance) GetScan(scanID string) (Scan, error) {
 	return scan, nil
 }
 
-func (sys *SystemInstance) GetScanMetadatas(scanIDs []string) ([]ScanMetadata, error) {
+func (sys *SystemInstance) GetScanConfiguration(projectID, scanID string) (map[string]string, error) {
+	config := map[string]string{}
+
+	params := url.Values{
+		"scan-id":    {scanID},
+		"project-id": {projectID},
+	}
+
+	data, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/configuration/scan?%v", params.Encode()), nil, http.Header{}, []int{})
+	if err != nil {
+		sys.logger.Errorf("Failed to fetch configuration for project %s scan %s, error was: %s", projectID, scanID, err)
+		return config, fmt.Errorf("failed to fetch metadata for scans: %w", err)
+	}
+
+	var configurations []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	}
+
+	err = json.Unmarshal(data, &configurations)
+	if err != nil {
+		return config, fmt.Errorf("failed to parse scan configurations: %s", err)
+	}
+
+	for _, conf := range configurations {
+		config[conf.Key] = conf.Value
+	}
+	return config, nil
+}
+
+func (sys *SystemInstance) GetScanMetadata(scan *Scan) (ScanMetadata, error) {
+	var scanmeta ScanMetadata
+	if slices.Contains(scan.Engines, "kics") {
+		meta, err := sys.GetScanIACMetadata(scan.ScanID)
+		if err != nil {
+			return scanmeta, err
+		}
+		scanmeta.IAC = &meta
+
+		if scanmeta.IAC.IACLOC == 0 {
+			sys.logger.Warnf("IAC scan %s shows 0 lines of code scanned.", scan.ScanID)
+		}
+	}
+	if slices.Contains(scan.Engines, "sast") {
+		meta, err := sys.GetScanSASTMetadata(scan.ScanID)
+		if err != nil {
+			details := scan.GetStatusDetails("sast")
+			if details != nil && (details.Status == "Completed" || details.Status == "Failed") {
+				meta = ScanSASTMetadata{
+					ScanID:                scan.ScanID,
+					ProjectID:             scan.ProjectID,
+					LOC:                   0,
+					FileCount:             0,
+					IsIncremental:         false,
+					IsIncrementalCanceled: false,
+					PresetName:            "",
+				}
+			} else {
+				return scanmeta, err
+			}
+		}
+		scanmeta.SAST = &meta
+		if scanmeta.SAST.LOC == 0 {
+			sys.logger.Warnf("SAST scan %s shows 0 lines of code scanned.", scan.ScanID)
+		}
+	}
+
+	return scanmeta, nil
+}
+
+func (sys *SystemInstance) GetScanSASTMetadatas(scanIDs []string) ([]ScanSASTMetadata, error) {
 	params := url.Values{
 		"scan-ids": scanIDs,
 	}
-	var scanmetadatalistresp ScanMetadataList
-	var scans []ScanMetadata
+	var scanmetadatalistresp struct {
+		TotalCount int
+		Scans      []ScanSASTMetadata
+		Missing    []string
+	}
+	var scanmetas []ScanSASTMetadata
 
 	data, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/sast-metadata?%v", params.Encode()), nil, http.Header{}, []int{})
 	if err != nil {
-		sys.logger.Errorf("Failed to fetch metadata for scans %s, error was: %s", fmt.Sprintf("%v", strings.Join(scanIDs, ",")), err)
-		return scans, fmt.Errorf("failed to fetch metadata for scans: %w", err)
+		sys.logger.Errorf("Failed to fetch SAST metadata for scans %s, error was: %s", fmt.Sprintf("%v", strings.Join(scanIDs, ",")), err)
+		return scanmetas, fmt.Errorf("failed to fetch SAST metadata for scans: %w", err)
 	}
 
 	json.Unmarshal(data, &scanmetadatalistresp)
-	scans = scanmetadatalistresp.Scans
-	return scans, nil
-
+	scanmetas = scanmetadatalistresp.Scans
+	return scanmetas, nil
 }
 
-func (sys *SystemInstance) GetScanMetadata(scanID string) (ScanMetadata, error) {
-	var scanmeta ScanMetadata
-
+func (sys *SystemInstance) GetScanSASTMetadata(scanID string) (ScanSASTMetadata, error) {
+	var scanmeta ScanSASTMetadata
 	data, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/sast-metadata/%v", scanID), nil, http.Header{}, []int{})
 	if err != nil {
-		sys.logger.Errorf("Failed to fetch metadata for scan with ID %v: %s", scanID, err)
-		return scanmeta, fmt.Errorf("failed to fetch metadata for scan with ID %v: %w", scanID, err)
+		sys.logger.Errorf("Failed to fetch SAST metadata for scan with ID %v: %s", scanID, err)
+		return scanmeta, fmt.Errorf("failed to fetch SAST metadata for scan with ID %v: %w", scanID, err)
 	}
 
-	json.Unmarshal(data, &scanmeta)
+	err = json.Unmarshal(data, &scanmeta)
+	if err != nil {
+		return scanmeta, err
+	}
+
+	return scanmeta, nil
+}
+
+func (sys *SystemInstance) GetScanIACMetadata(scanID string) (ScanIACMetadata, error) {
+	var scanmeta ScanIACMetadata
+	data, err := sendRequest(sys, http.MethodGet, fmt.Sprintf("/kics-metadata/%v", scanID), nil, http.Header{}, []int{})
+	if err != nil {
+		sys.logger.Errorf("Failed to fetch IAC metadata for scan with ID %v: %s", scanID, err)
+		return scanmeta, fmt.Errorf("failed to fetch IAC metadata for scan with ID %v: %w", scanID, err)
+	}
+
+	err = json.Unmarshal(data, &scanmeta)
+	if err != nil {
+		return scanmeta, err
+	}
+
+	presetName, err := sys.GetIACPresetNameByID(scanmeta.PresetID)
+	if err != nil {
+		sys.logger.Errorf("Failed to fetch IAC preset name for preset ID %s", scanmeta.PresetID)
+		scanmeta.PresetName = "unknown preset with id " + scanmeta.PresetID
+	} else {
+		scanmeta.PresetName = presetName
+	}
+
 	return scanmeta, nil
 }
 
@@ -1253,6 +1598,15 @@ func (s *Scan) IsIncremental() (bool, error) {
 	return false, fmt.Errorf("Scan %v did not have a sast-engine incremental flag set", s.ScanID)
 }
 
+func (s *Scan) GetStatusDetails(engine string) *ScanStatusDetails {
+	for _, detail := range s.StatusDetails {
+		if detail.Name == engine {
+			return &detail
+		}
+	}
+	return nil
+}
+
 func (sys *SystemInstance) GetScanResults(scanID string, limit uint64) ([]ScanResult, error) {
 	sys.logger.Debug("Get Cx1 Scan Results")
 	var resultResponse struct {
@@ -1295,6 +1649,10 @@ func (s *ScanSummary) TotalCount() uint64 {
 	count = 0
 
 	for _, c := range s.SASTCounters.StateCounters {
+		count += c.Counter
+	}
+
+	for _, c := range s.IACCounters.StateCounters {
 		count += c.Counter
 	}
 
@@ -1368,12 +1726,18 @@ func (sys *SystemInstance) GetResultsPredicates(SimilarityID int64, ProjectID st
 }
 
 // RequestNewReport triggers the generation of a  report for a specific scan addressed by scanID
-func (sys *SystemInstance) RequestNewReport(scanID, projectID, branch, reportType string) (string, error) {
-	return sys.RequestNewReportV2(scanID, reportType) // Report generation v1 API is removed in CxONE 3.36, use RequestNewReportV2 instead
-}
+func (sys *SystemInstance) RequestNewReport(scanID, projectID, branch, reportType string, engines []string) (string, error) {
+	return sys.RequestNewReportV2(scanID, reportType, engines) // Report generation v1 API is removed in CxONE 3.36, use RequestNewReportV2 instead
+} // TODO: remove this wrapper?
 
 // Use the new V2 Report API to generate a PDF report
-func (sys *SystemInstance) RequestNewReportV2(scanID, reportType string) (string, error) {
+func (sys *SystemInstance) RequestNewReportV2(scanID, reportType string, engines []string) (string, error) {
+	if len(engines) == 0 {
+		return "", fmt.Errorf("no engines specified for report")
+	}
+
+	engineAndType := strings.ToUpper(fmt.Sprintf("%s %s", engines[0], reportType))
+
 	jsonData := map[string]interface{}{
 		"reportName": "improved-scan-report",
 		"entities": []map[string]interface{}{
@@ -1384,7 +1748,7 @@ func (sys *SystemInstance) RequestNewReportV2(scanID, reportType string) (string
 			},
 		},
 		"filters": map[string][]string{
-			"scanners": {"sast"},
+			"scanners": engines,
 			"severities": {
 				"critical",
 				"high",
@@ -1409,9 +1773,9 @@ func (sys *SystemInstance) RequestNewReportV2(scanID, reportType string) (string
 	header.Set("Content-Type", "application/json")
 	data, err := sendRequest(sys, http.MethodPost, "/reports/v2", bytes.NewBuffer(jsonValue), header, []int{})
 	if err != nil {
-		return "", fmt.Errorf("Failed to trigger report generation for scan %v: %w", scanID, err)
+		return "", fmt.Errorf("Failed to trigger %s report generation for scan %v: %w", engineAndType, scanID, err)
 	} else {
-		sys.logger.Infof("Generating report %v", string(data))
+		sys.logger.Infof("Generating %s report %v", engineAndType, string(data))
 	}
 
 	var reportResponse struct {
@@ -1471,6 +1835,10 @@ func (sys *SystemInstance) DownloadReport(reportUrl string) ([]byte, error) {
 }
 
 func (sys *SystemInstance) GetVersion() (VersionInfo, error) {
+	if sys.version != nil {
+		return *sys.version, nil
+	}
+
 	sys.logger.Debug("Getting Version information...")
 	var version VersionInfo
 
@@ -1481,7 +1849,34 @@ func (sys *SystemInstance) GetVersion() (VersionInfo, error) {
 	}
 
 	err = json.Unmarshal(data, &version)
-	return version, err
+	if err != nil {
+		return version, err
+	}
+
+	sys.version = &version
+	return version, nil
+}
+
+func (s ScanMetadata) TotalLOC() int {
+	total := 0
+	if s.SAST != nil {
+		total += s.SAST.LOC
+	}
+	if s.IAC != nil {
+		total += s.IAC.IACLOC
+	}
+	return total
+}
+
+func (s ScanMetadata) TotalFiles() int {
+	total := 0
+	if s.SAST != nil {
+		total += s.SAST.FileCount
+	}
+	if s.IAC != nil {
+		total += s.IAC.FileCount
+	}
+	return total
 }
 
 func (v VersionInfo) CheckCxOne(version string) int {
@@ -1519,4 +1914,26 @@ func versionStringToInts(version string) []int64 {
 		ints[id], _ = strconv.ParseInt(val, 10, 64)
 	}
 	return ints
+}
+
+func (q *scanresultQueryID) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		q.Value = strings.TrimSuffix(s, " [Taken from query_id]")
+		return nil
+	}
+
+	var u uint64
+	if err := json.Unmarshal(data, &u); err != nil {
+		return err
+	}
+	q.Value = u
+	return nil
 }

--- a/pkg/checkmarxone/checkmarxone_test.go
+++ b/pkg/checkmarxone/checkmarxone_test.go
@@ -209,7 +209,8 @@ func TestGetGroups(t *testing.T) {
 	})
 }
 
-func TestGetScanMetadata(t *testing.T) {
+// TODO: similar test for IAC
+func TestGetScanSASTMetadata(t *testing.T) {
 	logger := log.Entry().WithField("package", "SAP/jenkins-library/pkg/checkmarxOne_test")
 	opts := piperHttp.ClientOptions{}
 	t.Run("test success", func(t *testing.T) {
@@ -217,7 +218,7 @@ func TestGetScanMetadata(t *testing.T) {
 		sys := SystemInstance{serverURL: "https://cx1.server.com", iamURL: "https://cx1iam.server.com", tenant: "tenant", client: &myTestClient, logger: logger}
 		myTestClient.SetOptions(opts)
 
-		scanmeta, err := sys.GetScanMetadata("03d66397-36df-40b5-8976-f38bcce695a7")
+		scanmeta, err := sys.GetScanSASTMetadata("03d66397-36df-40b5-8976-f38bcce695a7")
 		assert.NoError(t, err, "Error occurred but none expected")
 
 		assert.Equal(t, "03d66397-36df-40b5-8976-f38bcce695a7", scanmeta.ScanID, "ScanID is incorrect")
@@ -235,9 +236,73 @@ func TestGetScanMetadata(t *testing.T) {
 		myTestClient.SetOptions(opts)
 		myTestClient.errorExp = true
 
-		_, err := sys.GetScanMetadata("03d66397-36df-40b5-8976-f38bcce695a7")
+		_, err := sys.GetScanSASTMetadata("03d66397-36df-40b5-8976-f38bcce695a7")
 		assert.Contains(t, fmt.Sprint(err), "Provoked technical error")
 	})
+}
+func TestGetScanIACMetadata(t *testing.T) {
+	logger := log.Entry().WithField("package", "SAP/jenkins-library/pkg/checkmarxOne_test")
+	opts := piperHttp.ClientOptions{}
+	t.Run("test success", func(t *testing.T) {
+		myTestClient := senderMock{responseBody: `{"scanId":"b2f0ad4e-414c-45a1-8e49-9b2af97be7b2","projectId":"7553c43d-d371-4061-9173-594f713bce31","loc":9,"kicsLoc":11,"fileCount":1}`, httpStatusCode: 200}
+		sys := SystemInstance{serverURL: "https://cx1.server.com", iamURL: "https://cx1iam.server.com", tenant: "tenant", client: &myTestClient, logger: logger}
+		myTestClient.SetOptions(opts)
+
+		scanmeta, err := sys.GetScanIACMetadata("b2f0ad4e-414c-45a1-8e49-9b2af97be7b2")
+		assert.NoError(t, err, "Error occurred but none expected")
+
+		assert.Equal(t, "b2f0ad4e-414c-45a1-8e49-9b2af97be7b2", scanmeta.ScanID, "ScanID is incorrect")
+		assert.Equal(t, "7553c43d-d371-4061-9173-594f713bce31", scanmeta.ProjectID, "ProjectID is incorrect")
+		assert.Equal(t, 9, scanmeta.LOC, "LOC is incorrect")
+		assert.Equal(t, 11, scanmeta.IACLOC, "IAC LOC is incorrect")
+		assert.Equal(t, 1, scanmeta.FileCount, "FileCount is incorrect")
+		assert.Equal(t, IACDefaultBlankPreset, scanmeta.PresetName, "PresetName is incorrect")
+	})
+
+	t.Run("test technical error", func(t *testing.T) {
+		myTestClient := senderMock{httpStatusCode: 200}
+		sys := SystemInstance{serverURL: "https://cx1.server.com", iamURL: "https://cx1iam.server.com", tenant: "tenant", client: &myTestClient, logger: logger}
+		myTestClient.SetOptions(opts)
+		myTestClient.errorExp = true
+
+		_, err := sys.GetScanIACMetadata("03d66397-36df-40b5-8976-f38bcce695a7")
+		assert.Contains(t, fmt.Sprint(err), "Provoked technical error")
+	})
+}
+
+func TestGetIACFindingInfo(t *testing.T) {
+	logger := log.Entry().WithField("package", "SAP/jenkins-library/pkg/checkmarxOne_test")
+	opts := piperHttp.ClientOptions{}
+	result := ScanResult{
+		Data: ScanResultData{
+			QueryID:   scanresultQueryID{Value: "b03a748a-542d-44f4-bb86-9199ab4fd2d5"},
+			Platform:  "Dockerfile",
+			QueryName: "Healthcheck Instruction Missing",
+		},
+	}
+
+	t.Run("test success", func(t *testing.T) {
+		myTestClient := senderMock{responseBody: `[{"title":"Checkmarx predefined","key":"cx","children":[{"title":"common","key":"Cx-common","children":[{"isLeaf":true,"title":"Last User Is 'root'","key":"67fd0c4a-68cf-46d7-8c41-bc9fba7e40ae","data":{"custom":false,"cwe":250,"severity":"HIGH","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/67fd0c4a-68cf-46d7-8c41-bc9fba7e40ae"}},{"isLeaf":true,"title":"Missing User Instruction","key":"fd54f200-402c-4333-a5a4-36ef6709af2f","data":{"custom":false,"cwe":250,"severity":"HIGH","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/fd54f200-402c-4333-a5a4-36ef6709af2f"}},{"isLeaf":true,"title":"Add Instead of Copy","key":"9513a694-aa0d-41d8-be61-3271e056f36b","data":{"custom":false,"cwe":610,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/9513a694-aa0d-41d8-be61-3271e056f36b"}},{"isLeaf":true,"title":"Apt Get Install Pin Version Not Defined","key":"965a08d7-ef86-4f14-8792-4a3b2098937e","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/965a08d7-ef86-4f14-8792-4a3b2098937e"}},{"isLeaf":true,"title":"Changing Default Shell Using RUN Command","key":"8a301064-c291-4b20-adcb-403fe7fd95fd","data":{"custom":false,"cwe":710,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/8a301064-c291-4b20-adcb-403fe7fd95fd"}},{"isLeaf":true,"title":"Gem Install Without Version","key":"22cd11f7-9c6c-4f6e-84c0-02058120b341","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/22cd11f7-9c6c-4f6e-84c0-02058120b341"}},{"isLeaf":true,"title":"Image Version Not Explicit","key":"9efb0b2d-89c9-41a3-91ca-dcc0aec911fd","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/9efb0b2d-89c9-41a3-91ca-dcc0aec911fd"}},{"isLeaf":true,"title":"Image Version Using 'latest'","key":"f45ea400-6bbe-4501-9fc7-1c3d75c32067","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/f45ea400-6bbe-4501-9fc7-1c3d75c32067"}},{"isLeaf":true,"title":"Missing Version Specification In dnf install","key":"93d88cf7-f078-46a8-8ddc-178e03aeacf1","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/93d88cf7-f078-46a8-8ddc-178e03aeacf1"}},{"isLeaf":true,"title":"Missing Zypper Non-interactive Switch","key":"45e1fca5-f90e-465d-825f-c2cb63fa3944","data":{"custom":false,"cwe":710,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/45e1fca5-f90e-465d-825f-c2cb63fa3944"}},{"isLeaf":true,"title":"NPM Install Command Without Pinned Version","key":"e36d8880-3f78-4546-b9a1-12f0745ca0d5","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/e36d8880-3f78-4546-b9a1-12f0745ca0d5"}},{"isLeaf":true,"title":"Not Using JSON In CMD And ENTRYPOINT Arguments","key":"b86987e1-6397-4619-81d5-8807f2387c79","data":{"custom":false,"cwe":573,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/b86987e1-6397-4619-81d5-8807f2387c79"}},{"isLeaf":true,"title":"Run Using Sudo","key":"8ada6e80-0ade-439e-b176-0b28f6bce35a","data":{"custom":false,"cwe":440,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/8ada6e80-0ade-439e-b176-0b28f6bce35a"}},{"isLeaf":true,"title":"Unpinned Package Version in Apk Add","key":"d3499f6d-1651-41bb-a9a7-de925fea487b","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/d3499f6d-1651-41bb-a9a7-de925fea487b"}},{"isLeaf":true,"title":"Unpinned Package Version in Pip Install","key":"02d9c71f-3ee8-4986-9c27-1a20d0d19bfc","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/02d9c71f-3ee8-4986-9c27-1a20d0d19bfc"}},{"isLeaf":true,"title":"Yum install Without Version","key":"6452c424-1d92-4deb-bb18-a03e95d579c4","data":{"custom":false,"cwe":1357,"severity":"MEDIUM","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/6452c424-1d92-4deb-bb18-a03e95d579c4"}},{"isLeaf":true,"title":"APT-GET Missing Flags To Avoid Manual Input","key":"77783205-c4ca-4f80-bb80-c777f267c547","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/77783205-c4ca-4f80-bb80-c777f267c547"}},{"isLeaf":true,"title":"COPY '--from' References Current FROM Alias","key":"cdddb86f-95f6-4fc4-b5a1-483d9afceb2b","data":{"custom":false,"cwe":706,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/cdddb86f-95f6-4fc4-b5a1-483d9afceb2b"}},{"isLeaf":true,"title":"Chown Flag Exists","key":"aa93e17f-b6db-4162-9334-c70334e7ac28","data":{"custom":false,"cwe":282,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/aa93e17f-b6db-4162-9334-c70334e7ac28"}},{"isLeaf":true,"title":"Copy With More Than Two Arguments Not Ending With Slash","key":"6db6e0c2-32a3-4a2e-93b5-72c35f4119db","data":{"custom":false,"cwe":628,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/6db6e0c2-32a3-4a2e-93b5-72c35f4119db"}},{"isLeaf":true,"title":"Curl or Wget Instead of Add","key":"4b410d24-1cbe-4430-a632-62c9a931cf1c","data":{"custom":false,"cwe":610,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/4b410d24-1cbe-4430-a632-62c9a931cf1c"}},{"isLeaf":true,"title":"Exposing Port 22 (SSH)","key":"5907595b-5b6d-4142-b173-dbb0e73fbff8","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/5907595b-5b6d-4142-b173-dbb0e73fbff8"}},{"isLeaf":true,"title":"Healthcheck Instruction Missing","key":"b03a748a-542d-44f4-bb86-9199ab4fd2d5","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/b03a748a-542d-44f4-bb86-9199ab4fd2d5"}},{"isLeaf":true,"title":"MAINTAINER Instruction Being Used","key":"99614418-f82b-4852-a9ae-5051402b741c","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/99614418-f82b-4852-a9ae-5051402b741c"}},{"isLeaf":true,"title":"Missing Dnf Clean All","key":"295acb63-9246-4b21-b441-7c1f1fb62dc0","data":{"custom":false,"cwe":459,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/295acb63-9246-4b21-b441-7c1f1fb62dc0"}},{"isLeaf":true,"title":"Missing Flag From Dnf Install","key":"7ebd323c-31b7-4e5b-b26f-de5e9e477af8","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/7ebd323c-31b7-4e5b-b26f-de5e9e477af8"}},{"isLeaf":true,"title":"Missing Zypper Clean","key":"38300d1a-feb2-4a48-936a-d1ef1cd24313","data":{"custom":false,"cwe":459,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/38300d1a-feb2-4a48-936a-d1ef1cd24313"}},{"isLeaf":true,"title":"Multiple CMD Instructions Listed","key":"41c195f4-fc31-4a5c-8a1b-90605538d49f","data":{"custom":false,"cwe":1041,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/41c195f4-fc31-4a5c-8a1b-90605538d49f"}},{"isLeaf":true,"title":"Multiple ENTRYPOINT Instructions Listed","key":"6938958b-3f1a-451c-909b-baeee14bdc97","data":{"custom":false,"cwe":1041,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/6938958b-3f1a-451c-909b-baeee14bdc97"}},{"isLeaf":true,"title":"Multiple RUN, ADD, COPY, Instructions Listed","key":"0008c003-79aa-42d8-95b8-1c2fe37dbfe6","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/0008c003-79aa-42d8-95b8-1c2fe37dbfe6"}},{"isLeaf":true,"title":"Pip install Keeping Cached Packages","key":"f2f903fb-b977-461e-98d7-b3e2185c6118","data":{"custom":false,"cwe":459,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/f2f903fb-b977-461e-98d7-b3e2185c6118"}},{"isLeaf":true,"title":"RUN Instruction Using 'cd' Instead of WORKDIR","key":"f4a6bcd3-e231-4acf-993c-aa027be50d2e","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/f4a6bcd3-e231-4acf-993c-aa027be50d2e"}},{"isLeaf":true,"title":"Run Using 'wget' and 'curl'","key":"fc775e75-fcfb-4c98-b2f2-910c5858b359","data":{"custom":false,"cwe":1041,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/fc775e75-fcfb-4c98-b2f2-910c5858b359"}},{"isLeaf":true,"title":"Run Using apt","key":"b84a0b47-2e99-4c9f-8933-98bcabe2b94d","data":{"custom":false,"cwe":758,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/b84a0b47-2e99-4c9f-8933-98bcabe2b94d"}},{"isLeaf":true,"title":"Same Alias In Different Froms","key":"f2daed12-c802-49cd-afed-fe41d0b82fed","data":{"custom":false,"cwe":694,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/f2daed12-c802-49cd-afed-fe41d0b82fed"}},{"isLeaf":true,"title":"Shell Running A Pipe Without Pipefail Flag","key":"efbf148a-67e9-42d2-ac47-02fa1c0d0b22","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/efbf148a-67e9-42d2-ac47-02fa1c0d0b22"}},{"isLeaf":true,"title":"Update Instruction Alone","key":"9bae49be-0aa3-4de5-bab2-4c3a069e40cd","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/9bae49be-0aa3-4de5-bab2-4c3a069e40cd"}},{"isLeaf":true,"title":"Using Unnamed Build Stages","key":"68a51e22-ae5a-4d48-8e87-b01a323605c9","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/68a51e22-ae5a-4d48-8e87-b01a323605c9"}},{"isLeaf":true,"title":"WORKDIR Path Not Absolute","key":"6b376af8-cfe8-49ab-a08d-f32de23661a4","data":{"custom":false,"cwe":665,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/6b376af8-cfe8-49ab-a08d-f32de23661a4"}},{"isLeaf":true,"title":"Yum Clean All Missing","key":"00481784-25aa-4a55-8633-3136dfcf4f37","data":{"custom":false,"cwe":459,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/00481784-25aa-4a55-8633-3136dfcf4f37"}},{"isLeaf":true,"title":"Yum Install Allows Manual Input","key":"6e19193a-8753-436d-8a09-76dcff91bb03","data":{"custom":false,"cwe":710,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/6e19193a-8753-436d-8a09-76dcff91bb03"}},{"isLeaf":true,"title":"Zypper Install Without Version","key":"562952e4-0348-4dea-9826-44f3a2c6117b","data":{"custom":false,"cwe":1357,"severity":"LOW","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/562952e4-0348-4dea-9826-44f3a2c6117b"}},{"isLeaf":true,"title":"APT-GET Not Avoiding Additional Packages","key":"7384dfb2-fcd1-4fbf-91cd-6c44c318c33c","data":{"custom":false,"cwe":710,"severity":"INFO","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/7384dfb2-fcd1-4fbf-91cd-6c44c318c33c"}},{"isLeaf":true,"title":"Apk Add Using Local Cache Path","key":"ae9c56a6-3ed1-4ac0-9b54-31267f51151d","data":{"custom":false,"cwe":459,"severity":"INFO","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/ae9c56a6-3ed1-4ac0-9b54-31267f51151d"}},{"isLeaf":true,"title":"Apt Get Install Lists Were Not Deleted","key":"df746b39-6564-4fed-bf85-e9c44382303c","data":{"custom":false,"cwe":459,"severity":"INFO","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/df746b39-6564-4fed-bf85-e9c44382303c"}},{"isLeaf":true,"title":"Run Utilities And POSIX Commands","key":"9b6b0f38-92a2-41f9-b881-3a1083d99f1b","data":{"custom":false,"cwe":710,"severity":"INFO","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/9b6b0f38-92a2-41f9-b881-3a1083d99f1b"}},{"isLeaf":true,"title":"UNIX Ports Out Of Range","key":"71bf8cf8-f0a1-42fa-b9d2-d10525e0a38e","data":{"custom":false,"cwe":682,"severity":"INFO","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/71bf8cf8-f0a1-42fa-b9d2-d10525e0a38e"}},{"isLeaf":true,"title":"Using Platform Flag with FROM Command","key":"b16e8501-ef3c-44e1-a543-a093238099c9","data":{"custom":false,"cwe":695,"severity":"INFO","url":"https://docs.kics.io/2.1.20/queries/dockerfile-queries/b16e8501-ef3c-44e1-a543-a093238099c9"}}]}]}]`, httpStatusCode: 200}
+		sys := SystemInstance{serverURL: "https://cx1.server.com", iamURL: "https://cx1iam.server.com", tenant: "tenant", client: &myTestClient, logger: logger, iacQueryCache: make(map[string]IACFindingInfo)}
+		myTestClient.SetOptions(opts)
+
+		info, err := sys.GetIACFindingInfo(result)
+		assert.NoError(t, err, "Error occurred but none expected")
+
+		assert.Equal(t, 710, info.Cwe, "CWE is incorrect")
+		assert.Equal(t, "https://docs.kics.io/2.1.20/queries/dockerfile-queries/b03a748a-542d-44f4-bb86-9199ab4fd2d5", info.URL, "URL is incorrect")
+	})
+
+	t.Run("test technical error", func(t *testing.T) {
+		myTestClient := senderMock{httpStatusCode: 200}
+		sys := SystemInstance{serverURL: "https://cx1.server.com", iamURL: "https://cx1iam.server.com", tenant: "tenant", client: &myTestClient, logger: logger, iacQueryCache: make(map[string]IACFindingInfo)}
+		myTestClient.SetOptions(opts)
+		myTestClient.errorExp = true
+
+		_, err := sys.GetIACFindingInfo(result)
+		assert.Contains(t, fmt.Sprint(err), "Provoked technical error")
+	})
+
 }
 
 func TestGetScan(t *testing.T) {

--- a/pkg/checkmarxone/cxjson_to_sarif.go
+++ b/pkg/checkmarxone/cxjson_to_sarif.go
@@ -11,7 +11,25 @@ import (
 )
 
 // ConvertCxJSONToSarif is the entrypoint for the Parse function
-func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResult, scanMeta *ScanMetadata, scan *Scan) (format.SARIF, error) {
+func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResult, _ ScanSASTMetadata, scan *Scan) (format.SARIF, error) {
+	return ConvertCxSASTJSONToSarif(sys, serverURL, scanResults, scan)
+}
+
+func ConvertCxSASTJSONToSarif(sys System, serverURL string, scanResults *[]ScanResult, scan *Scan) (format.SARIF, error) {
+	baseURL := serverURL + "/results/" + scan.ScanID + "/" + scan.ProjectID
+	projectBaseURL := serverURL + "/projects/" + scan.ProjectID + "/"
+
+	return convertCxJSONToSarif(sys, "sast", baseURL, projectBaseURL, scanResults, scan)
+}
+
+func ConvertCxIACJSONToSarif(sys System, serverURL string, scanResults *[]ScanResult, scan *Scan) (format.SARIF, error) {
+	baseURL := serverURL + "/results/" + scan.ScanID + "/" + scan.ProjectID
+	projectBaseURL := serverURL + "/projects/" + scan.ProjectID + "/"
+
+	return convertCxJSONToSarif(sys, "kics", baseURL, projectBaseURL, scanResults, scan)
+}
+
+func convertCxJSONToSarif(sys System, resultType, baseURL, projectBaseURL string, scanResults *[]ScanResult, scan *Scan) (format.SARIF, error) {
 	// Process sarif
 	start := time.Now()
 
@@ -24,9 +42,6 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 	sarif.Runs = append(sarif.Runs, checkmarxRun)
 	rulesArray := []format.SarifRule{}
 
-	baseURL := serverURL + "/results/" + scanMeta.ScanID + "/" + scanMeta.ProjectID
-	projectBaseURL := serverURL + "/projects/" + scanMeta.ProjectID + "/"
-
 	cweIdsForTaxonomies := make(map[int]int) //use a map to avoid duplicates
 	cweCounter := 0
 	//maxretries := 5
@@ -37,6 +52,22 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 	log.Entry().Debug("[SARIF] Now handling results.")
 
 	for _, r := range *scanResults {
+		if resultType != r.Type {
+			continue
+		}
+
+		// Pending case 283343, the CweID for a KICS finding is not provided by the API.
+		// However, we need the IACFindingInfo struct data from another source, which also includes CWE
+		var iacFindingInfo *IACFindingInfo
+		if r.Type == "kics" {
+			findingInfo, err := sys.GetIACFindingInfo(r)
+			if err != nil {
+				log.Entry().Warningf("Error while retrieving IAC finding description for finding [%s] %s: %s", r.Data.QueryID, r.Data.QueryName, err)
+			} else {
+				iacFindingInfo = &findingInfo
+				r.VulnerabilityDetails.CweId = iacFindingInfo.Cwe
+			}
+		}
 		_, haskey := cweIdsForTaxonomies[r.VulnerabilityDetails.CweId]
 
 		if !haskey {
@@ -44,13 +75,23 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 			cweCounter++
 		}
 
-		simidString := fmt.Sprintf("%d", r.SimilarityID)
-
 		var apiDescription string
 		result := *new(format.Results)
 
 		//General
-		result.RuleID = fmt.Sprintf("checkmarxOne-%v/%d", r.Data.LanguageName, r.Data.QueryID)
+
+		var queryID string
+		switch r.Type {
+		case "sast":
+			if v, ok := r.Data.QueryID.Value.(uint64); ok {
+				queryID = fmt.Sprintf("checkmarxOne-%v/%d", r.Data.LanguageName, v)
+			} else {
+				queryID = fmt.Sprintf("checkmarxOne-%v/%s", r.Data.LanguageName, r.Data.QueryID.Value.(string))
+			}
+		case "kics":
+			queryID = fmt.Sprintf("checkmarxOne-%v/%s", r.Data.Platform, r.Data.QueryID.Value.(string))
+		}
+		result.RuleID = queryID
 		result.RuleIndex = cweIdsForTaxonomies[r.VulnerabilityDetails.CweId]
 		result.Level = "none"
 		msg := new(format.Message)
@@ -65,18 +106,65 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 		codeflow := *new(format.CodeFlow)
 		threadflow := *new(format.ThreadFlow)
 		locationSaved := false
-		for k := 0; k < len(r.Data.Nodes); k++ {
-			loc := *new(format.Location)
-			loc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName
-			// remove absolute path of file name (coming from JSON format)
-			if len(r.Data.Nodes[0].FileName) > 0 && r.Data.Nodes[0].FileName[0:1] == "/" {
-				loc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName[1:]
+		switch r.Type {
+		case "sast":
+			for k := 0; k < len(r.Data.Nodes); k++ {
+				loc := *new(format.Location)
+				loc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName
+				// remove absolute path of file name (coming from JSON format)
+				if len(r.Data.Nodes[0].FileName) > 0 && r.Data.Nodes[0].FileName[0:1] == "/" {
+					loc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName[1:]
+				}
+				loc.PhysicalLocation.Region.StartLine = r.Data.Nodes[k].Line
+				loc.PhysicalLocation.Region.EndLine = r.Data.Nodes[k].Line
+				loc.PhysicalLocation.Region.StartColumn = r.Data.Nodes[k].Column
+				snip := new(format.SnippetSarif)
+				snip.Text = r.Data.Nodes[k].Name
+				loc.PhysicalLocation.Region.Snippet = snip
+				if !locationSaved { // To avoid overloading log file, we only save the 1st location, or source, as in the webview
+					result.Locations = append(result.Locations, loc)
+					locationSaved = true
+				}
+
+				//Related Locations
+				relatedLocation := *new(format.RelatedLocation)
+				relatedLocation.ID = k + 1
+				relatedLocation.PhysicalLocation = *new(format.RelatedPhysicalLocation)
+				relatedLocation.PhysicalLocation.ArtifactLocation = loc.PhysicalLocation.ArtifactLocation
+				relatedLocation.PhysicalLocation.Region = *new(format.RelatedRegion)
+				relatedLocation.PhysicalLocation.Region.StartLine = loc.PhysicalLocation.Region.StartLine
+				relatedLocation.PhysicalLocation.Region.StartColumn = r.Data.Nodes[k].Column
+				result.RelatedLocations = append(result.RelatedLocations, relatedLocation)
+
+				threadFlowLocation := *new(format.Locations)
+				tfloc := new(format.Location)
+				tfloc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName
+				// remove absolute path of file name (coming from JSON format)
+				if len(r.Data.Nodes[0].FileName) > 0 && r.Data.Nodes[0].FileName[0:1] == "/" {
+					loc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName[1:]
+				}
+				tfloc.PhysicalLocation.Region.StartLine = r.Data.Nodes[k].Line
+				tfloc.PhysicalLocation.Region.EndLine = r.Data.Nodes[k].Line
+				tfloc.PhysicalLocation.Region.StartColumn = r.Data.Nodes[k].Column
+				tfloc.PhysicalLocation.Region.Snippet = snip
+				threadFlowLocation.Location = tfloc
+				threadflow.Locations = append(threadflow.Locations, threadFlowLocation)
 			}
-			loc.PhysicalLocation.Region.StartLine = r.Data.Nodes[k].Line
-			loc.PhysicalLocation.Region.EndLine = r.Data.Nodes[k].Line
-			loc.PhysicalLocation.Region.StartColumn = r.Data.Nodes[k].Column
-			snip := new(format.SnippetSarif)
-			snip.Text = r.Data.Nodes[k].Name
+		case "kics":
+			loc := *new(format.Location)
+
+			filename := r.Data.Filename
+			// remove absolute path of file name (coming from JSON format)
+			if len(filename) > 0 && filename[0:1] == "/" {
+				filename = filename[1:]
+			}
+
+			loc.PhysicalLocation.ArtifactLocation.URI = filename
+			loc.PhysicalLocation.Region.StartLine = r.Data.Line
+			loc.PhysicalLocation.Region.EndLine = r.Data.Line
+			loc.PhysicalLocation.Region.StartColumn = 0 // no column in IAC
+			snip := new(format.SnippetSarif)            // TODO: review the snippet for different IAC findings
+			snip.Text = r.Data.Value
 			loc.PhysicalLocation.Region.Snippet = snip
 			if !locationSaved { // To avoid overloading log file, we only save the 1st location, or source, as in the webview
 				result.Locations = append(result.Locations, loc)
@@ -85,39 +173,34 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 
 			//Related Locations
 			relatedLocation := *new(format.RelatedLocation)
-			relatedLocation.ID = k + 1
+			relatedLocation.ID = 1
 			relatedLocation.PhysicalLocation = *new(format.RelatedPhysicalLocation)
 			relatedLocation.PhysicalLocation.ArtifactLocation = loc.PhysicalLocation.ArtifactLocation
 			relatedLocation.PhysicalLocation.Region = *new(format.RelatedRegion)
 			relatedLocation.PhysicalLocation.Region.StartLine = loc.PhysicalLocation.Region.StartLine
-			relatedLocation.PhysicalLocation.Region.StartColumn = r.Data.Nodes[k].Column
+			relatedLocation.PhysicalLocation.Region.StartColumn = 0
 			result.RelatedLocations = append(result.RelatedLocations, relatedLocation)
 
 			threadFlowLocation := *new(format.Locations)
 			tfloc := new(format.Location)
-			tfloc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName
-			// remove absolute path of file name (coming from JSON format)
-			if len(r.Data.Nodes[0].FileName) > 0 && r.Data.Nodes[0].FileName[0:1] == "/" {
-				loc.PhysicalLocation.ArtifactLocation.URI = r.Data.Nodes[0].FileName[1:]
-			}
-			tfloc.PhysicalLocation.Region.StartLine = r.Data.Nodes[k].Line
-			tfloc.PhysicalLocation.Region.EndLine = r.Data.Nodes[k].Line
-			tfloc.PhysicalLocation.Region.StartColumn = r.Data.Nodes[k].Column
+			tfloc.PhysicalLocation.ArtifactLocation.URI = filename
+			tfloc.PhysicalLocation.Region.StartLine = r.Data.Line
+			tfloc.PhysicalLocation.Region.EndLine = r.Data.Line
+			tfloc.PhysicalLocation.Region.StartColumn = 0
 			tfloc.PhysicalLocation.Region.Snippet = snip
 			threadFlowLocation.Location = tfloc
 			threadflow.Locations = append(threadflow.Locations, threadFlowLocation)
-
 		}
 		codeflow.ThreadFlows = append(codeflow.ThreadFlows, threadflow)
 		result.CodeFlows = append(result.CodeFlows, codeflow)
 
-		result.PartialFingerprints.CheckmarxSimilarityID = simidString
-		result.PartialFingerprints.PrimaryLocationLineHash = simidString
+		result.PartialFingerprints.CheckmarxSimilarityID = r.SimilarityID
+		result.PartialFingerprints.PrimaryLocationLineHash = r.SimilarityID
 
 		//Properties
 		props := new(format.SarifProperties)
 		props.Audited = false
-		props.CheckmarxSimilarityID = simidString
+		props.CheckmarxSimilarityID = r.SimilarityID
 		props.InstanceID = r.ResultID // no more PathID in cx1
 		props.ToolSeverity = r.Severity
 
@@ -193,7 +276,7 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 			log.Entry().Warningf("Error while retrieving result predicates: %s", err)
 		}*/
 
-		props.RuleGUID = fmt.Sprintf("%d", r.Data.QueryID)
+		props.RuleGUID = queryID
 		props.UnifiedAuditState = ""
 		result.Properties = props
 
@@ -203,14 +286,26 @@ func ConvertCxJSONToSarif(sys System, serverURL string, scanResults *[]ScanResul
 		//handle the rules array
 		rule := *new(format.SarifRule)
 
-		rule.ID = fmt.Sprintf("checkmarxOne-%v/%d", r.Data.LanguageName, r.Data.QueryID)
+		rule.ID = queryID
 		words := strings.Split(r.Data.QueryName, "_")
 		for w := 0; w < len(words); w++ {
 			words[w] = piperutils.Title(strings.ToLower(words[w]))
 		}
 		rule.Name = strings.Join(words, "")
 
-		rule.HelpURI = fmt.Sprintf("%v/sast/description/%v/%v", baseURL, r.VulnerabilityDetails.CweId, r.Data.QueryID)
+		switch r.Type {
+		case "sast":
+			rule.HelpURI = fmt.Sprintf("%v/sast/description/%v/%v", baseURL, r.VulnerabilityDetails.CweId, r.Data.QueryID)
+		case "kics":
+			if iacFindingInfo == nil {
+				rule.HelpURI = "n/a"
+			} else {
+				rule.HelpURI = iacFindingInfo.URL
+			}
+
+		default:
+			rule.HelpURI = "n/a" // TODO: offsite links to kics docs eg https://docs.kics.io/2.1.20/queries/crossplane-queries/gcp/b4f65d13-a609-4dc1-af7c-63d2e08bffe9/
+		}
 		rule.Help = new(format.Help)
 		rule.Help.Text = rule.HelpURI
 		rule.ShortDescription = new(format.Message)

--- a/pkg/checkmarxone/reporting.go
+++ b/pkg/checkmarxone/reporting.go
@@ -27,12 +27,14 @@ type CheckmarxOneReportData struct {
 	GroupID         string     `json:"groupID"`
 	DeepLink        string     `json:"deepLink"`
 	Preset          string     `json:"preset"`
+	IACPreset       string     `json:"iacPreset"`
 	ScanType        string     `json:"scanType"`
 	Findings        *[]Finding `json:"findings"`
 }
 
 type Finding struct {
 	ClassificationName string         `json:"classificationName"`
+	Engine             string         `json:"engine"`
 	Total              int            `json:"total,omitempty"`
 	Audited            *int           `json:"audited,omitempty"`
 	Confirmed          int            `json:"confirmed,omitempty"`
@@ -61,10 +63,13 @@ func CreateCustomReport(data *map[string]interface{}, insecure, neutral []string
 			{Description: "Scan start", Details: fmt.Sprint((*data)["ScanStart"])},
 			{Description: "Scan duration", Details: fmt.Sprint((*data)["ScanTime"])},
 			{Description: "Scan type", Details: fmt.Sprint((*data)["ScanType"])},
-			{Description: "Preset", Details: fmt.Sprint((*data)["Preset"])},
+			{Description: "Preset", Details: fmt.Sprint((*data)["SastPreset"])},
+			{Description: "IAC Preset", Details: fmt.Sprint((*data)["IacPreset"])},
 			{Description: "Report creation time", Details: fmt.Sprint((*data)["ReportCreationTime"])},
-			{Description: "Lines of code scanned", Details: fmt.Sprint((*data)["LinesOfCodeScanned)"])},
-			{Description: "Files scanned", Details: fmt.Sprint((*data)["FilesScanned)"])},
+			{Description: "Lines of code scanned", Details: fmt.Sprint((*data)["LinesOfCodeScanned"])},
+			{Description: "Files scanned", Details: fmt.Sprint((*data)["FilesScanned"])},
+			{Description: "IAC Lines of code scanned", Details: fmt.Sprint((*data)["IacLinesOfCodeScanned"])},
+			{Description: "IAC Files scanned", Details: fmt.Sprint((*data)["IacFilesScanned"])},
 			{Description: "Tool version", Details: fmt.Sprint((*data)["ToolVersion"])},
 			{Description: "Deep link", Details: deepLink},
 		},
@@ -151,7 +156,7 @@ func CreateJSONHeaderReport(data *map[string]interface{}) CheckmarxOneReportData
 		ApplicationID:   fmt.Sprint((*data)["Application"]),
 		ApplicationName: fmt.Sprint((*data)["ApplicationFullPathOnReportDate"]),
 		DeepLink:        fmt.Sprint((*data)["DeepLink"]),
-		Preset:          fmt.Sprint((*data)["Preset"]),
+		Preset:          fmt.Sprint((*data)["SastPreset"]),
 		ToolVersion:     fmt.Sprint((*data)["ToolVersion"]),
 		ScanType:        fmt.Sprint((*data)["ScanType"]),
 		ProjectID:       fmt.Sprint((*data)["ProjectId"]),
@@ -236,11 +241,11 @@ func WriteJSONHeaderReport(jsonReport CheckmarxOneReportData) ([]piperutils.Path
 }
 
 // WriteSarif writes a json file to disk as a .sarif if it respects the specification declared in format.SARIF
-func WriteSarif(sarif format.SARIF) ([]piperutils.Path, error) {
+func WriteSASTSarif(sarif format.SARIF) ([]piperutils.Path, error) {
 	utils := piperutils.Files{}
 	reportPaths := []piperutils.Path{}
 
-	sarifReportPath := filepath.Join(ReportsDirectory, "result.sarif")
+	sarifReportPath := filepath.Join(ReportsDirectory, "result-sast.sarif")
 	// Ensure reporting directory exists
 	if err := utils.MkdirAll(ReportsDirectory, 0777); err != nil {
 		return reportPaths, fmt.Errorf("failed to create report directory: %w", err)
@@ -258,9 +263,39 @@ func WriteSarif(sarif format.SARIF) ([]piperutils.Path, error) {
 	log.Entry().Info("Writing file to disk: ", sarifReportPath)
 	if err := utils.FileWrite(sarifReportPath, buffer.Bytes(), 0666); err != nil {
 		log.SetErrorCategory(log.ErrorConfiguration)
-		return reportPaths, fmt.Errorf("failed to write CheckmarxOne SARIF report: %w", err)
+		return reportPaths, fmt.Errorf("failed to write CheckmarxOne SAST SARIF report: %w", err)
 	}
-	reportPaths = append(reportPaths, piperutils.Path{Name: "CheckmarxOne SARIF Report", Target: sarifReportPath})
+	reportPaths = append(reportPaths, piperutils.Path{Name: "CheckmarxOne SAST SARIF Report", Target: sarifReportPath})
+
+	return reportPaths, nil
+}
+
+// WriteSarif writes a json file to disk as a .sarif if it respects the specification declared in format.SARIF
+func WriteIACSarif(sarif format.SARIF) ([]piperutils.Path, error) {
+	utils := piperutils.Files{}
+	reportPaths := []piperutils.Path{}
+
+	sarifReportPath := filepath.Join(ReportsDirectory, "result-iac.sarif")
+	// Ensure reporting directory exists
+	if err := utils.MkdirAll(ReportsDirectory, 0777); err != nil {
+		return reportPaths, fmt.Errorf("failed to create report directory: %w", err)
+	}
+
+	// HTML characters will most likely be present: we need to use encode: create a buffer to hold JSON data
+	buffer := new(bytes.Buffer)
+	// create JSON encoder for buffer
+	bufEncoder := json.NewEncoder(buffer)
+	// set options
+	bufEncoder.SetEscapeHTML(false)
+	bufEncoder.SetIndent("", "  ")
+	//encode to buffer
+	bufEncoder.Encode(sarif)
+	log.Entry().Info("Writing file to disk: ", sarifReportPath)
+	if err := utils.FileWrite(sarifReportPath, buffer.Bytes(), 0666); err != nil {
+		log.SetErrorCategory(log.ErrorConfiguration)
+		return reportPaths, fmt.Errorf("failed to write CheckmarxOne SAST SARIF report: %w", err)
+	}
+	reportPaths = append(reportPaths, piperutils.Path{Name: "CheckmarxOne SAST SARIF Report", Target: sarifReportPath})
 
 	return reportPaths, nil
 }

--- a/pkg/checkmarxone/reporting_test.go
+++ b/pkg/checkmarxone/reporting_test.go
@@ -15,7 +15,7 @@ func TestCreateJSONReport(t *testing.T) {
 	resultMap["Application"] = `test-app`
 	resultMap["ApplicationFullPathOnReportDate"] = `test-app-path`
 	resultMap["DeepLink"] = `https://cx1.sap/projects/f5702f86-b396-417f-82e2-4949a55d5382/scans?branch=master&page=1&id=21e40b36-0dd7-48e5-9768-da1a8f36c907`
-	resultMap["Preset"] = `Checkmarx Default`
+	resultMap["SastPreset"] = `Checkmarx Default`
 	resultMap["ToolVersion"] = `v1`
 	resultMap["ScanType"] = `Incremental`
 	resultMap["ProjectId"] = `f5702f86-b396-417f-82e2-4949a55d5382`

--- a/resources/metadata/checkmarxOneExecuteScan.yaml
+++ b/resources/metadata/checkmarxOneExecuteScan.yaml
@@ -52,16 +52,24 @@ spec:
           - STAGES
           - STEPS
         default: true
+      - name: engines
+        type: "[]string"
+        description: "The scan engines to trigger for this scan. Can be: sast, iac"
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: [ sast ]
       - name: filterPattern
         type: string
-        description: The filter pattern used to zip the files relevant for scanning, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory
+        description: The filter pattern used to zip the files relevant for scanning, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory. For multiple-engine scans, this filter should include all files applicable to all engines - per-engine filters should be set separately through sastFileFilter and iacFileFilter.
         scope:
           - PARAMETERS
           - STAGES
           - STEPS
         default:
           "!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go,
-          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"
+          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"  
       - name: fullScanCycle
         type: string
         description: Indicates how often a full scan should happen between the incremental scans when activated
@@ -113,6 +121,31 @@ spec:
           - type: vaultSecret
             default: github
             name: githubVaultSecretName
+      - name: iacHelpLinks
+        type: string
+        description: A path to a json file (remote if http/https, local otherwise) containing a map of IAC_query_id:help_url
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default:
+          ""
+      - name: iacFilterPattern
+        type: string
+        description: The pattern to filter the files relevant for scanning in IAC, patterns can be negated by setting an exclamation mark in front i.e. `!**/*.yaml` would avoid adding any yaml files located in the test directory
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default:
+          ""
+      - name: iacPreset
+        type: string
+        description: The preset to use for IAC scanning, if not set explicitly the step will attempt to look up the project's setting based on the availability of `checkmarxOneCredentialsId`
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS    
       - name: scanSummaryInPullRequest
         description: Whether the scan summary shall be added to the pull request as a comment or not. This is only applied if the step is executed in a pull request context. githubToken and githubApiUrl parameters must be set to allow the step to create the comment.
         type: bool
@@ -185,13 +218,6 @@ spec:
           - type: vaultSecret
             name: checkmarxOneVaultSecretName
             default: checkmarxOne
-      - name: preset
-        type: string
-        description: The preset to use for scanning, if not set explicitly the step will attempt to look up the project's setting based on the availability of `checkmarxOneCredentialsId`
-        scope:
-          - PARAMETERS
-          - STAGES
-          - STEPS
       - name: languageMode
         type: string
         description: Specifies whether the scan should be run for a 'single' language or 'multi' language, default 'multi'
@@ -225,6 +251,24 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: sastFilterPattern
+        type: string
+        description: The pattern to filter the files relevant for scanning in SAST, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default:
+          ""   
+      - name: sastPreset
+        aliases:
+          - name: preset
+        type: string
+        description: The preset to use for SAST scanning, if not set explicitly the step will attempt to look up the project's setting based on the availability of `checkmarxOneCredentialsId`
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS     
       - name: scanTags
         type: string
         description: Used to tag a scan with a JSON string, e.g., {"key":"value", "keywithoutvalue":""}
@@ -550,6 +594,7 @@ spec:
               - name: tool_version
               - name: scan_type
               - name: preset
+              - name: iac_preset
               - name: deep_link
               - name: report_creation_time
       - name: reports

--- a/resources/metadata/checkmarxOneExecuteScan.yaml
+++ b/resources/metadata/checkmarxOneExecuteScan.yaml
@@ -59,7 +59,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        default: [ sast ]
+        default: [sast]
       - name: filterPattern
         type: string
         description: The filter pattern used to zip the files relevant for scanning, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory. For multiple-engine scans, this filter should include all files applicable to all engines - per-engine filters should be set separately through sastFileFilter and iacFileFilter.
@@ -69,7 +69,7 @@ spec:
           - STEPS
         default:
           "!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go,
-          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"  
+          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"
       - name: fullScanCycle
         type: string
         description: Indicates how often a full scan should happen between the incremental scans when activated
@@ -145,7 +145,7 @@ spec:
         scope:
           - PARAMETERS
           - STAGES
-          - STEPS    
+          - STEPS
       - name: scanSummaryInPullRequest
         description: Whether the scan summary shall be added to the pull request as a comment or not. This is only applied if the step is executed in a pull request context. githubToken and githubApiUrl parameters must be set to allow the step to create the comment.
         type: bool
@@ -259,7 +259,7 @@ spec:
           - STAGES
           - STEPS
         default:
-          ""   
+          ""
       - name: sastPreset
         aliases:
           - name: preset
@@ -268,7 +268,7 @@ spec:
         scope:
           - PARAMETERS
           - STAGES
-          - STEPS     
+          - STEPS
       - name: scanTags
         type: string
         description: Used to tag a scan with a JSON string, e.g., {"key":"value", "keywithoutvalue":""}


### PR DESCRIPTION
# Description

This PR adds support for the IaC engine in Checkmarx One.
Users can now use the Checkmarx step to scan with SAST, IAC, or both.
The PR introduces several new config parameters for IaC.