### PR TITLE
chore(documentation): speed up the Documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,9 +19,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # Matches the version the Ubuntu 'groovy' package used to provide, and the
-  # org.codehaus.groovy:groovy-all version in pom.xml (2.4.x).
-  GROOVY_VERSION: 2.4.21
+  # createDocu.sh pulls this one itself, in the background, while Maven runs.
   JENKINSFILE_RUNNER_IMAGE: ppiper/jenkinsfile-runner:latest
   MKDOCS_IMAGE: squidfunk/mkdocs-material:8.5.11
 
@@ -42,22 +40,6 @@ jobs:
           go-version: '1.26.6'
           # setup-go caches ~/go/pkg/mod and the build cache by default, keyed on go.sum.
 
-      - name: Cache Groovy
-        uses: actions/cache@v5
-        with:
-          path: ~/groovy
-          key: groovy-${{ env.GROOVY_VERSION }}
-
-      - name: Install Groovy
-        run: |
-          if [ ! -x "$HOME/groovy/bin/groovy" ]; then
-            curl -sSfL -o /tmp/groovy.zip \
-              "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip"
-            unzip -q /tmp/groovy.zip -d /tmp/groovy-dist
-            mv "/tmp/groovy-dist/groovy-${GROOVY_VERSION}" "$HOME/groovy"
-          fi
-          echo "$HOME/groovy/bin" >> "$GITHUB_PATH"
-
       - name: Cache Maven Packages
         uses: actions/cache@v5
         with:
@@ -67,13 +49,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-
-      - name: Pull Container Images
-        run: |
-          pids=()
-          docker pull "$JENKINSFILE_RUNNER_IMAGE" & pids+=($!)
-          docker pull "$MKDOCS_IMAGE" & pids+=($!)
-          for pid in "${pids[@]}"; do wait "$pid"; done
 
       - name: Generate Groovy Docs
         env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,14 +10,26 @@ on:
 
 permissions:
   contents: write  # peaceiris/actions-gh-pages deploys docs to gh-pages (master push only)
-  actions: write   # styfle/cancel-workflow-action cancels previous runs
+
+# Supersedes styfle/cancel-workflow-action: cancels queued/running PR builds as soon as a
+# new commit lands, instead of only once the replacement job gets a runner. Master builds
+# are never cancelled so a deploy can't be killed half way.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Matches the version the Ubuntu 'groovy' package used to provide, and the
+  # org.codehaus.groovy:groovy-all version in pom.xml (2.4.x).
+  GROOVY_VERSION: 2.4.21
+  JENKINSFILE_RUNNER_IMAGE: ppiper/jenkinsfile-runner:latest
+  MKDOCS_IMAGE: squidfunk/mkdocs-material:8.5.11
 
 jobs:
   Build:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
-      - uses: styfle/cancel-workflow-action@0.11.0
-
       - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v4
@@ -28,27 +40,40 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.6'
+          # setup-go caches ~/go/pkg/mod and the build cache by default, keyed on go.sum.
+
+      - name: Cache Groovy
+        uses: actions/cache@v5
+        with:
+          path: ~/groovy
+          key: groovy-${{ env.GROOVY_VERSION }}
 
       - name: Install Groovy
-        run: sudo apt-get update && sudo apt-get install groovy -y
+        run: |
+          if [ ! -x "$HOME/groovy/bin/groovy" ]; then
+            curl -sSfL -o /tmp/groovy.zip \
+              "https://archive.apache.org/dist/groovy/${GROOVY_VERSION}/distribution/apache-groovy-binary-${GROOVY_VERSION}.zip"
+            unzip -q /tmp/groovy.zip -d /tmp/groovy-dist
+            mv "/tmp/groovy-dist/groovy-${GROOVY_VERSION}" "$HOME/groovy"
+          fi
+          echo "$HOME/groovy/bin" >> "$GITHUB_PATH"
 
       - name: Cache Maven Packages
         uses: actions/cache@v5
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          # Only the root pom drives dependencies; the ~20 poms under test/ and
+          # integration/testdata are fixtures and must not churn the cache key.
+          key: ${{ runner.os }}-maven-${{ hashFiles('pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Cache Go Packages
-        uses: actions/cache@v5
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - run: docker pull ppiper/jenkinsfile-runner:latest
+      - name: Pull Container Images
+        run: |
+          pids=()
+          docker pull "$JENKINSFILE_RUNNER_IMAGE" & pids+=($!)
+          docker pull "$MKDOCS_IMAGE" & pids+=($!)
+          for pid in "${pids[@]}"; do wait "$pid"; done
 
       - name: Generate Groovy Docs
         env:
@@ -63,7 +88,7 @@ jobs:
           docker run \
             -u $(id -u):$(id -g) \
             -v ${GITHUB_WORKSPACE}/documentation:/docs \
-            squidfunk/mkdocs-material:8.5.11 build --clean --strict
+            "$MKDOCS_IMAGE" build --clean --strict
 
       - name: Provide Docs Metadata
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,8 +37,11 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.6'
-          # setup-go caches ~/go/pkg/mod and the build cache by default, keyed on go.sum.
+          go-version-file: go.mod
+          # setup-go already caches ~/go/pkg/mod and the build cache, so no separate
+          # actions/cache step is needed. Pin the key to the root go.sum: the default
+          # (**/go.sum) also hashes the fixtures under integration/testdata.
+          cache-dependency-path: go.sum
 
       - name: Cache Maven Packages
         uses: actions/cache@v5

--- a/documentation/bin/createDocu.sh
+++ b/documentation/bin/createDocu.sh
@@ -12,13 +12,38 @@ PLUGIN_MAPPING_FILE_NAME=plugin_mapping.json
 CALLS="${WS_OUT}/${STEP_CALL_MAPPING_FILE_NAME}"
 PLUGIN_MAPPING="${WS_OUT}/${PLUGIN_MAPPING_FILE_NAME}"
 
+JENKINSFILE_RUNNER_IMAGE="${JENKINSFILE_RUNNER_IMAGE:-ppiper/jenkinsfile-runner:latest}"
+
 for f in ${CALLS} ${PLUGIN_MAPPING}
 do
     [ -e "${f}" ] && rm -rf "${f}"
 done
 
+# The Jenkins runner image is only needed after the (multi-minute) Maven run below,
+# so download it in the background and let it overlap with the build. A failure here
+# is not fatal: the "docker run" further down still pulls on demand, and a locally
+# present image keeps working offline.
+echo "[INFO] Pulling ${JENKINSFILE_RUNNER_IMAGE} in the background."
+docker pull "${JENKINSFILE_RUNNER_IMAGE}" > /tmp/jenkinsfile-runner-pull.log 2>&1 &
+DOCKER_PULL_PID=$!
+
 export CLASSPATH_FILE='target/cp.txt'
-mvn --batch-mode --show-version clean test dependency:build-classpath -Dmdep.outputFile=${CLASSPATH_FILE}
+
+# Quality gates that only the "Groovy" workflow (mvn verify) needs are switched off here:
+# this run exists solely to produce target/trackedCalls.json and the classpath file.
+#  - jacoco: coverage instrumentation slows down the whole unit test suite. argLine is
+#    re-supplied explicitly because jacoco:prepare-agent normally sets it, and surefire
+#    inherits the value from the Jenkins plugin parent POM (-Djava.awt.headless=true).
+#  - javadoc: the parent POM binds maven-javadoc-plugin:javadoc to process-sources.
+#  - enforcer: its requirePluginVersions rule resolves metadata for every plugin.
+#  - animal-sniffer: JDK signature check, irrelevant for documentation.
+mvn --batch-mode --show-version clean test dependency:build-classpath \
+    -Dmdep.outputFile=${CLASSPATH_FILE} \
+    -Djacoco.skip=true \
+    -DargLine=-Djava.awt.headless=true \
+    -Dmaven.javadoc.skip=true \
+    -Denforcer.skip=true \
+    -Danimal.sniffer.skip=true
 
 if [ "$?" != "0" ];then
     echo "[ERROR] maven test / build-classpath failed"
@@ -30,6 +55,15 @@ if [ ! -f "${CLASSPATH_FILE}" ];then
     exit 1
 fi
 
+# Run the helper scripts with the project's own Groovy (org.codehaus.groovy:groovy-all is a
+# project dependency and therefore part of ${CLASSPATH_FILE}) instead of requiring a separate
+# Groovy installation on PATH. "groovy -cp X script" is exactly "java -cp <groovy>:X
+# groovy.ui.GroovyMain script" - that is what the groovy launcher script does internally.
+GROOVY_CP="target/classes:$(cat $CLASSPATH_FILE)"
+groovyRun() {
+    java -cp "${GROOVY_CP}" groovy.ui.GroovyMain "$@"
+}
+
 # --in: is created by the unit tests. It contains a mapping between the test case (name is
 # already adjusted).
 # --out: Contains a transformed version. The calls to other pipeline steps are resolved in a
@@ -37,20 +71,22 @@ fi
 # are performed by other pipeline steps. E.g.: each step includes basically a call to
 # handlePipelineStepErrors. The Plugin calls issues by handlePipelineStepErrors are also
 # reported for the step calling that auxiliar step).
-groovy  "${d}resolveTransitiveCalls" -in target/trackedCalls.json --out "${CALLS}"
+groovyRun "${d}resolveTransitiveCalls.groovy" -in target/trackedCalls.json --out "${CALLS}"
 
 [ -f "${CALLS}" ] || { echo "File \"${CALLS}\" does not exist." ; exit 1; }
+
+wait "${DOCKER_PULL_PID}" || echo "[WARN] Background pull of ${JENKINSFILE_RUNNER_IMAGE} failed, see /tmp/jenkinsfile-runner-pull.log. Falling back to the image already present locally."
 
 docker run \
     -w "${WS_IN}" \
     --env calls="${WS_IN}/${STEP_CALL_MAPPING_FILE_NAME}" \
     --env result="${WS_IN}/${PLUGIN_MAPPING_FILE_NAME}" \
     -v "${WS_OUT}:${WS_IN}"  \
-    ppiper/jenkinsfile-runner \
+    "${JENKINSFILE_RUNNER_IMAGE}" \
         -ns \
         -f Jenkinsfile \
         --runWorkspace /workspace
 
 [ -f "${PLUGIN_MAPPING}" ] || { echo "Result file containing step to plugin mapping not found (${PLUGIN_MAPPING})."; exit 1;  }
 
-groovy -cp "target/classes:$(cat $CLASSPATH_FILE)" "${d}createDocu" "${@}"
+groovyRun "${d}createDocu.groovy" "${@}"


### PR DESCRIPTION
## Problem

The `Documentation` workflow is by far the slowest job in the repo. Reading the workflow and `documentation/bin/createDocu.sh` end to end, the time goes into work that this build does not need:

1. **`sudo apt-get update && sudo apt-get install groovy -y`** refreshes every Ubuntu package index and then drags in the whole Debian Java chain (ant, ivy, junit4, bsh, a second JRE, docs) with dpkg triggers — all thrown away when the job ends. Groovy is used for exactly two script invocations.
2. **The Maven cache key was churning.** `hashFiles('**/pom.xml')` hashed **23** poms, 22 of which are fixtures under `test/resources/` and `integration/testdata/`. Touching any test fixture invalidated the exact key and forced a re-resolve of the full Jenkins plugin dependency tree from `repo.jenkins-ci.org`.
3. **`mvn clean test` ran four quality gates the docs build has no use for.** From `mvn help:effective-pom`, the Jenkins plugin parent 2.21 binds, before/at the `test` phase:
   - `jacoco:prepare-agent` — coverage instrumentation over the entire 66-class Pipeline Unit suite
   - `maven-javadoc-plugin:javadoc` bound to **`process-sources`**, so it runs on every build
   - `maven-enforcer-plugin:enforce` with `requirePluginVersions`, which resolves metadata for every plugin
   - `animal-sniffer:check`

   This Maven run exists only to produce `target/trackedCalls.json` and the dependency classpath. All four gates remain enforced by the `Groovy` workflow, which runs `mvn verify` on the same triggers.
4. **The `ppiper/jenkinsfile-runner` pull blocked its own step**, even though the image is not needed until after the multi-minute Maven run.
5. **The Go module cache was configured twice** — `actions/setup-go@v6` already caches `~/go/pkg/mod` and the build cache keyed on `go.sum`, so the extra `actions/cache` step restored and re-saved the same tree.

## Changes

### `documentation/bin/createDocu.sh`

- Skip `jacoco`, `javadoc`, `enforcer` and `animal-sniffer` for this run. `-DargLine=-Djava.awt.headless=true` is passed explicitly because `jacoco:prepare-agent` normally *sets* that property and surefire has no `<argLine>` of its own — it inherits the parent POM's value. Without this, skipping JaCoCo would silently drop the headless flag.
- Start the `ppiper/jenkinsfile-runner` pull in the background at the top of the script and `wait` for it just before `docker run`, so the download overlaps with the Maven build. A failed pull is non-fatal: `docker run` still pulls on demand, and a locally present image keeps working offline.
- Run the two helper scripts as `java -cp <deps> groovy.ui.GroovyMain <script>` instead of via a `groovy` binary on `PATH`. That is exactly what the `groovy` launcher does internally, and `org.codehaus.groovy:groovy-all` is already a compile-scope dependency, so it is part of `target/cp.txt`. Besides removing the toolchain, this fixes a version drift: CI was running these scripts on Groovy 2.4.21 while the project compiles against 2.4.12.
- The image name is overridable via `JENKINSFILE_RUNNER_IMAGE`.

### `.github/workflows/documentation.yml`

- Removed the `Install Groovy` step entirely — no `apt-get`, no download, no cache, no network dependency.
- Narrowed the Maven cache key to `hashFiles('pom.xml')`.
- Dropped the redundant Go module cache step.
- Replaced `styfle/cancel-workflow-action` with a native `concurrency` group. It cancels superseded PR runs at queue time rather than once a runner is assigned, and `cancel-in-progress` is false on `master` so a deploy can never be killed half way. The `actions: write` permission is no longer needed and has been removed.
- Added `timeout-minutes: 90` so a hang fails fast instead of burning the 6h default.
- Pinned the mkdocs image in a job-level `env` var alongside the runner image.

## Considered and rejected

Surefire `forkCount=1C` would parallelize the unit suite, but `test/groovy/util/StepTracker.groovy` accumulates into a static map and rewrites `target/trackedCalls.json` after every test. Parallel forks would each write a partial file, last writer wins, and the step-to-plugin mapping would come out silently incomplete.

## Behaviour to watch on the first run

The `GroovyMain` invocation is the only change that could not be exercised locally. If the mapping is wrong it fails loudly at the `resolveTransitiveCalls` call in `Generate Groovy Docs`, not silently.