### PR TITLE
fix(deps): replace pasztorpisti/qs with google/go-querystring

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/go-github/v68 v68.0.0
+	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/vault/api v1.20.0
 	github.com/hashicorp/vault/api/auth/approle v0.8.0
@@ -47,7 +48,6 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/motemen/go-nuts v0.0.0-20251105153347-936c09797748
 	github.com/package-url/packageurl-go v0.1.6
-	github.com/pasztorpisti/qs v0.0.0-20171216220353-8d6c33ee906c
 	github.com/piper-validation/fortify-client-go v0.0.0-20220126145513-7b3e9a72af01
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sirupsen/logrus v1.9.4
@@ -167,7 +167,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -667,8 +667,6 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/package-url/packageurl-go v0.1.6 h1:YO3p6u1XmCUliivUg/qWphaY8vI6hxSnnPv7Bfg3m5M=
 github.com/package-url/packageurl-go v0.1.6/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
-github.com/pasztorpisti/qs v0.0.0-20171216220353-8d6c33ee906c h1:Gcce/r5tSQeprxswXXOwQ/RBU1bjQWVd9dB7QKoPXBE=
-github.com/pasztorpisti/qs v0.0.0-20171216220353-8d6c33ee906c/go.mod h1:1iCZ0433JJMecYqCa+TdWA9Pax8MGl4ByuNDZ7eSnQY=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/pkg/apim/APIMUtility.go
+++ b/pkg/apim/APIMUtility.go
@@ -9,7 +9,7 @@ import (
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/xsuaa"
 
-	"github.com/pasztorpisti/qs"
+	"github.com/google/go-querystring/query"
 )
 
 // Utils for apim
@@ -25,9 +25,13 @@ type OdataUtils interface {
 
 // OdataParameters struct
 type OdataParameters struct {
-	Filter, Search          string
-	Top, Skip               int
-	Orderby, Select, Expand string
+	Filter  string `url:"filter,omitempty"`
+	Search  string `url:"search,omitempty"`
+	Top     int    `url:"top,omitempty"`
+	Skip    int    `url:"skip,omitempty"`
+	Orderby string `url:"orderby,omitempty"`
+	Select  string `url:"select,omitempty"`
+	Expand  string `url:"expand,omitempty"`
 }
 
 // Bundle struct
@@ -68,12 +72,13 @@ func (apim *Bundle) IsPayloadJSON() bool {
 
 func (odataFilters *OdataParameters) MakeOdataQuery() (string, error) {
 
-	customMarshaler := qs.NewMarshaler(&qs.MarshalOptions{
-		DefaultMarshalPresence: qs.OmitEmpty,
-	})
-	values, encodeErr := customMarshaler.Marshal(odataFilters)
-	if encodeErr == nil && len(values) > 0 {
-		values = "?" + strings.ReplaceAll(values, "&", "&$")
+	values, encodeErr := query.Values(odataFilters)
+	if encodeErr != nil {
+		return "", encodeErr
 	}
-	return values, encodeErr
+	encoded := values.Encode()
+	if len(encoded) > 0 {
+		encoded = "?" + strings.ReplaceAll(encoded, "&", "&$")
+	}
+	return encoded, nil
 }


### PR DESCRIPTION
## Changes

Removes `github.com/pasztorpisti/qs` (unmaintained since 2017). Its only use was `OdataParameters.MakeOdataQuery` in `pkg/apim`; the same query string is now produced with `google/go-querystring`, which is already a dependency.

The output is byte-identical (verified by the existing unit test): lowercased parameter names (now explicit via `url` struct tags), alphabetical ordering, `+`-encoded spaces, empty values omitted, and the existing `?`/`&$` OData prefixing untouched.

## Verification

- `go build ./...` ✅
- `go vet ./pkg/apim/... ./cmd/...` ✅
- `go test -tags unit ./pkg/apim/... ./cmd/...` ✅