### PR TITLE
docs(helmBuild): add helmBuild to navigation and fix helmExecute placeholder content

### DIFF
--- a/documentation/docs/steps/helmExecute.md
+++ b/documentation/docs/steps/helmExecute.md
@@ -1,9 +1,1 @@
 > **Deprecated:** This step has been renamed to [helmBuild](helmBuild.md). Please update your pipeline configuration to use `helmBuild` instead. The `helmExecute` name remains supported as an alias for backward compatibility.
-
-# ${docGenStepName}
-
-## ${docGenDescription}
-
-## ${docGenParameters}
-
-## ${docGenConfiguration}

--- a/documentation/mkdocs.yml
+++ b/documentation/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
         - hadolintExecute: steps/hadolintExecute.md
         - handlePipelineStepErrors: steps/handlePipelineStepErrors.md
         - healthExecuteCheck: steps/healthExecuteCheck.md
+        - helmBuild: steps/helmBuild.md
         - helmExecute: steps/helmExecute.md
         - imagePushToRegistry: steps/imagePushToRegistry.md
         - influxWriteData: steps/influxWriteData.md


### PR DESCRIPTION
## Summary

Fixes documentation issues raised after the `helmExecute` → `helmBuild` rename:

- **`helmBuild` not appearing in sidebar**: Added `helmBuild` entry to `documentation/mkdocs.yml` nav section so it shows up in the left-side navigation at https://pages.github.tools.sap/project-piper/steps/helmBuild/
- **`helmExecute` showing placeholders**: Removed unresolvable `${docGenStepName}` / `${docGenDescription}` / `${docGenParameters}` / `${docGenConfiguration}` placeholder sections from `helmExecute.md`. Since `helmExecute` is deprecated, only the redirect notice to `helmBuild` is needed.

## Related

- Rename PR: #5830
- Stage config cleanup: to follow in project-piper/resources