### PR TITLE
feat(npmExecuteScripts): add telesiactl-first SBOM generation

### DIFF
--- a/pkg/npm/bom.go
+++ b/pkg/npm/bom.go
@@ -8,6 +8,7 @@ import (
 
 	piperhttp "github.com/SAP/jenkins-library/pkg/http"
 	"github.com/SAP/jenkins-library/pkg/log"
+	"github.com/SAP/jenkins-library/pkg/telesiactl"
 )
 
 const (
@@ -37,6 +38,18 @@ var cycloneDxCliUrl = map[struct{ os, arch string }]string{
 // CreateBOM generates a CycloneDX Bill of Materials (BOM) file for the given package.json files.
 // It supports both pnpm and other package managers (npm/yarn) with different BOM generation strategies.
 func (exec *Execute) CreateBOM(packageJSONFiles []string) error {
+	telesiactlBinary, canRunTelesiactl, err := telesiactl.ResolveBinary(exec.Utils)
+	if err != nil {
+		log.Entry().Warnf("telesiactl availability check failed, falling back to legacy implementation: %v", err)
+	}
+	if canRunTelesiactl {
+		if err := exec.createBOMWithTelesiactl(telesiactlBinary, packageJSONFiles); err == nil {
+			return nil
+		} else {
+			log.Entry().Warnf("telesiactl BOM creation failed, falling back to legacy implementation: %v", err)
+		}
+	}
+
 	log.Entry().Debug("Detecting package manager...")
 	pm, err := exec.detectPackageManager()
 	if err != nil {
@@ -51,6 +64,20 @@ func (exec *Execute) CreateBOM(packageJSONFiles []string) error {
 	}
 
 	return exec.createNpmBOM(packageJSONFiles)
+}
+
+func (exec *Execute) createBOMWithTelesiactl(telesiactlBinary string, packageJSONFiles []string) error {
+	execRunner := exec.Utils.GetExecRunner()
+	for _, packageJSONFile := range packageJSONFiles {
+		projectPath := filepath.Dir(packageJSONFile)
+		args := []string{"sbom", "generate", "--tech", "npm", "--project-path", projectPath, "--output", npmBomFilename, "--schema-version", CycloneDxSchemaVersion}
+
+		if err := execRunner.RunExecutable(telesiactlBinary, args...); err != nil {
+			return fmt.Errorf("telesiactl BOM creation failed for package %s: %w", packageJSONFile, err)
+		}
+	}
+
+	return nil
 }
 
 // createPnpmBOM generates a BOM for pnpm projects using cdxgen and cyclonedx-cli

--- a/pkg/npm/bom_test.go
+++ b/pkg/npm/bom_test.go
@@ -11,11 +11,28 @@ import (
 	"testing"
 
 	"github.com/SAP/jenkins-library/pkg/mock"
-
+	"github.com/SAP/jenkins-library/pkg/telesiactl"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBom(t *testing.T) {
+	t.Run("Create BOM with telesiactl", func(t *testing.T) {
+		utils := newNpmMockUtilsBundle()
+		utils.AddFile("package.json", []byte("{}"))
+		utils.AddFile(filepath.Join("src", "package.json"), []byte("{}"))
+		utils.AddFile(telesiactl.BinaryCandidates()[0], []byte("binary"))
+
+		exec := &Execute{Utils: &utils, Options: ExecutorOptions{}}
+		err := exec.CreateBOM([]string{"package.json", filepath.Join("src", "package.json")})
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, []mock.ExecCall{
+				{Exec: telesiactl.BinaryCandidates()[0], Params: []string{"sbom", "generate", "--tech", "npm", "--project-path", ".", "--output", npmBomFilename, "--schema-version", CycloneDxSchemaVersion}},
+				{Exec: telesiactl.BinaryCandidates()[0], Params: []string{"sbom", "generate", "--tech", "npm", "--project-path", "src", "--output", npmBomFilename, "--schema-version", CycloneDxSchemaVersion}},
+			}, utils.execRunner.Calls)
+		}
+	})
+
 	t.Run("Create BOM with cyclonedx-npm", func(t *testing.T) {
 		utils := newNpmMockUtilsBundle()
 		utils.AddFile("package.json", []byte("{\"scripts\": { \"ci-lint\": \"exit 0\" } }"))

--- a/pkg/telesiactl/telesiactl.go
+++ b/pkg/telesiactl/telesiactl.go
@@ -1,0 +1,36 @@
+package telesiactl
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+)
+
+const workspaceBaseDir = ".pipeline/tools/telesiactl"
+
+// FileChecker provides access to workspace binary paths.
+type FileChecker interface {
+	FileExists(filename string) (bool, error)
+}
+
+// ResolveBinary returns the first available telesiactl workspace binary.
+func ResolveBinary(files FileChecker) (string, bool, error) {
+	for _, binary := range BinaryCandidates() {
+		exists, err := files.FileExists(binary)
+		if err != nil {
+			return "", false, fmt.Errorf("failed to check telesiactl binary '%s': %w", binary, err)
+		}
+		if exists {
+			return binary, true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+// BinaryCandidates returns the platform-specific binary path.
+func BinaryCandidates() []string {
+	platformPath := filepath.Join(workspaceBaseDir, runtime.GOOS+"-"+runtime.GOARCH, "telesiactl")
+
+	return []string{platformPath}
+}


### PR DESCRIPTION
# Description
Add telesiactl as the preferred SBOM generator for `npmExecuteScripts`.

Telesiactl integration design: [Piper Integration Notes](https://github.tools.sap/telesia/telesiactl/blob/main/docs/design/piper-integration/README.md)

## Changes

- Add shared telesiactl workspace lookup:
  - `.pipeline/tools/telesiactl/<goos>-<goarch>/telesiactl`
- Run telesiactl before the legacy SBOM implementation.
- Generate one SBOM per discovered `package.json`.
- Call telesiactl with `--tech npm`.
- Fall back to the existing package-manager-specific implementation when telesiactl is unavailable or fails:
  - npm/Yarn: `cyclonedx-npm`
  - pnpm: `cdxgen` and `cyclonedx-cli`
- Keep the existing `bom-npm.xml` output and `sbom` result type.

## Tests

Updated unit tests cover:

- telesiactl preferred path
- one telesiactl invocation per `package.json`
- legacy npm/Yarn CycloneDX behavior
- legacy pnpm BOM behavior
- legacy failure handling

# Checklist

- [ ] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
