### PR TITLE
chore: Update default_pipeline_environment.yml - updated default jnlp image from jdk 17 to jdk 21

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -52,7 +52,7 @@ general:
   gitSshKeyCredentialsId: '' #needed to allow sshagent to run with local ssh key
   globalExtensionsDirectory: '.pipeline/tmp/global_extensions/'
   jenkinsKubernetes:
-    jnlpAgent: 'jenkins/inbound-agent:jdk17'
+    jnlpAgent: 'jenkins/inbound-agent:jdk21'
     securityContext:
     # Setting security context globally is currently not working with jaas
     #  runAsUser: 1000


### PR DESCRIPTION
# Description
jdk17 is not support with most Jenkins versions now, updating default jnlp image so new jenkins version are able to communicate with jnlp agents

# Checklist

- [ x] Tests
- [ x] Documentation
- [ x] Inner source library needs updating
