### PR TITLE
fix(artifactPrepareVersion): read maven coordinates with a single mvn call

### DIFF
--- a/integration/integration_maven_test.go
+++ b/integration/integration_maven_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/SAP/jenkins-library/pkg/piperutils"
@@ -84,4 +85,53 @@ func TestMavenIntegrationBuildWithBOMValidation(t *testing.T) {
 	bomContent := ReadFile(t, container, "/cloud-sdk-spring-archetype/target/bom-maven.xml")
 	err := piperutils.ValidateBOM(bomContent)
 	assert.NoError(err, "BOM validation should pass for Maven project")
+}
+
+// DOCKER_IMAGE_MAVEN_JDK8 is the image which piper uses by default for maven steps.
+const DOCKER_IMAGE_MAVEN_JDK8 = "maven:3.8.6-jdk-8"
+
+// TestMavenIntegrationArtifactPrepareVersionCiFriendly makes sure that artifactPrepareVersion
+// reads and writes the version of a multi module project which uses ci-friendly versions
+// (`${revision}`) with as few maven calls as possible. Every maven call starts a JVM and builds
+// the project model, which dominates the runtime of the step on build agents with a cold maven
+// repository.
+func TestMavenIntegrationArtifactPrepareVersionCiFriendly(t *testing.T) {
+	t.Parallel()
+	assert := NewContainerAssert(t)
+
+	const workDir = "/multi-module-ci-friendly"
+
+	container := StartPiperContainer(t, ContainerConfig{
+		Image:    DOCKER_IMAGE_MAVEN_JDK8,
+		TestData: "TestMavenIntegration/multi-module-ci-friendly",
+		WorkDir:  workDir,
+	})
+
+	// artifactPrepareVersion requires a git repository with at least one commit
+	ExecCommand(t, container, workDir, []string{"sh", "-c",
+		"git init -q . && git config user.email piper@example.com && git config user.name piper && git add -A && git commit -q -m 'initial commit'"})
+
+	output := RunPiper(t, container, workDir, "artifactPrepareVersion",
+		"--buildTool", "maven", "--versioningType", "cloud_noTag", "--fetchCoordinates=true")
+
+	assert.Contains(output, "Version before automatic versioning: 1.0.0-SNAPSHOT")
+
+	// the coordinates are published to the common pipeline environment, unchanged behavior
+	assert.Equal("com.sap.piper.test", strings.TrimSpace(string(ReadFile(t, container, workDir+"/.pipeline/commonPipelineEnvironment/groupId"))))
+	assert.Equal("multi-module-ci-friendly", strings.TrimSpace(string(ReadFile(t, container, workDir+"/.pipeline/commonPipelineEnvironment/artifactId"))))
+	assert.Equal("pom", strings.TrimSpace(string(ReadFile(t, container, workDir+"/.pipeline/commonPipelineEnvironment/packaging"))))
+	assert.Equal("1.0.0-SNAPSHOT", strings.TrimSpace(string(ReadFile(t, container, workDir+"/.pipeline/commonPipelineEnvironment/originalArtifactVersion"))))
+
+	newVersion := strings.TrimSpace(string(ReadFile(t, container, workDir+"/.pipeline/commonPipelineEnvironment/artifactVersion")))
+	assert.True(strings.HasPrefix(newVersion, "1.0.0-SNAPSHOT-"), "unexpected version '%s'", newVersion)
+
+	// the new version has been written to all descriptors of the reactor
+	for _, pomPath := range []string{workDir + "/pom.xml", workDir + "/application/pom.xml", workDir + "/library/pom.xml"} {
+		assert.Contains(string(ReadFile(t, container, pomPath)), newVersion, "version not updated in %s", pomPath)
+	}
+
+	// regression guard for the runtime of the step: reading the version, reading the coordinates
+	// and setting the version must not result in one maven call per property
+	assert.Equal(2, strings.Count(output, "running command: mvn"),
+		"expected one evaluation and one versions:set call, got:\n%s", output)
 }

--- a/integration/testdata/TestMavenIntegration/multi-module-ci-friendly/application/pom.xml
+++ b/integration/testdata/TestMavenIntegration/multi-module-ci-friendly/application/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.sap.piper.test</groupId>
+		<artifactId>multi-module-ci-friendly</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>application</artifactId>
+	<version>${revision}</version>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.sap.piper.test</groupId>
+			<artifactId>library</artifactId>
+			<version>${revision}</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/integration/testdata/TestMavenIntegration/multi-module-ci-friendly/library/pom.xml
+++ b/integration/testdata/TestMavenIntegration/multi-module-ci-friendly/library/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.sap.piper.test</groupId>
+		<artifactId>multi-module-ci-friendly</artifactId>
+		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>library</artifactId>
+	<version>${revision}</version>
+	<packaging>jar</packaging>
+</project>

--- a/integration/testdata/TestMavenIntegration/multi-module-ci-friendly/pom.xml
+++ b/integration/testdata/TestMavenIntegration/multi-module-ci-friendly/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.sap.piper.test</groupId>
+	<artifactId>multi-module-ci-friendly</artifactId>
+	<version>${revision}</version>
+	<packaging>pom</packaging>
+
+	<properties>
+		<revision>1.0.0-SNAPSHOT</revision>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<modules>
+		<module>application</module>
+		<module>library</module>
+	</modules>
+</project>

--- a/pkg/maven/maven.go
+++ b/pkg/maven/maven.go
@@ -123,6 +123,81 @@ func Evaluate(options *EvaluateOptions, expression string, utils Utils) (string,
 	return value, nil
 }
 
+const (
+	// evaluateCompositeProperty is a user property which is used to let maven resolve several
+	// expressions within one invocation, see EvaluateMultiple.
+	evaluateCompositeProperty = "piper.evaluate.composite"
+	// evaluateCompositeSeparator separates the values of a composite expression. It must not be
+	// part of any evaluated value, which holds true for maven coordinates.
+	evaluateCompositeSeparator = "|"
+)
+
+// EvaluateMultiple evaluates a list of expressions from a pom file with one single mvn call and
+// returns the values in the order of the given expressions.
+// The maven-help-plugin accepts only one expression per invocation, therefore the expressions are
+// combined into a single user property which maven resolves with its own expression evaluator.
+// The result is thus identical to calling Evaluate() per expression, but only one JVM is started
+// and the maven project model is built only once, which matters a lot on build agents with a cold
+// maven repository.
+func EvaluateMultiple(options *EvaluateOptions, expressions []string, utils Utils) ([]string, error) {
+	if len(expressions) == 0 {
+		return nil, fmt.Errorf("no expressions provided")
+	}
+
+	references := make([]string, len(expressions))
+	for i, expression := range expressions {
+		if strings.Contains(expression, evaluateCompositeSeparator) {
+			return nil, fmt.Errorf("expression '%s' must not contain '%s'", expression, evaluateCompositeSeparator)
+		}
+		references[i] = "${" + expression + "}"
+	}
+
+	compositeOptions := *options
+	compositeOptions.Defines = append(slices.Clone(options.Defines),
+		fmt.Sprintf("-D%s=%s", evaluateCompositeProperty, strings.Join(references, evaluateCompositeSeparator)))
+
+	value, err := Evaluate(&compositeOptions, evaluateCompositeProperty, utils)
+	if err != nil {
+		return nil, err
+	}
+
+	values, err := parseCompositeValue(value, len(expressions))
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate expressions %v in file '%s': %w", expressions, options.PomPath, err)
+	}
+
+	for i, expressionValue := range values {
+		if strings.Contains(expressionValue, "${") {
+			return nil, fmt.Errorf("expression '%s' in file '%s' could not be resolved", expressions[i], options.PomPath)
+		}
+	}
+
+	return values, nil
+}
+
+// parseCompositeValue extracts the expected number of values out of the result of a composite
+// evaluation. Maven writes warnings to stdout as well, therefore the last line which has the
+// expected shape is used.
+func parseCompositeValue(value string, expected int) ([]string, error) {
+	lines := strings.Split(strings.ReplaceAll(value, "\r\n", "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		// maven log entries are prefixed with the log level, e.g. '[WARNING]'
+		if len(line) == 0 || strings.HasPrefix(line, "[") {
+			continue
+		}
+		values := strings.Split(line, evaluateCompositeSeparator)
+		if len(values) != expected {
+			continue
+		}
+		for j := range values {
+			values[j] = strings.TrimSpace(values[j])
+		}
+		return values, nil
+	}
+	return nil, fmt.Errorf("unexpected result '%s', expected %v values separated by '%s'", value, expected, evaluateCompositeSeparator)
+}
+
 func InstallModuleWithReactor(moduleName string, options *EvaluateOptions, utils Utils) error {
 	var defines = options.Defines
 

--- a/pkg/maven/maven_test.go
+++ b/pkg/maven/maven_test.go
@@ -5,6 +5,7 @@ package maven
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -113,6 +114,98 @@ func TestEvaluate(t *testing.T) {
 		if assert.EqualError(t, err, "expression 'project.groupId' in file 'pom.xml' could not be resolved") {
 			assert.Equal(t, "", result)
 		}
+	})
+}
+
+func TestEvaluateMultiple(t *testing.T) {
+	coordinateExpressions := []string{"project.groupId", "project.artifactId", "project.version", "project.packaging"}
+
+	t.Run("should evaluate all expressions with a single call", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.StdoutReturn = map[string]string{"maven-help-plugin:3.1.0:evaluate": "com.awesome|awesome-app|1.2.3|jar"}
+		options := EvaluateOptions{PomPath: "pom.xml"}
+
+		values, err := EvaluateMultiple(&options, coordinateExpressions, &utils)
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, []string{"com.awesome", "awesome-app", "1.2.3", "jar"}, values)
+		}
+		if assert.Equal(t, 1, len(utils.Calls)) {
+			assert.Equal(t, []string{
+				"--file", "pom.xml",
+				"-Dexpression=piper.evaluate.composite",
+				"-DforceStdout",
+				"-q",
+				"-Dpiper.evaluate.composite=${project.groupId}|${project.artifactId}|${project.version}|${project.packaging}",
+				"-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn",
+				"--batch-mode",
+				"org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate",
+			}, utils.Calls[0].Params)
+		}
+		assert.Empty(t, options.Defines, "defines of the caller must not be modified")
+	})
+
+	t.Run("should ignore maven log entries on stdout", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.StdoutReturn = map[string]string{"maven-help-plugin:3.1.0:evaluate": "[WARNING] Some problems were encountered\ncom.awesome|awesome-app|1.2.3|jar"}
+
+		values, err := EvaluateMultiple(&EvaluateOptions{PomPath: "pom.xml"}, coordinateExpressions, &utils)
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, []string{"com.awesome", "awesome-app", "1.2.3", "jar"}, values)
+		}
+	})
+
+	t.Run("should keep the defines of the caller", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.StdoutReturn = map[string]string{"maven-help-plugin:3.1.0:evaluate": "com.awesome|awesome-app|1.2.3|jar"}
+
+		_, err := EvaluateMultiple(&EvaluateOptions{PomPath: "pom.xml", Defines: []string{"-Drevision=1.2.3"}}, coordinateExpressions, &utils)
+
+		assert.NoError(t, err)
+		if assert.Equal(t, 1, len(utils.Calls)) {
+			assert.Contains(t, utils.Calls[0].Params, "-Drevision=1.2.3")
+		}
+	})
+
+	t.Run("should fail if the result does not match the expressions", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.StdoutReturn = map[string]string{"maven-help-plugin:3.1.0:evaluate": "com.awesome"}
+
+		values, err := EvaluateMultiple(&EvaluateOptions{PomPath: "pom.xml"}, coordinateExpressions, &utils)
+
+		assert.Contains(t, fmt.Sprint(err), "unexpected result")
+		assert.Nil(t, values)
+	})
+
+	t.Run("should fail if an expression could not be resolved", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.StdoutReturn = map[string]string{"maven-help-plugin:3.1.0:evaluate": "com.awesome|${project.artifactId}|1.2.3|jar"}
+
+		values, err := EvaluateMultiple(&EvaluateOptions{PomPath: "pom.xml"}, coordinateExpressions, &utils)
+
+		assert.EqualError(t, err, "expression 'project.artifactId' in file 'pom.xml' could not be resolved")
+		assert.Nil(t, values)
+	})
+
+	t.Run("should fail without expressions", func(t *testing.T) {
+		utils := NewMockUtils(false)
+
+		values, err := EvaluateMultiple(&EvaluateOptions{PomPath: "pom.xml"}, nil, &utils)
+
+		assert.EqualError(t, err, "no expressions provided")
+		assert.Nil(t, values)
+		assert.Equal(t, 0, len(utils.Calls))
+	})
+
+	t.Run("should propagate maven errors", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.ShouldFailOnCommand = map[string]error{"maven-help-plugin:3.1.0:evaluate": fmt.Errorf("maven failed")}
+
+		values, err := EvaluateMultiple(&EvaluateOptions{PomPath: "pom.xml"}, coordinateExpressions, &utils)
+
+		assert.Error(t, err)
+		assert.Nil(t, values)
 	})
 }
 

--- a/pkg/versioning/maven.go
+++ b/pkg/versioning/maven.go
@@ -3,12 +3,30 @@ package versioning
 import (
 	"fmt"
 
+	"github.com/SAP/jenkins-library/pkg/log"
 	"github.com/SAP/jenkins-library/pkg/maven"
 )
 
 type mavenRunner interface {
 	Execute(*maven.ExecuteOptions, maven.Utils) (string, error)
 	Evaluate(*maven.EvaluateOptions, string, maven.Utils) (string, error)
+	EvaluateMultiple(*maven.EvaluateOptions, []string, maven.Utils) ([]string, error)
+}
+
+const (
+	mavenGroupIDExpression    = "project.groupId"
+	mavenArtifactIDExpression = "project.artifactId"
+	mavenVersionExpression    = "project.version"
+	mavenPackagingExpression  = "project.packaging"
+)
+
+// mavenCoordinateExpressions are the expressions which are read with one single mvn call,
+// see Maven.evaluateCoordinates()
+var mavenCoordinateExpressions = []string{
+	mavenGroupIDExpression,
+	mavenArtifactIDExpression,
+	mavenVersionExpression,
+	mavenPackagingExpression,
 }
 
 // Maven defines a maven artifact used for versioning
@@ -16,6 +34,14 @@ type Maven struct {
 	options maven.EvaluateOptions
 	runner  mavenRunner
 	utils   maven.Utils
+	// evaluated holds the expression values matching the current state of the build descriptor.
+	// Reading a single property requires a complete maven run, therefore values are read only
+	// once and are kept in sync with the descriptor by SetVersion().
+	evaluated map[string]string
+	// coordinatesEvaluated is true as soon as it has been tried to read all coordinates with one
+	// single mvn call. It makes sure that a failing combined evaluation is not repeated for every
+	// single expression.
+	coordinatesEvaluated bool
 }
 
 func (m *Maven) init() {
@@ -26,6 +52,72 @@ func (m *Maven) init() {
 	if m.utils == nil {
 		m.utils = maven.NewUtilsBundle()
 	}
+
+	if m.evaluated == nil {
+		m.evaluated = map[string]string{}
+	}
+}
+
+// evaluate returns the value of the given maven expression.
+// Since every evaluation starts a JVM and builds the maven project model, which is expensive
+// especially for multi module projects with a cold maven repository, the coordinates of the
+// artifact are read with one single mvn call and are cached for subsequent calls.
+func (m *Maven) evaluate(expression string) (string, error) {
+	m.init()
+
+	if value, exists := m.evaluated[expression]; exists {
+		return value, nil
+	}
+
+	if !m.coordinatesEvaluated && isMavenCoordinateExpression(expression) {
+		m.coordinatesEvaluated = true
+		if err := m.evaluateCoordinates(); err != nil {
+			// reading all coordinates at once is an optimization only, thus fall back to
+			// evaluating the single expression in order to keep the previous behavior
+			log.Entry().WithError(err).Debug("Maven - reading coordinates with one call failed, evaluating single expressions")
+		} else if value, exists := m.evaluated[expression]; exists {
+			return value, nil
+		}
+	}
+
+	value, err := m.runner.Evaluate(&m.options, expression, m.utils)
+	if err != nil {
+		return "", err
+	}
+	m.evaluated[expression] = value
+	return value, nil
+}
+
+// evaluateCoordinates reads all coordinates of the artifact with one single mvn call.
+func (m *Maven) evaluateCoordinates() error {
+	values, err := m.runner.EvaluateMultiple(&m.options, mavenCoordinateExpressions, m.utils)
+	if err != nil {
+		return err
+	}
+
+	if len(values) != len(mavenCoordinateExpressions) {
+		return fmt.Errorf("expected %v values for file '%s', got %v", len(mavenCoordinateExpressions), m.options.PomPath, len(values))
+	}
+
+	for i, expression := range mavenCoordinateExpressions {
+		if len(values[i]) == 0 {
+			return fmt.Errorf("expression '%s' in file '%s' resolved to an empty value", expression, m.options.PomPath)
+		}
+	}
+
+	for i, expression := range mavenCoordinateExpressions {
+		m.evaluated[expression] = values[i]
+	}
+	return nil
+}
+
+func isMavenCoordinateExpression(expression string) bool {
+	for _, coordinateExpression := range mavenCoordinateExpressions {
+		if coordinateExpression == expression {
+			return true
+		}
+	}
+	return false
 }
 
 // VersioningScheme returns the relevant versioning scheme
@@ -58,9 +150,7 @@ func (m *Maven) GetCoordinates() (Coordinates, error) {
 
 // GetPackaging returns the current ID of the Group
 func (m *Maven) GetPackaging() (string, error) {
-	m.init()
-
-	packaging, err := m.runner.Evaluate(&m.options, "project.packaging", m.utils)
+	packaging, err := m.evaluate(mavenPackagingExpression)
 	if err != nil {
 		return "", fmt.Errorf("Maven - getting packaging failed: %w", err)
 	}
@@ -69,9 +159,7 @@ func (m *Maven) GetPackaging() (string, error) {
 
 // GetGroupID returns the current ID of the Group
 func (m *Maven) GetGroupID() (string, error) {
-	m.init()
-
-	groupID, err := m.runner.Evaluate(&m.options, "project.groupId", m.utils)
+	groupID, err := m.evaluate(mavenGroupIDExpression)
 	if err != nil {
 		return "", fmt.Errorf("Maven - getting groupId failed: %w", err)
 	}
@@ -80,9 +168,7 @@ func (m *Maven) GetGroupID() (string, error) {
 
 // GetArtifactID returns the current ID of the artifact
 func (m *Maven) GetArtifactID() (string, error) {
-	m.init()
-
-	artifactID, err := m.runner.Evaluate(&m.options, "project.artifactId", m.utils)
+	artifactID, err := m.evaluate(mavenArtifactIDExpression)
 	if err != nil {
 		return "", fmt.Errorf("Maven - getting artifactId failed: %w", err)
 	}
@@ -91,9 +177,7 @@ func (m *Maven) GetArtifactID() (string, error) {
 
 // GetVersion returns the current version of the artifact
 func (m *Maven) GetVersion() (string, error) {
-	m.init()
-
-	version, err := m.runner.Evaluate(&m.options, "project.version", m.utils)
+	version, err := m.evaluate(mavenVersionExpression)
 	if err != nil {
 		return "", fmt.Errorf("Maven - getting version failed: %w", err)
 	}
@@ -105,7 +189,7 @@ func (m *Maven) GetVersion() (string, error) {
 func (m *Maven) SetVersion(version string) error {
 	m.init()
 
-	groupID, err := m.runner.Evaluate(&m.options, "project.groupId", m.utils)
+	groupID, err := m.evaluate(mavenGroupIDExpression)
 	if err != nil {
 		return fmt.Errorf("Maven - getting groupId failed: %w", err)
 	}
@@ -127,5 +211,7 @@ func (m *Maven) SetVersion(version string) error {
 	if err != nil {
 		return fmt.Errorf("Maven - setting version %v failed: %w", version, err)
 	}
+	// versions:set changes versions only, the remaining coordinates of the descriptor are untouched
+	m.evaluated[mavenVersionExpression] = version
 	return nil
 }

--- a/pkg/versioning/maven_test.go
+++ b/pkg/versioning/maven_test.go
@@ -12,25 +12,59 @@ import (
 )
 
 type mavenMockRunner struct {
-	evaluateErrorString string
-	executeErrorString  string
-	stdout              string
-	opts                *maven.EvaluateOptions
-	execOpts            *maven.ExecuteOptions
-	expression          string
+	evaluateErrorString         string
+	evaluateMultipleErrorString string
+	executeErrorString          string
+	stdout                      string
+	// values allows to return a dedicated value per expression, stdout is used if it is not set
+	values                map[string]string
+	opts                  *maven.EvaluateOptions
+	execOpts              *maven.ExecuteOptions
+	expression            string
+	expressions           []string
+	evaluateCalls         int
+	evaluateMultipleCalls int
+	executeCalls          int
+}
+
+func (m *mavenMockRunner) value(expression string) string {
+	if m.values != nil {
+		return m.values[expression]
+	}
+	return m.stdout
 }
 
 func (m *mavenMockRunner) Evaluate(opts *maven.EvaluateOptions, expression string, utils maven.Utils) (string, error) {
 	m.opts = opts
 	m.expression = expression
+	m.evaluateCalls++
 	if len(m.evaluateErrorString) > 0 {
 		return "", fmt.Errorf("%s", m.evaluateErrorString)
 	}
-	return m.stdout, nil
+	return m.value(expression), nil
+}
+
+func (m *mavenMockRunner) EvaluateMultiple(opts *maven.EvaluateOptions, expressions []string, utils maven.Utils) ([]string, error) {
+	m.opts = opts
+	m.expressions = expressions
+	m.evaluateMultipleCalls++
+	if len(m.evaluateMultipleErrorString) > 0 {
+		return nil, fmt.Errorf("%s", m.evaluateMultipleErrorString)
+	}
+	// a combined evaluation is a single mvn call, thus it fails as well if evaluation fails
+	if len(m.evaluateErrorString) > 0 {
+		return nil, fmt.Errorf("%s", m.evaluateErrorString)
+	}
+	values := []string{}
+	for _, expression := range expressions {
+		values = append(values, m.value(expression))
+	}
+	return values, nil
 }
 
 func (m *mavenMockRunner) Execute(opts *maven.ExecuteOptions, utils maven.Utils) (string, error) {
 	m.execOpts = opts
+	m.executeCalls++
 	if len(m.executeErrorString) > 0 {
 		return "", fmt.Errorf("%s", m.executeErrorString)
 	}
@@ -38,6 +72,15 @@ func (m *mavenMockRunner) Execute(opts *maven.ExecuteOptions, utils maven.Utils)
 		return m.stdout, nil
 	}
 	return "", nil
+}
+
+func mavenCoordinateValues() map[string]string {
+	return map[string]string{
+		"project.groupId":    "com.sap.cp",
+		"project.artifactId": "my-app",
+		"project.version":    "1.0.0-SNAPSHOT",
+		"project.packaging":  "jar",
+	}
 }
 
 func TestMavenGetVersion(t *testing.T) {
@@ -52,7 +95,7 @@ func TestMavenGetVersion(t *testing.T) {
 		version, err := mvn.GetVersion()
 		assert.NoError(t, err)
 		assert.Equal(t, "1.2.3", version)
-		assert.Equal(t, "project.version", runner.expression)
+		assert.Equal(t, mavenCoordinateExpressions, runner.expressions)
 		assert.Equal(t, "path/to/pom.xml", runner.opts.PomPath)
 		assert.Equal(t, "path/to/m2", runner.opts.M2Path)
 	})
@@ -70,6 +113,91 @@ func TestMavenGetVersion(t *testing.T) {
 		assert.Equal(t, "", version)
 	})
 
+	t.Run("falls back to single evaluation", func(t *testing.T) {
+		runner := mavenMockRunner{
+			stdout:                      "1.2.3",
+			evaluateMultipleErrorString: "combined evaluation failed",
+		}
+		mvn := &Maven{
+			runner:  &runner,
+			options: maven.EvaluateOptions{PomPath: "path/to/pom.xml"},
+		}
+		version, err := mvn.GetVersion()
+		assert.NoError(t, err)
+		assert.Equal(t, "1.2.3", version)
+		assert.Equal(t, "project.version", runner.expression)
+		assert.Equal(t, 1, runner.evaluateCalls)
+	})
+}
+
+func TestMavenGetCoordinates(t *testing.T) {
+	t.Run("reads all coordinates with one maven call", func(t *testing.T) {
+		runner := mavenMockRunner{values: mavenCoordinateValues()}
+		mvn := &Maven{
+			runner:  &runner,
+			options: maven.EvaluateOptions{PomPath: "path/to/pom.xml"},
+		}
+
+		coordinates, err := mvn.GetCoordinates()
+
+		assert.NoError(t, err)
+		assert.Equal(t, Coordinates{GroupID: "com.sap.cp", ArtifactID: "my-app", Version: "1.0.0-SNAPSHOT", Packaging: "jar"}, coordinates)
+		assert.Equal(t, 1, runner.evaluateMultipleCalls)
+		assert.Equal(t, 0, runner.evaluateCalls)
+	})
+
+	t.Run("caches coordinates", func(t *testing.T) {
+		runner := mavenMockRunner{values: mavenCoordinateValues()}
+		mvn := &Maven{runner: &runner}
+
+		first, err := mvn.GetCoordinates()
+		assert.NoError(t, err)
+		second, err := mvn.GetCoordinates()
+		assert.NoError(t, err)
+
+		assert.Equal(t, first, second)
+		assert.Equal(t, 1, runner.evaluateMultipleCalls)
+		assert.Equal(t, 0, runner.evaluateCalls)
+	})
+
+	t.Run("falls back to single evaluations", func(t *testing.T) {
+		runner := mavenMockRunner{
+			values:                      mavenCoordinateValues(),
+			evaluateMultipleErrorString: "combined evaluation failed",
+		}
+		mvn := &Maven{runner: &runner}
+
+		coordinates, err := mvn.GetCoordinates()
+
+		assert.NoError(t, err)
+		assert.Equal(t, Coordinates{GroupID: "com.sap.cp", ArtifactID: "my-app", Version: "1.0.0-SNAPSHOT", Packaging: "jar"}, coordinates)
+		assert.Equal(t, 4, runner.evaluateCalls)
+		// a failing combined evaluation must not be repeated for every single expression
+		assert.Equal(t, 1, runner.evaluateMultipleCalls)
+	})
+
+	t.Run("falls back if a coordinate is empty", func(t *testing.T) {
+		values := mavenCoordinateValues()
+		values["project.packaging"] = ""
+		runner := mavenMockRunner{values: values}
+		mvn := &Maven{runner: &runner}
+
+		coordinates, err := mvn.GetCoordinates()
+
+		assert.NoError(t, err)
+		assert.Equal(t, "com.sap.cp", coordinates.GroupID)
+		assert.Equal(t, "", coordinates.Packaging)
+		assert.Equal(t, 4, runner.evaluateCalls)
+	})
+
+	t.Run("error case", func(t *testing.T) {
+		runner := mavenMockRunner{evaluateErrorString: "maven eval failed"}
+		mvn := &Maven{runner: &runner}
+
+		_, err := mvn.GetCoordinates()
+
+		assert.EqualError(t, err, "Maven - getting groupId failed: maven eval failed")
+	})
 }
 
 func TestMavenSetVersion(t *testing.T) {
@@ -122,5 +250,34 @@ func TestMavenSetVersion(t *testing.T) {
 		}
 		err := mvn.SetVersion("1.2.4")
 		assert.EqualError(t, err, "Maven - setting version 1.2.4 failed: maven exec failed")
+	})
+
+	t.Run("version is updated without another maven call", func(t *testing.T) {
+		runner := mavenMockRunner{values: mavenCoordinateValues()}
+		mvn := &Maven{
+			runner:  &runner,
+			options: maven.EvaluateOptions{PomPath: "path/to/pom.xml"},
+		}
+
+		// this is the sequence artifactPrepareVersion runs for a maven project
+		version, err := mvn.GetVersion()
+		assert.NoError(t, err)
+		assert.Equal(t, "1.0.0-SNAPSHOT", version)
+
+		assert.NoError(t, mvn.SetVersion("1.0.0-20260827_deadbeef"))
+
+		coordinates, err := mvn.GetCoordinates()
+		assert.NoError(t, err)
+		assert.Equal(t, Coordinates{
+			GroupID:    "com.sap.cp",
+			ArtifactID: "my-app",
+			Version:    "1.0.0-20260827_deadbeef",
+			Packaging:  "jar",
+		}, coordinates)
+
+		// one evaluation and the versions:set call, instead of 7 maven calls
+		assert.Equal(t, 1, runner.evaluateMultipleCalls)
+		assert.Equal(t, 0, runner.evaluateCalls)
+		assert.Equal(t, 1, runner.executeCalls)
 	})
 }

--- a/pkg/versioning/versioning.go
+++ b/pkg/versioning/versioning.go
@@ -69,6 +69,9 @@ func (m *mvnRunner) Execute(options *maven.ExecuteOptions, utils maven.Utils) (s
 func (m *mvnRunner) Evaluate(options *maven.EvaluateOptions, expression string, utils maven.Utils) (string, error) {
 	return maven.Evaluate(options, expression, utils)
 }
+func (m *mvnRunner) EvaluateMultiple(options *maven.EvaluateOptions, expressions []string, utils maven.Utils) ([]string, error) {
+	return maven.EvaluateMultiple(options, expressions, utils)
+}
 
 var fileExists func(string) (bool, error)
 


### PR DESCRIPTION
# Description

For `buildTool: maven`, `artifactPrepareVersion` starts **7 `mvn` processes** in order to read and write four pom properties:

| # | call | goal |
|---|---|---|
| 1 | `GetVersion()` | `help:evaluate -Dexpression=project.version` |
| 2 | `SetVersion()` | `help:evaluate -Dexpression=project.groupId` |
| 3 | `SetVersion()` | `versions:set` |
| 4-7 | `GetCoordinates()` | `help:evaluate` for `project.groupId`, `project.artifactId`, `project.version`, `project.packaging` |

Every one of them starts a JVM and builds the maven project model. On build agents where the local maven repository is cold - or not writable at all, so that nothing can be cached between the calls - a single `help:evaluate` takes minutes and the step spends nearly its complete runtime on values which are already known. In a reported multi module build the step needed 27 minutes for this.

`mavenBuild` uses the same pattern: `GetCoordinates()` is called for every `**/pom.xml`, which results in 4 processes per module.

## Solution

`pkg/maven` gets `EvaluateMultiple()`. The maven-help-plugin evaluates one expression per invocation, therefore the expressions are combined into a single user property which maven resolves with its own expression evaluator:

```
mvn ... -Dexpression=piper.evaluate.composite -DforceStdout -q \
        '-Dpiper.evaluate.composite=${project.groupId}|${project.artifactId}|${project.version}|${project.packaging}' \
        org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate

com.sap.piper.test|my-app|1.0.0-SNAPSHOT|jar
```

The values are the same ones `Evaluate()` returns per expression, since it is the same evaluator, the same plugin and the same parameters - only one JVM is started and the project model is built once.

In `pkg/versioning` the maven artifact reads its coordinates with that single call and keeps the values as long as they match the build descriptor. `versions:set` only rewrites versions, so after `SetVersion()` the remaining coordinates are still valid and the new version is known without reading it again.

As a result `artifactPrepareVersion` runs **2** `mvn` calls instead of 7, `mavenBuild` **1** instead of 4 per module.

## Compatibility

* No change of the step logic, the metadata or the commonPipelineEnvironment. In particular the behavior of `fetchCoordinates` is untouched.
* If the combined evaluation fails for any reason, every expression is evaluated separately as before and the error messages stay unchanged. A failing combined evaluation is not repeated for the single expressions, so the worst case is one additional call - never more than today.

# Checklist

- [x] Tests
- [ ] Documentation
- [ ] Inner source library needs updating

## Tests

Unit tests for `EvaluateMultiple()` (command construction, maven warnings on stdout, unresolved expressions, unexpected results, defines of the caller) and for the versioning artifact (single call, caching, fallback to single evaluations, empty values, and the complete `GetVersion()` -> `SetVersion()` -> `GetCoordinates()` sequence of the step).

New integration test `TestMavenIntegrationArtifactPrepareVersionCiFriendly` runs the step in `maven:3.8.6-jdk-8` against a multi module project which uses ci-friendly versions (`${revision}`). It asserts the coordinates in the commonPipelineEnvironment, that the new version is written into all descriptors of the reactor, and that only two `mvn` calls are made. Executed against `master` the same test logs the 7 calls listed above and fails.
