### PR TITLE
feat(helmBuild): add createBuildArtifactsMetadata option for published charts

### DIFF
--- a/cmd/helmBuild.go
+++ b/cmd/helmBuild.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 
+	"github.com/SAP/jenkins-library/pkg/build"
 	"github.com/SAP/jenkins-library/pkg/buildsettings"
 	"github.com/SAP/jenkins-library/pkg/command"
 	"github.com/SAP/jenkins-library/pkg/docker"
@@ -93,12 +95,16 @@ func helmBuild(config helmBuildOptions, telemetryData *telemetry.CustomData, com
 	fileUtils := &piperutils.Files{}
 
 	// error situations should stop execution through log.Entry().Fatal() call which leads to an os.Exit(1) in the end
-	if err := runHelmBuild(config, helmExecutor, utils, commonPipelineEnvironment, execRunner, fileUtils, httpClient); err != nil {
+	if err := runHelmBuild(config, helmExecutor, utils, commonPipelineEnvironment, execRunner, fileUtils, httpClient, artifactInfo); err != nil {
 		log.Entry().WithError(err).Fatalf("step execution failed: %v", err)
 	}
 }
 
-func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, utils fileHandler, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
+func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, utils fileHandler, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender, artifact ...versioning.Coordinates) error {
+	var artifactInfo versioning.Coordinates
+	if len(artifact) > 0 {
+		artifactInfo = artifact[0]
+	}
 	if config.RenderValuesTemplate {
 		err := parseAndRenderCPETemplate(config, GeneralConfig.EnvRootPath, utils)
 		if err != nil {
@@ -139,8 +145,13 @@ func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor,
 		if config.CreateBOM {
 			generateSBOMs(config, helmExecutor, execRunner, fileUtils, httpClient)
 		}
+		if config.CreateBuildArtifactsMetadata {
+			if err := createHelmBuildArtifactsMetadata(artifactInfo, targetURL, commonPipelineEnvironment); err != nil {
+				return err
+			}
+		}
 	default:
-		if err := runHelmBuildDefault(config, helmExecutor, commonPipelineEnvironment, execRunner, fileUtils, httpClient); err != nil {
+		if err := runHelmBuildDefault(config, helmExecutor, commonPipelineEnvironment, execRunner, fileUtils, httpClient, artifactInfo); err != nil {
 			return err
 		}
 	}
@@ -167,7 +178,7 @@ func runHelmBuild(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor,
 	return nil
 }
 
-func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
+func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmExecutor, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment, execRunner command.ExecRunner, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender, artifact versioning.Coordinates) error {
 	if len(config.Dependency) > 0 {
 		if err := helmExecutor.RunHelmDependency(); err != nil {
 			return fmt.Errorf("failed to execute helm dependency: %v", err)
@@ -186,6 +197,11 @@ func runHelmBuildDefault(config helmBuildOptions, helmExecutor kubernetes.HelmEx
 		commonPipelineEnvironment.custom.helmChartURL = targetURL
 		if config.CreateBOM {
 			generateSBOMs(config, helmExecutor, execRunner, fileUtils, httpClient)
+		}
+		if config.CreateBuildArtifactsMetadata {
+			if err := createHelmBuildArtifactsMetadata(artifact, targetURL, commonPipelineEnvironment); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -299,6 +315,30 @@ func injectContainerBOMPurls() error {
 		}
 	}
 
+	return nil
+}
+
+func createHelmBuildArtifactsMetadata(artifact versioning.Coordinates, targetURL string, commonPipelineEnvironment *helmBuildCommonPipelineEnvironment) error {
+	// defensive: need chart name + version to build a coordinate
+	if len(artifact.ArtifactID) == 0 || len(artifact.Version) == 0 {
+		log.Entry().Warnf("missing chart name or version, not creating helm build artifact metadata")
+		return nil
+	}
+	coordinate := versioning.Coordinates{
+		ArtifactID: artifact.ArtifactID,
+		Version:    artifact.Version,
+		URL:        targetURL,
+		PURL:       fmt.Sprintf("pkg:helm/%s@%s", artifact.ArtifactID, artifact.Version),
+	}
+	var buildArtifacts build.BuildArtifacts
+	buildArtifacts.Coordinates = []versioning.Coordinates{coordinate}
+	jsonResult, err := json.Marshal(buildArtifacts)
+	if err != nil {
+		log.Entry().Warnf("unable to marshal helm build artifact metadata: %v", err)
+		return nil
+	}
+	commonPipelineEnvironment.custom.helmBuildArtifacts = string(jsonResult)
+	log.Entry().Infof("helm build artifact metadata created for %s@%s", coordinate.ArtifactID, coordinate.Version)
 	return nil
 }
 

--- a/cmd/helmBuild_generated.go
+++ b/cmd/helmBuild_generated.go
@@ -23,47 +23,49 @@ import (
 )
 
 type helmBuildOptions struct {
-	AdditionalParameters      []string `json:"additionalParameters,omitempty"`
-	ChartPath                 string   `json:"chartPath,omitempty"`
-	TargetRepositoryURL       string   `json:"targetRepositoryURL,omitempty"`
-	TargetRepositoryName      string   `json:"targetRepositoryName,omitempty"`
-	TargetRepositoryUser      string   `json:"targetRepositoryUser,omitempty"`
-	TargetRepositoryPassword  string   `json:"targetRepositoryPassword,omitempty"`
-	SourceRepositoryURL       string   `json:"sourceRepositoryURL,omitempty"`
-	SourceRepositoryName      string   `json:"sourceRepositoryName,omitempty"`
-	SourceRepositoryUser      string   `json:"sourceRepositoryUser,omitempty"`
-	SourceRepositoryPassword  string   `json:"sourceRepositoryPassword,omitempty"`
-	HelmDeployWaitSeconds     int      `json:"helmDeployWaitSeconds,omitempty"`
-	HelmValues                []string `json:"helmValues,omitempty"`
-	Image                     string   `json:"image,omitempty"`
-	KeepFailedDeployments     bool     `json:"keepFailedDeployments,omitempty"`
-	KubeConfig                string   `json:"kubeConfig,omitempty"`
-	KubeContext               string   `json:"kubeContext,omitempty"`
-	Namespace                 string   `json:"namespace,omitempty"`
-	DockerConfigJSON          string   `json:"dockerConfigJSON,omitempty"`
-	HelmCommand               string   `json:"helmCommand,omitempty" validate:"possible-values=upgrade lint install test uninstall dependency publish"`
-	AppVersion                string   `json:"appVersion,omitempty"`
-	Dependency                string   `json:"dependency,omitempty" validate:"possible-values=build list update"`
-	PackageDependencyUpdate   bool     `json:"packageDependencyUpdate,omitempty"`
-	DumpLogs                  bool     `json:"dumpLogs,omitempty"`
-	FilterTest                string   `json:"filterTest,omitempty"`
-	CustomTLSCertificateLinks []string `json:"customTlsCertificateLinks,omitempty"`
-	Publish                   bool     `json:"publish,omitempty"`
-	Version                   string   `json:"version,omitempty"`
-	RenderSubchartNotes       bool     `json:"renderSubchartNotes,omitempty"`
-	TemplateStartDelimiter    string   `json:"templateStartDelimiter,omitempty"`
-	TemplateEndDelimiter      string   `json:"templateEndDelimiter,omitempty"`
-	RenderValuesTemplate      bool     `json:"renderValuesTemplate,omitempty"`
-	CreateBOM                 bool     `json:"createBOM,omitempty"`
-	SyftDownloadURL           string   `json:"syftDownloadUrl,omitempty"`
-	ContainerImageNameTags    []string `json:"containerImageNameTags,omitempty"`
-	BuildSettingsInfo         string   `json:"buildSettingsInfo,omitempty"`
+	AdditionalParameters         []string `json:"additionalParameters,omitempty"`
+	ChartPath                    string   `json:"chartPath,omitempty"`
+	TargetRepositoryURL          string   `json:"targetRepositoryURL,omitempty"`
+	TargetRepositoryName         string   `json:"targetRepositoryName,omitempty"`
+	TargetRepositoryUser         string   `json:"targetRepositoryUser,omitempty"`
+	TargetRepositoryPassword     string   `json:"targetRepositoryPassword,omitempty"`
+	SourceRepositoryURL          string   `json:"sourceRepositoryURL,omitempty"`
+	SourceRepositoryName         string   `json:"sourceRepositoryName,omitempty"`
+	SourceRepositoryUser         string   `json:"sourceRepositoryUser,omitempty"`
+	SourceRepositoryPassword     string   `json:"sourceRepositoryPassword,omitempty"`
+	HelmDeployWaitSeconds        int      `json:"helmDeployWaitSeconds,omitempty"`
+	HelmValues                   []string `json:"helmValues,omitempty"`
+	Image                        string   `json:"image,omitempty"`
+	KeepFailedDeployments        bool     `json:"keepFailedDeployments,omitempty"`
+	KubeConfig                   string   `json:"kubeConfig,omitempty"`
+	KubeContext                  string   `json:"kubeContext,omitempty"`
+	Namespace                    string   `json:"namespace,omitempty"`
+	DockerConfigJSON             string   `json:"dockerConfigJSON,omitempty"`
+	HelmCommand                  string   `json:"helmCommand,omitempty" validate:"possible-values=upgrade lint install test uninstall dependency publish"`
+	AppVersion                   string   `json:"appVersion,omitempty"`
+	Dependency                   string   `json:"dependency,omitempty" validate:"possible-values=build list update"`
+	PackageDependencyUpdate      bool     `json:"packageDependencyUpdate,omitempty"`
+	DumpLogs                     bool     `json:"dumpLogs,omitempty"`
+	FilterTest                   string   `json:"filterTest,omitempty"`
+	CustomTLSCertificateLinks    []string `json:"customTlsCertificateLinks,omitempty"`
+	Publish                      bool     `json:"publish,omitempty"`
+	CreateBuildArtifactsMetadata bool     `json:"createBuildArtifactsMetadata,omitempty"`
+	Version                      string   `json:"version,omitempty"`
+	RenderSubchartNotes          bool     `json:"renderSubchartNotes,omitempty"`
+	TemplateStartDelimiter       string   `json:"templateStartDelimiter,omitempty"`
+	TemplateEndDelimiter         string   `json:"templateEndDelimiter,omitempty"`
+	RenderValuesTemplate         bool     `json:"renderValuesTemplate,omitempty"`
+	CreateBOM                    bool     `json:"createBOM,omitempty"`
+	SyftDownloadURL              string   `json:"syftDownloadUrl,omitempty"`
+	ContainerImageNameTags       []string `json:"containerImageNameTags,omitempty"`
+	BuildSettingsInfo            string   `json:"buildSettingsInfo,omitempty"`
 }
 
 type helmBuildCommonPipelineEnvironment struct {
 	custom struct {
-		helmChartURL      string
-		buildSettingsInfo string
+		helmChartURL       string
+		buildSettingsInfo  string
+		helmBuildArtifacts string
 	}
 }
 
@@ -75,6 +77,7 @@ func (p *helmBuildCommonPipelineEnvironment) persist(path, resourceName string) 
 	}{
 		{category: "custom", name: "helmChartUrl", value: p.custom.helmChartURL},
 		{category: "custom", name: "buildSettingsInfo", value: p.custom.buildSettingsInfo},
+		{category: "custom", name: "helmBuildArtifacts", value: p.custom.helmBuildArtifacts},
 	}
 
 	errCount := 0
@@ -316,6 +319,7 @@ func addHelmBuildFlags(cmd *cobra.Command, stepConfig *helmBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.FilterTest, "filterTest", os.Getenv("PIPER_filterTest"), "specify tests by attribute (currently `name`) using attribute=value syntax or `!attribute=value` to exclude a test (can specify multiple or separate values with commas `name=test1,name=test2`)")
 	cmd.Flags().StringSliceVar(&stepConfig.CustomTLSCertificateLinks, "customTlsCertificateLinks", []string{}, "List of download links to custom TLS certificates. This is required to ensure trusted connections to instances with repositories (like nexus) when publish flag is set to true.")
 	cmd.Flags().BoolVar(&stepConfig.Publish, "publish", false, "Configures helm to run the deploy command to publish artifacts to a repository.")
+	cmd.Flags().BoolVar(&stepConfig.CreateBuildArtifactsMetadata, "createBuildArtifactsMetadata", false, "metadata about the artifacts that are build and published, this metadata is generally used by steps downstream in the pipeline")
 	cmd.Flags().StringVar(&stepConfig.Version, "version", os.Getenv("PIPER_version"), "Defines the artifact version to use from helm package/publish commands.")
 	cmd.Flags().BoolVar(&stepConfig.RenderSubchartNotes, "renderSubchartNotes", true, "If set, render subchart notes along with the parent.")
 	cmd.Flags().StringVar(&stepConfig.TemplateStartDelimiter, "templateStartDelimiter", `{{`, "When templating value files, use this start delimiter.")
@@ -689,6 +693,15 @@ func helmBuildMetadata() config.StepData {
 						Default:     false,
 					},
 					{
+						Name:        "createBuildArtifactsMetadata",
+						ResourceRef: []config.ResourceReference{},
+						Scope:       []string{"STEPS", "STAGES", "PARAMETERS"},
+						Type:        "bool",
+						Mandatory:   false,
+						Aliases:     []config.Alias{},
+						Default:     false,
+					},
+					{
 						Name:        "version",
 						ResourceRef: []config.ResourceReference{},
 						Scope:       []string{"GENERAL", "PARAMETERS", "STAGES", "STEPS"},
@@ -792,6 +805,7 @@ func helmBuildMetadata() config.StepData {
 						Parameters: []map[string]interface{}{
 							{"name": "custom/helmChartUrl"},
 							{"name": "custom/buildSettingsInfo"},
+							{"name": "custom/helmBuildArtifacts"},
 						},
 					},
 					{

--- a/cmd/helmBuild_test.go
+++ b/cmd/helmBuild_test.go
@@ -14,10 +14,12 @@ import (
 
 	"errors"
 
+	"github.com/SAP/jenkins-library/pkg/build"
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/kubernetes/mocks"
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/SAP/jenkins-library/pkg/piperenv"
+	"github.com/SAP/jenkins-library/pkg/versioning"
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -322,6 +324,46 @@ func TestRunHelmPush(t *testing.T) {
 		})
 
 	}
+
+	t.Run("build artifacts metadata - flag on populates CPE", func(t *testing.T) {
+		cpe := helmBuildCommonPipelineEnvironment{}
+		config := helmBuildOptions{
+			HelmCommand:                  "publish",
+			CreateBuildArtifactsMetadata: true,
+		}
+		artifact := versioning.Coordinates{ArtifactID: "my-chart", Version: "1.2.3"}
+
+		helmExecute := &mocks.HelmExecutor{}
+		helmExecute.On("RunHelmPublish").Return("https://my.target.repository/charts", nil)
+
+		err := runHelmBuild(config, helmExecute, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), artifact)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, cpe.custom.helmBuildArtifacts)
+
+		var buildArtifacts build.BuildArtifacts
+		require.NoError(t, json.Unmarshal([]byte(cpe.custom.helmBuildArtifacts), &buildArtifacts))
+		require.Len(t, buildArtifacts.Coordinates, 1)
+		assert.Equal(t, "pkg:helm/my-chart@1.2.3", buildArtifacts.Coordinates[0].PURL)
+		assert.Equal(t, "https://my.target.repository/charts", buildArtifacts.Coordinates[0].URL)
+	})
+
+	t.Run("build artifacts metadata - flag off leaves CPE empty", func(t *testing.T) {
+		cpe := helmBuildCommonPipelineEnvironment{}
+		config := helmBuildOptions{
+			HelmCommand:                  "publish",
+			CreateBuildArtifactsMetadata: false,
+		}
+		artifact := versioning.Coordinates{ArtifactID: "my-chart", Version: "1.2.3"}
+
+		helmExecute := &mocks.HelmExecutor{}
+		helmExecute.On("RunHelmPublish").Return("https://my.target.repository/charts", nil)
+
+		err := runHelmBuild(config, helmExecute, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), artifact)
+
+		require.NoError(t, err)
+		assert.Empty(t, cpe.custom.helmBuildArtifacts)
+	})
 }
 
 func TestRunHelmPushSBOM(t *testing.T) {
@@ -496,6 +538,49 @@ func TestRunHelmDefaultCommand(t *testing.T) {
 
 		})
 	}
+
+	t.Run("build artifacts metadata - flag on populates CPE", func(t *testing.T) {
+		cpe := helmBuildCommonPipelineEnvironment{}
+		config := helmBuildOptions{
+			HelmCommand:                  "",
+			Publish:                      true,
+			CreateBuildArtifactsMetadata: true,
+		}
+		artifact := versioning.Coordinates{ArtifactID: "my-chart", Version: "1.2.3"}
+
+		helmExecute := &mocks.HelmExecutor{}
+		helmExecute.On("RunHelmLint").Return(nil)
+		helmExecute.On("RunHelmPublish").Return("https://my.target.repository/charts", nil)
+
+		err := runHelmBuild(config, helmExecute, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), artifact)
+
+		require.NoError(t, err)
+		require.NotEmpty(t, cpe.custom.helmBuildArtifacts)
+
+		var buildArtifacts build.BuildArtifacts
+		require.NoError(t, json.Unmarshal([]byte(cpe.custom.helmBuildArtifacts), &buildArtifacts))
+		require.Len(t, buildArtifacts.Coordinates, 1)
+		assert.Equal(t, "pkg:helm/my-chart@1.2.3", buildArtifacts.Coordinates[0].PURL)
+	})
+
+	t.Run("build artifacts metadata - flag off leaves CPE empty", func(t *testing.T) {
+		cpe := helmBuildCommonPipelineEnvironment{}
+		config := helmBuildOptions{
+			HelmCommand:                  "",
+			Publish:                      true,
+			CreateBuildArtifactsMetadata: false,
+		}
+		artifact := versioning.Coordinates{ArtifactID: "my-chart", Version: "1.2.3"}
+
+		helmExecute := &mocks.HelmExecutor{}
+		helmExecute.On("RunHelmLint").Return(nil)
+		helmExecute.On("RunHelmPublish").Return("https://my.target.repository/charts", nil)
+
+		err := runHelmBuild(config, helmExecute, &fileHandlerMock{}, &cpe, newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), newHelmMockUtilsBundle(), artifact)
+
+		require.NoError(t, err)
+		assert.Empty(t, cpe.custom.helmBuildArtifacts)
+	})
 
 }
 
@@ -1153,6 +1238,61 @@ tag: {{ imageTag "test-image" }}
 			}
 		})
 	}
+}
+
+func TestCreateHelmBuildArtifactsMetadata(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path - valid name, version and url produce correct metadata", func(t *testing.T) {
+		cpe := helmBuildCommonPipelineEnvironment{}
+		artifact := versioning.Coordinates{
+			ArtifactID: "my-chart",
+			Version:    "1.2.3",
+		}
+		targetURL := "https://my.target.repository/charts"
+
+		err := createHelmBuildArtifactsMetadata(artifact, targetURL, &cpe)
+
+		assert.NoError(t, err)
+		require.NotEmpty(t, cpe.custom.helmBuildArtifacts)
+
+		var buildArtifacts build.BuildArtifacts
+		err = json.Unmarshal([]byte(cpe.custom.helmBuildArtifacts), &buildArtifacts)
+		require.NoError(t, err)
+
+		require.Len(t, buildArtifacts.Coordinates, 1)
+		coordinate := buildArtifacts.Coordinates[0]
+		assert.Equal(t, "my-chart", coordinate.ArtifactID)
+		assert.Equal(t, "1.2.3", coordinate.Version)
+		assert.Equal(t, targetURL, coordinate.URL)
+		assert.Equal(t, "pkg:helm/my-chart@1.2.3", coordinate.PURL)
+	})
+
+	t.Run("empty ArtifactID - nothing written", func(t *testing.T) {
+		cpe := helmBuildCommonPipelineEnvironment{}
+		artifact := versioning.Coordinates{
+			ArtifactID: "",
+			Version:    "1.2.3",
+		}
+
+		err := createHelmBuildArtifactsMetadata(artifact, "https://my.target.repository/charts", &cpe)
+
+		assert.NoError(t, err)
+		assert.Empty(t, cpe.custom.helmBuildArtifacts)
+	})
+
+	t.Run("empty Version - nothing written", func(t *testing.T) {
+		cpe := helmBuildCommonPipelineEnvironment{}
+		artifact := versioning.Coordinates{
+			ArtifactID: "my-chart",
+			Version:    "",
+		}
+
+		err := createHelmBuildArtifactsMetadata(artifact, "https://my.target.repository/charts", &cpe)
+
+		assert.NoError(t, err)
+		assert.Empty(t, cpe.custom.helmBuildArtifacts)
+	})
 }
 
 type fileHandlerMock struct {

--- a/resources/metadata/helmBuild.yaml
+++ b/resources/metadata/helmBuild.yaml
@@ -337,6 +337,14 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+      - name: createBuildArtifactsMetadata
+        type: bool
+        default: false
+        description: metadata about the artifacts that are build and published, this metadata is generally used by steps downstream in the pipeline
+        scope:
+          - STEPS
+          - STAGES
+          - PARAMETERS
       - name: version
         type: string
         description: Defines the artifact version to use from helm package/publish commands.
@@ -424,6 +432,7 @@ spec:
         params:
           - name: custom/helmChartUrl
           - name: custom/buildSettingsInfo
+          - name: custom/helmBuildArtifacts
       - name: reports
         type: reports
         params:


### PR DESCRIPTION
# Add createBuildArtifactsMetadata option for published charts

## Description
Add an opt-in `createBuildArtifactsMetadata` parameter (bool, default false) that records the published Helm chart as build-artifact metadata in the Common Pipeline Environment, so downstream steps — staging/promote and Cumulus traceability — can consume the chart coordinate.

When enabled, after a successful publish the step emits a new CPE output `custom/helmBuildArtifacts`: a `build.BuildArtifacts` JSON carrying one coordinate for the chart with its artifact ID, version, published URL, and PURL (`pkg:helm/<name>@<version>`). A missing chart name or version is handled gracefully (nothing is written), and a success info log line is emitted so the producer is visible in the pipeline output.

The metadata is produced on both the explicit `publish` command path and the default command path. It is off by default, so existing pipelines are unaffected, and the output is forward-compatible — inert until a consumer reads it.

### Updated files
- resources/metadata/helmBuild.yaml: new `createBuildArtifactsMetadata` param and `custom/helmBuildArtifacts` output
- cmd/helmBuild.go: `createHelmBuildArtifactsMetadata` producer + wiring
- cmd/helmBuild_generated.go: regenerated
- cmd/helmBuild_test.go: unit tests for the producer and both wiring paths


# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
