### PR TITLE
fix(helmExecute): pass additionalParameters to lint, test and uninstall

### DIFF
--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -210,6 +210,10 @@ func (h *HelmExecute) RunHelmLint() error {
 		helmParams = append(helmParams, "--debug")
 	}
 
+	if len(h.config.AdditionalParameters) > 0 {
+		helmParams = append(helmParams, expandEnv(h.config.AdditionalParameters)...)
+	}
+
 	h.utils.Stdout(h.stdout)
 	log.Entry().Info("Calling helm lint ...")
 	log.Entry().Debugf("Helm parameters: %v", helmParams)
@@ -299,6 +303,11 @@ func (h *HelmExecute) RunHelmUninstall() error {
 	if h.config.HelmDeployWaitSeconds > 0 {
 		helmParams = append(helmParams, "--wait", "--timeout", fmt.Sprintf("%vs", h.config.HelmDeployWaitSeconds))
 	}
+
+	if len(h.config.AdditionalParameters) > 0 {
+		helmParams = append(helmParams, expandEnv(h.config.AdditionalParameters)...)
+	}
+
 	if h.verbose {
 		helmParams = append(helmParams, "--debug")
 
@@ -369,6 +378,10 @@ func (h *HelmExecute) RunHelmTest() error {
 	}
 	if h.verbose {
 		helmParams = append(helmParams, "--debug")
+	}
+
+	if len(h.config.AdditionalParameters) > 0 {
+		helmParams = append(helmParams, expandEnv(h.config.AdditionalParameters)...)
 	}
 
 	if err := h.runHelmCommand(helmParams); err != nil {

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -221,10 +221,11 @@ func TestRunHelmLint(t *testing.T) {
 	}{
 		{
 			config: HelmExecuteOptions{
-				ChartPath: ".",
+				ChartPath:            ".",
+				AdditionalParameters: []string{"additional", "parameters"},
 			},
 			expectedExecCalls: []mock.ExecCall{
-				{Exec: "helm", Params: []string{"lint", "."}},
+				{Exec: "helm", Params: []string{"lint", ".", "additional", "parameters"}},
 			},
 		},
 		{
@@ -378,9 +379,24 @@ func TestRunHelmUninstall(t *testing.T) {
 				DeploymentName:       "testPackage",
 				Namespace:            "test-namespace",
 				TargetRepositoryName: "test",
+				AdditionalParameters: []string{"additional", "parameters"},
 			},
 			expectedExecCalls: []mock.ExecCall{
-				{Exec: "helm", Params: []string{"uninstall", "testPackage", "--namespace", "test-namespace"}},
+				{Exec: "helm", Params: []string{"uninstall", "testPackage", "--namespace", "test-namespace", "additional", "parameters"}},
+			},
+		},
+		{
+			config: HelmExecuteOptions{
+				ChartPath:            ".",
+				DeploymentName:       "testPackage",
+				Namespace:            "test-namespace",
+				TargetRepositoryName: "test",
+				AdditionalParameters: []string{"additional", "parameters"},
+			},
+			generalVerbose: true,
+			expectedExecCalls: []mock.ExecCall{
+				{Exec: "helm", Params: []string{"uninstall", "testPackage", "--namespace", "test-namespace", "additional", "parameters", "--debug", "--dry-run"}},
+				{Exec: "helm", Params: []string{"uninstall", "testPackage", "--namespace", "test-namespace", "additional", "parameters", "--debug"}},
 			},
 		},
 		{
@@ -478,11 +494,12 @@ func TestRunHelmTest(t *testing.T) {
 	}{
 		{
 			config: HelmExecuteOptions{
-				ChartPath:      ".",
-				DeploymentName: "testPackage",
+				ChartPath:            ".",
+				DeploymentName:       "testPackage",
+				AdditionalParameters: []string{"additional", "parameters"},
 			},
 			expectedExecCalls: []mock.ExecCall{
-				{Exec: "helm", Params: []string{"test", "."}},
+				{Exec: "helm", Params: []string{"test", ".", "additional", "parameters"}},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes #5799

`RunHelmLint`, `RunHelmTest` and `RunHelmUninstall` now append `additionalParameters` to the helm command, like `RunHelmUpgrade`, `RunHelmInstall` and `RunHelmDependency` already do. Previously the flags were silently dropped — e.g. `helmExecute(helmCommand: 'lint', additionalParameters: ['--strict'])` ran `helm lint <chart>` without `--strict`.

For uninstall, the parameters are appended before the verbose `--dry-run` pre-pass, so the dry-run validates the same command that is actually executed (matching `RunHelmInstall`).

## Notes from verifying against current master

- The issue body says `runHelmPackage` also appends `additionalParameters`. It does not at the linked commit, and the full git history (introduced in #3419, changed only by #3669) shows `runHelmPackage` has never appended them. I left `package`/`publish` unchanged here; whether they should forward parameters too is a separate question.
- The `helmBuild` default path (`runHelmBuildDefault`) calls `RunHelmLint` with the same step configuration before publishing. With this fix, `additionalParameters` set on that path now reach `helm lint`: flags lint understands (e.g. `--strict`, `--set`, `--values`) take effect; command-specific flags that helm lint does not accept (e.g. `--atomic`) would make lint fail where they were previously silently dropped (and never applied). If you prefer the implicit lint call to keep ignoring `additionalParameters`, I am happy to add that guard — just let me know which direction you want.

## Test

`go test -tags unit ./pkg/kubernetes/` — green. The new assertions compare the exact helm call arguments; removing any one of the three new append blocks makes the corresponding test fail (verified).
