### PR TITLE
fix(piper): match .yaml extension with leading dot in getProjectConfigFile

### DIFF
--- a/cmd/piper.go
+++ b/cmd/piper.go
@@ -537,7 +537,7 @@ func getProjectConfigFile(name string) string {
 	var altName string
 	if ext := filepath.Ext(name); ext == ".yml" {
 		altName = fmt.Sprintf("%v.yaml", strings.TrimSuffix(name, ext))
-	} else if ext == "yaml" {
+	} else if ext == ".yaml" {
 		altName = fmt.Sprintf("%v.yml", strings.TrimSuffix(name, ext))
 	}
 

--- a/cmd/piper_test.go
+++ b/cmd/piper_test.go
@@ -203,6 +203,7 @@ func TestGetProjectConfigFile(t *testing.T) {
 		{filename: ".pipeline/config.yml", filesAvailable: []string{}, expected: ".pipeline/config.yml"},
 		{filename: ".pipeline/config.yml", filesAvailable: []string{".pipeline/config.yml"}, expected: ".pipeline/config.yml"},
 		{filename: ".pipeline/config.yml", filesAvailable: []string{".pipeline/config.yaml"}, expected: ".pipeline/config.yaml"},
+		{filename: ".pipeline/config.yaml", filesAvailable: []string{".pipeline/config.yml"}, expected: ".pipeline/config.yml"},
 		{filename: ".pipeline/config.yaml", filesAvailable: []string{".pipeline/config.yml", ".pipeline/config.yaml"}, expected: ".pipeline/config.yaml"},
 		{filename: ".pipeline/config.yml", filesAvailable: []string{".pipeline/config.yml", ".pipeline/config.yaml"}, expected: ".pipeline/config.yml"},
 	}


### PR DESCRIPTION
## Summary

Fixes #5486 (closed by the stale bot without triage; verified the bug is still present on current master).

`getProjectConfigFile` compared the result of `filepath.Ext(name)` against `"yaml"`, but `filepath.Ext` returns the extension with the leading dot (`.yaml`), so the alternative-name lookup for `.yaml` config files could never match. Configuring `.pipeline/config.yaml` while only `.pipeline/config.yml` exists therefore silently skipped the fallback to the existing file (the other direction, `.yml` → `.yaml`, works correctly).

The fix compares against `".yaml"`.

## Test

Added a regression case to `TestGetProjectConfigFile` for the `.yaml` → `.yml` fallback; it fails without the fix and passes with it. Full `go test -tags unit ./cmd/` suite is green.
