### PR TITLE
fix(deps): migrate mitchellh/mapstructure to go-viper/mapstructure/v2

### DIFF
--- a/cmd/cnbBuild.go
+++ b/cmd/cnbBuild.go
@@ -24,7 +24,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 
 	"dario.cat/mergo"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	ignore "github.com/sabhiram/go-gitignore"
 )
 

--- a/cmd/kanikoExecute.go
+++ b/cmd/kanikoExecute.go
@@ -19,7 +19,7 @@ import (
 	"github.com/SAP/jenkins-library/pkg/telemetry"
 	"github.com/SAP/jenkins-library/pkg/versioning"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 func kanikoExecute(config kanikoExecuteOptions, telemetryData *telemetry.CustomData, commonPipelineEnvironment *kanikoExecuteCommonPipelineEnvironment) {

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.30.3
+	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/go-github/v68 v68.0.0
@@ -42,7 +43,6 @@ require (
 	github.com/jarcoal/httpmock v1.0.8
 	github.com/magiconair/properties v1.8.10
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/buildkit v0.32.2
 	github.com/moby/moby/api v1.55.0
 	github.com/motemen/go-nuts v0.0.0-20251105153347-936c09797748
@@ -161,7 +161,6 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.26.1 // indirect
 	github.com/go-openapi/validate v0.26.0 // indirect
 	github.com/go-test/deep v1.1.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
@@ -194,6 +193,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.1 // indirect

--- a/pkg/piperutils/slices.go
+++ b/pkg/piperutils/slices.go
@@ -92,7 +92,7 @@ func UniqueStrings(values []string) []string {
 }
 
 // CopyAtoB copies the contents of a into slice b given that they are of equal size and compatible type
-func CopyAtoB(a, b interface{}) {
+func CopyAtoB(a, b any) {
 	src := reflect.ValueOf(a)
 	tgt := reflect.ValueOf(b)
 	if src.Kind() != reflect.Slice || tgt.Kind() != reflect.Slice {

--- a/pkg/piperutils/templateUtils.go
+++ b/pkg/piperutils/templateUtils.go
@@ -7,12 +7,12 @@ import (
 )
 
 // ExecuteTemplate parses the provided template, substitutes values and returns the output
-func ExecuteTemplate(txtTemplate string, context interface{}) (string, error) {
+func ExecuteTemplate(txtTemplate string, context any) (string, error) {
 	return ExecuteTemplateFunctions(txtTemplate, nil, context)
 }
 
 // ExecuteTemplateFunctions parses the provided template, applies the transformation functions, substitutes values and returns the output
-func ExecuteTemplateFunctions(txtTemplate string, functionMap template.FuncMap, context interface{}) (string, error) {
+func ExecuteTemplateFunctions(txtTemplate string, functionMap template.FuncMap, context any) (string, error) {
 	template := template.New("tmp")
 	if functionMap != nil {
 		template = template.Funcs(functionMap)


### PR DESCRIPTION
## Changes

Migrates the archived `github.com/mitchellh/mapstructure` v1.5.0 (2022, [archived](https://github.com/mitchellh/mapstructure)) to its maintained successor `github.com/go-viper/mapstructure/v2` v2.5.0, which was already present in the dependency tree.

Only `mapstructure.Decode()` is used (`cmd/cnbBuild.go`, `cmd/kanikoExecute.go`) — API-compatible, pure import-path change. mitchellh/mapstructure remains as an indirect dependency via hashicorp/vault.

Also replaces the remaining `interface{}` occurrences with `any` in `pkg/piperutils`.

## Verification

- `go build ./...` ✅
- `go vet ./cmd/... ./pkg/...` ✅
- `go test ./cmd/... ./pkg/...` ✅ (all pass)