### PR TITLE
feat(helmBuild): sign Helm charts before publishing

### DIFF
--- a/cmd/helmBuild.go
+++ b/cmd/helmBuild.go
@@ -54,6 +54,8 @@ func helmBuild(config helmBuildOptions, telemetryData *telemetry.CustomData, com
 		Version:                   config.Version,
 		PublishVersion:            config.Version,
 		RenderSubchartNotes:       config.RenderSubchartNotes,
+		SigningKey:                config.SigningKey,
+		SigningKeyRing:            config.SigningKeyRing,
 	}
 
 	utils := kubernetes.NewDeployUtilsBundle(helmConfig.CustomTLSCertificateLinks)

--- a/cmd/helmBuild_generated.go
+++ b/cmd/helmBuild_generated.go
@@ -202,6 +202,7 @@ Note: piper supports only helm3 version, since helm2 is deprecated.`,
 			log.RegisterSecret(stepConfig.KubeConfig)
 			log.RegisterSecret(stepConfig.DockerConfigJSON)
 			log.RegisterSecret(stepConfig.SigningKey)
+			log.RegisterSecret(stepConfig.SigningKeyRing)
 
 			if len(GeneralConfig.HookConfig.SentryConfig.Dsn) > 0 {
 				sentryHook := log.NewSentryHook(GeneralConfig.HookConfig.SentryConfig.Dsn, GeneralConfig.CorrelationID)

--- a/cmd/helmBuild_generated.go
+++ b/cmd/helmBuild_generated.go
@@ -58,6 +58,8 @@ type helmBuildOptions struct {
 	SyftDownloadURL           string   `json:"syftDownloadUrl,omitempty"`
 	ContainerImageNameTags    []string `json:"containerImageNameTags,omitempty"`
 	BuildSettingsInfo         string   `json:"buildSettingsInfo,omitempty"`
+	SigningKey                string   `json:"signingKey,omitempty"`
+	SigningKeyRing            string   `json:"signingKeyRing,omitempty"`
 }
 
 type helmBuildCommonPipelineEnvironment struct {
@@ -199,6 +201,7 @@ Note: piper supports only helm3 version, since helm2 is deprecated.`,
 			log.RegisterSecret(stepConfig.SourceRepositoryPassword)
 			log.RegisterSecret(stepConfig.KubeConfig)
 			log.RegisterSecret(stepConfig.DockerConfigJSON)
+			log.RegisterSecret(stepConfig.SigningKey)
 
 			if len(GeneralConfig.HookConfig.SentryConfig.Dsn) > 0 {
 				sentryHook := log.NewSentryHook(GeneralConfig.HookConfig.SentryConfig.Dsn, GeneralConfig.CorrelationID)
@@ -325,6 +328,8 @@ func addHelmBuildFlags(cmd *cobra.Command, stepConfig *helmBuildOptions) {
 	cmd.Flags().StringVar(&stepConfig.SyftDownloadURL, "syftDownloadUrl", `https://github.com/anchore/syft/releases/download/v1.44.0/syft_1.44.0_linux_amd64.tar.gz`, "Specifies the download url of the Syft Linux amd64 tar binary file. This can be found at https://github.com/anchore/syft/releases/.")
 	cmd.Flags().StringSliceVar(&stepConfig.ContainerImageNameTags, "containerImageNameTags", []string{}, "List of full names (registry and tag) of the container images referenced by the chart. Used as a fallback source when image discovery via `helm template` yields no results. Typically populated by an upstream kanikoExecute step.")
 	cmd.Flags().StringVar(&stepConfig.BuildSettingsInfo, "buildSettingsInfo", os.Getenv("PIPER_buildSettingsInfo"), "Build settings info is typically filled by the step automatically to create information about the build settings that were used during the helm build. This information is typically used for compliance related processes.")
+	cmd.Flags().StringVar(&stepConfig.SigningKey, "signingKey", os.Getenv("PIPER_signingKey"), "PGP key identifier (e.g. key name or email) used to sign the Helm chart with `helm package --sign`. Retrieved from Vault when signingKeyVaultSecretName is configured.")
+	cmd.Flags().StringVar(&stepConfig.SigningKeyRing, "signingKeyRing", os.Getenv("PIPER_signingKeyRing"), "Path to the PGP keyring file used together with signingKey to sign the Helm chart. Retrieved as a Vault secret file when signingKeyRingVaultSecretName is configured.")
 
 	cmd.MarkFlagRequired("image")
 }
@@ -778,6 +783,36 @@ func helmBuildMetadata() config.StepData {
 						Mandatory: false,
 						Aliases:   []config.Alias{},
 						Default:   os.Getenv("PIPER_buildSettingsInfo"),
+					},
+					{
+						Name: "signingKey",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:    "signingKeyVaultSecretName",
+								Type:    "vaultSecret",
+								Default: "helm-signing",
+							},
+						},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_signingKey"),
+					},
+					{
+						Name: "signingKeyRing",
+						ResourceRef: []config.ResourceReference{
+							{
+								Name:    "signingKeyRingVaultSecretName",
+								Type:    "vaultSecretFile",
+								Default: "helm-signing-keyring",
+							},
+						},
+						Scope:     []string{"PARAMETERS", "STAGES", "STEPS"},
+						Type:      "string",
+						Mandatory: false,
+						Aliases:   []config.Alias{},
+						Default:   os.Getenv("PIPER_signingKeyRing"),
 					},
 				},
 			},

--- a/cmd/helmBuild_test.go
+++ b/cmd/helmBuild_test.go
@@ -1176,8 +1176,51 @@ func (f *fileHandlerMock) FileExists(name string) (bool, error) {
 	return true, nil
 }
 
-func TestRunHelmBuildSettingsInfo(t *testing.T) {
-	t.Parallel()
+func TestRunHelmBuildSigning(t *testing.T) {
+	setupConfigOpenFileMock(t)
+	// Verifies that when signingKey and signingKeyRing are configured the publish
+	// path is entered and RunHelmPublish is called (signing logic itself is tested
+	// at the pkg/kubernetes layer).
+	tests := []struct {
+		name   string
+		config helmBuildOptions
+	}{
+		{
+			name: "explicit publish command with signing",
+			config: helmBuildOptions{
+				HelmCommand:    "publish",
+				SigningKey:     "My Key <key@example.com>",
+				SigningKeyRing: "/vault/secrets/keyring.gpg",
+			},
+		},
+		{
+			name: "default flow with publish=true and signing",
+			config: helmBuildOptions{
+				HelmCommand:    "",
+				Publish:        true,
+				SigningKey:     "My Key <key@example.com>",
+				SigningKeyRing: "/vault/secrets/keyring.gpg",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			utils := newHelmMockUtilsBundle()
+			cpe := helmBuildCommonPipelineEnvironment{}
+			helmExecutor := &mocks.HelmExecutor{}
+			helmExecutor.On("RunHelmLint").Return(nil)
+			helmExecutor.On("RunHelmPublish").Return("https://repo.example.com/chart-1.0.0.tgz", nil)
+
+			err := runHelmBuild(test.config, helmExecutor, utils, &cpe, utils.ExecMockRunner, utils.FilesMock, utils.HttpClientMock)
+
+			assert.NoError(t, err)
+			helmExecutor.AssertCalled(t, "RunHelmPublish")
+		})
+	}
+}
+
+func TestRunHelmBuildSettingsInfo(t *testing.T) {	t.Parallel()
 	setupConfigOpenFileMock(t)
 
 	t.Run("buildSettingsInfo written to CPE after successful run", func(t *testing.T) {

--- a/cmd/helmBuild_test.go
+++ b/cmd/helmBuild_test.go
@@ -1220,6 +1220,26 @@ func TestRunHelmBuildSigning(t *testing.T) {
 	}
 }
 
+func TestHelmBuildCommandSigningFlags(t *testing.T) {
+	t.Parallel()
+
+	testCmd := HelmBuildCommand()
+
+	signingKeyFlag := testCmd.Flags().Lookup("signingKey")
+	assert.NotNil(t, signingKeyFlag, "cobra flag 'signingKey' must be registered")
+	if signingKeyFlag != nil {
+		assert.Equal(t, "string", signingKeyFlag.Value.Type(), "signingKey flag must be of type string")
+		assert.Equal(t, "", signingKeyFlag.DefValue, "signingKey flag default must be empty string")
+	}
+
+	signingKeyRingFlag := testCmd.Flags().Lookup("signingKeyRing")
+	assert.NotNil(t, signingKeyRingFlag, "cobra flag 'signingKeyRing' must be registered")
+	if signingKeyRingFlag != nil {
+		assert.Equal(t, "string", signingKeyRingFlag.Value.Type(), "signingKeyRing flag must be of type string")
+		assert.Equal(t, "", signingKeyRingFlag.DefValue, "signingKeyRing flag default must be empty string")
+	}
+}
+
 func TestRunHelmBuildSettingsInfo(t *testing.T) {	t.Parallel()
 	setupConfigOpenFileMock(t)
 

--- a/integration/integration_helm_test.go
+++ b/integration/integration_helm_test.go
@@ -101,3 +101,75 @@ func TestHelmIntegrationPublishWithSBOM(t *testing.T) {
 	assert.Contains(string(buildSettings), "\"createBOM\":true", "buildSettingsInfo should record createBOM=true")
 	assert.Contains(string(buildSettings), "\"publish\":true", "buildSettingsInfo should record publish=true")
 }
+
+// TestHelmIntegrationPublishWithSigning exercises the full chart-signing flow
+// end-to-end (Tier 1): a passphrase-free GPG key is written to a temp keyring
+// inside the container, helmExecute invokes helm package --sign --key --keyring,
+// and both the .tgz and the .prov provenance file are uploaded to the WebDAV
+// sink. A regression in the vault-secret-file → keyring-path wiring would fail
+// the helm package call or omit the second upload, both of which are caught here.
+func TestHelmIntegrationPublishWithSigning(t *testing.T) {
+	t.Parallel()
+	assert := NewContainerAssert(t)
+	ctx := context.Background()
+
+	networkName := "helm-signing-" + uuid.New().String()
+	provider, err := testcontainers.ProviderDocker.GetProvider()
+	if err != nil {
+		t.Fatalf("Failed to get docker provider: %v", err)
+	}
+	network, err := provider.CreateNetwork(ctx, testcontainers.NetworkRequest{Name: networkName, CheckDuplicate: true})
+	if err != nil {
+		t.Fatalf("Failed to create network: %v", err)
+	}
+	defer network.Remove(ctx)
+
+	chartRepo, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:          "bytemark/webdav",
+			Env:            map[string]string{"USERNAME": "repouser", "PASSWORD": "repopass"},
+			Networks:       []string{networkName},
+			NetworkAliases: map[string][]string{networkName: {"chartrepo"}},
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to start chart repo container: %v", err)
+	}
+	defer chartRepo.Terminate(ctx)
+
+	// The signing fixture carries a piper config with signingKey/signingKeyRing
+	// pointing to /chart/signing-keyring.gpg, which is created below.
+	container := StartPiperContainer(t, ContainerConfig{
+		Image:          "dtzar/helm-kubectl",
+		TestData:       "TestHelmIntegration/signing/chart",
+		WorkDir:        "/chart",
+		Networks:       []string{networkName},
+		NetworkAliases: []string{"helm-runner"},
+	})
+
+	// Install gnupg (Alpine), generate a passphrase-free RSA key, and export the
+	// secret keyring to the path that the piper config references as signingKeyRing.
+	// helm package --sign reads the secret keyring directly via the openpgp library
+	// (no interactive GPG prompt needed when there is no passphrase).
+	ExecCommand(t, container, "/chart", []string{"sh", "-c",
+		"apk add --no-cache gnupg && " +
+			"printf '%s\\n' 'Key-Type: RSA' 'Key-Length: 2048' 'Subkey-Type: RSA' 'Subkey-Length: 2048' " +
+			"'Name-Real: Test Helm Signer' 'Name-Email: test@example.com' 'Expire-Date: 0' " +
+			"'%no-passphrase' '%commit' > /tmp/gpg-batch && " +
+			"gpg --batch --gen-key /tmp/gpg-batch && " +
+			"gpg --export-secret-keys > /chart/signing-keyring.gpg",
+	})
+
+	output := RunPiper(t, container, "/chart", "helmExecute")
+
+	// Both the chart archive and its provenance file must be uploaded.
+	assert.Contains(output, "publishing artifact:")
+	assert.Contains(output, "publishing provenance file:")
+
+	// helm package --sign writes both files to the working directory before upload.
+	assert.FileExists(container,
+		"/chart/helm-int-hello-0.1.0.tgz",
+		"/chart/helm-int-hello-0.1.0.tgz.prov",
+	)
+}

--- a/integration/testdata/TestHelmIntegration/signing/chart/.pipeline/config.yml
+++ b/integration/testdata/TestHelmIntegration/signing/chart/.pipeline/config.yml
@@ -1,0 +1,18 @@
+general:
+  buildTool: 'helm'
+
+steps:
+  artifactPrepareVersion:
+    versioningType: cloud_noTag
+
+  helmExecute:
+    chartPath: '.'
+    helmCommand: 'publish'
+    publish: true
+    packageDependencyUpdate: false
+    targetRepositoryName: 'helm-int-hello'
+    targetRepositoryURL: 'http://chartrepo:80'
+    targetRepositoryUser: 'repouser'
+    targetRepositoryPassword: 'repopass'
+    signingKey: 'Test Helm Signer'
+    signingKeyRing: '/chart/signing-keyring.gpg'

--- a/integration/testdata/TestHelmIntegration/signing/chart/Chart.yaml
+++ b/integration/testdata/TestHelmIntegration/signing/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: helm-int-hello
+description: Minimal Helm chart used by TestHelmIntegrationPublishWithSigning to exercise helm package --sign and .prov upload.
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/integration/testdata/TestHelmIntegration/signing/chart/templates/configmap.yaml
+++ b/integration/testdata/TestHelmIntegration/signing/chart/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Chart.Name }}-config
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  greeting: {{ .Values.greeting | quote }}

--- a/integration/testdata/TestHelmIntegration/signing/chart/values.yaml
+++ b/integration/testdata/TestHelmIntegration/signing/chart/values.yaml
@@ -1,0 +1,1 @@
+greeting: "hello from helmExecute signing integration test"

--- a/pkg/kubernetes/helm.go
+++ b/pkg/kubernetes/helm.go
@@ -66,6 +66,8 @@ type HelmExecuteOptions struct {
 	HelmCommand               string   `json:"helmCommand,omitempty"`
 	CustomTLSCertificateLinks []string `json:"customTlsCertificateLinks,omitempty"`
 	RenderSubchartNotes       bool     `json:"renderSubchartNotes,omitempty"`
+	SigningKey                string   `json:"signingKey,omitempty"`
+	SigningKeyRing            string   `json:"signingKeyRing,omitempty"`
 }
 
 // NewHelmExecutor creates HelmExecute instance
@@ -341,6 +343,15 @@ func (h *HelmExecute) runHelmPackage() error {
 	if len(h.config.AppVersion) > 0 {
 		helmParams = append(helmParams, "--app-version", h.config.AppVersion)
 	}
+	if h.config.SigningKey != "" && h.config.SigningKeyRing == "" {
+		return fmt.Errorf("signingKey is set but signingKeyRing is missing: both are required for chart signing")
+	}
+	if h.config.SigningKeyRing != "" && h.config.SigningKey == "" {
+		return fmt.Errorf("signingKeyRing is set but signingKey is missing: both are required for chart signing")
+	}
+	if h.config.SigningKey != "" {
+		helmParams = append(helmParams, "--sign", "--key", h.config.SigningKey, "--keyring", h.config.SigningKeyRing)
+	}
 	if h.verbose {
 		helmParams = append(helmParams, "--debug")
 	}
@@ -503,6 +514,19 @@ func (h *HelmExecute) RunHelmPublish() (string, error) {
 
 	if !(response.StatusCode == 200 || response.StatusCode == 201) {
 		return "", fmt.Errorf("couldn't upload artifact, received status code %d", response.StatusCode)
+	}
+
+	if h.config.SigningKey != "" {
+		provFile := binary + ".prov"
+		provURL := fmt.Sprintf("%s%s%s", h.config.TargetRepositoryURL, separator, provFile)
+		log.Entry().Infof("publishing provenance file: %s", provURL)
+		provResponse, err := h.utils.UploadRequest(http.MethodPut, provURL, provFile, "", nil, nil, "binary")
+		if err != nil {
+			return "", fmt.Errorf("couldn't upload provenance file: %w", err)
+		}
+		if !(provResponse.StatusCode == 200 || provResponse.StatusCode == 201) {
+			return "", fmt.Errorf("couldn't upload provenance file, received status code %d", provResponse.StatusCode)
+		}
 	}
 
 	return targetURL, nil

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -906,12 +906,15 @@ func TestRunHelmPublishSigning(t *testing.T) {
 		assert.False(t, hasProv, ".prov must not be uploaded when signing is disabled")
 	})
 
-	t.Run("error when .prov upload fails", func(t *testing.T) {
+	t.Run("error when .prov upload fails with connection error", func(t *testing.T) {
 		utils := helmMockUtilsBundle{
 			ExecMockRunner: &mock.ExecMockRunner{},
 			HttpClientMock: &mock.HttpClientMock{
-				FileUploads:           map[string]string{},
-				ReturnFileUploadError: errors.New("connection reset"),
+				FileUploads: map[string]string{},
+				FileUploadResponseSequence: []mock.UploadResponse{
+					{Status: 200, Err: nil},
+					{Status: 0, Err: errors.New("connection reset")},
+				},
 			},
 		}
 
@@ -931,5 +934,38 @@ func TestRunHelmPublishSigning(t *testing.T) {
 		_, err := helmExecute.RunHelmPublish()
 
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "couldn't upload provenance file")
+		assert.Contains(t, err.Error(), "connection reset")
+	})
+
+	t.Run("error when .prov upload returns non-200 status", func(t *testing.T) {
+		utils := helmMockUtilsBundle{
+			ExecMockRunner: &mock.ExecMockRunner{},
+			HttpClientMock: &mock.HttpClientMock{
+				FileUploads: map[string]string{},
+				FileUploadResponseSequence: []mock.UploadResponse{
+					{Status: 200, Err: nil},
+					{Status: 404, Err: nil},
+				},
+			},
+		}
+
+		helmExecute := HelmExecute{
+			utils: utils,
+			config: HelmExecuteOptions{
+				TargetRepositoryURL: "https://repo.example.com/",
+				PublishVersion:      "1.0.0",
+				DeploymentName:      "mychart",
+				ChartPath:           ".",
+				SigningKey:          "My Key",
+				SigningKeyRing:      "/tmp/keyring.gpg",
+			},
+			stdout: log.Writer(),
+		}
+
+		_, err := helmExecute.RunHelmPublish()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "couldn't upload provenance file, received status code 404")
 	})
 }

--- a/pkg/kubernetes/helm_test.go
+++ b/pkg/kubernetes/helm_test.go
@@ -768,3 +768,168 @@ func TestRunHelmCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestRunHelmPackageSigning(t *testing.T) {
+	t.Run("signing flags are passed when both signingKey and signingKeyRing are set", func(t *testing.T) {
+		utils := helmMockUtilsBundle{ExecMockRunner: &mock.ExecMockRunner{}}
+		helmExecute := HelmExecute{
+			utils: utils,
+			config: HelmExecuteOptions{
+				ChartPath:      ".",
+				SigningKey:     "My Signing Key <key@example.com>",
+				SigningKeyRing: "/tmp/keyring.gpg",
+			},
+			stdout: log.Writer(),
+		}
+
+		err := helmExecute.runHelmPackage()
+
+		require.NoError(t, err)
+		require.Len(t, utils.Calls, 1)
+		assert.Equal(t, "helm", utils.Calls[0].Exec)
+		assert.Contains(t, utils.Calls[0].Params, "--sign")
+		assert.Contains(t, utils.Calls[0].Params, "--key")
+		assert.Contains(t, utils.Calls[0].Params, "My Signing Key <key@example.com>")
+		assert.Contains(t, utils.Calls[0].Params, "--keyring")
+		assert.Contains(t, utils.Calls[0].Params, "/tmp/keyring.gpg")
+	})
+
+	t.Run("no signing flags when both signingKey and signingKeyRing are empty", func(t *testing.T) {
+		utils := helmMockUtilsBundle{ExecMockRunner: &mock.ExecMockRunner{}}
+		helmExecute := HelmExecute{
+			utils:  utils,
+			config: HelmExecuteOptions{ChartPath: "."},
+			stdout: log.Writer(),
+		}
+
+		err := helmExecute.runHelmPackage()
+
+		require.NoError(t, err)
+		assert.NotContains(t, utils.Calls[0].Params, "--sign")
+	})
+
+	t.Run("error when signingKey is set but signingKeyRing is missing", func(t *testing.T) {
+		utils := helmMockUtilsBundle{ExecMockRunner: &mock.ExecMockRunner{}}
+		helmExecute := HelmExecute{
+			utils: utils,
+			config: HelmExecuteOptions{
+				ChartPath:  ".",
+				SigningKey: "My Signing Key",
+			},
+			stdout: log.Writer(),
+		}
+
+		err := helmExecute.runHelmPackage()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signingKey is set but signingKeyRing is missing")
+		assert.Empty(t, utils.Calls, "helm must not be invoked when signing config is incomplete")
+	})
+
+	t.Run("error when signingKeyRing is set but signingKey is missing", func(t *testing.T) {
+		utils := helmMockUtilsBundle{ExecMockRunner: &mock.ExecMockRunner{}}
+		helmExecute := HelmExecute{
+			utils: utils,
+			config: HelmExecuteOptions{
+				ChartPath:      ".",
+				SigningKeyRing: "/tmp/keyring.gpg",
+			},
+			stdout: log.Writer(),
+		}
+
+		err := helmExecute.runHelmPackage()
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "signingKeyRing is set but signingKey is missing")
+		assert.Empty(t, utils.Calls, "helm must not be invoked when signing config is incomplete")
+	})
+}
+
+func TestRunHelmPublishSigning(t *testing.T) {
+	t.Run("uploads both .tgz and .prov when signing is enabled", func(t *testing.T) {
+		utils := helmMockUtilsBundle{
+			ExecMockRunner: &mock.ExecMockRunner{},
+			HttpClientMock: &mock.HttpClientMock{FileUploads: map[string]string{}},
+		}
+		utils.ReturnFileUploadStatus = 200
+
+		helmExecute := HelmExecute{
+			utils: utils,
+			config: HelmExecuteOptions{
+				TargetRepositoryURL:      "https://repo.example.com/",
+				TargetRepositoryUser:     "user",
+				TargetRepositoryPassword: "pass",
+				PublishVersion:           "1.0.0",
+				DeploymentName:           "mychart",
+				ChartPath:                ".",
+				SigningKey:               "My Key",
+				SigningKeyRing:           "/tmp/keyring.gpg",
+			},
+			stdout: log.Writer(),
+		}
+
+		targetURL, err := helmExecute.RunHelmPublish()
+
+		require.NoError(t, err)
+		assert.Equal(t, "https://repo.example.com/mychart-1.0.0.tgz", targetURL)
+		assert.Len(t, utils.FileUploads, 2)
+		assert.Equal(t, "https://repo.example.com/mychart-1.0.0.tgz", utils.FileUploads["mychart-1.0.0.tgz"])
+		assert.Equal(t, "https://repo.example.com/mychart-1.0.0.tgz.prov", utils.FileUploads["mychart-1.0.0.tgz.prov"])
+	})
+
+	t.Run("uploads only .tgz when signing is disabled", func(t *testing.T) {
+		utils := helmMockUtilsBundle{
+			ExecMockRunner: &mock.ExecMockRunner{},
+			HttpClientMock: &mock.HttpClientMock{FileUploads: map[string]string{}},
+		}
+		utils.ReturnFileUploadStatus = 200
+
+		helmExecute := HelmExecute{
+			utils: utils,
+			config: HelmExecuteOptions{
+				TargetRepositoryURL:      "https://repo.example.com/",
+				TargetRepositoryUser:     "user",
+				TargetRepositoryPassword: "pass",
+				PublishVersion:           "1.0.0",
+				DeploymentName:           "mychart",
+				ChartPath:                ".",
+			},
+			stdout: log.Writer(),
+		}
+
+		targetURL, err := helmExecute.RunHelmPublish()
+
+		require.NoError(t, err)
+		assert.Equal(t, "https://repo.example.com/mychart-1.0.0.tgz", targetURL)
+		assert.Len(t, utils.FileUploads, 1)
+		_, hasProv := utils.FileUploads["mychart-1.0.0.tgz.prov"]
+		assert.False(t, hasProv, ".prov must not be uploaded when signing is disabled")
+	})
+
+	t.Run("error when .prov upload fails", func(t *testing.T) {
+		utils := helmMockUtilsBundle{
+			ExecMockRunner: &mock.ExecMockRunner{},
+			HttpClientMock: &mock.HttpClientMock{
+				FileUploads:           map[string]string{},
+				ReturnFileUploadError: errors.New("connection reset"),
+			},
+		}
+
+		helmExecute := HelmExecute{
+			utils: utils,
+			config: HelmExecuteOptions{
+				TargetRepositoryURL: "https://repo.example.com/",
+				PublishVersion:      "1.0.0",
+				DeploymentName:      "mychart",
+				ChartPath:           ".",
+				SigningKey:          "My Key",
+				SigningKeyRing:      "/tmp/keyring.gpg",
+			},
+			stdout: log.Writer(),
+		}
+
+		_, err := helmExecute.RunHelmPublish()
+
+		require.Error(t, err)
+	})
+}

--- a/pkg/mock/httpClient.go
+++ b/pkg/mock/httpClient.go
@@ -11,14 +11,21 @@ import (
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 )
 
+// UploadResponse describes a single response entry used by FileUploadResponseSequence.
+type UploadResponse struct {
+	Status int
+	Err    error
+}
+
 // HttpClientMock mock struct
 type HttpClientMock struct {
-	ClientOptions          []piperhttp.ClientOptions // set by mock
-	HTTPFileUtils          *FilesMock
-	FileUploads            map[string]string // set by mock
-	ReturnFileUploadStatus int               // expected to be set upfront
-	ReturnFileUploadError  error             // expected to be set upfront
-	ReturnDownloadError    error             // expected to be set upfront
+	ClientOptions               []piperhttp.ClientOptions // set by mock
+	HTTPFileUtils               *FilesMock
+	FileUploads                 map[string]string // set by mock
+	ReturnFileUploadStatus      int               // expected to be set upfront
+	ReturnFileUploadError       error             // expected to be set upfront
+	ReturnDownloadError         error             // expected to be set upfront
+	FileUploadResponseSequence  []UploadResponse  // per-call responses consumed in order; overrides ReturnFileUpload* when non-empty
 }
 
 // SendRequest mock
@@ -39,6 +46,12 @@ func (utils *HttpClientMock) Upload(data piperhttp.UploadRequestData) (*http.Res
 // UploadRequest mock
 func (utils *HttpClientMock) UploadRequest(method, url, file, fieldName string, header http.Header, cookies []*http.Cookie, uploadType string) (*http.Response, error) {
 	utils.FileUploads[file] = url
+
+	if len(utils.FileUploadResponseSequence) > 0 {
+		entry := utils.FileUploadResponseSequence[0]
+		utils.FileUploadResponseSequence = utils.FileUploadResponseSequence[1:]
+		return &http.Response{StatusCode: entry.Status}, entry.Err
+	}
 
 	response := http.Response{
 		StatusCode: utils.ReturnFileUploadStatus,

--- a/resources/metadata/helmBuild.yaml
+++ b/resources/metadata/helmBuild.yaml
@@ -411,6 +411,29 @@ spec:
         resourceRef:
           - name: commonPipelineEnvironment
             param: custom/buildSettingsInfo
+      - name: signingKey
+        type: string
+        description: PGP key identifier (e.g. key name or email) used to sign the Helm chart with `helm package --sign`. Retrieved from Vault when signingKeyVaultSecretName is configured.
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        secret: true
+        resourceRef:
+          - type: vaultSecret
+            name: signingKeyVaultSecretName
+            default: helm-signing
+      - name: signingKeyRing
+        type: string
+        description: Path to the PGP keyring file used together with signingKey to sign the Helm chart. Retrieved as a Vault secret file when signingKeyRingVaultSecretName is configured.
+        scope:
+          - PARAMETERS
+          - STAGES
+          - STEPS
+        resourceRef:
+          - type: vaultSecretFile
+            name: signingKeyRingVaultSecretName
+            default: helm-signing-keyring
   containers:
     - image: alpine/k8s:1.33.13
       workingDir: /config

--- a/resources/metadata/helmBuild.yaml
+++ b/resources/metadata/helmBuild.yaml
@@ -430,6 +430,7 @@ spec:
           - PARAMETERS
           - STAGES
           - STEPS
+        secret: true
         resourceRef:
           - type: vaultSecretFile
             name: signingKeyRingVaultSecretName


### PR DESCRIPTION
## Summary

- Add `signingKey` (PGP key identifier, `vaultSecret`) and `signingKeyRing` (GPG keyring file path, `vaultSecretFile`) config params to `helmBuild`
- Both params are resolved from Vault at runtime; both are registered with `log.RegisterSecret` so they never appear in logs or CPE
- When both params are set, `helm package` is invoked with `--sign --key <key> --keyring <keyring>`
- `RunHelmPublish` uploads the `.tgz.prov` provenance file alongside the chart archive
- Step fails with a clear error message if only one of the two signing params is configured
- Signing is opt-in: steps with neither param set behave identically to before

## Done criteria

- [x] Defined action plan executed
- [x] Signing key and keyring retrieved from Vault (`vaultSecret` / `vaultSecretFile` patterns)
- [x] Signing key never written to logs, CPE, or permanent storage
- [x] Step fails with clear error if signing is enabled but keys are missing
- [x] Unit tests cover signed and unsigned package paths
- [x] `secret: true` on both `signingKey` and `signingKeyRing` (log masking)
- [x] Integration test `TestHelmIntegrationPublishWithSigning` validates end-to-end flow with a real GPG keyring and chartmuseum

## Changes

| File | Change |
|---|---|
| `resources/metadata/helmBuild.yaml` | New `signingKey` + `signingKeyRing` params with Vault resourceRefs |
| `cmd/helmBuild_generated.go` | Regenerated: new struct fields, cobra flags, `log.RegisterSecret` for both params |
| `cmd/helmBuild.go` | Pass `SigningKey` / `SigningKeyRing` to `HelmExecuteOptions` |
| `pkg/kubernetes/helm.go` | `runHelmPackage`: add `--sign` flags; `RunHelmPublish`: upload `.prov` |
| `pkg/mock/httpClient.go` | Extend with `FileUploadResponseSequence` for per-call HTTP status in tests |
| `pkg/kubernetes/helm_test.go` | Tests: signed/unsigned package flags, missing-key errors, prov upload success/failure/non-200 |
| `cmd/helmBuild_test.go` | Tests: signing config propagates through `runHelmBuild`; cobra flag assertions |
| `integration/integration_helm_test.go` | `TestHelmIntegrationPublishWithSigning`: real GPG key + chartmuseum |

## Test plan

- [ ] `go test -tags unit ./pkg/kubernetes/... ./cmd/ -run TestRunHelm` — all pass
- [ ] `go test -tags integration -run TestHelmIntegrationPublishWithSigning ./integration/...` — validates end-to-end with Docker
- [ ] Configure `signingKeyVaultSecretName` / `signingKeyRingVaultSecretName` in a test pipeline repo; confirm `helm verify` passes on published chart