### PR TITLE
Fix vaultCredentialEnvPrefix examples to include the trailing underscore

### DIFF
--- a/documentation/docs/infrastructure/vault.md
+++ b/documentation/docs/infrastructure/vault.md
@@ -132,11 +132,12 @@ The `vaultCredentialKeys`parameter is a list of credential IDs. The secret value
 !!! hint "Using a custom prefix for credentials"
     By default the prefix for credentials is `PIPER_VAULTCREDENTIAL_`.
 
-    It is possible to use a custom prefix by setting for example `vaultCredentialEnvPrefix: MY_CUSTOM_PREFIX` in your configuration.
+    It is possible to use a custom prefix by setting for example `vaultCredentialEnvPrefix: MY_CUSTOM_PREFIX_` in your configuration.
     With this above credential ID named `myAppId` will be populated into an environment variable with the name `MY_CUSTOM_PREFIX_MYAPPID`.
+    Note that the prefix is used as-is, so include a trailing underscore if you want one to separate the prefix from the credential name.
 
     In case you want to use specific prefix for secrets retrieved from different vault folders, pass multiple prefixes as
-    `vaultCredentialEnvPrefix: ['MY_CUSTOM_PREFIX_1', 'MY_CUSTOM_PREFIX_2']`.
+    `vaultCredentialEnvPrefix: ['MY_CUSTOM_PREFIX_1_', 'MY_CUSTOM_PREFIX_2_']`.
     With this above credential ID named `myAppId1` will be populated into an environment variable with the name `MY_CUSTOM_PREFIX_1_MYAPPID1` and `myAppId2` will be populated into an environment variable with name `MY_CUSTOM_PREFIX_2_MYAPPID2`
 
 Extended logging for Vault secret fetching (e.g. found credentials and environment variable names) can be activated via `verbose: true` configuration.


### PR DESCRIPTION
The custom prefix examples are incorrect: the prefix is concatenated with the credential name as-is in `pkg/config/vault.go` (`envVariable := vaultCredentialEnvPrefix + ConvertEnvVar(secretKey)`), without adding a separator. So `vaultCredentialEnvPrefix: MY_CUSTOM_PREFIX` populates `MY_CUSTOM_PREFIXMYAPPID`, not `MY_CUSTOM_PREFIX_MYAPPID` as the docs claim.

Update the examples to include the trailing underscore (the default prefix `PIPER_VAULTCREDENTIAL_` already has one) and add a short note that the prefix is used as-is. The hint for test credentials further down already shows the underscore correctly.

Fixes #5409
