### PR TITLE
fix(helmBuild): call helmExecute binary command for compatibility with released binaries

### DIFF
--- a/vars/helmBuild.groovy
+++ b/vars/helmBuild.groovy
@@ -10,5 +10,9 @@ void call(Map parameters = [:]) {
         [type: 'usernamePassword', id: 'sourceRepositoryCredentialsId', env: ['PIPER_sourceRepositoryUser', 'PIPER_sourceRepositoryPassword']],
         [type: 'usernamePassword', id: 'targetRepositoryCredentialsId', env: ['PIPER_targetRepositoryUser', 'PIPER_targetRepositoryPassword']],
     ]
-    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
+    // Use helmExecute as the binary step name for compatibility with released binaries
+    // predating the helmBuild rename (v1.519.0 and earlier only register helmExecute).
+    // The cliAliases in metadata ensure helmExecute routes to helmBuild in new binaries.
+    // Revert to STEP_NAME once a binary release with helmBuild ships.
+    piperExecuteBin(parameters, 'helmExecute', METADATA_FILE, credentials)
 }


### PR DESCRIPTION
## Problem

PR #5830 (merged 2026-08-06) renamed `helmExecute` to `helmBuild` in the Groovy wrapper, but the latest released binary (`v1.519.0`, 2026-07-27) predates the rename and only registers `helmExecute`. Any pipeline loading `piper-lib-os@master` with a released binary fails immediately:

```
Error: unknown command "helmBuild" for "piper"
```

## Fix

Make `vars/helmBuild.groovy` invoke `helmExecute` as the binary step name instead of `STEP_NAME` (`helmBuild`). This works on:
- **Old binaries** (≤ v1.519.0): `helmExecute` is the primary command
- **New binaries** (post-rename): `helmExecute` is registered as a `cliAliases` entry

Config resolution is unaffected — `metadataFile` (`helmBuild.yaml`) is passed separately to `piperExecuteBin` and used independently of the binary step name.

## Follow-up

Revert `'helmExecute'` back to `STEP_NAME` in `vars/helmBuild.groovy` once a binary release shipping `helmBuild` as the primary command is the current latest release.