### PR TITLE
feat(syft): add ScanImageTo for per-image stateless SBOM generation with explicit output file

### DIFF
--- a/pkg/syft/syft.go
+++ b/pkg/syft/syft.go
@@ -82,6 +82,31 @@ func (s *SyftScanner) ScanImages(dockerConfigDir string, execRunner command.Exec
 	return nil
 }
 
+// ScanImageTo scans a single image and writes the SBOM to the given output file.
+// Extra arguments (e.g. "--platform=linux/arm64") are forwarded directly to syft so
+// the scanner instance is not mutated and can be safely reused across multiple calls.
+func (s *SyftScanner) ScanImageTo(dockerConfigDir string, execRunner command.ExecRunner, registryURL, image, outputFile string, extraArgs ...string) error {
+	if registryURL == "" {
+		return errors.New("syft: registry url must not be empty")
+	}
+	if image == "" {
+		return errors.New("syft: image name must not be empty")
+	}
+	execRunner.AppendEnv([]string{fmt.Sprintf("DOCKER_CONFIG=%s", dockerConfigDir)})
+	args := []string{
+		"scan",
+		fmt.Sprintf("registry:%s/%s", strings.TrimPrefix(registryURL, "https://"), image),
+		"-o", fmt.Sprintf("cyclonedx-xml%s=%s", cyclonedxFormatForSyft, outputFile),
+		"-q",
+		"--exclude=**/{distlib,distlib-*}/**/*.exe",
+	}
+	args = append(args, extraArgs...)
+	if err := execRunner.RunExecutable(s.syftFile, args...); err != nil {
+		return fmt.Errorf("failed to generate SBOM: %w", err)
+	}
+	return nil
+}
+
 func install(syftDownloadURL, dest string, fileUtils piperutils.FileUtils, httpClient piperhttp.Sender) error {
 	response, err := httpClient.SendRequest(http.MethodGet, syftDownloadURL, nil, nil, nil)
 	if err != nil {

--- a/pkg/syft/syft_test.go
+++ b/pkg/syft/syft_test.go
@@ -92,3 +92,85 @@ func TestGenerateSBOM(t *testing.T) {
 		assert.Equal(t, "failed to install syft: failed to download syft binary: HTTP GET request to http://failure.com/syft.tar.gz failed: Get \"http://failure.com/syft.tar.gz\": network error", err.Error())
 	})
 }
+
+func TestScanImageTo(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	fileMock := mock.FilesMock{}
+	fakeArchive, err := fileMock.CreateArchive(map[string][]byte{"syft": []byte("test")})
+	assert.NoError(t, err)
+
+	httpmock.RegisterResponder(http.MethodGet, "http://test-syft-gh-release.com/syft.tar.gz",
+		httpmock.NewBytesResponder(http.StatusOK, fakeArchive))
+	client := &piperhttp.Client{}
+	client.SetOptions(piperhttp.ClientOptions{MaxRetries: -1, UseDefaultTransport: true})
+
+	t.Run("writes SBOM to explicit output file with --platform arg", func(t *testing.T) {
+		execMock := mock.ExecMockRunner{}
+		scanner, err := syft.CreateSyftScanner("http://test-syft-gh-release.com/syft.tar.gz", &fileMock, client)
+		assert.NoError(t, err)
+
+		err = scanner.ScanImageTo("", &execMock, "https://my-registry", "image:1.0", "bom-docker-linux-arm64.xml", "--platform=linux/arm64")
+		assert.NoError(t, err)
+
+		assert.Len(t, execMock.Calls, 1)
+		call := execMock.Calls[0]
+		assert.Equal(t, []string{
+			"scan", "registry:my-registry/image:1.0",
+			"-o", "cyclonedx-xml@1.4=bom-docker-linux-arm64.xml",
+			"-q", "--exclude=**/{distlib,distlib-*}/**/*.exe",
+			"--platform=linux/arm64",
+		}, call.Params)
+	})
+
+	t.Run("scanner can be reused across platforms without arg accumulation", func(t *testing.T) {
+		execMock := mock.ExecMockRunner{}
+		scanner, err := syft.CreateSyftScanner("http://test-syft-gh-release.com/syft.tar.gz", &fileMock, client)
+		assert.NoError(t, err)
+
+		assert.NoError(t, scanner.ScanImageTo("", &execMock, "https://my-registry", "image:1.0", "bom-docker-linux-amd64.xml", "--platform=linux/amd64"))
+		assert.NoError(t, scanner.ScanImageTo("", &execMock, "https://my-registry", "image:1.0", "bom-docker-linux-arm64.xml", "--platform=linux/arm64"))
+
+		assert.Len(t, execMock.Calls, 2)
+		// Each call must carry exactly its own --platform, not both
+		assert.Contains(t, execMock.Calls[0].Params, "--platform=linux/amd64")
+		assert.NotContains(t, execMock.Calls[0].Params, "--platform=linux/arm64")
+		assert.Contains(t, execMock.Calls[1].Params, "--platform=linux/arm64")
+		assert.NotContains(t, execMock.Calls[1].Params, "--platform=linux/amd64")
+	})
+
+	t.Run("no extraArgs — no extra flags appended", func(t *testing.T) {
+		execMock := mock.ExecMockRunner{}
+		scanner, err := syft.CreateSyftScanner("http://test-syft-gh-release.com/syft.tar.gz", &fileMock, client)
+		assert.NoError(t, err)
+
+		err = scanner.ScanImageTo("", &execMock, "https://my-registry", "image:1.0", "bom-docker-0.xml")
+		assert.NoError(t, err)
+
+		call := execMock.Calls[0]
+		assert.Equal(t, []string{
+			"scan", "registry:my-registry/image:1.0",
+			"-o", "cyclonedx-xml@1.4=bom-docker-0.xml",
+			"-q", "--exclude=**/{distlib,distlib-*}/**/*.exe",
+		}, call.Params)
+	})
+
+	t.Run("error: empty registry", func(t *testing.T) {
+		execMock := mock.ExecMockRunner{}
+		scanner, err := syft.CreateSyftScanner("http://test-syft-gh-release.com/syft.tar.gz", &fileMock, client)
+		assert.NoError(t, err)
+
+		err = scanner.ScanImageTo("", &execMock, "", "image:1.0", "out.xml")
+		assert.EqualError(t, err, "syft: registry url must not be empty")
+	})
+
+	t.Run("error: empty image", func(t *testing.T) {
+		execMock := mock.ExecMockRunner{}
+		scanner, err := syft.CreateSyftScanner("http://test-syft-gh-release.com/syft.tar.gz", &fileMock, client)
+		assert.NoError(t, err)
+
+		err = scanner.ScanImageTo("", &execMock, "https://my-registry", "", "out.xml")
+		assert.EqualError(t, err, "syft: image name must not be empty")
+	})
+}


### PR DESCRIPTION
# Description
Adds ScanImageTo, a new method on SyftScanner that scans a single image and writes the SBOM to an explicitly named output
  file.

  The existing ScanImages method auto-names outputs as bom-docker-N.xml (index-based) and appends extra flags to the scanner
  instance via AddArgument / s.additionalArgs. This makes it unsuitable for multi-arch fan-out scenarios where the same
  scanner must be called repeatedly with different per-call arguments (e.g. --platform=linux/amd64, --platform=linux/arm64)
  without accumulating state between calls.

  ScanImageTo solves this by:
  - Accepting an explicit outputFile parameter — caller controls the filename
  - Accepting extraArgs ...string — forwarded directly to syft for that call only, never appended to the instance

  The scanner instance is not mutated, so it can safely be reused across multiple images and platforms in a single build.

  Changes

  - pkg/syft/syft.go — adds ScanImageTo(dockerConfigDir, execRunner, registryURL, image, outputFile string, extraArgs
  ...string) error
  - pkg/syft/syft_test.go — adds TestScanImageTo covering: explicit output filename with --platform arg, no arg accumulation
  across reuse, no-extraArgs baseline, empty registry error, empty image error

  Test plan

  - [X] go test ./pkg/syft/... -tags unit passes
  - [X] Verify no arg bleed between two consecutive calls with different --platform values (covered by "scanner can be
  reused across platforms without arg accumulation" test case)

  ---
  This is internal API — no step metadata or user-facing docs changes required.
# Checklist

- [X] Tests
- [ ] Documentation
- [ ] Inner source library needs updating
