### PR TITLE
fix(maven): use a usable local repository if the default one does not work

### DIFF
--- a/integration/integration_maven_test.go
+++ b/integration/integration_maven_test.go
@@ -135,3 +135,34 @@ func TestMavenIntegrationArtifactPrepareVersionCiFriendly(t *testing.T) {
 	assert.Equal(2, strings.Count(output, "running command: mvn"),
 		"expected one evaluation and one versions:set call, got:\n%s", output)
 }
+
+// TestMavenIntegrationUnknownContainerUser makes sure that maven uses a usable local repository if
+// the container is started with a user which the image does not know - which is what the piper
+// GitHub action does with `docker run --user 1000:1000`. In that case the JVM cannot resolve
+// ${user.home} and maven would otherwise download the artifacts into a directory named '?' within
+// the checked out repository.
+func TestMavenIntegrationUnknownContainerUser(t *testing.T) {
+	t.Parallel()
+	assert := NewContainerAssert(t)
+
+	const workDir = "/tmp/project"
+
+	container := StartPiperContainer(t, ContainerConfig{
+		Image:    DOCKER_IMAGE_MAVEN_JDK8,
+		User:     "1000:1000",
+		TestData: "TestMavenIntegration/multi-module-ci-friendly",
+		WorkDir:  "/multi-module-ci-friendly",
+	})
+
+	// the test data belongs to root, therefore work on a copy which the container user can write
+	ExecCommand(t, container, "/", []string{"sh", "-c",
+		"cp -r /multi-module-ci-friendly " + workDir + " && cd " + workDir +
+			" && git init -q . && git config user.email piper@example.com && git config user.name piper && git add -A && git commit -q -m 'initial commit'"})
+
+	output := RunPiper(t, container, workDir, "artifactPrepareVersion", "--buildTool", "maven", "--versioningType", "library")
+	assert.Contains(output, "Version before automatic versioning: 1.0.0-SNAPSHOT")
+
+	// maven must not create a local repository within the workspace
+	entries := ExecCommand(t, container, workDir, []string{"ls", "-a"})
+	assert.NotContains(entries, "?", "maven created a local repository named '?' in the workspace")
+}

--- a/pkg/maven/maven.go
+++ b/pkg/maven/maven.go
@@ -2,13 +2,18 @@ package maven
 
 import (
 	"bytes"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"os/user"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/SAP/jenkins-library/pkg/command"
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
@@ -412,6 +417,85 @@ func evaluateStdOut(options *ExecuteOptions) (*bytes.Buffer, io.Writer) {
 	return stdOutBuf, stdOut
 }
 
+// localRepositoryFallback returns the local repository maven should use in case it is not able to
+// use its default one. The result is determined once, it is a variable in order to be exchangeable
+// in tests.
+var localRepositoryFallback = sync.OnceValue(func() string {
+	repository := localRepositoryFallbackFor(runtime.GOOS, os.Getuid(), user.LookupId, os.TempDir(), directoryWritable)
+	if repository != "" {
+		log.Entry().Infof("The default maven local repository cannot be used, '%s' is used instead. Configure 'm2Path' in order to use a different location.", repository)
+	}
+	return repository
+})
+
+// localRepositoryFallbackFor returns a local repository path if maven would not be able to use its
+// default local repository, otherwise an empty string.
+// Maven derives the default local repository from '${user.home}/.m2/repository' and the JVM reads the
+// home directory from the passwd database. If the user has no entry there - which is the case when a
+// container is started with a numeric user which the image does not know, for example
+// 'docker run --user 1000:1000 maven:3.8.6-jdk-8' as done by the piper GitHub action - the JVM
+// resolves '${user.home}' to '?'. Maven then uses a directory named '?' relative to the current
+// directory, which means that the artifacts are downloaded into the checked out repository instead of
+// a location which other steps can reuse. The same applies if the home directory is not writable.
+func localRepositoryFallbackFor(goos string, uid int, lookupID func(string) (*user.User, error), tempDir string, writable func(string) bool) string {
+	if goos == "windows" {
+		return ""
+	}
+	currentUser, err := lookupID(strconv.Itoa(uid))
+	if err == nil && len(currentUser.HomeDir) > 0 && writable(filepath.Join(currentUser.HomeDir, ".m2")) {
+		return ""
+	}
+	return filepath.Join(tempDir, ".m2", "repository")
+}
+
+// directoryWritable tells whether the given directory can be created and written to. Since the
+// directory itself does not need to exist yet, the check is done on its closest existing parent.
+func directoryWritable(path string) bool {
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if !info.IsDir() {
+				return false
+			}
+			file, err := os.CreateTemp(path, ".piper-*")
+			if err != nil {
+				return false
+			}
+			name := file.Name()
+			file.Close()
+			os.Remove(name)
+			return true
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return false
+		}
+		path = parent
+	}
+}
+
+// settingsDefineLocalRepository tells whether one of the settings files of the given maven command
+// line defines a local repository. Maven does not need a fallback in that case.
+func settingsDefineLocalRepository(parameters []string, utils Utils) bool {
+	for i, parameter := range parameters {
+		if parameter != "--settings" && parameter != "--global-settings" || i+1 >= len(parameters) {
+			continue
+		}
+		content, err := utils.FileRead(parameters[i+1])
+		if err != nil {
+			continue
+		}
+		settings := Settings{}
+		if err := xml.Unmarshal(content, &settings); err != nil {
+			continue
+		}
+		if len(settings.LocalRepository) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func getParametersFromOptions(options *ExecuteOptions, utils Utils) ([]string, error) {
 	var parameters []string
 
@@ -422,6 +506,8 @@ func getParametersFromOptions(options *ExecuteOptions, utils Utils) ([]string, e
 
 	if options.M2Path != "" {
 		parameters = append(parameters, "-Dmaven.repo.local="+options.M2Path)
+	} else if repository := localRepositoryFallback(); repository != "" && !settingsDefineLocalRepository(parameters, utils) {
+		parameters = append(parameters, "-Dmaven.repo.local="+repository)
 	}
 
 	if options.PomPath != "" {

--- a/pkg/maven/maven_test.go
+++ b/pkg/maven/maven_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/SAP/jenkins-library/pkg/mock"
 
@@ -15,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type MockUtils struct {
@@ -206,6 +209,120 @@ func TestEvaluateMultiple(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, values)
+	})
+}
+
+func TestLocalRepositoryFallback(t *testing.T) {
+	knownUser := func(id string) (*user.User, error) { return &user.User{Uid: id, HomeDir: "/home/piper"}, nil }
+	unknownUser := func(id string) (*user.User, error) { return nil, fmt.Errorf("user: unknown userid %s", id) }
+	writable := func(string) bool { return true }
+	notWritable := func(string) bool { return false }
+
+	t.Run("should not be used if the default local repository works", func(t *testing.T) {
+		assert.Equal(t, "", localRepositoryFallbackFor("linux", 1000, knownUser, "/tmp", writable))
+	})
+
+	t.Run("should be used if the user is unknown to the container", func(t *testing.T) {
+		assert.Equal(t, filepath.Join("/tmp", ".m2", "repository"), localRepositoryFallbackFor("linux", 1000, unknownUser, "/tmp", writable))
+	})
+
+	t.Run("should be used if the home directory is not writable", func(t *testing.T) {
+		assert.Equal(t, filepath.Join("/tmp", ".m2", "repository"), localRepositoryFallbackFor("linux", 1000, knownUser, "/tmp", notWritable))
+	})
+
+	t.Run("should be used if the user has no home directory", func(t *testing.T) {
+		noHome := func(id string) (*user.User, error) { return &user.User{Uid: id}, nil }
+		assert.Equal(t, filepath.Join("/tmp", ".m2", "repository"), localRepositoryFallbackFor("linux", 1000, noHome, "/tmp", writable))
+	})
+
+	t.Run("should not be used on windows", func(t *testing.T) {
+		assert.Equal(t, "", localRepositoryFallbackFor("windows", -1, unknownUser, "/tmp", notWritable))
+	})
+}
+
+func TestDirectoryWritable(t *testing.T) {
+	t.Run("should accept a directory which can be created", func(t *testing.T) {
+		assert.True(t, directoryWritable(filepath.Join(t.TempDir(), "not", "there", "yet")))
+	})
+
+	t.Run("should reject a file", func(t *testing.T) {
+		file := filepath.Join(t.TempDir(), "file")
+		require.NoError(t, os.WriteFile(file, []byte("content"), 0o644))
+		assert.False(t, directoryWritable(file))
+	})
+}
+
+func TestSettingsDefineLocalRepository(t *testing.T) {
+	const settingsWithRepository = `<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"><localRepository>/opt/m2</localRepository></settings>`
+	const settingsWithoutRepository = `<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"><servers/></settings>`
+
+	t.Run("should detect a local repository", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.AddFile("settings.xml", []byte(settingsWithRepository))
+		assert.True(t, settingsDefineLocalRepository([]string{"--settings", "settings.xml"}, &utils))
+		assert.True(t, settingsDefineLocalRepository([]string{"--global-settings", "settings.xml"}, &utils))
+	})
+
+	t.Run("should not detect anything without a local repository", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.AddFile("settings.xml", []byte(settingsWithoutRepository))
+		assert.False(t, settingsDefineLocalRepository([]string{"--settings", "settings.xml"}, &utils))
+	})
+
+	t.Run("should ignore unreadable and invalid settings", func(t *testing.T) {
+		utils := NewMockUtils(false)
+		utils.AddFile("broken.xml", []byte("no xml at all"))
+		assert.False(t, settingsDefineLocalRepository([]string{"--settings", "missing.xml"}, &utils))
+		assert.False(t, settingsDefineLocalRepository([]string{"--settings", "broken.xml"}, &utils))
+		assert.False(t, settingsDefineLocalRepository([]string{"--settings"}, &utils))
+	})
+}
+
+func TestGetParametersLocalRepository(t *testing.T) {
+	defaultFallback := localRepositoryFallback
+	defer func() { localRepositoryFallback = defaultFallback }()
+
+	t.Run("should not set the local repository if maven can use its default one", func(t *testing.T) {
+		localRepositoryFallback = func() string { return "" }
+		utils := NewMockUtils(false)
+
+		parameters, err := getParametersFromOptions(&ExecuteOptions{PomPath: "pom.xml"}, &utils)
+
+		assert.NoError(t, err)
+		assert.NotContains(t, strings.Join(parameters, " "), "-Dmaven.repo.local")
+	})
+
+	t.Run("should set the local repository if maven cannot use its default one", func(t *testing.T) {
+		localRepositoryFallback = func() string { return "/tmp/.m2/repository" }
+		utils := NewMockUtils(false)
+
+		parameters, err := getParametersFromOptions(&ExecuteOptions{PomPath: "pom.xml"}, &utils)
+
+		assert.NoError(t, err)
+		assert.Contains(t, parameters, "-Dmaven.repo.local=/tmp/.m2/repository")
+	})
+
+	t.Run("should prefer the configured m2Path", func(t *testing.T) {
+		localRepositoryFallback = func() string { return "/tmp/.m2/repository" }
+		utils := NewMockUtils(false)
+
+		parameters, err := getParametersFromOptions(&ExecuteOptions{PomPath: "pom.xml", M2Path: "my/m2"}, &utils)
+
+		assert.NoError(t, err)
+		assert.Contains(t, parameters, "-Dmaven.repo.local=my/m2")
+		assert.NotContains(t, parameters, "-Dmaven.repo.local=/tmp/.m2/repository")
+	})
+
+	t.Run("should not overrule a local repository from the settings", func(t *testing.T) {
+		localRepositoryFallback = func() string { return "/tmp/.m2/repository" }
+		utils := NewMockUtils(false)
+		workingDirectory, _ := os.Getwd()
+		utils.AddFile(filepath.Join(workingDirectory, "settings.xml"), []byte(`<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"><localRepository>/opt/m2</localRepository></settings>`))
+
+		parameters, err := getParametersFromOptions(&ExecuteOptions{PomPath: "pom.xml", ProjectSettingsFile: "settings.xml"}, &utils)
+
+		assert.NoError(t, err)
+		assert.NotContains(t, strings.Join(parameters, " "), "-Dmaven.repo.local")
 	})
 }
 


### PR DESCRIPTION
# Description

> Stacked on #5899, therefore the base branch is `v/maven-batch-coordinates`. It will retarget to `master` automatically once #5899 is merged.

Maven derives its local repository from `${user.home}/.m2/repository`, and the JVM reads the home directory from the passwd database. If the user which runs the build has no entry there, `${user.home}` resolves to `?` and maven uses a directory named `?` **relative to the current directory** as local repository.

This is not an exotic case: it happens whenever a container is started with a numeric user which the image does not know, which is how the piper GitHub action runs the step containers (`docker run --user 1000:1000 <image>`), and piper's default image for maven steps is `maven:3.8.6-jdk-8`, which knows root only:

```
$ docker run --rm --user 1000:1000 maven:3.8.6-jdk-8 <mvn help:evaluate ...>
user.home = ?
settings.localRepository = <workspace>/?/.m2/repository

$ ls -a <workspace>
.  ..  ?  pom.xml  srv  ...
```

Consequences:

* the downloaded artifacts end up in the checked out repository, in a directory named `?`,
* the local repository depends on the working directory of the process, so it is not reused reliably,
* nothing is shared with the other steps of the pipeline, and
* if the home directory is not writable at all the maven call simply fails.

## Solution

If neither `m2Path` nor a `localRepository` in the settings files is configured, piper checks once whether maven can use its default local repository - the user must be known and the home directory must be writable - and passes an explicit `-Dmaven.repo.local` below the temporary directory otherwise:

```
info  The default maven local repository cannot be used, '/tmp/.m2/repository' is used instead.
      Configure 'm2Path' in order to use a different location.
info  running command: mvn -Dmaven.repo.local=/tmp/.m2/repository --file pom.xml ...
```

Precedence is unchanged for everything which works today:

1. `m2Path` if configured,
2. a `localRepository` from the project or global settings file,
3. the maven default, as long as it is usable,
4. the fallback below the temporary directory.

The check is done once per process and is skipped on Windows.

# Checklist

- [x] Tests
- [ ] Documentation
- [ ] Inner source library needs updating

## Tests

Unit tests for the detection (known user, unknown user, home directory not writable, no home directory, Windows), for the writability probe, for the settings evaluation, and for the resulting maven parameters including the precedence rules.

New integration test `TestMavenIntegrationUnknownContainerUser` runs `artifactPrepareVersion` in `maven:3.8.6-jdk-8` started with `--user 1000:1000` and asserts that the step succeeds and that no local repository is created within the workspace. Without the change the step fails in that container with `mvn` exit code 1 or leaves a `?` directory behind, depending on whether the container runtime provides a passwd entry.
