### PR TITLE
Resolve Jenkins credentials in vaultRotateSecretId step

### DIFF
--- a/cmd/vaultRotateSecretId_generated.go
+++ b/cmd/vaultRotateSecretId_generated.go
@@ -207,6 +207,11 @@ func vaultRotateSecretIdMetadata() config.StepData {
 		},
 		Spec: config.StepSpec{
 			Inputs: config.StepInputs{
+				Secrets: []config.StepSecrets{
+					{Name: "jenkinsUrlCredentialsId", Description: "Jenkins credential ID containing the Jenkins URL", Type: "jenkins"},
+					{Name: "jenkinsUsernameCredentialsId", Description: "Jenkins credential ID containing the Jenkins user name", Type: "jenkins"},
+					{Name: "jenkinsTokenCredentialsId", Description: "Jenkins credential ID containing the Jenkins API token", Type: "jenkins"},
+				},
 				Parameters: []config.StepParameters{
 					{
 						Name:        "secretStore",

--- a/resources/metadata/vaultRotateSecretId.yaml
+++ b/resources/metadata/vaultRotateSecretId.yaml
@@ -4,6 +4,16 @@ metadata:
   longDescription: This step takes the given Vault secret ID and checks whether it needs to be renewed and if so it will update the secret ID in the configured secret store.
 spec:
   inputs:
+    secrets:
+      - name: jenkinsUrlCredentialsId
+        description: Jenkins credential ID containing the Jenkins URL
+        type: jenkins
+      - name: jenkinsUsernameCredentialsId
+        description: Jenkins credential ID containing the Jenkins user name
+        type: jenkins
+      - name: jenkinsTokenCredentialsId
+        description: Jenkins credential ID containing the Jenkins API token
+        type: jenkins
     params:
       - name: secretStore
         type: string

--- a/vars/vaultRotateSecretId.groovy
+++ b/vars/vaultRotateSecretId.groovy
@@ -6,5 +6,10 @@ import static com.sap.piper.Prerequisites.checkScript
 
 void call(Map parameters = [:]) {
         def script = checkScript(this, parameters) ?: this
-        piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, [], false, false, false)
+        List credentials = [
+            [type: 'token', id: 'jenkinsUrlCredentialsId', env: ['PIPER_jenkinsUrl']],
+            [type: 'token', id: 'jenkinsUsernameCredentialsId', env: ['PIPER_jenkinsUsername']],
+            [type: 'token', id: 'jenkinsTokenCredentialsId', env: ['PIPER_jenkinsToken']]
+        ]
+        piperExecuteBin(parameters, STEP_NAME, METADATA_FILE, credentials, false, false, false)
 }


### PR DESCRIPTION
`vaultRotateSecretId` passes an empty credential info list to `piperExecuteBin`, so the `jenkinsUrl`, `jenkinsUsername` and `jenkinsToken` parameters (all `secret: true` in the step metadata) are never resolved via the Jenkins credential store. When users pass Jenkins credential IDs, the literal ID strings are serialized into `PIPER_parametersJSON` and forwarded to the Go binary, which then fails to connect to Jenkins.

**Fix (two parts):**

1. `vars/vaultRotateSecretId.groovy` — register the three credentials so credential IDs passed via `jenkinsUrlCredentialsId`, `jenkinsUsernameCredentialsId` and `jenkinsTokenCredentialsId` are resolved with `withCredentials` and exposed as `PIPER_jenkinsUrl`, `PIPER_jenkinsUsername` and `PIPER_jenkinsToken` — exactly the env vars the step binary reads as flag defaults (`cmd/vaultRotateSecretId_generated.go`).
2. `resources/metadata/vaultRotateSecretId.yaml` — declare the three credentials in `spec.inputs.secrets` and regenerate. This is required for the fix to work: `piperExecuteBin`'s `credentialWrapper` reads the credential IDs from the step's *context config*, which is filtered by `GetContextParameterFilters()` to only include keys declared in `spec.inputs.secrets` (plus stash/container/vault keys). Without the declaration, the IDs never reach the config and the wrapper entries would be skipped (found in review).

Follows the pattern of the `abapAddonAssemblyKit*` steps, which declare their `*CredentialsId` entries in `spec.inputs.secrets` with `type: jenkins` and list them in the Groovy wrapper.

**Verification:** `go build ./...` clean; `go test -tags unit ./cmd/` and `./pkg/config/...` green; generated `Secrets:` block confirmed in `cmd/vaultRotateSecretId_generated.go`.

Fixes #5696
