### PR TITLE
Revert "fix(helmBuild): call helmExecute binary command for compatibility with released binaries (#5868)"

### DIFF
--- a/vars/helmBuild.groovy
+++ b/vars/helmBuild.groovy
@@ -10,9 +10,5 @@ void call(Map parameters = [:]) {
         [type: 'usernamePassword', id: 'sourceRepositoryCredentialsId', env: ['PIPER_sourceRepositoryUser', 'PIPER_sourceRepositoryPassword']],
         [type: 'usernamePassword', id: 'targetRepositoryCredentialsId', env: ['PIPER_targetRepositoryUser', 'PIPER_targetRepositoryPassword']],
     ]
-    // Use helmExecute as the binary step name for compatibility with released binaries
-    // predating the helmBuild rename (v1.519.0 and earlier only register helmExecute).
-    // The cliAliases in metadata ensure helmExecute routes to helmBuild in new binaries.
-    // Revert to STEP_NAME once a binary release with helmBuild ships.
-    piperExecuteBin(parameters, 'helmExecute', METADATA_FILE, credentials)
+    piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials)
 }


### PR DESCRIPTION
## Summary

Reverts #5868, which temporarily made `vars/helmBuild.groovy` invoke the binary step name `helmExecute` instead of `STEP_NAME` (`helmBuild`) for compatibility with released binaries predating the `helmExecute` -> `helmBuild` rename (#5830).

## Why now

PR #5868 explicitly stated: *"Revert to STEP_NAME once a binary release with helmBuild ships."* Release **v1.520.0** (published 2026-08-10) includes the rename (#5830), so the compatibility shim is no longer needed and the wrapper can go back to using `STEP_NAME`.

## Change

`vars/helmBuild.groovy`: `piperExecuteBin(parameters, 'helmExecute', ...)` -> `piperExecuteBin(parameters, STEP_NAME, ...)` and removes the temporary compatibility comment.

This reverts commit 588b4a4ed46d951f1c1f70726fab9f9f34846bdc.
