### PR TITLE
feat(cxone) Improve iac reporting

### DIFF
--- a/cmd/checkmarxOneExecuteScan.go
+++ b/cmd/checkmarxOneExecuteScan.go
@@ -140,19 +140,6 @@ func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteS
 		}
 	}
 
-	err = cx1sh.SetProjectPresetsAndFilters()
-	if err != nil {
-		return fmt.Errorf("failed to set configuration: %s", err)
-	}
-
-	// update project's tags
-	if (len(config.ProjectTags)) > 0 {
-		err = cx1sh.UpdateProjectTags()
-		if err != nil {
-			log.Entry().WithError(err).Warnf("failed to tags the project: %s", err)
-		}
-	}
-
 	fullScanCycle, err := strconv.Atoi(cx1sh.config.FullScanCycle)
 	if err != nil {
 		log.SetErrorCategory(log.ErrorConfiguration)
@@ -166,20 +153,22 @@ func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteS
 
 	if config.VerifyOnly {
 		if len(scans) > 0 {
-			results, err := cx1sh.ParseResults(&scans[0]) // incl report-gen
-			if err != nil {
-				return fmt.Errorf("failed to get scan results: %s", err)
-			}
-
-			err = cx1sh.CheckCompliance(&scans[0], &results)
-			if err != nil {
-				log.SetErrorCategory(log.ErrorCompliance)
-				return fmt.Errorf("project %v not compliant: %s", cx1sh.Project.Name, err)
-			}
-
-			return nil
+			return cx1sh.CheckScanCompliance(&scans[0])
 		} else {
-			log.Entry().Warnf("Cannot load scans for project %v, verification only mode aborted", cx1sh.Project.Name)
+			return fmt.Errorf("Cannot load scans for project %v, verification only mode aborted", cx1sh.Project.Name)
+		}
+	}
+
+	err = cx1sh.SetProjectPresetsAndFilters()
+	if err != nil {
+		return fmt.Errorf("failed to set configuration: %s", err)
+	}
+
+	// update project's tags
+	if (len(config.ProjectTags)) > 0 {
+		err = cx1sh.UpdateProjectTags()
+		if err != nil {
+			log.Entry().WithError(err).Warnf("failed to tags the project: %s", err)
 		}
 	}
 
@@ -246,14 +235,9 @@ func runStep(config checkmarxOneExecuteScanOptions, influx *checkmarxOneExecuteS
 		return fmt.Errorf("failed while polling scan status: %s", err)
 	}
 
-	results, err := cx1sh.ParseResults(scan) // incl report-gen
+	err = cx1sh.CheckScanCompliance(scan)
 	if err != nil {
-		return fmt.Errorf("failed to get scan results: %s", err)
-	}
-	err = cx1sh.CheckCompliance(scan, &results)
-	if err != nil {
-		log.SetErrorCategory(log.ErrorCompliance)
-		return fmt.Errorf("project %v not compliant: %s", cx1sh.Project.Name, err)
+		return err
 	}
 	// TODO: upload logs to Splunk, influxDB?
 	return nil
@@ -783,6 +767,94 @@ func (c *checkmarxOneExecuteScanHelper) PollScanStatus(scan *checkmarxOne.Scan) 
 	return &scan_refresh, nil
 }
 
+type gitComment struct {
+	criticalSeverityString, highSeverityString, mediumSeverityString, lowSeverityString, criticalComplianceCheckString, highComplianceCheckString, mediumComplianceCheckString, lowComplianceCheckString string
+}
+
+func (g *gitComment) String() string {
+	return fmt.Sprintf(`Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | %s
+:red_circle: High | %s
+:orange_circle: Medium | %s
+:yellow_circle: Low | %s`, g.criticalSeverityString, g.highSeverityString, g.mediumSeverityString, g.lowSeverityString)
+}
+func (g *gitComment) Parse(findings *[]checkmarxOne.Finding, config *checkmarxOneExecuteScanOptions) {
+	for _, finding := range *findings {
+		switch finding.ClassificationName {
+		case "Critical":
+			// TODO: check if config threshold unit is percent or absolute number
+			if *finding.Audited < int(math.Ceil((float64(config.VulnerabilityThresholdCritical)/100.0)*float64(finding.Total))) {
+				g.criticalComplianceCheckString = ":x:"
+			} else {
+				g.criticalComplianceCheckString = ":white_check_mark:"
+			}
+			if finding.Confirmed > 0 {
+				g.criticalSeverityString = fmt.Sprintf("%s %d (%d confirmed)", g.criticalComplianceCheckString, finding.Total-*finding.Audited, finding.Confirmed)
+			} else {
+				g.criticalSeverityString = fmt.Sprintf("%s %d", g.criticalComplianceCheckString, finding.Total-*finding.Audited)
+			}
+		case "High":
+			if *finding.Audited < int(math.Ceil((float64(config.VulnerabilityThresholdHigh)/100.0)*float64(finding.Total))) {
+				g.highComplianceCheckString = ":x:"
+			} else {
+				g.highComplianceCheckString = ":white_check_mark:"
+			}
+			if finding.Confirmed > 0 {
+				g.highSeverityString = fmt.Sprintf("%s %d (%d confirmed)", g.highComplianceCheckString, finding.Total-*finding.Audited, finding.Confirmed)
+			} else {
+				g.highSeverityString = fmt.Sprintf("%s %d", g.highComplianceCheckString, finding.Total-*finding.Audited)
+			}
+		case "Medium":
+			if *finding.Audited < int(math.Ceil((float64(config.VulnerabilityThresholdMedium)/100.0)*float64(finding.Total))) {
+				g.mediumComplianceCheckString = ":x:"
+			} else {
+				g.mediumComplianceCheckString = ":white_check_mark:"
+			}
+			if finding.Confirmed > 0 {
+				g.mediumSeverityString = fmt.Sprintf("%s %d (%d confirmed)", g.mediumComplianceCheckString, finding.Total-*finding.Audited, finding.Confirmed)
+			} else {
+				g.mediumSeverityString = fmt.Sprintf("%s %d", g.mediumComplianceCheckString, finding.Total-*finding.Audited)
+			}
+		case "Low":
+			if finding.LowPerQuery != nil {
+				for _, lowFinding := range *finding.LowPerQuery {
+					if config.VulnerabilityThresholdLowPerQuery {
+						confirmedLowString := ""
+						if lowFinding.Confirmed > 0 {
+							confirmedLowString = fmt.Sprintf(", of which %d confirmed", lowFinding.Confirmed)
+						}
+						lowAuditedRequiredPerQuery := min(int(math.Ceil(float64(lowFinding.Total)*float64(config.VulnerabilityThresholdLow)/100.0)), config.VulnerabilityThresholdLowPerQueryMax)
+						if lowFinding.Audited < lowAuditedRequiredPerQuery {
+							g.lowComplianceCheckString = ":x:"
+						} else {
+							g.lowComplianceCheckString = ":white_check_mark:"
+						}
+						g.lowSeverityString = fmt.Sprintf("%s%s %d %s (%d audited / %d required%s) <br>", g.lowSeverityString, g.lowComplianceCheckString, lowFinding.Total-lowFinding.Audited, lowFinding.QueryName, lowFinding.Audited, lowAuditedRequiredPerQuery, confirmedLowString)
+					} else {
+						g.lowSeverityString = fmt.Sprintf("%s%s %d %s<br>", g.lowSeverityString, g.lowComplianceCheckString, lowFinding.Total-lowFinding.Audited, lowFinding.QueryName)
+					}
+				}
+
+				if g.lowSeverityString == "" { // no findings at all
+					g.lowSeverityString = ":white_check_mark: 0"
+				}
+			} else {
+				if *finding.Audited < int(math.Ceil((float64(config.VulnerabilityThresholdLow)/100.0)*float64(finding.Total))) {
+					g.lowComplianceCheckString = ":x:"
+				} else {
+					g.lowComplianceCheckString = ":white_check_mark:"
+				}
+				if finding.Confirmed > 0 {
+					g.lowSeverityString = fmt.Sprintf("%s %d (%d confirmed)", g.lowComplianceCheckString, finding.Total-*finding.Audited, finding.Confirmed)
+				} else {
+					g.lowSeverityString = fmt.Sprintf("%s %d", g.lowComplianceCheckString, finding.Total-*finding.Audited)
+				}
+			}
+		}
+	}
+}
+
 func (c *checkmarxOneExecuteScanHelper) PostScanSummaryInPullRequest(detailedResults *map[string]interface{}, insecure bool) error {
 	cicdOrch := orchestrator.GetOrchestratorConfigProvider(nil)
 	isPullRequest := cicdOrch.IsPullRequest()
@@ -820,65 +892,39 @@ func (c *checkmarxOneExecuteScanHelper) PostScanSummaryInPullRequest(detailedRes
 	if c.config.ScanSummaryInPullRequest && isPullRequest && pullRequestId != "n/a" && len(c.config.GithubToken) > 0 && len(c.config.GithubAPIURL) > 0 && len(owner) > 0 && len(repository) > 0 {
 		ghIssues := c.utils.GetIssueService()
 		log.Entry().Debugf("Creating/updating GitHub issue with check results with PR: %s, GithubAPIURL: %s, Owner: %s, Repository: %s", c.config.PullRequestName, c.config.GithubAPIURL, owner, repository)
-		scanReportOverview := checkmarxOne.CreateJSONHeaderReport(detailedResults)
-		var criticalSeverityString, highSeverityString, mediumSeverityString, lowSeverityString, criticalComplianceCheckString, highComplianceCheckString, mediumComplianceCheckString, lowComplianceCheckString string
-		for _, finding := range *scanReportOverview.Findings {
-			switch finding.ClassificationName {
-			case "Critical":
-				// TODO: check if config threshold unit is percent or absolute number
-				if *finding.Audited < int(math.Ceil((float64(c.config.VulnerabilityThresholdCritical)/100.0)*float64(finding.Total))) {
-					criticalComplianceCheckString = ":x:"
-				} else {
-					criticalComplianceCheckString = ":white_check_mark:"
-				}
-				if finding.Confirmed > 0 {
-					criticalSeverityString = fmt.Sprintf("%s %d (%d confirmed)", criticalComplianceCheckString, finding.Total-*finding.Audited, finding.Confirmed)
-				} else {
-					criticalSeverityString = fmt.Sprintf("%s %d", criticalComplianceCheckString, finding.Total-*finding.Audited)
-				}
-			case "High":
-				if *finding.Audited < int(math.Ceil((float64(c.config.VulnerabilityThresholdHigh)/100.0)*float64(finding.Total))) {
-					highComplianceCheckString = ":x:"
-				} else {
-					highComplianceCheckString = ":white_check_mark:"
-				}
-				if finding.Confirmed > 0 {
-					highSeverityString = fmt.Sprintf("%s %d (%d confirmed)", highComplianceCheckString, finding.Total-*finding.Audited, finding.Confirmed)
-				} else {
-					highSeverityString = fmt.Sprintf("%s %d", highComplianceCheckString, finding.Total-*finding.Audited)
-				}
-			case "Medium":
-				if *finding.Audited < int(math.Ceil((float64(c.config.VulnerabilityThresholdMedium)/100.0)*float64(finding.Total))) {
-					mediumComplianceCheckString = ":x:"
-				} else {
-					mediumComplianceCheckString = ":white_check_mark:"
-				}
-				if finding.Confirmed > 0 {
-					mediumSeverityString = fmt.Sprintf("%s %d (%d confirmed)", mediumComplianceCheckString, finding.Total-*finding.Audited, finding.Confirmed)
-				} else {
-					mediumSeverityString = fmt.Sprintf("%s %d", mediumComplianceCheckString, finding.Total-*finding.Audited)
-				}
-			case "Low":
-				if finding.LowPerQuery != nil {
-					for _, lowFinding := range *finding.LowPerQuery {
-						if c.config.VulnerabilityThresholdLowPerQuery {
-							confirmedLowString := ""
-							if lowFinding.Confirmed > 0 {
-								confirmedLowString = fmt.Sprintf(", of which %d confirmed", lowFinding.Confirmed)
-							}
-							lowAuditedRequiredPerQuery := min(int(math.Ceil(float64(lowFinding.Total)*float64(c.config.VulnerabilityThresholdLow)/100.0)), c.config.VulnerabilityThresholdLowPerQueryMax)
-							if lowFinding.Audited < lowAuditedRequiredPerQuery {
-								lowComplianceCheckString = ":x:"
-							} else {
-								lowComplianceCheckString = ":white_check_mark:"
-							}
-							lowSeverityString = fmt.Sprintf("%s%s %d %s (%d audited / %d required%s) <br>", lowSeverityString, lowComplianceCheckString, lowFinding.Total-lowFinding.Audited, lowFinding.QueryName, lowFinding.Audited, lowAuditedRequiredPerQuery, confirmedLowString)
-						} else {
-							lowSeverityString = fmt.Sprintf("%s%s %d %s<br>", lowSeverityString, lowComplianceCheckString, lowFinding.Total-lowFinding.Audited, lowFinding.QueryName)
-						}
-					}
-				}
+
+		var scanId, deepLink string
+		var sastScan, iacScan string
+		if c.ScanSAST {
+			var sast_status gitComment
+			sastScanReportOverview := checkmarxOne.CreateJSONHeaderReport(detailedResults, "sast")
+			deepLink = sastScanReportOverview.DeepLink
+			scanId = sastScanReportOverview.ScanID
+			sast_status.Parse(sastScanReportOverview.Findings, &c.config)
+			sastTable := sast_status.String()
+
+			sastScan = fmt.Sprintf(`**SAST Scan type**: %s
+**SAST Scan Preset**: %s
+**SAST Results**
+%s
+
+`, strings.ToLower(sastScanReportOverview.ScanType), sastScanReportOverview.Preset, sastTable)
+
+		}
+		if c.ScanIAC {
+			var iac_status gitComment
+			iacScanReportOverview := checkmarxOne.CreateJSONHeaderReport(detailedResults, "iac")
+			if deepLink == "" {
+				deepLink = iacScanReportOverview.DeepLink
 			}
+			iac_status.Parse(iacScanReportOverview.Findings, &c.config)
+			iacTable := iac_status.String()
+
+			iacScan = fmt.Sprintf(`**IAC Preset**: %s
+**IAC Results**
+%s
+
+`, iacScanReportOverview.Preset, iacTable)
 		}
 		var scanIcon string
 		if insecure {
@@ -888,19 +934,13 @@ func (c *checkmarxOneExecuteScanHelper) PostScanSummaryInPullRequest(detailedRes
 		}
 		comment := &github.IssueComment{
 			Body: github.Ptr(fmt.Sprintf(`<!-- Piper CxOne Scan Summary -->
-# %s Checkmarx %s scan completed 
+# %s CheckmarxOne scan completed 
 **Project**: %s
 **ScanId**: %s
-**Preset**: %s
-Severity | Number of unaudited findings
---- | ---
-:bangbang: Critical | %s
-:red_circle: High | %s
-:orange_circle: Medium | %s
-:yellow_circle: Low | %s
+%s%s
 
 [Go to the scan results](%s)
-		`, scanIcon, strings.ToLower(scanReportOverview.ScanType), c.Project.Name, scanReportOverview.ScanID, scanReportOverview.Preset, criticalSeverityString, highSeverityString, mediumSeverityString, lowSeverityString, scanReportOverview.DeepLink)),
+		`, scanIcon, c.Project.Name, scanId, sastScan, iacScan, deepLink)),
 		}
 		pullRequestNumber, err := strconv.Atoi(pullRequestId)
 		if err != nil {
@@ -934,13 +974,26 @@ Severity | Number of unaudited findings
 	return nil
 }
 
+func (c *checkmarxOneExecuteScanHelper) CheckScanCompliance(scan *checkmarxOne.Scan) error {
+	results, err := c.ParseResults(scan) // incl report-gen
+	if err != nil {
+		return fmt.Errorf("failed to get scan results: %s", err)
+	}
+	err = c.CheckCompliance(scan, &results)
+	if err != nil {
+		log.SetErrorCategory(log.ErrorCompliance)
+		return fmt.Errorf("project %v not compliant: %s", c.Project.Name, err)
+	}
+	return nil
+}
+
 func (c *checkmarxOneExecuteScanHelper) CheckCompliance(scan *checkmarxOne.Scan, detailedResults *map[string]interface{}) error {
 	links := []piperutils.Path{{Target: (*detailedResults)["DeepLink"].(string), Name: "Checkmarx One Web UI"}}
 	insecure := false
 	var insecureResults []string
 	var neutralResults []string
 
-	if c.config.VulnerabilityThresholdEnabled {
+	if c.config.VulnerabilityThresholdEnabled || c.config.IacVulnerabilityThresholdEnabled {
 		insecure, insecureResults, neutralResults = c.enforceThresholds(detailedResults)
 		scanReport := checkmarxOne.CreateCustomReport(detailedResults, insecureResults, neutralResults)
 
@@ -1062,13 +1115,26 @@ func (c *checkmarxOneExecuteScanHelper) GetReportJSON(scan *checkmarxOne.Scan, e
 
 func (c *checkmarxOneExecuteScanHelper) GetHeaderReportJSON(detailedResults *map[string]interface{}) error {
 	// This is for the SAP-piper-format short-form JSON report
-	jsonReport := checkmarxOne.CreateJSONHeaderReport(detailedResults)
-	paths, err := checkmarxOne.WriteJSONHeaderReport(jsonReport)
-	if err != nil {
-		return fmt.Errorf("Failed to write JSON header report: %s", err)
-	} else {
-		// add JSON report to archiving list
-		c.reports = append(c.reports, paths...)
+	if c.ScanSAST {
+		jsonReport := checkmarxOne.CreateJSONHeaderReport(detailedResults, "sast")
+		paths, err := checkmarxOne.WriteJSONHeaderReport(jsonReport, "sast")
+		if err != nil {
+			return fmt.Errorf("Failed to write JSON header report: %s", err)
+		} else {
+			// add JSON report to archiving list
+			c.reports = append(c.reports, paths...)
+		}
+	}
+
+	if c.ScanIAC {
+		jsonReport := checkmarxOne.CreateJSONHeaderReport(detailedResults, "iac")
+		paths, err := checkmarxOne.WriteJSONHeaderReport(jsonReport, "iac")
+		if err != nil {
+			return fmt.Errorf("Failed to write JSON header report: %s", err)
+		} else {
+			// add JSON report to archiving list
+			c.reports = append(c.reports, paths...)
+		}
 	}
 	return nil
 }
@@ -1244,7 +1310,9 @@ func (c *checkmarxOneExecuteScanHelper) getDetailedResults(scan *checkmarxOne.Sc
 	if err != nil {
 		resultMap["ToolVersion"] = "Error fetching current version"
 	} else {
-		resultMap["ToolVersion"] = fmt.Sprintf("CxOne: %v, SAST: %v, KICS: %v", version.CxOne, version.SAST, version.KICS)
+		resultMap["ToolVersion"] = "CxOne: " + version.CxOne
+		resultMap["SASTVersion"] = "SAST: " + version.SAST
+		resultMap["IACVersion"] = "IAC: " + version.KICS
 	}
 
 	if scanmeta.SAST != nil {
@@ -1282,6 +1350,12 @@ func (c *checkmarxOneExecuteScanHelper) getDetailedResults(scan *checkmarxOne.Sc
 	resultMap["Low"] = map[string]int{}
 	resultMap["Information"] = map[string]int{}
 
+	resultMap["IACCritical"] = map[string]int{}
+	resultMap["IACHigh"] = map[string]int{}
+	resultMap["IACMedium"] = map[string]int{}
+	resultMap["IACLow"] = map[string]int{}
+	resultMap["IACInformation"] = map[string]int{}
+
 	if len(*results) > 0 {
 		for _, result := range *results {
 			key := "Information"
@@ -1297,6 +1371,10 @@ func (c *checkmarxOneExecuteScanHelper) getDetailedResults(scan *checkmarxOne.Sc
 			case "INFORMATION":
 			default:
 				key = "Information"
+			}
+
+			if strings.EqualFold(result.Type, "kics") {
+				key = "IAC" + key
 			}
 
 			var submap map[string]int
@@ -1331,10 +1409,14 @@ func (c *checkmarxOneExecuteScanHelper) getDetailedResults(scan *checkmarxOne.Sc
 		}
 
 		// if the flag is switched on, build the list  of Low findings per query
+		// this only covers SAST findings
 		if c.config.VulnerabilityThresholdLowPerQuery {
 			var lowPerQuery = map[string]map[string]int{}
 
 			for _, result := range *results {
+				if !strings.EqualFold(result.Type, "sast") {
+					continue
+				}
 				if result.Severity != "LOW" {
 					continue
 				}
@@ -1369,6 +1451,47 @@ func (c *checkmarxOneExecuteScanHelper) getDetailedResults(scan *checkmarxOne.Sc
 			}
 
 			resultMap["LowPerQuery"] = lowPerQuery
+
+			lowPerQuery = map[string]map[string]int{}
+
+			for _, result := range *results {
+				if !strings.EqualFold(result.Type, "kics") {
+					continue
+				}
+				if result.Severity != "LOW" {
+					continue
+				}
+				key := result.Data.QueryName
+				var submap map[string]int
+				if lowPerQuery[key] == nil {
+					submap = map[string]int{}
+					lowPerQuery[key] = submap
+				} else {
+					submap = lowPerQuery[key]
+				}
+				submap["Issues"]++
+				auditState := "ToVerify"
+				switch result.State {
+				case "NOT_EXPLOITABLE":
+					auditState = "NotExploitable"
+				case "CONFIRMED":
+					auditState = "Confirmed"
+				case "URGENT", "URGENT ":
+					auditState = "Urgent"
+				case "PROPOSED_NOT_EXPLOITABLE":
+					auditState = "ProposedNotExploitable"
+				case "TO_VERIFY":
+				default:
+					auditState = "ToVerify"
+				}
+				submap[auditState]++
+
+				if auditState != "NotExploitable" {
+					submap["NotFalsePositive"]++
+				}
+			}
+
+			resultMap["IACLowPerQuery"] = lowPerQuery
 		}
 	}
 	return resultMap, nil
@@ -1562,6 +1685,34 @@ func (c *checkmarxOneExecuteScanHelper) enforceThresholds(results *map[string]in
 	neutralResults := []string{}
 	insecureResults := []string{}
 	insecure := false
+	if c.ScanSAST && c.config.VulnerabilityThresholdEnabled {
+		insecure, neutralResults, insecureResults = c.enforceThresholdsPerEngine("SAST", results)
+	}
+	if c.ScanIAC {
+		if c.config.VulnerabilityThresholdEnabled {
+			insecure2, neutralResults2, insecureResults2 := c.enforceThresholdsPerEngine("IAC", results)
+			if c.config.IacVulnerabilityThresholdEnabled {
+				insecure = insecure || insecure2
+				neutralResults = append(neutralResults, neutralResults2...)
+				insecureResults = append(insecureResults, insecureResults2...)
+			} else {
+				log.Entry().Infof("Skipping IAC threshold enforcement, IacVulnerabilityThresholdEnabled is set to false")
+			}
+		} else {
+			log.Entry().Warnf("IacVulnerabilityThresholdEnabled is set to true, but VulnerabilityThresholdEnabled is set to false. IAC threshold enforcement will be skipped.")
+		}
+	}
+	return insecure, neutralResults, insecureResults
+}
+
+func (c *checkmarxOneExecuteScanHelper) enforceThresholdsPerEngine(engine string, results *map[string]interface{}) (bool, []string, []string) {
+	pre := ""
+	if strings.EqualFold(engine, "iac") {
+		pre = "IAC"
+	}
+	neutralResults := []string{}
+	insecureResults := []string{}
+	insecure := false
 
 	cxCriticalThreshold := c.config.VulnerabilityThresholdCritical
 	cxHighThreshold := c.config.VulnerabilityThresholdHigh
@@ -1570,14 +1721,14 @@ func (c *checkmarxOneExecuteScanHelper) enforceThresholds(results *map[string]in
 	cxLowThresholdPerQuery := c.config.VulnerabilityThresholdLowPerQuery
 	cxLowThresholdPerQueryMax := c.config.VulnerabilityThresholdLowPerQueryMax
 	// findings are audited if they are in state Confirmed, Urgent or NotExploitable
-	criticalValue := (*results)["Critical"].(map[string]int)["ToVerify"] + (*results)["Critical"].(map[string]int)["ProposedNotExploitable"]
-	confirmedCriticalValue := (*results)["Critical"].(map[string]int)["Confirmed"] + (*results)["Critical"].(map[string]int)["Urgent"]
-	highValue := (*results)["High"].(map[string]int)["ToVerify"] + (*results)["High"].(map[string]int)["ProposedNotExploitable"]
-	confirmedHighValue := (*results)["High"].(map[string]int)["Confirmed"] + (*results)["High"].(map[string]int)["Urgent"]
-	mediumValue := (*results)["Medium"].(map[string]int)["ToVerify"] + (*results)["Medium"].(map[string]int)["ProposedNotExploitable"]
-	confirmedMediumValue := (*results)["Medium"].(map[string]int)["Confirmed"] + (*results)["Medium"].(map[string]int)["Urgent"]
-	lowValue := (*results)["Low"].(map[string]int)["ToVerify"] + (*results)["Low"].(map[string]int)["ProposedNotExploitable"]
-	confirmedLowValue := (*results)["Low"].(map[string]int)["Confirmed"] + (*results)["Low"].(map[string]int)["Urgent"]
+	criticalValue := (*results)[pre+"Critical"].(map[string]int)["ToVerify"] + (*results)[pre+"Critical"].(map[string]int)["ProposedNotExploitable"]
+	confirmedCriticalValue := (*results)[pre+"Critical"].(map[string]int)["Confirmed"] + (*results)[pre+"Critical"].(map[string]int)["Urgent"]
+	highValue := (*results)[pre+"High"].(map[string]int)["ToVerify"] + (*results)[pre+"High"].(map[string]int)["ProposedNotExploitable"]
+	confirmedHighValue := (*results)[pre+"High"].(map[string]int)["Confirmed"] + (*results)[pre+"High"].(map[string]int)["Urgent"]
+	mediumValue := (*results)[pre+"Medium"].(map[string]int)["ToVerify"] + (*results)[pre+"Medium"].(map[string]int)["ProposedNotExploitable"]
+	confirmedMediumValue := (*results)[pre+"Medium"].(map[string]int)["Confirmed"] + (*results)[pre+"Medium"].(map[string]int)["Urgent"]
+	lowValue := (*results)[pre+"Low"].(map[string]int)["ToVerify"] + (*results)[pre+"Low"].(map[string]int)["ProposedNotExploitable"]
+	confirmedLowValue := (*results)[pre+"Low"].(map[string]int)["Confirmed"] + (*results)[pre+"Low"].(map[string]int)["Urgent"]
 	var unit string
 	criticalViolation := ""
 	highViolation := ""
@@ -1585,26 +1736,26 @@ func (c *checkmarxOneExecuteScanHelper) enforceThresholds(results *map[string]in
 	lowViolation := ""
 	if c.config.VulnerabilityThresholdUnit == "percentage" {
 		unit = "%"
-		criticalAudited := (*results)["Critical"].(map[string]int)["NotExploitable"] + (*results)["Critical"].(map[string]int)["Confirmed"] + (*results)["Critical"].(map[string]int)["Urgent"]
-		criticalOverall := (*results)["Critical"].(map[string]int)["Issues"]
+		criticalAudited := (*results)[pre+"Critical"].(map[string]int)["NotExploitable"] + (*results)[pre+"Critical"].(map[string]int)["Confirmed"] + (*results)[pre+"Critical"].(map[string]int)["Urgent"]
+		criticalOverall := (*results)[pre+"Critical"].(map[string]int)["Issues"]
 		if criticalOverall == 0 {
 			criticalAudited = 1
 			criticalOverall = 1
 		}
-		highAudited := (*results)["High"].(map[string]int)["NotExploitable"] + (*results)["High"].(map[string]int)["Confirmed"] + (*results)["High"].(map[string]int)["Urgent"]
-		highOverall := (*results)["High"].(map[string]int)["Issues"]
+		highAudited := (*results)[pre+"High"].(map[string]int)["NotExploitable"] + (*results)[pre+"High"].(map[string]int)["Confirmed"] + (*results)[pre+"High"].(map[string]int)["Urgent"]
+		highOverall := (*results)[pre+"High"].(map[string]int)["Issues"]
 		if highOverall == 0 {
 			highAudited = 1
 			highOverall = 1
 		}
-		mediumAudited := (*results)["Medium"].(map[string]int)["NotExploitable"] + (*results)["Medium"].(map[string]int)["Confirmed"] + (*results)["Medium"].(map[string]int)["Urgent"]
-		mediumOverall := (*results)["Medium"].(map[string]int)["Issues"]
+		mediumAudited := (*results)[pre+"Medium"].(map[string]int)["NotExploitable"] + (*results)[pre+"Medium"].(map[string]int)["Confirmed"] + (*results)[pre+"Medium"].(map[string]int)["Urgent"]
+		mediumOverall := (*results)[pre+"Medium"].(map[string]int)["Issues"]
 		if mediumOverall == 0 {
 			mediumAudited = 1
 			mediumOverall = 1
 		}
-		lowAudited := (*results)["Low"].(map[string]int)["Confirmed"] + (*results)["Low"].(map[string]int)["NotExploitable"] + (*results)["Low"].(map[string]int)["Urgent"]
-		lowOverall := (*results)["Low"].(map[string]int)["Issues"]
+		lowAudited := (*results)[pre+"Low"].(map[string]int)["Confirmed"] + (*results)[pre+"Low"].(map[string]int)["NotExploitable"] + (*results)[pre+"Low"].(map[string]int)["Urgent"]
+		lowOverall := (*results)[pre+"Low"].(map[string]int)["Issues"]
 		if lowOverall == 0 {
 			lowAudited = 1
 			lowOverall = 1
@@ -1628,8 +1779,8 @@ func (c *checkmarxOneExecuteScanHelper) enforceThresholds(results *map[string]in
 		}
 		// if the flag is switched on, calculate the Low findings threshold per query
 		if cxLowThresholdPerQuery {
-			if (*results)["LowPerQuery"] != nil {
-				lowPerQueryMap := (*results)["LowPerQuery"].(map[string]map[string]int)
+			if (*results)[pre+"LowPerQuery"] != nil {
+				lowPerQueryMap := (*results)[pre+"LowPerQuery"].(map[string]map[string]int)
 
 				for lowQuery, resultsLowQuery := range lowPerQueryMap {
 					lowAuditedPerQuery := resultsLowQuery["Confirmed"] + resultsLowQuery["NotExploitable"] + resultsLowQuery["Urgent"]
@@ -1690,7 +1841,7 @@ func (c *checkmarxOneExecuteScanHelper) enforceThresholds(results *map[string]in
 	highText := fmt.Sprintf("High %v%v %v %v", highValue, unit, confirmedHighString, highViolation)
 	mediumText := fmt.Sprintf("Medium %v%v %v %v", mediumValue, unit, confirmedMediumString, mediumViolation)
 	lowText := fmt.Sprintf("Low %v%v %v %v", lowValue, unit, confirmedLowString, lowViolation)
-	log.Entry().Info("Result auditing status per severity:")
+	log.Entry().Info(engine + " Result auditing status per severity:")
 	if len(criticalViolation) > 0 {
 		insecureResults = append(insecureResults, criticalText)
 		log.Entry().Error(criticalText)
@@ -1724,42 +1875,59 @@ func (c *checkmarxOneExecuteScanHelper) enforceThresholds(results *map[string]in
 }
 
 func (c *checkmarxOneExecuteScanHelper) reportToInflux(results *map[string]interface{}) {
-	c.influx.checkmarxOne_data.fields.critical_issues = (*results)["Critical"].(map[string]int)["Issues"]
-	c.influx.checkmarxOne_data.fields.critical_not_false_postive = (*results)["Critical"].(map[string]int)["NotFalsePositive"]
-	c.influx.checkmarxOne_data.fields.critical_not_exploitable = (*results)["Critical"].(map[string]int)["NotExploitable"]
-	c.influx.checkmarxOne_data.fields.critical_confirmed = (*results)["Critical"].(map[string]int)["Confirmed"]
-	c.influx.checkmarxOne_data.fields.critical_urgent = (*results)["Critical"].(map[string]int)["Urgent"]
-	c.influx.checkmarxOne_data.fields.critical_proposed_not_exploitable = (*results)["Critical"].(map[string]int)["ProposedNotExploitable"]
-	c.influx.checkmarxOne_data.fields.critical_to_verify = (*results)["Critical"].(map[string]int)["ToVerify"]
+	getCount := func(severity, key string) int {
+		count := 0
 
-	c.influx.checkmarxOne_data.fields.high_issues = (*results)["High"].(map[string]int)["Issues"]
-	c.influx.checkmarxOne_data.fields.high_not_false_postive = (*results)["High"].(map[string]int)["NotFalsePositive"]
-	c.influx.checkmarxOne_data.fields.high_not_exploitable = (*results)["High"].(map[string]int)["NotExploitable"]
-	c.influx.checkmarxOne_data.fields.high_confirmed = (*results)["High"].(map[string]int)["Confirmed"]
-	c.influx.checkmarxOne_data.fields.high_urgent = (*results)["High"].(map[string]int)["Urgent"]
-	c.influx.checkmarxOne_data.fields.high_proposed_not_exploitable = (*results)["High"].(map[string]int)["ProposedNotExploitable"]
-	c.influx.checkmarxOne_data.fields.high_to_verify = (*results)["High"].(map[string]int)["ToVerify"]
-	c.influx.checkmarxOne_data.fields.medium_issues = (*results)["Medium"].(map[string]int)["Issues"]
-	c.influx.checkmarxOne_data.fields.medium_not_false_postive = (*results)["Medium"].(map[string]int)["NotFalsePositive"]
-	c.influx.checkmarxOne_data.fields.medium_not_exploitable = (*results)["Medium"].(map[string]int)["NotExploitable"]
-	c.influx.checkmarxOne_data.fields.medium_confirmed = (*results)["Medium"].(map[string]int)["Confirmed"]
-	c.influx.checkmarxOne_data.fields.medium_urgent = (*results)["Medium"].(map[string]int)["Urgent"]
-	c.influx.checkmarxOne_data.fields.medium_proposed_not_exploitable = (*results)["Medium"].(map[string]int)["ProposedNotExploitable"]
-	c.influx.checkmarxOne_data.fields.medium_to_verify = (*results)["Medium"].(map[string]int)["ToVerify"]
-	c.influx.checkmarxOne_data.fields.low_issues = (*results)["Low"].(map[string]int)["Issues"]
-	c.influx.checkmarxOne_data.fields.low_not_false_postive = (*results)["Low"].(map[string]int)["NotFalsePositive"]
-	c.influx.checkmarxOne_data.fields.low_not_exploitable = (*results)["Low"].(map[string]int)["NotExploitable"]
-	c.influx.checkmarxOne_data.fields.low_confirmed = (*results)["Low"].(map[string]int)["Confirmed"]
-	c.influx.checkmarxOne_data.fields.low_urgent = (*results)["Low"].(map[string]int)["Urgent"]
-	c.influx.checkmarxOne_data.fields.low_proposed_not_exploitable = (*results)["Low"].(map[string]int)["ProposedNotExploitable"]
-	c.influx.checkmarxOne_data.fields.low_to_verify = (*results)["Low"].(map[string]int)["ToVerify"]
-	c.influx.checkmarxOne_data.fields.information_issues = (*results)["Information"].(map[string]int)["Issues"]
-	c.influx.checkmarxOne_data.fields.information_not_false_postive = (*results)["Information"].(map[string]int)["NotFalsePositive"]
-	c.influx.checkmarxOne_data.fields.information_not_exploitable = (*results)["Information"].(map[string]int)["NotExploitable"]
-	c.influx.checkmarxOne_data.fields.information_confirmed = (*results)["Information"].(map[string]int)["Confirmed"]
-	c.influx.checkmarxOne_data.fields.information_urgent = (*results)["Information"].(map[string]int)["Urgent"]
-	c.influx.checkmarxOne_data.fields.information_proposed_not_exploitable = (*results)["Information"].(map[string]int)["ProposedNotExploitable"]
-	c.influx.checkmarxOne_data.fields.information_to_verify = (*results)["Information"].(map[string]int)["ToVerify"]
+		if m, ok := (*results)[severity]; ok {
+			if m, ok := m.(map[string]int); ok {
+				count += m[key]
+			}
+		}
+		if m, ok := (*results)["IAC"+severity]; ok {
+			if m, ok := m.(map[string]int); ok {
+				count += m[key]
+			}
+		}
+		return count
+	}
+
+	c.influx.checkmarxOne_data.fields.critical_issues = getCount("Critical", "Issues")
+	c.influx.checkmarxOne_data.fields.critical_not_false_postive = getCount("Critical", "NotFalsePositive")
+	c.influx.checkmarxOne_data.fields.critical_not_exploitable = getCount("Critical", "NotExploitable")
+	c.influx.checkmarxOne_data.fields.critical_confirmed = getCount("Critical", "Confirmed")
+	c.influx.checkmarxOne_data.fields.critical_urgent = getCount("Critical", "Urgent")
+	c.influx.checkmarxOne_data.fields.critical_proposed_not_exploitable = getCount("Critical", "ProposedNotExploitable")
+	c.influx.checkmarxOne_data.fields.critical_to_verify = getCount("Critical", "ToVerify")
+
+	c.influx.checkmarxOne_data.fields.high_issues = getCount("High", "Issues")
+	c.influx.checkmarxOne_data.fields.high_not_false_postive = getCount("High", "NotFalsePositive")
+	c.influx.checkmarxOne_data.fields.high_not_exploitable = getCount("High", "NotExploitable")
+	c.influx.checkmarxOne_data.fields.high_confirmed = getCount("High", "Confirmed")
+	c.influx.checkmarxOne_data.fields.high_urgent = getCount("High", "Urgent")
+	c.influx.checkmarxOne_data.fields.high_proposed_not_exploitable = getCount("High", "ProposedNotExploitable")
+	c.influx.checkmarxOne_data.fields.high_to_verify = getCount("High", "ToVerify")
+	c.influx.checkmarxOne_data.fields.medium_issues = getCount("Medium", "Issues")
+	c.influx.checkmarxOne_data.fields.medium_not_false_postive = getCount("Medium", "NotFalsePositive")
+	c.influx.checkmarxOne_data.fields.medium_not_exploitable = getCount("Medium", "NotExploitable")
+	c.influx.checkmarxOne_data.fields.medium_confirmed = getCount("Medium", "Confirmed")
+	c.influx.checkmarxOne_data.fields.medium_urgent = getCount("Medium", "Urgent")
+	c.influx.checkmarxOne_data.fields.medium_proposed_not_exploitable = getCount("Medium", "ProposedNotExploitable")
+	c.influx.checkmarxOne_data.fields.medium_to_verify = getCount("Medium", "ToVerify")
+	c.influx.checkmarxOne_data.fields.low_issues = getCount("Low", "Issues")
+	c.influx.checkmarxOne_data.fields.low_not_false_postive = getCount("Low", "NotFalsePositive")
+	c.influx.checkmarxOne_data.fields.low_not_exploitable = getCount("Low", "NotExploitable")
+	c.influx.checkmarxOne_data.fields.low_confirmed = getCount("Low", "Confirmed")
+	c.influx.checkmarxOne_data.fields.low_urgent = getCount("Low", "Urgent")
+	c.influx.checkmarxOne_data.fields.low_proposed_not_exploitable = getCount("Low", "ProposedNotExploitable")
+	c.influx.checkmarxOne_data.fields.low_to_verify = getCount("Low", "ToVerify")
+	c.influx.checkmarxOne_data.fields.information_issues = getCount("Information", "Issues")
+	c.influx.checkmarxOne_data.fields.information_not_false_postive = getCount("Information", "NotFalsePositive")
+	c.influx.checkmarxOne_data.fields.information_not_exploitable = getCount("Information", "NotExploitable")
+	c.influx.checkmarxOne_data.fields.information_confirmed = getCount("Information", "Confirmed")
+	c.influx.checkmarxOne_data.fields.information_urgent = getCount("Information", "Urgent")
+	c.influx.checkmarxOne_data.fields.information_proposed_not_exploitable = getCount("Information", "ProposedNotExploitable")
+	c.influx.checkmarxOne_data.fields.information_to_verify = getCount("Information", "ToVerify")
+
 	c.influx.checkmarxOne_data.fields.initiator_name = (*results)["InitiatorName"].(string)
 	c.influx.checkmarxOne_data.fields.owner = (*results)["Owner"].(string)
 	c.influx.checkmarxOne_data.fields.scan_id = (*results)["ScanId"].(string)
@@ -1771,7 +1939,7 @@ func (c *checkmarxOneExecuteScanHelper) reportToInflux(results *map[string]inter
 	c.influx.checkmarxOne_data.fields.scan_time = (*results)["ScanTime"].(string)
 	c.influx.checkmarxOne_data.fields.lines_of_code_scanned = (*results)["LinesOfCodeScanned"].(int)
 	c.influx.checkmarxOne_data.fields.files_scanned = (*results)["FilesScanned"].(int)
-	c.influx.checkmarxOne_data.fields.tool_version = (*results)["ToolVersion"].(string)
+	c.influx.checkmarxOne_data.fields.tool_version = fmt.Sprintf("%s, %s, %s", (*results)["ToolVersion"], (*results)["SASTVersion"], (*results)["IACVersion"])
 
 	c.influx.checkmarxOne_data.fields.scan_type = (*results)["ScanType"].(string)
 	c.influx.checkmarxOne_data.fields.preset = (*results)["SastPreset"].(string)

--- a/cmd/checkmarxOneExecuteScan_generated.go
+++ b/cmd/checkmarxOneExecuteScan_generated.go
@@ -62,6 +62,7 @@ type checkmarxOneExecuteScanOptions struct {
 	ClientID                             string   `json:"clientId,omitempty"`
 	VerifyOnly                           bool     `json:"verifyOnly,omitempty"`
 	VulnerabilityThresholdEnabled        bool     `json:"vulnerabilityThresholdEnabled,omitempty"`
+	IacVulnerabilityThresholdEnabled     bool     `json:"iacVulnerabilityThresholdEnabled,omitempty"`
 	VulnerabilityThresholdCritical       int      `json:"vulnerabilityThresholdCritical,omitempty"`
 	VulnerabilityThresholdHigh           int      `json:"vulnerabilityThresholdHigh,omitempty"`
 	VulnerabilityThresholdMedium         int      `json:"vulnerabilityThresholdMedium,omitempty"`
@@ -447,6 +448,7 @@ func addCheckmarxOneExecuteScanFlags(cmd *cobra.Command, stepConfig *checkmarxOn
 	cmd.Flags().StringVar(&stepConfig.ClientID, "clientId", os.Getenv("PIPER_clientId"), "The username to authenticate")
 	cmd.Flags().BoolVar(&stepConfig.VerifyOnly, "verifyOnly", false, "Whether the step shall only apply verification checks or whether it does a full scan and check cycle")
 	cmd.Flags().BoolVar(&stepConfig.VulnerabilityThresholdEnabled, "vulnerabilityThresholdEnabled", true, "Whether the thresholds are enabled or not. If enabled the build will be set to `vulnerabilityThresholdResult` in case a specific threshold value is exceeded")
+	cmd.Flags().BoolVar(&stepConfig.IacVulnerabilityThresholdEnabled, "iacVulnerabilityThresholdEnabled", false, "Whether the thresholds are enabled or not for IAC. If enabled the build will be set to `vulnerabilityThresholdResult` in case a specific threshold value is exceeded")
 	cmd.Flags().IntVar(&stepConfig.VulnerabilityThresholdCritical, "vulnerabilityThresholdCritical", 100, "The specific threshold for Critical severity findings")
 	cmd.Flags().IntVar(&stepConfig.VulnerabilityThresholdHigh, "vulnerabilityThresholdHigh", 100, "The specific threshold for High severity findings")
 	cmd.Flags().IntVar(&stepConfig.VulnerabilityThresholdMedium, "vulnerabilityThresholdMedium", 100, "The specific threshold for Medium severity findings")
@@ -913,6 +915,15 @@ func checkmarxOneExecuteScanMetadata() config.StepData {
 						Mandatory:   false,
 						Aliases:     []config.Alias{},
 						Default:     true,
+					},
+					{
+						Name:        "iacVulnerabilityThresholdEnabled",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
 					},
 					{
 						Name:        "vulnerabilityThresholdCritical",

--- a/cmd/checkmarxOneExecuteScan_test.go
+++ b/cmd/checkmarxOneExecuteScan_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,7 @@ import (
 
 type checkmarxOneSystemMock struct {
 	response interface{}
+	influx   *checkmarxOneExecuteScanInflux
 }
 
 func (sys *checkmarxOneSystemMock) DownloadReport(reportID string) ([]byte, error) {
@@ -471,4 +473,447 @@ func TestCheckmarxOneZipFolder(t *testing.T) {
 		// only the two regular source files must be archived, never the output archive
 		assert.Len(t, reader.File, 2)
 	})
+}
+
+func testRawDetailedResults() map[string]any {
+	return map[string]interface{}{
+		"Application":                     "80fdd5b7-9269-423e-a483-878ecb3c7ae8",
+		"ApplicationFullPathOnReportDate": "SSBA",
+		"Critical":                        map[string]int{"Issues": 2, "NotExploitable": 2},
+		"DeepLink":                        "test/projects/ca6bbcca-c75a-4a07-8298-552ec400732a/overview?branch=new-branch2",
+		"FilesScanned":                    10,
+		"Group":                           "",
+		"GroupFullPathOnReportDate":       "",
+		"High":                            map[string]int{"Issues": 1, "NotExploitable": 1},
+		"IACCritical":                     map[string]int{},
+		"IACHigh":                         map[string]int{"Issues": 1, "NotFalsePositive": 1, "ToVerify": 1},
+		"IACInformation":                  map[string]int{},
+		"IACLow":                          map[string]int{"Issues": 1, "NotFalsePositive": 1, "ToVerify": 1},
+		"IACLowPerQuery": map[string]map[string]int{
+			"Healthcheck Instruction Missing": map[string]int{"Issues": 1, "NotFalsePositive": 1, "ToVerify": 1},
+		},
+		"IACMedium":             map[string]int{},
+		"IACVersion":            "IAC: 2.1.20",
+		"IacFilesScanned":       1,
+		"IacLinesOfCodeScanned": 11,
+		"IacPreset":             "all checks",
+		"Information":           map[string]int{"Issues": 13, "NotExploitable": 1, "NotFalsePositive": 12, "ToVerify": 12},
+		"InitiatorName":         "michael.kubiaczyk@checkmarx.com",
+		"LinesOfCodeScanned":    158,
+		"Low":                   map[string]int{"Issues": 2, "NotExploitable": 1, "NotFalsePositive": 1, "ToVerify": 1},
+		"LowPerQuery": map[string]map[string]int{
+			"Reflected_XSS":                          map[string]int{"Issues": 1, "NotFalsePositive": 1, "ToVerify": 1},
+			"Spring_Missing_Content_Security_Policy": map[string]int{"Issues": 1, "NotExploitable": 1},
+		},
+		"Medium":             map[string]int{"Issues": 4, "NotExploitable": 1, "NotFalsePositive": 3, "ToVerify": 3},
+		"Owner":              "Cx1 Gap: no project owner",
+		"ProjectId":          "ca6bbcca-c75a-4a07-8298-552ec400732a",
+		"ProjectName":        "piper-iac-sast-test1",
+		"ReportCreationTime": "2026-08-11 13:38:56.647088 +0200 CEST m=+1.527286701",
+		"SASTVersion":        "SAST: 9.7.6",
+		"SastPreset":         "All",
+		"ScanId":             "bdff84f5-f226-4591-86e0-f43511474f35",
+		"ScanStart":          "2026-08-05T14:40:31.707039Z",
+		"ScanTime":           "9.299223s",
+		"ScanType":           "Incremental",
+		"ToolVersion":        "CxOne: 3.64.0",
+	}
+}
+
+func TestCheckmarxOneGitComment(t *testing.T) {
+	detailedResults := testRawDetailedResults()
+
+	mainconfig := checkmarxOneExecuteScanOptions{
+		VulnerabilityThresholdEnabled:        true,
+		VulnerabilityThresholdCritical:       100,
+		VulnerabilityThresholdHigh:           100,
+		VulnerabilityThresholdMedium:         100,
+		VulnerabilityThresholdLow:            10,
+		VulnerabilityThresholdLowPerQuery:    true,
+		VulnerabilityThresholdLowPerQueryMax: 10,
+		VulnerabilityThresholdResult:         "FAILURE",
+		VulnerabilityThresholdUnit:           "percentage",
+		IacVulnerabilityThresholdEnabled:     false,
+	}
+
+	t.Run("sast report with LowPerQuery enabled", func(t *testing.T) {
+		var sast_status gitComment
+		sastScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "sast")
+		sast_status.Parse(sastScanReportOverview.Findings, &mainconfig)
+		sastTable := sast_status.String()
+
+		sastScan := fmt.Sprintf(`**SAST Scan type**: %s
+**SAST Scan Preset**: %s
+**SAST Results**
+%s
+
+`, strings.ToLower(sastScanReportOverview.ScanType), sastScanReportOverview.Preset, sastTable)
+
+		t.Logf("Generated report: %s", sastScan)
+		expectedReport := `**SAST Scan type**: incremental
+**SAST Scan Preset**: All
+**SAST Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :white_check_mark: 0
+:orange_circle: Medium | :x: 3
+:yellow_circle: Low | :x: 1 Reflected_XSS (0 audited / 1 required) <br>:white_check_mark: 0 Spring_Missing_Content_Security_Policy (1 audited / 1 required) <br>
+
+`
+		assert.Equal(t, expectedReport, sastScan)
+	})
+
+	t.Run("iac report with LowPerQuery enabled", func(t *testing.T) {
+		var iac_status gitComment
+		iacScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "iac")
+		iac_status.Parse(iacScanReportOverview.Findings, &mainconfig)
+		iacTable := iac_status.String()
+
+		iacScan := fmt.Sprintf(`**IAC Scan Preset**: %s
+**IAC Results**
+%s
+
+`, iacScanReportOverview.Preset, iacTable)
+
+		t.Logf("Generated report: %s", iacScan)
+
+		expectedReport := `**IAC Scan Preset**: all checks
+**IAC Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :x: 1
+:orange_circle: Medium | :white_check_mark: 0
+:yellow_circle: Low | :x: 1 Healthcheck Instruction Missing (0 audited / 1 required) <br>
+
+`
+		assert.Equal(t, expectedReport, iacScan)
+	})
+
+	// remove lowPerQuery from config
+	mainconfig.VulnerabilityThresholdLowPerQuery = false
+	// remove lowPerQuery data from detailedResults
+	delete(detailedResults, "LowPerQuery")
+	delete(detailedResults, "IACLowPerQuery")
+
+	t.Run("sast report with LowPerQuery disabled", func(t *testing.T) {
+		var sast_status gitComment
+		sastScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "sast")
+		sast_status.Parse(sastScanReportOverview.Findings, &mainconfig)
+		sastTable := sast_status.String()
+
+		sastScan := fmt.Sprintf(`**SAST Scan type**: %s
+**SAST Scan Preset**: %s
+**SAST Results**
+%s
+
+`, strings.ToLower(sastScanReportOverview.ScanType), sastScanReportOverview.Preset, sastTable)
+
+		t.Logf("Generated report: %s", sastScan)
+
+		expectedReport := `**SAST Scan type**: incremental
+**SAST Scan Preset**: All
+**SAST Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :white_check_mark: 0
+:orange_circle: Medium | :x: 3
+:yellow_circle: Low | :white_check_mark: 1
+
+`
+
+		assert.Equal(t, expectedReport, sastScan)
+	})
+
+	t.Run("iac report with LowPerQuery disabled", func(t *testing.T) {
+		var iac_status gitComment
+		iacScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "iac")
+		iac_status.Parse(iacScanReportOverview.Findings, &mainconfig)
+		iacTable := iac_status.String()
+
+		iacScan := fmt.Sprintf(`**IAC Scan Preset**: %s
+**IAC Results**
+%s
+
+`, iacScanReportOverview.Preset, iacTable)
+
+		t.Logf("Generated report: %s", iacScan)
+
+		expectedReport := `**IAC Scan Preset**: all checks
+**IAC Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :x: 1
+:orange_circle: Medium | :white_check_mark: 0
+:yellow_circle: Low | :x: 1
+
+`
+
+		assert.Equal(t, expectedReport, iacScan)
+	})
+
+	// remove all findings from report
+	detailedResults["Critical"] = map[string]int{}
+	detailedResults["High"] = map[string]int{}
+	detailedResults["Medium"] = map[string]int{}
+	detailedResults["Low"] = map[string]int{}
+	detailedResults["Information"] = map[string]int{}
+	detailedResults["IACCritical"] = map[string]int{}
+	detailedResults["IACHigh"] = map[string]int{}
+	detailedResults["IACMedium"] = map[string]int{}
+	detailedResults["IACLow"] = map[string]int{}
+	detailedResults["IACInformation"] = map[string]int{}
+	t.Run("sast report with no findings LowPerQuery disabled", func(t *testing.T) {
+		var sast_status gitComment
+		sastScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "sast")
+		sast_status.Parse(sastScanReportOverview.Findings, &mainconfig)
+		sastTable := sast_status.String()
+
+		sastScan := fmt.Sprintf(`**SAST Scan type**: %s
+**SAST Scan Preset**: %s
+**SAST Results**
+%s
+
+`, strings.ToLower(sastScanReportOverview.ScanType), sastScanReportOverview.Preset, sastTable)
+
+		t.Logf("Generated report: %s", sastScan)
+
+		expectedReport := `**SAST Scan type**: incremental
+**SAST Scan Preset**: All
+**SAST Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :white_check_mark: 0
+:orange_circle: Medium | :white_check_mark: 0
+:yellow_circle: Low | :white_check_mark: 0
+
+`
+
+		assert.Equal(t, expectedReport, sastScan)
+	})
+
+	t.Run("iac report with no findings LowPerQuery disabled", func(t *testing.T) {
+		var iac_status gitComment
+		iacScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "iac")
+		iac_status.Parse(iacScanReportOverview.Findings, &mainconfig)
+		iacTable := iac_status.String()
+
+		iacScan := fmt.Sprintf(`**IAC Scan Preset**: %s
+**IAC Results**
+%s
+
+`, iacScanReportOverview.Preset, iacTable)
+
+		t.Logf("Generated report: %s", iacScan)
+
+		expectedReport := `**IAC Scan Preset**: all checks
+**IAC Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :white_check_mark: 0
+:orange_circle: Medium | :white_check_mark: 0
+:yellow_circle: Low | :white_check_mark: 0
+
+`
+
+		assert.Equal(t, expectedReport, iacScan)
+	})
+
+	// add lowPerQuery to config
+	mainconfig.VulnerabilityThresholdLowPerQuery = true
+	// add lowPerQuery data to detailedResults
+	detailedResults["LowPerQuery"] = map[string]map[string]int{}
+	detailedResults["IACLowPerQuery"] = map[string]map[string]int{}
+
+	t.Run("sast report with no findings LowPerQuery enabled", func(t *testing.T) {
+		var sast_status gitComment
+		sastScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "sast")
+		sast_status.Parse(sastScanReportOverview.Findings, &mainconfig)
+		sastTable := sast_status.String()
+
+		sastScan := fmt.Sprintf(`**SAST Scan type**: %s
+**SAST Scan Preset**: %s
+**SAST Results**
+%s
+
+`, strings.ToLower(sastScanReportOverview.ScanType), sastScanReportOverview.Preset, sastTable)
+
+		t.Logf("Generated report: %s", sastScan)
+
+		expectedReport := `**SAST Scan type**: incremental
+**SAST Scan Preset**: All
+**SAST Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :white_check_mark: 0
+:orange_circle: Medium | :white_check_mark: 0
+:yellow_circle: Low | :white_check_mark: 0
+
+`
+
+		assert.Equal(t, expectedReport, sastScan)
+	})
+
+	t.Run("iac report with no findings LowPerQuery enabled", func(t *testing.T) {
+		var iac_status gitComment
+		iacScanReportOverview := checkmarxOne.CreateJSONHeaderReport(&detailedResults, "iac")
+		iac_status.Parse(iacScanReportOverview.Findings, &mainconfig)
+		iacTable := iac_status.String()
+
+		iacScan := fmt.Sprintf(`**IAC Scan Preset**: %s
+**IAC Results**
+%s
+
+`, iacScanReportOverview.Preset, iacTable)
+
+		t.Logf("Generated report: %s", iacScan)
+
+		expectedReport := `**IAC Scan Preset**: all checks
+**IAC Results**
+Severity | Number of unaudited findings
+--- | ---
+:bangbang: Critical | :white_check_mark: 0
+:red_circle: High | :white_check_mark: 0
+:orange_circle: Medium | :white_check_mark: 0
+:yellow_circle: Low | :white_check_mark: 0
+
+`
+
+		assert.Equal(t, expectedReport, iacScan)
+	})
+}
+
+func TestCheckmarxOneInflux(t *testing.T) {
+	influx := checkmarxOneExecuteScanInflux{}
+	cx1sh := checkmarxOneExecuteScanHelper{
+		influx: &influx,
+	}
+
+	type measurement struct {
+		Name  string
+		Value interface{}
+	}
+	referenceData := []measurement{
+		{Name: "checkmarxOne", Value: false},
+		{Name: "critical_issues", Value: 2},
+		{Name: "critical_not_false_postive", Value: 0},
+		{Name: "critical_not_exploitable", Value: 2},
+		{Name: "critical_confirmed", Value: 0},
+		{Name: "critical_urgent", Value: 0},
+		{Name: "critical_proposed_not_exploitable", Value: 0},
+		{Name: "critical_to_verify", Value: 0},
+		{Name: "high_issues", Value: 2},
+		{Name: "high_not_false_postive", Value: 1},
+		{Name: "high_not_exploitable", Value: 1},
+		{Name: "high_confirmed", Value: 0},
+		{Name: "high_urgent", Value: 0},
+		{Name: "high_proposed_not_exploitable", Value: 0},
+		{Name: "high_to_verify", Value: 1},
+		{Name: "medium_issues", Value: 4},
+		{Name: "medium_not_false_postive", Value: 3},
+		{Name: "medium_not_exploitable", Value: 1},
+		{Name: "medium_confirmed", Value: 0},
+		{Name: "medium_urgent", Value: 0},
+		{Name: "medium_proposed_not_exploitable", Value: 0},
+		{Name: "medium_to_verify", Value: 3},
+		{Name: "low_issues", Value: 3},
+		{Name: "low_not_false_postive", Value: 2},
+		{Name: "low_not_exploitable", Value: 1},
+		{Name: "low_confirmed", Value: 0},
+		{Name: "low_urgent", Value: 0},
+		{Name: "low_proposed_not_exploitable", Value: 0},
+		{Name: "low_to_verify", Value: 2},
+		{Name: "information_issues", Value: 13},
+		{Name: "information_not_false_postive", Value: 12},
+		{Name: "information_not_exploitable", Value: 1},
+		{Name: "information_confirmed", Value: 0},
+		{Name: "information_urgent", Value: 0},
+		{Name: "information_proposed_not_exploitable", Value: 0},
+		{Name: "information_to_verify", Value: 12},
+		{Name: "lines_of_code_scanned", Value: 158},
+		{Name: "files_scanned", Value: 10},
+		{Name: "initiator_name", Value: "michael.kubiaczyk@checkmarx.com"},
+		{Name: "owner", Value: "Cx1 Gap: no project owner"},
+		{Name: "scan_id", Value: "bdff84f5-f226-4591-86e0-f43511474f35"},
+		{Name: "project_id", Value: "ca6bbcca-c75a-4a07-8298-552ec400732a"},
+		{Name: "projectName", Value: "piper-iac-sast-test1"},
+		{Name: "group", Value: ""},
+		{Name: "group_full_path_on_report_date", Value: ""},
+		{Name: "scan_start", Value: "2026-08-05T14:40:31.707039Z"},
+		{Name: "scan_time", Value: "9.299223s"},
+		{Name: "tool_version", Value: "CxOne: 3.64.0, SAST: 9.7.6, IAC: 2.1.20"},
+		{Name: "scan_type", Value: "Incremental"},
+		{Name: "preset", Value: "All"},
+		{Name: "iac_preset", Value: "all checks"},
+		{Name: "deep_link", Value: "test/projects/ca6bbcca-c75a-4a07-8298-552ec400732a/overview?branch=new-branch2"},
+		{Name: "report_creation_time", Value: "2026-08-11 13:38:56.647088 +0200 CEST m=+1.527286701"},
+	}
+
+	detailedResults := testRawDetailedResults()
+	cx1sh.reportToInflux(&detailedResults)
+	measurementContent := []measurement{
+		{Name: "checkmarxOne", Value: influx.step_data.fields.checkmarxOne},
+		{Name: "critical_issues", Value: influx.checkmarxOne_data.fields.critical_issues},
+		{Name: "critical_not_false_postive", Value: influx.checkmarxOne_data.fields.critical_not_false_postive},
+		{Name: "critical_not_exploitable", Value: influx.checkmarxOne_data.fields.critical_not_exploitable},
+		{Name: "critical_confirmed", Value: influx.checkmarxOne_data.fields.critical_confirmed},
+		{Name: "critical_urgent", Value: influx.checkmarxOne_data.fields.critical_urgent},
+		{Name: "critical_proposed_not_exploitable", Value: influx.checkmarxOne_data.fields.critical_proposed_not_exploitable},
+		{Name: "critical_to_verify", Value: influx.checkmarxOne_data.fields.critical_to_verify},
+		{Name: "high_issues", Value: influx.checkmarxOne_data.fields.high_issues},
+		{Name: "high_not_false_postive", Value: influx.checkmarxOne_data.fields.high_not_false_postive},
+		{Name: "high_not_exploitable", Value: influx.checkmarxOne_data.fields.high_not_exploitable},
+		{Name: "high_confirmed", Value: influx.checkmarxOne_data.fields.high_confirmed},
+		{Name: "high_urgent", Value: influx.checkmarxOne_data.fields.high_urgent},
+		{Name: "high_proposed_not_exploitable", Value: influx.checkmarxOne_data.fields.high_proposed_not_exploitable},
+		{Name: "high_to_verify", Value: influx.checkmarxOne_data.fields.high_to_verify},
+		{Name: "medium_issues", Value: influx.checkmarxOne_data.fields.medium_issues},
+		{Name: "medium_not_false_postive", Value: influx.checkmarxOne_data.fields.medium_not_false_postive},
+		{Name: "medium_not_exploitable", Value: influx.checkmarxOne_data.fields.medium_not_exploitable},
+		{Name: "medium_confirmed", Value: influx.checkmarxOne_data.fields.medium_confirmed},
+		{Name: "medium_urgent", Value: influx.checkmarxOne_data.fields.medium_urgent},
+		{Name: "medium_proposed_not_exploitable", Value: influx.checkmarxOne_data.fields.medium_proposed_not_exploitable},
+		{Name: "medium_to_verify", Value: influx.checkmarxOne_data.fields.medium_to_verify},
+		{Name: "low_issues", Value: influx.checkmarxOne_data.fields.low_issues},
+		{Name: "low_not_false_postive", Value: influx.checkmarxOne_data.fields.low_not_false_postive},
+		{Name: "low_not_exploitable", Value: influx.checkmarxOne_data.fields.low_not_exploitable},
+		{Name: "low_confirmed", Value: influx.checkmarxOne_data.fields.low_confirmed},
+		{Name: "low_urgent", Value: influx.checkmarxOne_data.fields.low_urgent},
+		{Name: "low_proposed_not_exploitable", Value: influx.checkmarxOne_data.fields.low_proposed_not_exploitable},
+		{Name: "low_to_verify", Value: influx.checkmarxOne_data.fields.low_to_verify},
+		{Name: "information_issues", Value: influx.checkmarxOne_data.fields.information_issues},
+		{Name: "information_not_false_postive", Value: influx.checkmarxOne_data.fields.information_not_false_postive},
+		{Name: "information_not_exploitable", Value: influx.checkmarxOne_data.fields.information_not_exploitable},
+		{Name: "information_confirmed", Value: influx.checkmarxOne_data.fields.information_confirmed},
+		{Name: "information_urgent", Value: influx.checkmarxOne_data.fields.information_urgent},
+		{Name: "information_proposed_not_exploitable", Value: influx.checkmarxOne_data.fields.information_proposed_not_exploitable},
+		{Name: "information_to_verify", Value: influx.checkmarxOne_data.fields.information_to_verify},
+		{Name: "lines_of_code_scanned", Value: influx.checkmarxOne_data.fields.lines_of_code_scanned},
+		{Name: "files_scanned", Value: influx.checkmarxOne_data.fields.files_scanned},
+		{Name: "initiator_name", Value: influx.checkmarxOne_data.fields.initiator_name},
+		{Name: "owner", Value: influx.checkmarxOne_data.fields.owner},
+		{Name: "scan_id", Value: influx.checkmarxOne_data.fields.scan_id},
+		{Name: "project_id", Value: influx.checkmarxOne_data.fields.project_id},
+		{Name: "projectName", Value: influx.checkmarxOne_data.fields.projectName},
+		{Name: "group", Value: influx.checkmarxOne_data.fields.group},
+		{Name: "group_full_path_on_report_date", Value: influx.checkmarxOne_data.fields.group_full_path_on_report_date},
+		{Name: "scan_start", Value: influx.checkmarxOne_data.fields.scan_start},
+		{Name: "scan_time", Value: influx.checkmarxOne_data.fields.scan_time},
+		{Name: "tool_version", Value: influx.checkmarxOne_data.fields.tool_version},
+		{Name: "scan_type", Value: influx.checkmarxOne_data.fields.scan_type},
+		{Name: "preset", Value: influx.checkmarxOne_data.fields.preset},
+		{Name: "iac_preset", Value: influx.checkmarxOne_data.fields.iac_preset},
+		{Name: "deep_link", Value: influx.checkmarxOne_data.fields.deep_link},
+		{Name: "report_creation_time", Value: influx.checkmarxOne_data.fields.report_creation_time},
+	}
+
+	data, _ := json.Marshal(measurementContent)
+	reference, _ := json.Marshal(referenceData)
+	assert.Equal(t, reference, data)
 }

--- a/pkg/checkmarxone/checkmarxone.go
+++ b/pkg/checkmarxone/checkmarxone.go
@@ -225,8 +225,10 @@ type ScanResult struct {
 	VulnerabilityDetails ScanResultDetails
 }
 
+type maybeStringInt int
+
 type ScanResultDetails struct {
-	CweId       int // empty for kics results, pending case 283343
+	CweId       maybeStringInt // empty for kics results, pending case 283343
 	Compliances []string
 }
 
@@ -1935,5 +1937,36 @@ func (q *scanresultQueryID) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	q.Value = u
+	return nil
+}
+
+func (fi *maybeStringInt) UnmarshalJSON(data []byte) error {
+	// First, try to unmarshal directly as a standard integer
+	var rawInt int
+	if err := json.Unmarshal(data, &rawInt); err == nil {
+		*fi = maybeStringInt(rawInt)
+		return nil
+	}
+
+	// If that fails, try to unmarshal as a string
+	var rawString string
+	if err := json.Unmarshal(data, &rawString); err != nil {
+		return err
+	}
+
+	// Handle empty string cases gracefully (sets value to 0)
+	rawString = strings.TrimSpace(rawString)
+	if rawString == "" {
+		*fi = 0
+		return nil
+	}
+
+	// Convert the string to an integer
+	parsedInt, err := strconv.Atoi(rawString)
+	if err != nil {
+		return fmt.Errorf("failed to parse string as integer: %v", err)
+	}
+
+	*fi = maybeStringInt(parsedInt)
 	return nil
 }

--- a/pkg/checkmarxone/cxjson_to_sarif.go
+++ b/pkg/checkmarxone/cxjson_to_sarif.go
@@ -365,7 +365,8 @@ func convertCxJSONToSarif(sys System, resultType, baseURL, projectBaseURL string
 
 	//handle automationDetails
 	// This field corresponds to the configuration category in GitHub Security tab, it is meant to be used for monorepos so that each project can have its own findings
-	sarif.Runs[0].AutomationDetails = &format.AutomationDetails{Id: projectBaseURL}
+	sarif.Runs[0].AutomationDetails = &format.AutomationDetails{Id: fmt.Sprintf("%s/%s", projectBaseURL, resultType)}
+	// resultType suffix is needed to enable uploading both sarif files (sast and iac)
 
 	//handle taxonomies
 	//Only one exists apparently: CWE. It is fixed

--- a/pkg/checkmarxone/cxjson_to_sarif.go
+++ b/pkg/checkmarxone/cxjson_to_sarif.go
@@ -65,13 +65,13 @@ func convertCxJSONToSarif(sys System, resultType, baseURL, projectBaseURL string
 				log.Entry().Warningf("Error while retrieving IAC finding description for finding [%s] %s: %s", r.Data.QueryID, r.Data.QueryName, err)
 			} else {
 				iacFindingInfo = &findingInfo
-				r.VulnerabilityDetails.CweId = iacFindingInfo.Cwe
+				r.VulnerabilityDetails.CweId = maybeStringInt(iacFindingInfo.Cwe)
 			}
 		}
-		_, haskey := cweIdsForTaxonomies[r.VulnerabilityDetails.CweId]
+		_, haskey := cweIdsForTaxonomies[int(r.VulnerabilityDetails.CweId)]
 
 		if !haskey {
-			cweIdsForTaxonomies[r.VulnerabilityDetails.CweId] = cweCounter
+			cweIdsForTaxonomies[int(r.VulnerabilityDetails.CweId)] = cweCounter
 			cweCounter++
 		}
 
@@ -92,7 +92,7 @@ func convertCxJSONToSarif(sys System, resultType, baseURL, projectBaseURL string
 			queryID = fmt.Sprintf("checkmarxOne-%v/%s", r.Data.Platform, r.Data.QueryID.Value.(string))
 		}
 		result.RuleID = queryID
-		result.RuleIndex = cweIdsForTaxonomies[r.VulnerabilityDetails.CweId]
+		result.RuleIndex = cweIdsForTaxonomies[int(r.VulnerabilityDetails.CweId)]
 		result.Level = "none"
 		msg := new(format.Message)
 		if apiDescription != "" {
@@ -295,7 +295,7 @@ func convertCxJSONToSarif(sys System, resultType, baseURL, projectBaseURL string
 
 		switch r.Type {
 		case "sast":
-			rule.HelpURI = fmt.Sprintf("%v/sast/description/%v/%v", baseURL, r.VulnerabilityDetails.CweId, r.Data.QueryID)
+			rule.HelpURI = fmt.Sprintf("%v/sast/description/%v/%v", baseURL, int(r.VulnerabilityDetails.CweId), r.Data.QueryID)
 		case "kics":
 			if iacFindingInfo == nil {
 				rule.HelpURI = "n/a"
@@ -335,8 +335,8 @@ func convertCxJSONToSarif(sys System, resultType, baseURL, projectBaseURL string
 			rule.Properties.SecuritySeverity = "10.0"
 		}
 
-		if r.VulnerabilityDetails.CweId != 0 {
-			rule.Properties.Tags = append(rule.Properties.Tags, fmt.Sprintf("external/cwe/cwe-%d", r.VulnerabilityDetails.CweId))
+		if int(r.VulnerabilityDetails.CweId) != 0 {
+			rule.Properties.Tags = append(rule.Properties.Tags, fmt.Sprintf("external/cwe/cwe-%d", int(r.VulnerabilityDetails.CweId)))
 		}
 
 		match := false
@@ -365,8 +365,7 @@ func convertCxJSONToSarif(sys System, resultType, baseURL, projectBaseURL string
 
 	//handle automationDetails
 	// This field corresponds to the configuration category in GitHub Security tab, it is meant to be used for monorepos so that each project can have its own findings
-	sarif.Runs[0].AutomationDetails = &format.AutomationDetails{Id: fmt.Sprintf("%s/%s", projectBaseURL, resultType)}
-	// resultType sufix is needed to enable uploading both sarif files (sast and iac)
+	sarif.Runs[0].AutomationDetails = &format.AutomationDetails{Id: projectBaseURL}
 
 	//handle taxonomies
 	//Only one exists apparently: CWE. It is fixed

--- a/pkg/checkmarxone/reporting.go
+++ b/pkg/checkmarxone/reporting.go
@@ -27,14 +27,12 @@ type CheckmarxOneReportData struct {
 	GroupID         string     `json:"groupID"`
 	DeepLink        string     `json:"deepLink"`
 	Preset          string     `json:"preset"`
-	IACPreset       string     `json:"iacPreset"`
 	ScanType        string     `json:"scanType"`
 	Findings        *[]Finding `json:"findings"`
 }
 
 type Finding struct {
 	ClassificationName string         `json:"classificationName"`
-	Engine             string         `json:"engine"`
 	Total              int            `json:"total,omitempty"`
 	Audited            *int           `json:"audited,omitempty"`
 	Confirmed          int            `json:"confirmed,omitempty"`
@@ -70,7 +68,7 @@ func CreateCustomReport(data *map[string]interface{}, insecure, neutral []string
 			{Description: "Files scanned", Details: fmt.Sprint((*data)["FilesScanned"])},
 			{Description: "IAC Lines of code scanned", Details: fmt.Sprint((*data)["IacLinesOfCodeScanned"])},
 			{Description: "IAC Files scanned", Details: fmt.Sprint((*data)["IacFilesScanned"])},
-			{Description: "Tool version", Details: fmt.Sprint((*data)["ToolVersion"])},
+			{Description: "Tool version", Details: fmt.Sprintf("%s, %s, %s", (*data)["ToolVersion"], (*data)["SASTVersion"], (*data)["IACVersion"])},
 			{Description: "Deep link", Details: deepLink},
 		},
 		Overview:   []reporting.OverviewRow{},
@@ -98,42 +96,59 @@ func CreateCustomReport(data *map[string]interface{}, insecure, neutral []string
 		},
 		WithCounter: false,
 	}
+
+	getCount := func(severity, key string) string {
+		count := 0
+
+		if m, ok := (*data)[severity]; ok {
+			if m, ok := m.(map[string]int); ok {
+				count += m[key]
+			}
+		}
+		if m, ok := (*data)["IAC"+severity]; ok {
+			if m, ok := m.(map[string]int); ok {
+				count += m[key]
+			}
+		}
+		return fmt.Sprint(count)
+	}
+
 	detailRows := []reporting.OverviewRow{
-		{Description: "Critical issues", Details: fmt.Sprint((*data)["Critical"].(map[string]int)["Issues"])},
-		{Description: "Critical not false positive issues", Details: fmt.Sprint((*data)["Critical"].(map[string]int)["NotFalsePositive"])},
-		{Description: "Critical not exploitable issues", Details: fmt.Sprint((*data)["Critical"].(map[string]int)["NotExploitable"])},
-		{Description: "Critical confirmed issues", Details: fmt.Sprint((*data)["Critical"].(map[string]int)["Confirmed"])},
-		{Description: "Critical urgent issues", Details: fmt.Sprint((*data)["Critical"].(map[string]int)["Urgent"])},
-		{Description: "Critical proposed not exploitable issues", Details: fmt.Sprint((*data)["Critical"].(map[string]int)["ProposedNotExploitable"])},
-		{Description: "Critical to verify issues", Details: fmt.Sprint((*data)["Critical"].(map[string]int)["ToVerify"])},
-		{Description: "High issues", Details: fmt.Sprint((*data)["High"].(map[string]int)["Issues"])},
-		{Description: "High not false positive issues", Details: fmt.Sprint((*data)["High"].(map[string]int)["NotFalsePositive"])},
-		{Description: "High not exploitable issues", Details: fmt.Sprint((*data)["High"].(map[string]int)["NotExploitable"])},
-		{Description: "High confirmed issues", Details: fmt.Sprint((*data)["High"].(map[string]int)["Confirmed"])},
-		{Description: "High urgent issues", Details: fmt.Sprint((*data)["High"].(map[string]int)["Urgent"])},
-		{Description: "High proposed not exploitable issues", Details: fmt.Sprint((*data)["High"].(map[string]int)["ProposedNotExploitable"])},
-		{Description: "High to verify issues", Details: fmt.Sprint((*data)["High"].(map[string]int)["ToVerify"])},
-		{Description: "Medium issues", Details: fmt.Sprint((*data)["Medium"].(map[string]int)["Issues"])},
-		{Description: "Medium not false positive issues", Details: fmt.Sprint((*data)["Medium"].(map[string]int)["NotFalsePositive"])},
-		{Description: "Medium not exploitable issues", Details: fmt.Sprint((*data)["Medium"].(map[string]int)["NotExploitable"])},
-		{Description: "Medium confirmed issues", Details: fmt.Sprint((*data)["Medium"].(map[string]int)["Confirmed"])},
-		{Description: "Medium urgent issues", Details: fmt.Sprint((*data)["Medium"].(map[string]int)["Urgent"])},
-		{Description: "Medium proposed not exploitable issues", Details: fmt.Sprint((*data)["Medium"].(map[string]int)["ProposedNotExploitable"])},
-		{Description: "Medium to verify issues", Details: fmt.Sprint((*data)["Medium"].(map[string]int)["ToVerify"])},
-		{Description: "Low issues", Details: fmt.Sprint((*data)["Low"].(map[string]int)["Issues"])},
-		{Description: "Low not false positive issues", Details: fmt.Sprint((*data)["Low"].(map[string]int)["NotFalsePositive"])},
-		{Description: "Low not exploitable issues", Details: fmt.Sprint((*data)["Low"].(map[string]int)["NotExploitable"])},
-		{Description: "Low confirmed issues", Details: fmt.Sprint((*data)["Low"].(map[string]int)["Confirmed"])},
-		{Description: "Low urgent issues", Details: fmt.Sprint((*data)["Low"].(map[string]int)["Urgent"])},
-		{Description: "Low proposed not exploitable issues", Details: fmt.Sprint((*data)["Low"].(map[string]int)["ProposedNotExploitable"])},
-		{Description: "Low to verify issues", Details: fmt.Sprint((*data)["Low"].(map[string]int)["ToVerify"])},
-		{Description: "Informational issues", Details: fmt.Sprint((*data)["Information"].(map[string]int)["Issues"])},
-		{Description: "Informational not false positive issues", Details: fmt.Sprint((*data)["Information"].(map[string]int)["NotFalsePositive"])},
-		{Description: "Informational not exploitable issues", Details: fmt.Sprint((*data)["Information"].(map[string]int)["NotExploitable"])},
-		{Description: "Informational confirmed issues", Details: fmt.Sprint((*data)["Information"].(map[string]int)["Confirmed"])},
-		{Description: "Informational urgent issues", Details: fmt.Sprint((*data)["Information"].(map[string]int)["Urgent"])},
-		{Description: "Informational proposed not exploitable issues", Details: fmt.Sprint((*data)["Information"].(map[string]int)["ProposedNotExploitable"])},
-		{Description: "Informational to verify issues", Details: fmt.Sprint((*data)["Information"].(map[string]int)["ToVerify"])},
+		{Description: "Critical issues", Details: getCount("Critical", "Issues")},
+		{Description: "Critical not false positive issues", Details: getCount("Critical", "NotFalsePositive")},
+		{Description: "Critical not exploitable issues", Details: getCount("Critical", "NotExploitable")},
+		{Description: "Critical confirmed issues", Details: getCount("Critical", "Confirmed")},
+		{Description: "Critical urgent issues", Details: getCount("Critical", "Urgent")},
+		{Description: "Critical proposed not exploitable issues", Details: getCount("Critical", "ProposedNotExploitable")},
+		{Description: "Critical to verify issues", Details: getCount("Critical", "ToVerify")},
+		{Description: "High issues", Details: getCount("High", "Issues")},
+		{Description: "High not false positive issues", Details: getCount("High", "NotFalsePositive")},
+		{Description: "High not exploitable issues", Details: getCount("High", "NotExploitable")},
+		{Description: "High confirmed issues", Details: getCount("High", "Confirmed")},
+		{Description: "High urgent issues", Details: getCount("High", "Urgent")},
+		{Description: "High proposed not exploitable issues", Details: getCount("High", "ProposedNotExploitable")},
+		{Description: "High to verify issues", Details: getCount("High", "ToVerify")},
+		{Description: "Medium issues", Details: getCount("Medium", "Issues")},
+		{Description: "Medium not false positive issues", Details: getCount("Medium", "NotFalsePositive")},
+		{Description: "Medium not exploitable issues", Details: getCount("Medium", "NotExploitable")},
+		{Description: "Medium confirmed issues", Details: getCount("Medium", "Confirmed")},
+		{Description: "Medium urgent issues", Details: getCount("Medium", "Urgent")},
+		{Description: "Medium proposed not exploitable issues", Details: getCount("Medium", "ProposedNotExploitable")},
+		{Description: "Medium to verify issues", Details: getCount("Medium", "ToVerify")},
+		{Description: "Low issues", Details: getCount("Low", "Issues")},
+		{Description: "Low not false positive issues", Details: getCount("Low", "NotFalsePositive")},
+		{Description: "Low not exploitable issues", Details: getCount("Low", "NotExploitable")},
+		{Description: "Low confirmed issues", Details: getCount("Low", "Confirmed")},
+		{Description: "Low urgent issues", Details: getCount("Low", "Urgent")},
+		{Description: "Low proposed not exploitable issues", Details: getCount("Low", "ProposedNotExploitable")},
+		{Description: "Low to verify issues", Details: getCount("Low", "ToVerify")},
+		{Description: "Informational issues", Details: getCount("Information", "Issues")},
+		{Description: "Informational not false positive issues", Details: getCount("Information", "NotFalsePositive")},
+		{Description: "Informational not exploitable issues", Details: getCount("Information", "NotExploitable")},
+		{Description: "Informational confirmed issues", Details: getCount("Information", "Confirmed")},
+		{Description: "Informational urgent issues", Details: getCount("Information", "Urgent")},
+		{Description: "Informational proposed not exploitable issues", Details: getCount("Information", "ProposedNotExploitable")},
+		{Description: "Informational to verify issues", Details: getCount("Information", "ToVerify")},
 	}
 	for _, detailRow := range detailRows {
 		row := reporting.ScanRow{}
@@ -147,7 +162,7 @@ func CreateCustomReport(data *map[string]interface{}, insecure, neutral []string
 	return scanReport
 }
 
-func CreateJSONHeaderReport(data *map[string]interface{}) CheckmarxOneReportData {
+func CreateJSONHeaderReport(data *map[string]interface{}, engine string) CheckmarxOneReportData {
 	checkmarxReportData := CheckmarxOneReportData{
 		ToolName:        `CheckmarxOne`,
 		ProjectName:     fmt.Sprint((*data)["ProjectName"]),
@@ -164,36 +179,57 @@ func CreateJSONHeaderReport(data *map[string]interface{}) CheckmarxOneReportData
 	}
 
 	findings := []Finding{}
+	pre := ""
+	if strings.EqualFold(engine, "iac") {
+		pre = "IAC"
+		checkmarxReportData.Preset = fmt.Sprint((*data)["IacPreset"])
+		checkmarxReportData.ScanType = "Full"
+		checkmarxReportData.ToolVersion += ", " + fmt.Sprint((*data)["IACVersion"])
+	} else {
+		checkmarxReportData.ToolVersion += ", " + fmt.Sprint((*data)["SASTVersion"])
+	}
+	getCount := func(severity, key string) int {
+		count := 0
+
+		if m, ok := (*data)[pre+severity]; ok {
+			if m, ok := m.(map[string]int); ok {
+				count += m[key]
+			}
+		}
+		return count
+	}
+
 	// Critical
 	criticalFindings := Finding{}
 	criticalFindings.ClassificationName = "Critical"
-	criticalFindings.Total = (*data)["Critical"].(map[string]int)["Issues"]
-	criticalAudited := (*data)["Critical"].(map[string]int)["NotExploitable"] + (*data)["Critical"].(map[string]int)["Urgent"] + (*data)["Critical"].(map[string]int)["Confirmed"]
+	criticalFindings.Total = getCount("Critical", "Issues")
+	criticalAudited := getCount("Critical", "NotExploitable") + getCount("Critical", "Urgent") + getCount("Critical", "Confirmed")
 	criticalFindings.Audited = &criticalAudited
-	criticalFindings.Confirmed = (*data)["Critical"].(map[string]int)["Confirmed"] + (*data)["Critical"].(map[string]int)["Urgent"]
+	criticalFindings.Confirmed = getCount("Critical", "Confirmed") + getCount("Critical", "Urgent")
 	findings = append(findings, criticalFindings)
 	// High
 	highFindings := Finding{}
 	highFindings.ClassificationName = "High"
-	highFindings.Total = (*data)["High"].(map[string]int)["Issues"]
-	highAudited := (*data)["High"].(map[string]int)["NotExploitable"] + (*data)["High"].(map[string]int)["Urgent"] + (*data)["High"].(map[string]int)["Confirmed"]
+	highFindings.Total = getCount("High", "Issues")
+	highAudited := getCount("High", "NotExploitable") + getCount("High", "Urgent") + getCount("High", "Confirmed")
 	highFindings.Audited = &highAudited
-	highFindings.Confirmed = (*data)["High"].(map[string]int)["Confirmed"] + (*data)["High"].(map[string]int)["Urgent"]
+	highFindings.Confirmed = getCount("High", "Confirmed") + getCount("High", "Urgent")
 	findings = append(findings, highFindings)
 	// Medium
 	mediumFindings := Finding{}
 	mediumFindings.ClassificationName = "Medium"
-	mediumFindings.Total = (*data)["Medium"].(map[string]int)["Issues"]
-	mediumAudited := (*data)["Medium"].(map[string]int)["NotExploitable"] + (*data)["Medium"].(map[string]int)["Urgent"] + (*data)["Medium"].(map[string]int)["Confirmed"]
+	mediumFindings.Total = getCount("Medium", "Issues")
+	mediumAudited := getCount("Medium", "NotExploitable") + getCount("Medium", "Urgent") + getCount("Medium", "Confirmed")
 	mediumFindings.Audited = &mediumAudited
-	mediumFindings.Confirmed = (*data)["Medium"].(map[string]int)["Confirmed"] + (*data)["Medium"].(map[string]int)["Urgent"]
+	mediumFindings.Confirmed = getCount("Medium", "Confirmed") + getCount("Medium", "Urgent")
 	findings = append(findings, mediumFindings)
 	// Low
 	lowFindings := Finding{}
 	lowFindings.ClassificationName = "Low"
-	if _, ok := (*data)["LowPerQuery"]; ok {
+
+	if _, ok := (*data)[pre+"LowPerQuery"]; ok {
 		lowPerQueryList := []LowPerQuery{}
-		lowPerQueryMap := (*data)["LowPerQuery"].(map[string]map[string]int)
+		lowPerQueryMap := (*data)[pre+"LowPerQuery"].(map[string]map[string]int)
 		for queryName, resultsLowQuery := range lowPerQueryMap {
 			audited := resultsLowQuery["Confirmed"] + resultsLowQuery["NotExploitable"] + resultsLowQuery["Urgent"]
 			total := resultsLowQuery["Issues"]
@@ -207,9 +243,9 @@ func CreateJSONHeaderReport(data *map[string]interface{}) CheckmarxOneReportData
 		lowFindings.LowPerQuery = &lowPerQueryList
 		findings = append(findings, lowFindings)
 	} else {
-		lowFindings.Total = (*data)["Low"].(map[string]int)["Issues"]
-		lowAudited := (*data)["Low"].(map[string]int)["Confirmed"] + (*data)["Low"].(map[string]int)["NotExploitable"] + (*data)["Low"].(map[string]int)["Urgent"]
-		lowFindings.Confirmed = (*data)["Low"].(map[string]int)["Confirmed"] + (*data)["Low"].(map[string]int)["Urgent"]
+		lowFindings.Total = getCount("Low", "Issues")
+		lowAudited := getCount("Low", "Confirmed") + getCount("Low", "NotExploitable") + getCount("Low", "Urgent")
+		lowFindings.Confirmed = getCount("Low", "Confirmed") + getCount("Low", "Urgent")
 		lowFindings.Audited = &lowAudited
 		findings = append(findings, lowFindings)
 	}
@@ -219,12 +255,18 @@ func CreateJSONHeaderReport(data *map[string]interface{}) CheckmarxOneReportData
 	return checkmarxReportData
 }
 
-func WriteJSONHeaderReport(jsonReport CheckmarxOneReportData) ([]piperutils.Path, error) {
+func WriteJSONHeaderReport(jsonReport CheckmarxOneReportData, engine string) ([]piperutils.Path, error) {
 	utils := piperutils.Files{}
 	reportPaths := []piperutils.Path{}
 
+	filename := "piper_checkmarxone_report.json"
+	reportName := "CheckmarxOne JSON compliance report"
+	if strings.EqualFold(engine, "iac") {
+		filename = "piper_checkmarxone_iac_report.json"
+		reportName = "CheckmarxOne IAC JSON compliance report"
+	}
 	// Standard JSON Report
-	jsonComplianceReportPath := filepath.Join(ReportsDirectory, "piper_checkmarxone_report.json")
+	jsonComplianceReportPath := filepath.Join(ReportsDirectory, filename)
 	// Ensure reporting directory exists
 	if err := utils.MkdirAll(ReportsDirectory, 0777); err != nil {
 		return reportPaths, fmt.Errorf("failed to create report directory: %w", err)
@@ -233,9 +275,9 @@ func WriteJSONHeaderReport(jsonReport CheckmarxOneReportData) ([]piperutils.Path
 	file, _ := json.Marshal(jsonReport)
 	if err := utils.FileWrite(jsonComplianceReportPath, file, 0666); err != nil {
 		log.SetErrorCategory(log.ErrorConfiguration)
-		return reportPaths, fmt.Errorf("failed to write CheckmarxOne JSON compliance report: %w", err)
+		return reportPaths, fmt.Errorf("failed to write %s: %w", reportName, err)
 	}
-	reportPaths = append(reportPaths, piperutils.Path{Name: "CheckmarxOne JSON Compliance Report", Target: jsonComplianceReportPath})
+	reportPaths = append(reportPaths, piperutils.Path{Name: reportName, Target: jsonComplianceReportPath})
 
 	return reportPaths, nil
 }

--- a/pkg/checkmarxone/reporting_test.go
+++ b/pkg/checkmarxone/reporting_test.go
@@ -15,7 +15,7 @@ func TestCreateJSONReport(t *testing.T) {
 	resultMap["Application"] = `test-app`
 	resultMap["ApplicationFullPathOnReportDate"] = `test-app-path`
 	resultMap["DeepLink"] = `https://cx1.sap/projects/f5702f86-b396-417f-82e2-4949a55d5382/scans?branch=master&page=1&id=21e40b36-0dd7-48e5-9768-da1a8f36c907`
-	resultMap["SastPreset"] = `Checkmarx Default`
+	resultMap["Preset"] = `Checkmarx Default`
 	resultMap["ToolVersion"] = `v1`
 	resultMap["ScanType"] = `Incremental`
 	resultMap["ProjectId"] = `f5702f86-b396-417f-82e2-4949a55d5382`
@@ -69,7 +69,7 @@ func TestCreateJSONReport(t *testing.T) {
 
 	resultMap["LowPerQuery"] = lowPerQuery
 
-	reportingData := CreateJSONHeaderReport(&resultMap)
+	reportingData := CreateJSONHeaderReport(&resultMap, "sast")
 	assert.Equal(t, "21e40b36-0dd7-48e5-9768-da1a8f36c907", reportingData.ScanID)
 	assert.Equal(t, "ssba", reportingData.ProjectName)
 	assert.Equal(t, "f5702f86-b396-417f-82e2-4949a55d5382", reportingData.ProjectID)

--- a/pkg/checkmarxone/reporting_test.go
+++ b/pkg/checkmarxone/reporting_test.go
@@ -15,8 +15,9 @@ func TestCreateJSONReport(t *testing.T) {
 	resultMap["Application"] = `test-app`
 	resultMap["ApplicationFullPathOnReportDate"] = `test-app-path`
 	resultMap["DeepLink"] = `https://cx1.sap/projects/f5702f86-b396-417f-82e2-4949a55d5382/scans?branch=master&page=1&id=21e40b36-0dd7-48e5-9768-da1a8f36c907`
-	resultMap["Preset"] = `Checkmarx Default`
+	resultMap["SastPreset"] = `Checkmarx Default`
 	resultMap["ToolVersion"] = `v1`
+	resultMap["SASTVersion"] = `SAST: 9.7.6`
 	resultMap["ScanType"] = `Incremental`
 	resultMap["ProjectId"] = `f5702f86-b396-417f-82e2-4949a55d5382`
 	resultMap["ScanId"] = `21e40b36-0dd7-48e5-9768-da1a8f36c907`
@@ -78,7 +79,7 @@ func TestCreateJSONReport(t *testing.T) {
 	assert.Equal(t, "CheckmarxOne", reportingData.ToolName)
 	assert.Equal(t, "https://cx1.sap/projects/f5702f86-b396-417f-82e2-4949a55d5382/scans?branch=master&page=1&id=21e40b36-0dd7-48e5-9768-da1a8f36c907", reportingData.DeepLink)
 	assert.Equal(t, "Checkmarx Default", reportingData.Preset)
-	assert.Equal(t, "v1", reportingData.ToolVersion)
+	assert.Equal(t, "v1, SAST: 9.7.6", reportingData.ToolVersion)
 	assert.Equal(t, "Incremental", reportingData.ScanType)
 
 	lowList := (*reportingData.Findings)[3].LowPerQuery

--- a/resources/metadata/checkmarxOneExecuteScan.yaml
+++ b/resources/metadata/checkmarxOneExecuteScan.yaml
@@ -59,7 +59,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        default: [sast]
+        default: [ sast ]
       - name: filterPattern
         type: string
         description: The filter pattern used to zip the files relevant for scanning, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory. For multiple-engine scans, this filter should include all files applicable to all engines - per-engine filters should be set separately through sastFileFilter and iacFileFilter.
@@ -69,7 +69,7 @@ spec:
           - STEPS
         default:
           "!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go,
-          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"
+          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"  
       - name: fullScanCycle
         type: string
         description: Indicates how often a full scan should happen between the incremental scans when activated
@@ -145,7 +145,7 @@ spec:
         scope:
           - PARAMETERS
           - STAGES
-          - STEPS
+          - STEPS    
       - name: scanSummaryInPullRequest
         description: Whether the scan summary shall be added to the pull request as a comment or not. This is only applied if the step is executed in a pull request context. githubToken and githubApiUrl parameters must be set to allow the step to create the comment.
         type: bool
@@ -259,7 +259,7 @@ spec:
           - STAGES
           - STEPS
         default:
-          ""
+          ""   
       - name: sastPreset
         aliases:
           - name: preset
@@ -268,7 +268,7 @@ spec:
         scope:
           - PARAMETERS
           - STAGES
-          - STEPS
+          - STEPS     
       - name: scanTags
         type: string
         description: Used to tag a scan with a JSON string, e.g., {"key":"value", "keywithoutvalue":""}
@@ -400,6 +400,14 @@ spec:
           - STAGES
           - STEPS
         default: true
+      - name: iacVulnerabilityThresholdEnabled
+        type: bool
+        description: Whether the thresholds are enabled or not for IAC. If enabled the build will be set to `vulnerabilityThresholdResult` in case a specific threshold value is exceeded
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        default: false
       - name: vulnerabilityThresholdCritical
         type: int
         description: The specific threshold for Critical severity findings

--- a/resources/metadata/checkmarxOneExecuteScan.yaml
+++ b/resources/metadata/checkmarxOneExecuteScan.yaml
@@ -59,7 +59,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
-        default: [ sast ]
+        default: [sast]
       - name: filterPattern
         type: string
         description: The filter pattern used to zip the files relevant for scanning, patterns can be negated by setting an exclamation mark in front i.e. `!test/*.js` would avoid adding any javascript files located in the test directory. For multiple-engine scans, this filter should include all files applicable to all engines - per-engine filters should be set separately through sastFileFilter and iacFileFilter.
@@ -69,7 +69,7 @@ spec:
           - STEPS
         default:
           "!**/node_modules/**, !**/.xmake/**, !**/*_test.go, !**/vendor/**/*.go,
-          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"  
+          **/*.html, **/*.xml, **/*.go, **/*.py, **/*.js, **/*.rb, **/*.scala, **/*.ts"
       - name: fullScanCycle
         type: string
         description: Indicates how often a full scan should happen between the incremental scans when activated
@@ -145,7 +145,7 @@ spec:
         scope:
           - PARAMETERS
           - STAGES
-          - STEPS    
+          - STEPS
       - name: scanSummaryInPullRequest
         description: Whether the scan summary shall be added to the pull request as a comment or not. This is only applied if the step is executed in a pull request context. githubToken and githubApiUrl parameters must be set to allow the step to create the comment.
         type: bool
@@ -259,7 +259,7 @@ spec:
           - STAGES
           - STEPS
         default:
-          ""   
+          ""
       - name: sastPreset
         aliases:
           - name: preset
@@ -268,7 +268,7 @@ spec:
         scope:
           - PARAMETERS
           - STAGES
-          - STEPS     
+          - STEPS
       - name: scanTags
         type: string
         description: Used to tag a scan with a JSON string, e.g., {"key":"value", "keywithoutvalue":""}


### PR DESCRIPTION
# Description

Add a new param iacVulnerabilityThresholdEnabled to enable or disable the compliance check for IaC (off by default). 

Improve IaC reporting in GH comments and create two separate report files for IaC and SAST.

Fix an issue with verifyOnly parameter that could try to update project if the preset did not match. 
