### PR TITLE
golangBuild: use telesiactl for Go SBOM generation

### DIFF
--- a/cmd/golangBuild.go
+++ b/cmd/golangBuild.go
@@ -21,6 +21,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/piperenv"
 	"github.com/SAP/jenkins-library/pkg/piperutils"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
+	"github.com/SAP/jenkins-library/pkg/telesiactl"
 
 	"github.com/SAP/jenkins-library/pkg/multiarch"
 	"github.com/SAP/jenkins-library/pkg/versioning"
@@ -139,12 +140,6 @@ func runGolangBuild(config *golangBuildOptions, telemetryData *telemetry.CustomD
 	// install test pre-requisites only in case testing should be performed
 	if config.RunTests || config.RunIntegrationTests {
 		if err := utils.RunExecutable("go", "install", golangTestsumPackage); err != nil {
-			return fmt.Errorf("failed to install pre-requisite: %w", err)
-		}
-	}
-
-	if config.CreateBOM {
-		if err := utils.RunExecutable("go", "install", GolangCycloneDXPackage); err != nil {
 			return fmt.Errorf("failed to install pre-requisite: %w", err)
 		}
 	}
@@ -620,9 +615,38 @@ func runGolangBuildPerArchitecture(config *golangBuildOptions, goModFile *modfil
 }
 
 func runBOMCreation(utils golangBuildUtils, outputFilename string) error {
+	telesiactlBinary, canRunTelesiactl, err := telesiactl.ResolveBinary(utils)
+	if err != nil {
+		log.Entry().Warnf("telesiactl availability check failed, falling back to legacy implementation: %v", err)
+	}
+	if canRunTelesiactl {
+		if err := runTelesiactlBOMCreation(utils, telesiactlBinary, outputFilename); err == nil {
+			return nil
+		} else {
+			log.Entry().Warnf("telesiactl BOM creation failed, falling back to legacy implementation: %v", err)
+		}
+	}
+
+	if err := utils.RunExecutable("go", "install", GolangCycloneDXPackage); err != nil {
+		return fmt.Errorf("failed to install pre-requisite: %w", err)
+	}
+
 	if err := utils.RunExecutable("cyclonedx-gomod", "mod", "-licenses", fmt.Sprintf("-verbose=%t", GeneralConfig.Verbose), "-test", "-output", outputFilename, "-output-version", GolangCycloneDXSchemaVersion); err != nil {
 		return fmt.Errorf("BOM creation failed: %w", err)
 	}
+	return nil
+}
+
+func runTelesiactlBOMCreation(utils golangBuildUtils, telesiactlBinary, outputFilename string) error {
+	args := []string{"sbom", "generate", "--tech", "golang", "--project-path", ".", "--output", outputFilename}
+	if GeneralConfig.Verbose {
+		args = append(args, "--verbose")
+	}
+
+	if err := utils.RunExecutable(telesiactlBinary, args...); err != nil {
+		return fmt.Errorf("telesiactl BOM creation failed: %w", err)
+	}
+
 	return nil
 }
 

--- a/cmd/golangBuild_test.go
+++ b/cmd/golangBuild_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/mock"
 	"github.com/SAP/jenkins-library/pkg/multiarch"
 	"github.com/SAP/jenkins-library/pkg/telemetry"
+	"github.com/SAP/jenkins-library/pkg/telesiactl"
 
 	"github.com/stretchr/testify/assert"
 
@@ -1763,8 +1764,6 @@ func setVerbose(t *testing.T, v bool) {
 }
 
 func TestRunBOMCreation(t *testing.T) {
-	t.Parallel()
-
 	t.Run("success - verbose disabled", func(t *testing.T) {
 		setVerbose(t, false)
 		utils := newGolangBuildTestsUtils()
@@ -1772,9 +1771,11 @@ func TestRunBOMCreation(t *testing.T) {
 		err := runBOMCreation(utils, "bom-golang.xml")
 
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(utils.ExecMockRunner.Calls))
-		assert.Equal(t, "cyclonedx-gomod", utils.ExecMockRunner.Calls[0].Exec)
-		assert.Equal(t, []string{"mod", "-licenses", "-verbose=false", "-test", "-output", "bom-golang.xml", "-output-version", GolangCycloneDXSchemaVersion}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, 2, len(utils.ExecMockRunner.Calls))
+		assert.Equal(t, "go", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"install", GolangCycloneDXPackage}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, "cyclonedx-gomod", utils.ExecMockRunner.Calls[1].Exec)
+		assert.Equal(t, []string{"mod", "-licenses", "-verbose=false", "-test", "-output", "bom-golang.xml", "-output-version", GolangCycloneDXSchemaVersion}, utils.ExecMockRunner.Calls[1].Params)
 	})
 
 	t.Run("success - verbose enabled", func(t *testing.T) {
@@ -1784,9 +1785,11 @@ func TestRunBOMCreation(t *testing.T) {
 		err := runBOMCreation(utils, "bom-golang.xml")
 
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(utils.ExecMockRunner.Calls))
-		assert.Equal(t, "cyclonedx-gomod", utils.ExecMockRunner.Calls[0].Exec)
-		assert.Equal(t, []string{"mod", "-licenses", "-verbose=true", "-test", "-output", "bom-golang.xml", "-output-version", GolangCycloneDXSchemaVersion}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, 2, len(utils.ExecMockRunner.Calls))
+		assert.Equal(t, "go", utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"install", GolangCycloneDXPackage}, utils.ExecMockRunner.Calls[0].Params)
+		assert.Equal(t, "cyclonedx-gomod", utils.ExecMockRunner.Calls[1].Exec)
+		assert.Equal(t, []string{"mod", "-licenses", "-verbose=true", "-test", "-output", "bom-golang.xml", "-output-version", GolangCycloneDXSchemaVersion}, utils.ExecMockRunner.Calls[1].Params)
 	})
 
 	t.Run("success - custom output filename", func(t *testing.T) {
@@ -1796,8 +1799,41 @@ func TestRunBOMCreation(t *testing.T) {
 		err := runBOMCreation(utils, "custom-bom.xml")
 
 		assert.NoError(t, err)
+		assert.Equal(t, 2, len(utils.ExecMockRunner.Calls))
+		assert.Contains(t, utils.ExecMockRunner.Calls[1].Params, "custom-bom.xml")
+	})
+
+	t.Run("success - telesiactl preferred when available", func(t *testing.T) {
+		setVerbose(t, false)
+		utils := newGolangBuildTestsUtils()
+		telesiactlPath := telesiactl.BinaryCandidates()[0]
+		utils.AddFile(telesiactlPath, []byte("binary"))
+
+		err := runBOMCreation(utils, "bom-golang.xml")
+
+		assert.NoError(t, err)
 		assert.Equal(t, 1, len(utils.ExecMockRunner.Calls))
-		assert.Contains(t, utils.ExecMockRunner.Calls[0].Params, "custom-bom.xml")
+		assert.Equal(t, telesiactlPath, utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, []string{"sbom", "generate", "--tech", "golang", "--project-path", ".", "--output", "bom-golang.xml"}, utils.ExecMockRunner.Calls[0].Params)
+	})
+
+	t.Run("success - telesiactl failure falls back to cyclonedx-gomod", func(t *testing.T) {
+		setVerbose(t, false)
+		utils := newGolangBuildTestsUtils()
+		telesiactlPath := telesiactl.BinaryCandidates()[0]
+		utils.AddFile(telesiactlPath, []byte("binary"))
+		utils.ShouldFailOnCommand = map[string]error{
+			telesiactlPath + " sbom generate --tech golang --project-path . --output bom-golang.xml": fmt.Errorf("telesiactl failure"),
+		}
+
+		err := runBOMCreation(utils, "bom-golang.xml")
+
+		assert.NoError(t, err)
+		assert.Equal(t, 3, len(utils.ExecMockRunner.Calls))
+		assert.Equal(t, telesiactlPath, utils.ExecMockRunner.Calls[0].Exec)
+		assert.Equal(t, "go", utils.ExecMockRunner.Calls[1].Exec)
+		assert.Equal(t, []string{"install", GolangCycloneDXPackage}, utils.ExecMockRunner.Calls[1].Params)
+		assert.Equal(t, "cyclonedx-gomod", utils.ExecMockRunner.Calls[2].Exec)
 	})
 
 	t.Run("failure - cyclonedx-gomod execution fails", func(t *testing.T) {
@@ -1810,5 +1846,17 @@ func TestRunBOMCreation(t *testing.T) {
 		err := runBOMCreation(utils, "bom-golang.xml")
 
 		assert.EqualError(t, err, "BOM creation failed: BOM creation failure")
+	})
+
+	t.Run("failure - cyclonedx-gomod prerequisite installation fails", func(t *testing.T) {
+		setVerbose(t, false)
+		utils := newGolangBuildTestsUtils()
+		utils.ShouldFailOnCommand = map[string]error{
+			"go install " + GolangCycloneDXPackage: fmt.Errorf("install failure"),
+		}
+
+		err := runBOMCreation(utils, "bom-golang.xml")
+
+		assert.EqualError(t, err, "failed to install pre-requisite: install failure")
 	})
 }

--- a/pkg/telesiactl/telesiactl.go
+++ b/pkg/telesiactl/telesiactl.go
@@ -1,0 +1,36 @@
+package telesiactl
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+const workspaceBaseDir = ".pipeline/tools/telesiactl"
+
+// FileChecker provides access to workspace binary paths.
+type FileChecker interface {
+	FileExists(filename string) (bool, error)
+}
+
+// ResolveBinary returns the first available telesiactl workspace binary.
+func ResolveBinary(files FileChecker) (string, bool, error) {
+	for _, binary := range BinaryCandidates() {
+		exists, err := files.FileExists(binary)
+		if err != nil {
+			return "", false, fmt.Errorf("failed to check telesiactl binary '%s': %w", binary, err)
+		}
+		if exists {
+			return binary, true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+// BinaryCandidates returns the platform-specific binary path.
+func BinaryCandidates() []string {
+	platformPath := filepath.Join(workspaceBaseDir, runtime.GOOS+"-"+runtime.GOARCH, "telesiactl")
+
+	return []string{platformPath}
+}


### PR DESCRIPTION
# Description

Add telesiactl as the preferred SBOM generator for `golangBuild`.

Telesiactl integration design: [Piper Integration Notes](https://github.tools.sap/telesia/telesiactl/blob/main/docs/design/piper-integration/README.md)

## Changes

- Look up telesiactl from the workspace:
  - `.pipeline/tools/telesiactl/<goos>-<goarch>/telesiactl`
  - `.pipeline/tools/telesiactl/telesiactl`
- Run telesiactl before the legacy CycloneDX implementation.
- Fall back to `cyclonedx-gomod` when telesiactl is unavailable or fails.
- Keep the existing `bom-golang.xml` output and `sbom` result type.
- Use `--tech golang` for telesiactl.

## Tests

Updated unit tests cover:

- telesiactl preferred path
- legacy workspace path
- telesiactl failure with fallback
- legacy CycloneDX behavior
- failure handling

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
